### PR TITLE
filter: add new ipv6 netmask filter by "netmask6" tag

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -296,6 +296,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_MESSAGE                     10354
 %token KW_NETMASK                     10355
 %token KW_TAGS                        10356
+%token KW_NETMASK6                    10357
 
 /* parser items */
 

--- a/lib/filter/Makefile.am
+++ b/lib/filter/Makefile.am
@@ -7,6 +7,7 @@ filterinclude_HEADERS = 			\
 	lib/filter/filter-in-list.h		\
 	lib/filter/filter-tags.h		\
 	lib/filter/filter-netmask.h		\
+	lib/filter/filter-netmask6.h	\
 	lib/filter/filter-call.h		\
 	lib/filter/filter-re.h			\
 	lib/filter/filter-pri.h			\
@@ -20,6 +21,7 @@ filter_sources = 				\
 	lib/filter/filter-in-list.c		\
 	lib/filter/filter-tags.c		\
 	lib/filter/filter-netmask.c		\
+	lib/filter/filter-netmask6.c	\
 	lib/filter/filter-call.c		\
 	lib/filter/filter-re.c			\
 	lib/filter/filter-pri.c			\

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -32,6 +32,7 @@
 
 #include "filter/filter-expr-grammar.h"
 #include "filter/filter-netmask.h"
+#include "filter/filter-netmask6.h"
 #include "filter/filter-op.h"
 #include "filter/filter-cmp.h"
 #include "filter/filter-in-list.h"
@@ -99,7 +100,15 @@ filter_simple_expr
 	| KW_FACILITY '(' LL_NUMBER ')'		{ $$ = filter_facility_new(0x80000000 | $3); }
 	| KW_LEVEL '(' filter_level_list ')' 	{ $$ = filter_level_new($3); }
 	| KW_FILTER '(' string ')'		{ $$ = filter_call_new($3, configuration); free($3); }
-	| KW_NETMASK '(' string ')'		{ $$ = filter_netmask_new($3); free($3); }
+	| KW_NETMASK '(' string ')'    { $$ = filter_netmask_new($3); free($3); }
+  | KW_NETMASK6 '(' string ')'   {
+  #if ENABLE_IPV6
+                                    $$ = filter_netmask6_new($3);
+  #else
+                                    YYERROR;
+  #endif
+                                    free($3);
+                                  }
         | KW_TAGS '(' string_list ')'           { $$ = filter_tags_new($3); }
         | KW_IN_LIST '(' string string ')'
           {

--- a/lib/filter/filter-expr-parser.c
+++ b/lib/filter/filter-expr-parser.c
@@ -56,6 +56,9 @@ static CfgLexerKeyword filter_expr_keywords[] = {
   { "netmask",		  KW_NETMASK },
   { "tags",		  KW_TAGS, 0x0301 },
   { "in_list",            KW_IN_LIST, 0x0305 },
+#if ENABLE_IPV6
+  { "netmask6",     KW_NETMASK6 },
+#endif
 
   { "type",               KW_TYPE, 0x0300 },
   { "value",              KW_VALUE, 0x0300 },

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Zoltan Fried
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#include "filter-netmask6.h"
+#include "gsocket.h"
+#include "logmsg.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#if ENABLE_IPV6
+typedef struct _FilterNetmask6
+{
+  FilterExprNode super;
+  struct in6_addr address;
+  int prefix;
+  gboolean is_valid;
+} FilterNetmask6;
+
+static inline uint64_t
+_calculate_mask_by_prefix(int prefix)
+{
+  return (uint64_t) (~0) << (64 - prefix);
+}
+
+static inline uint64_t
+_mask(uint64_t base, uint64_t mask)
+{
+  if (G_BYTE_ORDER == G_BIG_ENDIAN)
+    return GUINT64_SWAP_LE_BE(base & mask);
+  else
+    return GUINT64_SWAP_LE_BE(GUINT64_SWAP_LE_BE(base) & mask);
+}
+
+void
+get_network_address(unsigned char *ipv6, int prefix, struct in6_addr *network)
+{
+  struct ipv6_parts
+  {
+    uint64_t lo;
+    uint64_t hi;
+  } ipv6_parts;
+
+  int length;
+
+  memcpy(&ipv6_parts, ipv6, sizeof(ipv6_parts));
+  if (prefix <= 64)
+    {
+      ipv6_parts.lo = _mask(ipv6_parts.lo, _calculate_mask_by_prefix(prefix));
+      length = sizeof(uint64_t);
+    }
+  else
+    {
+      ipv6_parts.hi = _mask(ipv6_parts.hi, _calculate_mask_by_prefix(prefix - 64));
+      length = 2 * sizeof(uint64_t);
+    }
+
+  memcpy(network->s6_addr, &ipv6_parts, length);
+}
+
+static inline gboolean
+_in6_addr_compare(const struct in6_addr* address1, const struct in6_addr* address2)
+{
+  return memcmp(address1, address2, sizeof(struct in6_addr)) == 0;
+}
+
+static gboolean
+_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
+{
+  FilterNetmask6 *self = (FilterNetmask6 *) s;
+  LogMessage *msg = msgs[0];
+  gboolean result = FALSE;
+  struct in6_addr network_address;
+  struct in6_addr address;
+
+  if (!self->is_valid)
+    return s->comp;
+
+  if (msg->saddr && g_sockaddr_inet6_check(msg->saddr))
+    {
+      address = ((struct sockaddr_in6 *) &msg->saddr->sa)->sin6_addr;
+    }
+  else if (!msg->saddr || msg->saddr->sa.sa_family == AF_UNIX)
+    {
+      address = in6addr_loopback;
+    }
+  else
+    {
+      return s->comp;
+    }
+
+  memset(&network_address, 0, sizeof(struct in6_addr));
+  get_network_address((unsigned char *) &address, self->prefix, &network_address);
+  result = _in6_addr_compare(&network_address, &self->address);
+
+  return result ^ s->comp;
+}
+
+FilterExprNode *
+filter_netmask6_new(gchar *cidr)
+{
+  FilterNetmask6 *self = g_new0(FilterNetmask6, 1);
+  struct in6_addr packet_addr;
+  gchar address[INET6_ADDRSTRLEN] = "";
+  gchar *slash = strchr(cidr, '/');
+
+  if (strlen(cidr) >= INET6_ADDRSTRLEN + 5 || !slash)
+    {
+      strcpy(address, cidr);
+      self->prefix = 128;
+    }
+  else
+    {
+      self->prefix = atol(slash + 1);
+      if (self->prefix > 0 && self->prefix < 129)
+        {
+          strncpy(address, cidr, slash - cidr);
+          address[slash - cidr] = 0;
+        }
+    }
+
+  self->is_valid = ((strlen(address) > 0) && inet_pton(AF_INET6, address, &packet_addr) == 1);
+  if (self->is_valid)
+    get_network_address((unsigned char *) &packet_addr, self->prefix, &self->address);
+  else
+    self->address = in6addr_loopback;
+
+  self->super.eval = _eval;
+  return &self->super;
+}
+#endif

--- a/lib/filter/filter-netmask6.h
+++ b/lib/filter/filter-netmask6.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Zoltan Fried
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTER_NETMASK6_H_INCLUDED
+#define FILTER_NETMASK6_H_INCLUDED
+
+#include "filter-expr.h"
+
+FilterExprNode *filter_netmask6_new(gchar *cidr);
+void get_network_address(unsigned char *ipv6, int prefix, struct in6_addr *network);
+
+#endif

--- a/lib/filter/tests/Makefile.am
+++ b/lib/filter/tests/Makefile.am
@@ -1,6 +1,7 @@
 lib_filter_tests_TESTS		 = \
 	lib/filter/tests/test_filters				\
-	lib/filter/tests/test_filters_in_list
+    lib/filter/tests/test_filters_in_list       \
+	lib/filter/tests/test_filters_netmask6
 
 check_PROGRAMS				+= ${lib_filter_tests_TESTS}
 
@@ -15,5 +16,10 @@ lib_filter_tests_test_filters_in_list_CFLAGS	= $(TEST_CFLAGS) \
 	-I${top_srcdir}/lib/filter/tests
 lib_filter_tests_test_filters_in_list_LDADD	= $(TEST_LDADD)  \
 	$(PREOPEN_SYSLOGFORMAT)
+
+lib_filter_tests_test_filters_netmask6_CFLAGS    = $(TEST_CFLAGS) \
+    -I${top_srcdir}/lib/filter/tests
+lib_filter_tests_test_filters_netmask6_LDADD = $(TEST_LDADD)  \
+    $(PREOPEN_SYSLOGFORMAT)
 
 include lib/filter/tests/filters-in-list/Makefile.am

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -1,6 +1,7 @@
 #include "filter/filter-expr.h"
 #include "filter/filter-expr-grammar.h"
 #include "filter/filter-netmask.h"
+#include "filter/filter-netmask6.h"
 #include "filter/filter-op.h"
 #include "filter/filter-cmp.h"
 #include "filter/filter-tags.h"
@@ -299,12 +300,46 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   TEST_ASSERT(create_posix_regexp_match("((", 0) == NULL);
 
+#if ENABLE_IPV6
+  sender_saddr = g_sockaddr_inet6_new("2001:db80:85a3:8d30:1319:8a2e:3700:7348", 5000);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::/1"), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("2001:db80:85a3:8d30:1319:8a2e::/95"), 1);
+
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("2001:db80:85a3:8d30:1319:8a2e:3700:7348/60"), 1);
+
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("2001:db80:85a3:8d30:1319:8a2e:3700::/114"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::85a3:8d30:1319:8a2e:3700::/114"), 0);
+
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("aaaaaa/32"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("/8"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new(""), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::1/8"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::1/128"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::2/32"), 0);
+
+  g_sockaddr_unref(sender_saddr);
+
+  sender_saddr = NULL;
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("aaaaaa/32"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("/8"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new(""), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::1"), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::/32"), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::1/8"), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::1/128"), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::/16"), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::/599"), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask6_new("::/aaa"), 0);
+#endif
+
   sender_saddr = g_sockaddr_inet_new("10.10.0.1", 5000);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask_new("10.10.0.0/16"), 1);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask_new("10.10.0.0/24"), 1);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask_new("10.10.10.0/24"), 0);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask_new("0.0.10.10/24"), 0);
   g_sockaddr_unref(sender_saddr);
+
   sender_saddr = NULL;
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask_new("127.0.0.1/32"), 1);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter_netmask_new("127.0.0.2/32"), 0);

--- a/lib/filter/tests/test_filters_netmask6.c
+++ b/lib/filter/tests/test_filters_netmask6.c
@@ -1,0 +1,93 @@
+#include "gsocket.h"
+#include "logmsg.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "testutils.h"
+#include "filter/filter-netmask6.h"
+
+gchar*
+calculate_network6(gchar* ipv6, int prefix, gchar *calculated_network)
+{
+  struct in6_addr network;
+  struct in6_addr address;
+
+  memset(&network, 0, sizeof(struct in6_addr));
+
+  inet_pton(AF_INET6, ipv6, &address);
+  get_network_address((unsigned char *)&address, prefix, &network);
+  inet_ntop(AF_INET6, &network, calculated_network, INET6_ADDRSTRLEN);
+  return calculated_network;
+}
+
+void
+assert_netmask6(gchar* ipv6, gint prefix, gchar* expected_network)
+{
+  char error_msg[64];
+  sprintf(error_msg, "prefix: %d", prefix);
+
+  gchar *calculated_network = g_new0(char, INET6_ADDRSTRLEN);
+  calculate_network6(ipv6, prefix, calculated_network);
+  assert_string(calculated_network, expected_network, error_msg);
+  g_free(calculated_network);
+}
+
+int
+main()
+{
+  const gchar* ipv6 = "2001:db80:85a3:8d30:1319:8a2e:3700:7348";
+
+  assert_netmask6(ipv6, 1,   "::");
+  assert_netmask6(ipv6, 3,   "2000::");
+  assert_netmask6(ipv6, 16,  "2001::");
+  assert_netmask6(ipv6, 17,  "2001:8000::");
+  assert_netmask6(ipv6, 18,  "2001:c000::");
+  assert_netmask6(ipv6, 20,  "2001:d000::");
+  assert_netmask6(ipv6, 21,  "2001:d800::");
+  assert_netmask6(ipv6, 23,  "2001:da00::");
+  assert_netmask6(ipv6, 24,  "2001:db00::");
+  assert_netmask6(ipv6, 25,  "2001:db80::");
+  assert_netmask6(ipv6, 33,  "2001:db80:8000::");
+  assert_netmask6(ipv6, 38,  "2001:db80:8400::");
+  assert_netmask6(ipv6, 40,  "2001:db80:8500::");
+  assert_netmask6(ipv6, 41,  "2001:db80:8580::");
+  assert_netmask6(ipv6, 43,  "2001:db80:85a0::");
+  assert_netmask6(ipv6, 47,  "2001:db80:85a2::");
+  assert_netmask6(ipv6, 48,  "2001:db80:85a3::");
+  assert_netmask6(ipv6, 49,  "2001:db80:85a3:8000::");
+  assert_netmask6(ipv6, 54,  "2001:db80:85a3:8c00::");
+  assert_netmask6(ipv6, 56,  "2001:db80:85a3:8d00::");
+  assert_netmask6(ipv6, 59,  "2001:db80:85a3:8d20::");
+  assert_netmask6(ipv6, 60,  "2001:db80:85a3:8d30::");
+  assert_netmask6(ipv6, 68,  "2001:db80:85a3:8d30:1000::");
+  assert_netmask6(ipv6, 71,  "2001:db80:85a3:8d30:1200::");
+  assert_netmask6(ipv6, 72,  "2001:db80:85a3:8d30:1300::");
+  assert_netmask6(ipv6, 76,  "2001:db80:85a3:8d30:1310::");
+  assert_netmask6(ipv6, 77,  "2001:db80:85a3:8d30:1318::");
+  assert_netmask6(ipv6, 80,  "2001:db80:85a3:8d30:1319::");
+  assert_netmask6(ipv6, 81,  "2001:db80:85a3:8d30:1319:8000::");
+  assert_netmask6(ipv6, 87,  "2001:db80:85a3:8d30:1319:8a00::");
+  assert_netmask6(ipv6, 91,  "2001:db80:85a3:8d30:1319:8a20::");
+  assert_netmask6(ipv6, 93,  "2001:db80:85a3:8d30:1319:8a28::");
+  assert_netmask6(ipv6, 94,  "2001:db80:85a3:8d30:1319:8a2c::");
+  assert_netmask6(ipv6, 95,  "2001:db80:85a3:8d30:1319:8a2e::");
+  assert_netmask6(ipv6, 99,  "2001:db80:85a3:8d30:1319:8a2e:2000:0");
+  assert_netmask6(ipv6, 100, "2001:db80:85a3:8d30:1319:8a2e:3000:0");
+  assert_netmask6(ipv6, 102, "2001:db80:85a3:8d30:1319:8a2e:3400:0");
+  assert_netmask6(ipv6, 103, "2001:db80:85a3:8d30:1319:8a2e:3600:0");
+  assert_netmask6(ipv6, 104, "2001:db80:85a3:8d30:1319:8a2e:3700:0");
+  assert_netmask6(ipv6, 114, "2001:db80:85a3:8d30:1319:8a2e:3700:4000");
+  assert_netmask6(ipv6, 115, "2001:db80:85a3:8d30:1319:8a2e:3700:6000");
+  assert_netmask6(ipv6, 116, "2001:db80:85a3:8d30:1319:8a2e:3700:7000");
+  assert_netmask6(ipv6, 119, "2001:db80:85a3:8d30:1319:8a2e:3700:7200");
+  assert_netmask6(ipv6, 120, "2001:db80:85a3:8d30:1319:8a2e:3700:7300");
+  assert_netmask6(ipv6, 122, "2001:db80:85a3:8d30:1319:8a2e:3700:7340");
+  assert_netmask6(ipv6, 125, "2001:db80:85a3:8d30:1319:8a2e:3700:7348");
+  return 0;
+}
+
+


### PR DESCRIPTION
usage:
	"ipv6address/prefix"
where
	ipv6address = valid ipv6 address
	prefix = integer number from 1 to 128

Signed-off-by: Fried Zoltan <zoltan.fried@balabit.com>