### PR TITLE
riemann: Add batched event sending support

### DIFF
--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -126,6 +126,10 @@ riemann_option
           {
             riemann_dd_set_field_attributes(last_driver, last_value_pairs);
           }
+        | KW_FLUSH_LINES '(' LL_NUMBER ')'
+          {
+            riemann_dd_set_flush_lines(last_driver,  $3);
+          }
         | dest_driver_option
         | threaded_dest_driver_option
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option

--- a/modules/riemann/riemann.h
+++ b/modules/riemann/riemann.h
@@ -42,5 +42,6 @@ void riemann_dd_set_field_ttl(LogDriver *d, LogTemplate *value);
 void riemann_dd_set_field_tags(LogDriver *d, GList *taglist);
 void riemann_dd_set_field_attributes(LogDriver *d, ValuePairs *vp);
 gboolean riemann_dd_set_connection_type(LogDriver *d, const gchar *type);
+void riemann_dd_set_flush_lines(LogDriver *d, gint lines);
 
 #endif


### PR DESCRIPTION
This makes the riemann destination respect `flush-lines()`, and send event in batches of configurable amount (defaults to 1). In case of an error, all messages within the batch will be retried, and eventually lost if retries do not succeed. Dropped messages, and messages that result in formatting errors do not count towards the batch size.

There is no timeout, but messages will be flushed upon deinit.

This fixes #284.

Requested-by: Fabien Wernli
Signed-off-by: Gergely Nagy <algernon@madhouse-project.org>