### PR TITLE
Allow special chars to be escaped again

### DIFF
--- a/lib/template/escaping.c
+++ b/lib/template/escaping.c
@@ -47,7 +47,7 @@ result_append(GString *result, const gchar *sstr, gssize len, gboolean escape)
             }
           else if (ustr[i] < ' ')
             {
-              format_uint32_padded(result, 3, '0', 8, ustr[i]);
+              g_string_sprintfa(result, "\\%03o", ustr[i]);
             }
           else
             g_string_append_c(result, ustr[i]);


### PR DESCRIPTION
Symptom: Using template() and template_escape(yes), then before the
introduction of this bug, the string "foo\nbar" would be escaped as
"foo\\012bar". After the introduction of this bug in
67bc063609b0d6ab45dff696d8e7c614300c6f40, it gets escaped as "foobar"
- the \n is simply omitted and cannot be reconstructed.

commit 67bc063609b0d6ab45dff696d8e7c614300c6f40
Author: Balazs Scheidler <bazsi@balabit.hu>
Date:   Thu Sep 15 13:59:08 2011 +0200

    templates: improve performance of escaped template formatting

    Signed-off-by: Attila Nagy <naat@balabit.hu>
    Signed-off-by: Balazs Scheidler <bazsi@balabit.hu>

Introduced a change in what is now lib/escaping.c's result_append:
where all for all chars:

      len = strlen(sstr);
      ...
      for (i = 0; i < len; i++)
        {
          ...
          else if (ustr[i] < ' ')
            {
    -         g_string_sprintfa(result, "\\%03o", ustr[i]);
    +         format_uint32_padded(result, 3, '0', 8, ustr[i]);
            }

But format_uint32_padded() is just a wrapper around format_padded_int32().
Notice base, the 8 in the call above. Now format_padded_int32()
contains:

      if (base == 10)
        len = format_uint32_base10_rev(num, sizeof(num), sign, value);
      else if (base == 16)
        len = format_uint32_base16_rev(num, sizeof(num), value);
      else
        return 0;

So for base == 8, format_padded_int32(), and hence
format_uint32_padded() is a no-op. ( No wonder it gave a performance
boost ! ).

For that reason, I suggest effectively a revert of
67bc063609b0d6ab45dff696d8e7c614300c6f40 - a re-introduction of
g_string_sprintfa() so that it really is possible to reliably
re-create the original string, which is currently not possible.

One could change to 8 to 16 in the format_uint32_padded call above,
but that would leave "foo\nbar" encoded as "foo0Abar" which is
indistiguishable from a no-op encoding of "foo0Abar". So the leading
'\' is absolutely necessary for reliably un-escaping.

If this is rejected, then for clarity at the very least we should
change:

    -             format_uint32_padded(result, 3, '0', 8, ustr[i]);
    +             /*
    +               For performance reasons, we omit control characters
    +               completely
    +             */