### PR TITLE
syslog-ng: set OpenSSL as a hard dependency

### DIFF
--- a/Mk/subdir.mk
+++ b/Mk/subdir.mk
@@ -43,7 +43,7 @@ else
 INSTALL_ARGS	+= lib_LTLIBRARIES= pkginclude_HEADERS= pkgconfig_DATA=
   ifneq (${self_sub},modules)
    ifeq (${self_sub},modules_afsocket)
-INSTALL_ARGS	+= module_LTLIBRARIES="modules/afsocket/libafsocket-notls.la modules/afsocket/libafsocket-tls.la"
+INSTALL_ARGS	+= module_LTLIBRARIES="modules/afsocket/libafsocket.la"
 INSTALL_ARGS	+= INSTALL_EXEC_HOOKS=afsocket-install-exec-hook
    else ifeq (${self_sub},modules_json)
 INSTALL_ARGS	+= module_LTLIBRARIES="modules/json/libjson-plugin.la"

--- a/configure.ac
+++ b/configure.ac
@@ -116,9 +116,6 @@ AC_ARG_ENABLE(gprof,
 AC_ARG_ENABLE(memtrace,
               [  --enable-memtrace   Enable alternative leak debugging code.])
 
-AC_ARG_ENABLE(ssl,
-              [  --enable-ssl        Enable SSL support.],,enable_ssl="auto")
-
 AC_ARG_ENABLE(dynamic-linking,
               [  --enable-dynamic-linking        Link everything dynamically.],,enable_dynamic_linking="auto")
 
@@ -239,7 +236,7 @@ if test "x$enable_all_modules" != "xauto"; then
    state="$enable_all_modules"
 
    MODULES="spoof_source sun_streams sql pacct mongodb json amqp stomp \
-            redis systemd geoip riemann ssl ipv6 smtp"
+            redis systemd geoip riemann ipv6 smtp"
    for mod in ${MODULES}; do
        modstate=$(eval echo \$enable_${mod})
        if test "x$modstate" = "xauto"; then
@@ -765,7 +762,9 @@ dnl ***************************************************************************
 #  * TLS support
 
 dnl check OpenSSL static linking
-PKG_CHECK_MODULES(OPENSSL, openssl >= $OPENSSL_MIN_VERSION,, OPENSSL_LIBS="")
+PKG_CHECK_MODULES(OPENSSL, 
+                  openssl >= $OPENSSL_MIN_VERSION,,
+                  AC_MSG_ERROR(Cannot find OpenSSL libraries with version >= $OPENSSL_MIN_VERSION it is a hard dependency from syslog-ng 3.7 onwards))
 
 if test -n "$OPENSSL_LIBS" -a "$linking_mode" != "dynamic"; then
         dnl required for openssl, but only when linking statically
@@ -780,17 +779,6 @@ if test -n "$OPENSSL_LIBS" -a "$linking_mode" != "dynamic"; then
 	LIBS=$old_LIBS
 fi
 
-if test "x$OPENSSL_LIBS" != "x"; then
-        if test "x$enable_ssl" = "xauto"; then
-	        enable_ssl="yes"
-        fi
-else
-        enable_ssl="no"
-fi
-
-if test "x$enable_ssl" = "xno"; then
-	OPENSSL_LIBS=""
-fi
 
 dnl
 dnl Right now, openssl is never linked statically as it is only used by the
@@ -1339,7 +1327,6 @@ AC_DEFINE_UNQUOTED(MODULE_PATH, "$module_path", [module search path])
 
 AC_DEFINE_UNQUOTED(WITH_COMPILE_DATE, $wcmp_date, [Include the compile date in the binary])
 AC_DEFINE_UNQUOTED(ENABLE_DEBUG, `enable_value $enable_debug`, [Enable debugging])
-AC_DEFINE_UNQUOTED(ENABLE_SSL, `enable_value $enable_ssl`, [Enable SSL support])
 AC_DEFINE_UNQUOTED(ENABLE_LIBUUID, `enable_value $enable_libuuid`, [Enable libuuid support])
 AC_DEFINE_UNQUOTED(ENABLE_GPROF, `enable_value $enable_gprof`, [Enable gcc profiling])
 AC_DEFINE_UNQUOTED(ENABLE_MEMTRACE, `enable_value $enable_memtrace`, [Enable memtrace])
@@ -1355,7 +1342,6 @@ AC_DEFINE_UNQUOTED(SYSTEMD_JOURNAL_MODE, `journald_mode`, [Systemd-journal suppo
 AM_CONDITIONAL(ENABLE_ENV_WRAPPER, [test "$enable_env_wrapper" = "yes"])
 AM_CONDITIONAL(ENABLE_SYSTEMD, [test "$enable_systemd" = "yes"])
 AM_CONDITIONAL(ENABLE_SYSTEMD_UNIT_INSTALL, [test "$systemdsystemunitdir" != ""])
-AM_CONDITIONAL(ENABLE_SSL, [test "$enable_ssl" = "yes"])
 AM_CONDITIONAL(ENABLE_SQL, [test "$enable_sql" = "yes"])
 AM_CONDITIONAL(ENABLE_SUN_STREAMS, [test "$enable_sun_streams" = "yes"])
 AM_CONDITIONAL(ENABLE_PACCT, [test "$enable_pacct" = "yes"])
@@ -1465,7 +1451,6 @@ echo "  systemd-journal support     : ${with_systemd_journal:=no}"
 echo " Modules:"
 echo "  Module search path          : ${module_path}"
 echo "  Sun STREAMS support (module): ${enable_sun_streams:=no}"
-echo "  SSL support (module)        : ${enable_ssl:=no}"
 echo "  SQL support (module)        : ${enable_sql:=no}"
 echo "  PACCT module (EXPERIMENTAL) : ${enable_pacct:=no}"
 echo "  MongoDB destination (module): ${enable_mongodb:=no}"

--- a/lib/crypto.c
+++ b/lib/crypto.c
@@ -30,8 +30,6 @@
 #include "apphook.h"
 #include "thread-utils.h"
 
-#if ENABLE_SSL
-
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <stdio.h>
@@ -138,4 +136,3 @@ crypto_unload(void)
 
 /* the crypto options (seed) are handled in main.c */
 
-#endif

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -25,8 +25,6 @@
 #include "misc.h"
 #include "messages.h"
 
-#if ENABLE_SSL
-
 #include <arpa/inet.h>
 #include <openssl/x509_vfy.h>
 #include <openssl/x509v3.h>
@@ -567,4 +565,3 @@ tls_verify_certificate_name(X509 *cert, const gchar *host_name)
   return result;
 }
 
-#endif

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -26,8 +26,6 @@
 
 #include "syslog-ng.h"
 
-#if ENABLE_SSL
-
 #include <openssl/ssl.h>
 
 typedef enum
@@ -88,13 +86,5 @@ void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);
 
 void tls_x509_format_dn(X509_NAME *name, GString *dn);
-#else
-
-typedef struct _TLSContext TLSContext;
-typedef struct _TLSSession TLSSession;
-
-#define tls_context_new(m)
-
-#endif
 
 #endif

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -23,8 +23,6 @@
 
 #include "transport/transport-tls.h"
 
-#if ENABLE_SSL
-
 #include "messages.h"
 
 #include <openssl/ssl.h>
@@ -168,4 +166,3 @@ log_transport_tls_free_method(LogTransport *s)
   log_transport_free_method(s);
 }
 
-#endif

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -24,7 +24,6 @@
 
 #include "uuid.h"
 
-#if ENABLE_SSL
 #include <openssl/rand.h>
 #include <arpa/inet.h>
 
@@ -59,33 +58,3 @@ uuid_gen_random(gchar *buf, gsize buflen)
                   uuid.node[3], uuid.node[4], uuid.node[5]);
 
 }
-#else
-
-#if ENABLE_LIBUUID
-#include <uuid/uuid.h>
-
-void
-uuid_gen_random(gchar *buf, gsize buflen)
-{
-  uuid_t uuid;
-  char out[37];
-
-  uuid_generate(uuid);
-  uuid_unparse(uuid, out);
-
-  g_strlcpy(buf, out, buflen);
-}
-
-#else /* Neither openssl, nor libuuid */
-
-#warning "Neither openssl, nor libuuid was found on your system, UUID generation will be disabled"
-
-void
-uuid_gen_random(gchar *buf, gsize buflen)
-{
-  static int counter = 1;
-
-  g_snprintf(buf, buflen, "unable-to-generate-uuid-without-random-source-%d", counter++);
-}
-#endif
-#endif

--- a/modules/afsocket/Makefile.am
+++ b/modules/afsocket/Makefile.am
@@ -1,6 +1,4 @@
-module_LTLIBRARIES				+= modules/afsocket/libafsocket-notls.la
-noinst_DATA					+= modules/afsocket/libafsocket.la
-modules_afsocket_libafsocket_notls_la_SOURCES	=	\
+modules_afsocket_libafsocket_la_SOURCES	=	\
 	modules/afsocket/afsocket.c			\
 	modules/afsocket/afsocket.h			\
 	modules/afsocket/afsocket-source.c		\
@@ -39,46 +37,23 @@ modules_afsocket_libafsocket_notls_la_SOURCES	=	\
 	modules/afsocket/systemd-syslog-source.c	\
 	modules/afsocket/afsocket-systemd-override.h
 
-modules_afsocket_libafsocket_notls_la_CPPFLAGS	=	\
+module_LTLIBRARIES				+= modules/afsocket/libafsocket.la
+modules_afsocket_libafsocket_la_CPPFLAGS	=	\
 	$(AM_CPPFLAGS) $(libsystemd_CFLAGS)	\
 	-I${top_srcdir}/modules/afsocket		\
 	-I${top_builddir}/modules/afsocket
-modules_afsocket_libafsocket_notls_la_LIBADD	=	\
-	$(MODULE_DEPS_LIBS) $(LIBNET_LIBS)		\
-	$(LIBWRAP_LIBS) $(libsystemd_LIBS)
-modules_afsocket_libafsocket_notls_la_LDFLAGS	  =	\
-	$(MODULE_LDFLAGS)
-modules_afsocket_libafsocket_notls_la_DEPENDENCIES=	\
-	$(MODULE_DEPS_LIBS)
 
-if ENABLE_SSL
-module_LTLIBRARIES				+= modules/afsocket/libafsocket-tls.la
-modules_afsocket_libafsocket_tls_la_SOURCES	=	\
-	$(modules_afsocket_libafsocket_notls_la_SOURCES)
-modules_afsocket_libafsocket_tls_la_CPPFLAGS	=	\
-	$(AM_CPPFLAGS) $(libsystemd_CFLAGS)	\
-	-I${top_srcdir}/modules/afsocket		\
-	-I${top_builddir}/modules/afsocket		\
-	-DBUILD_WITH_SSL=1
-
-modules_afsocket_libafsocket_tls_la_LIBADD	=	\
+modules_afsocket_libafsocket_la_LIBADD	=	\
 	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS) 		\
 	$(OPENSSL_LIBS) $(ZLIB_LIBS) $(LIBNET_LIBS)	\
 	$(LIBWRAP_LIBS) $(libsystemd_LIBS)
-modules_afsocket_libafsocket_tls_la_DEPENDENCIES= 	\
+modules_afsocket_libafsocket_la_DEPENDENCIES= 	\
 	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS)
-modules_afsocket_libafsocket_tls_la_LDFLAGS	= 	\
+modules_afsocket_libafsocket_la_LDFLAGS	= 	\
 	$(MODULE_LDFLAGS)
 
 modules/afsocket modules/afsocket/ mod-afsocket mod-socket: \
-	modules/afsocket/libafsocket-notls.la \
-	modules/afsocket/libafsocket-tls.la \
 	modules/afsocket/libafsocket.la
-else
-modules/afsocket modules/afsocket/ mod-afsocket mod-socket: \
-	modules/afsocket/libafsocket-notls.la \
-	modules/afsocket/libafsocket.la
-endif
 
 BUILT_SOURCES					+=	\
 	modules/afsocket/afsocket-grammar.y		\
@@ -86,34 +61,6 @@ BUILT_SOURCES					+=	\
 	modules/afsocket/afsocket-grammar.h
 EXTRA_DIST 					+=	\
 	modules/afsocket/afsocket-grammar.ym
-
-if ENABLE_SSL
-afsocket-install-exec-hook:
-	$(mkinstalldirs) $(DESTDIR)$(moduledir)
-	ln -sf libafsocket-tls.so $(DESTDIR)$(moduledir)/libafsocket.so
-
-modules/afsocket/libafsocket.la: modules/afsocket/libafsocket-tls.la
-	ln -sf libafsocket-tls.la modules/afsocket/libafsocket.la
-
-else
-afsocket-install-exec-hook:
-	$(mkinstalldirs) $(DESTDIR)$(moduledir)
-	ln -sf libafsocket-notls.so $(DESTDIR)$(moduledir)/libafsocket.so
-
-
-modules/afsocket/libafsocket.la: modules/afsocket/libafsocket-tls.la
-	ln -sf libafsocket-notls.la modules/afsocket/libafsocket.la
-
-endif
-
-INSTALL_EXEC_HOOKS				+= \
-	afsocket-install-exec-hook
-
-afsocket-uninstall-hook:
-	rm -f $(DESTDIR)$(moduledir)/libafsocket.so
-
-UNINSTALL_HOOKS					+= \
-	afsocket-uninstall-hook
 
 CLEANFILES					+= \
 	modules/afsocket/libafsocket.la

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -92,8 +92,6 @@ afinet_dd_set_spoof_source(LogDriver *s, gboolean enable)
 #endif
 }
 
-#if BUILD_WITH_SSL
-
 static gint
 afinet_dd_verify_callback(gint ok, X509_STORE_CTX *ctx, gpointer user_data)
 {
@@ -115,8 +113,6 @@ afinet_dd_set_tls_context(LogDriver *s, TLSContext *tls_context)
   transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context, afinet_dd_verify_callback, self);
 }
 
-#endif
-
 static LogWriter *
 afinet_dd_construct_writer(AFSocketDestDriver *s)
 {
@@ -125,7 +121,6 @@ afinet_dd_construct_writer(AFSocketDestDriver *s)
   TransportMapperInet *transport_mapper_inet G_GNUC_UNUSED = ((TransportMapperInet *) (self->super.transport_mapper));
 
   writer = afsocket_dd_construct_writer_method(s);
-#if BUILD_WITH_SSL
   /* SSL is duplex, so we can certainly expect input from the server, which
    * would cause the LogWriter to close this connection.  In a better world
    * LW_DETECT_EOF would be implemented by the LogProto class and would
@@ -135,7 +130,7 @@ afinet_dd_construct_writer(AFSocketDestDriver *s)
 
   if (((self->super.transport_mapper->sock_type == SOCK_STREAM) && transport_mapper_inet->tls_context))
     log_writer_set_flags(writer, log_writer_get_flags(writer) & ~LW_DETECT_EOF);
-#endif
+
   return writer;
 }
 

--- a/modules/afsocket/afinet-source.c
+++ b/modules/afsocket/afinet-source.c
@@ -55,7 +55,6 @@ afinet_sd_set_localip(LogDriver *s, gchar *ip)
   self->bind_ip = g_strdup(ip);
 }
 
-#if BUILD_WITH_SSL
 void
 afinet_sd_set_tls_context(LogDriver *s, TLSContext *tls_context)
 {
@@ -63,8 +62,6 @@ afinet_sd_set_tls_context(LogDriver *s, TLSContext *tls_context)
 
   transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context, NULL, NULL);
 }
-#endif
-
 
 static gboolean
 afinet_sd_setup_addresses(AFSocketSourceDriver *s)

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -47,17 +47,13 @@
 #include "systemd-syslog-source.h"
 #include "afsocket-systemd-override.h"
 
-#if BUILD_WITH_SSL
 #include "tlscontext.h"
-#endif
 
 
 static SocketOptions *last_sock_options;
 static TransportMapper *last_transport_mapper;
 
-#if BUILD_WITH_SSL
 TLSContext *last_tls_context;
-#endif
 
 
 #if ! ENABLE_IPV6
@@ -342,15 +338,11 @@ source_afinet_tcp_option
         : source_afinet_option
 	| KW_TLS
 	  {
-#if BUILD_WITH_SSL
 	    last_tls_context = tls_context_new(TM_SERVER);
-#endif
 	  }
 	  '(' tls_options ')'
 	  {
-#if BUILD_WITH_SSL
 	    afinet_sd_set_tls_context(last_driver, last_tls_context);
-#endif
           }
 	| source_afsocket_stream_params		{}
 	;
@@ -416,15 +408,11 @@ source_afsocket_transport
 	: afsocket_transport
 	| KW_TLS
 	  {
-#if BUILD_WITH_SSL
 	    last_tls_context = tls_context_new(TM_SERVER);
-#endif
 	  }
 	  '(' tls_options ')'
 	  {
-#if BUILD_WITH_SSL
 	    afinet_sd_set_tls_context(last_driver, last_tls_context);
-#endif
           }
         ;
 
@@ -581,15 +569,11 @@ dest_afinet_tcp_option
 	: dest_afinet_option
 	| KW_TLS
 	  {
-#if BUILD_WITH_SSL
 	    last_tls_context = tls_context_new(TM_CLIENT);
-#endif
 	  }
 	  '(' tls_options ')'
 	  {
-#if BUILD_WITH_SSL
 	    afinet_dd_set_tls_context(last_driver, last_tls_context);
-#endif
           }
 	;
 
@@ -653,15 +637,11 @@ dest_afsocket_transport
 	| KW_SPOOF_SOURCE '(' yesno ')'		         { afinet_dd_set_spoof_source(last_driver, $3); }
 	| KW_TLS
 	  {
-  #if BUILD_WITH_SSL
             last_tls_context = tls_context_new(TM_CLIENT);
-  #endif
           }
           '(' tls_options ')'
           {
-  #if BUILD_WITH_SSL
             afinet_dd_set_tls_context(last_driver, last_tls_context);
-  #endif
           }
         ;
 
@@ -681,7 +661,6 @@ tls_options
 
 tls_option
         : KW_IFDEF {
-#if BUILD_WITH_SSL
 }
 
 	| KW_PEER_VERIFY '(' string ')'
@@ -723,7 +702,6 @@ tls_option
             free($3);
 	  }
         | KW_ENDIF {
-#endif
 }
         ;
 

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -41,7 +41,6 @@ static CfgLexerKeyword afsocket_keywords[] = {
   { "udp6",               KW_UDP6 },
   { "tcp6",               KW_TCP6 },
 #endif
-#if BUILD_WITH_SSL
   /* ssl */
   { "tls",                KW_TLS },
   { "peer_verify",        KW_PEER_VERIFY },
@@ -52,7 +51,6 @@ static CfgLexerKeyword afsocket_keywords[] = {
   { "trusted_keys",       KW_TRUSTED_KEYS },
   { "trusted_dn",         KW_TRUSTED_DN },
   { "cipher_suite",       KW_CIPHER_SUITE },
-#endif
 
   { "localip",            KW_LOCALIP },
   { "ip",                 KW_IP },

--- a/modules/afsocket/afsocket-plugin.c
+++ b/modules/afsocket/afsocket-plugin.c
@@ -127,12 +127,8 @@ const ModuleInfo module_info =
 {
   .canonical_name = "afsocket",
   .version = VERSION,
-#if BUILD_WITH_SSL
   .preference = 100,
   .description = "The afsocket module provides socket based transports for syslog-ng, such as the udp(), tcp() and syslog() drivers. This module is compiled with SSL support.",
-#else
-  .description = "The afsocket module provides socket based transports for syslog-ng, such as the udp(), tcp() and syslog() drivers. This module is compiled without SSL support.",
-#endif
   .core_revision = SOURCE_REVISION,
   .plugins = afsocket_plugins,
   .plugins_len = G_N_ELEMENTS(afsocket_plugins),

--- a/modules/afsocket/tests/Makefile.am
+++ b/modules/afsocket/tests/Makefile.am
@@ -1,5 +1,4 @@
-if ENABLE_SSL
-TEST_TRANSPORT_MAPPER_CFLAGS = $(TEST_CFLAGS) -DBUILD_WITH_SSL=1
+TEST_TRANSPORT_MAPPER_CFLAGS = $(TEST_CFLAGS)
 
 TRANSPORT_MAPPER_LIB = 					\
 	modules/afsocket/tests/transport-mapper-lib.c	\
@@ -54,4 +53,3 @@ modules_afsocket_tests_test_transport_mapper_unix_LDFLAGS =	\
 modules_afsocket_tests_test_transport_mapper_unix_SOURCES = 	\
 	modules/afsocket/tests/test-transport-mapper-unix.c	\
 	$(TRANSPORT_MAPPER_LIB)
-endif

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -109,7 +109,6 @@ assert_create_socket_succeeds(void)
   close(sock);
 }
 
-#ifdef BUILD_WITH_SSL
 static TLSContext *
 create_dummy_tls_context(void)
 {
@@ -118,7 +117,6 @@ create_dummy_tls_context(void)
   tls_context = tls_context_new(TM_SERVER);
   return tls_context;
 }
-#endif
 
 /******************************************************************************
  * Tests start here
@@ -163,10 +161,8 @@ test_udp_apply_transport_sets_defaults(void)
 static void
 test_udp_apply_fails_when_tls_context_is_set(void)
 {
-#ifdef BUILD_WITH_SSL
   transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
-#endif
 }
 
 static void
@@ -196,10 +192,8 @@ test_network_transport_udp_apply_transport_sets_defaults(void)
 static void
 test_network_transport_udp_apply_fails_when_tls_context_is_set(void)
 {
-#ifdef BUILD_WITH_SSL
   transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
-#endif
 }
 
 static void
@@ -223,7 +217,6 @@ test_network_transport_tls_apply_fails_without_tls_context(void)
 static void
 test_network_transport_tls_apply_transport_sets_defaults(void)
 {
-#ifdef BUILD_WITH_SSL
   transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
   assert_transport_mapper_apply(transport_mapper, "tls");
   assert_transport_mapper_tcp_socket(transport_mapper);
@@ -232,7 +225,6 @@ test_network_transport_tls_apply_transport_sets_defaults(void)
   assert_transport_mapper_logproto(transport_mapper, "text");
   assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-#endif
 }
 
 static void
@@ -262,10 +254,8 @@ test_syslog_transport_udp_apply_transport_sets_defaults(void)
 static void
 test_syslog_transport_udp_apply_fails_when_tls_context_is_set(void)
 {
-#ifdef BUILD_WITH_SSL
   transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
-#endif
 }
 
 static void
@@ -289,7 +279,6 @@ test_syslog_transport_tls_apply_fails_without_tls_context(void)
 static void
 test_syslog_transport_tls_apply_transport_sets_defaults(void)
 {
-#ifdef BUILD_WITH_SSL
   transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
   assert_transport_mapper_apply(transport_mapper, "tls");
   assert_transport_mapper_tcp_socket(transport_mapper);
@@ -298,7 +287,6 @@ test_syslog_transport_tls_apply_transport_sets_defaults(void)
   assert_transport_mapper_logproto(transport_mapper, "framed");
   assert_transport_mapper_stats_source(transport_mapper, SCS_SYSLOG);
   assert_transport_mapper_inet_server_port(transport_mapper, 6514);
-#endif
 }
 
 static void

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -40,8 +40,6 @@
 #define SYSLOG_TRANSPORT_TCP_PORT 601
 #define SYSLOG_TRANSPORT_TLS_PORT 6514
 
-#ifdef BUILD_WITH_SSL
-
 static inline gboolean
 _is_tls_required(TransportMapperInet *self)
 {
@@ -115,17 +113,6 @@ transport_mapper_inet_free_method(TransportMapper *s)
     tls_context_free(self->tls_context);
   transport_mapper_free_method(s);
 }
-
-
-#else
-
-#define transport_mapper_inet_apply_transport_method      transport_mapper_apply_transport_method
-#define transport_mapper_inet_validate_tls_options(self)  (TRUE)
-#define transport_mapper_inet_construct_log_transport     transport_mapper_construct_log_transport_method
-#define transport_mapper_inet_free_method                 transport_mapper_free_method
-
-#endif
-
 
 void
 transport_mapper_inet_init_instance(TransportMapperInet *self, const gchar *transport)

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -34,11 +34,9 @@ typedef struct _TransportMapperInet
   const gchar *server_port_change_warning;
   gboolean require_tls;
   gboolean allow_tls;
-#if BUILD_WITH_SSL
   TLSContext *tls_context;
   TLSSessionVerifyFunc tls_verify_callback;
   gpointer tls_verify_data;
-#endif
 } TransportMapperInet;
 
 static inline gint
@@ -55,7 +53,6 @@ transport_mapper_inet_get_port_change_warning(TransportMapper *s)
   return self->server_port_change_warning;
 }
 
-#if BUILD_WITH_SSL
 static inline void
 transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context, TLSSessionVerifyFunc tls_verify_callback, gpointer tls_verify_data)
 {
@@ -63,7 +60,6 @@ transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls
   self->tls_verify_callback = tls_verify_callback;
   self->tls_verify_data = tls_verify_data;
 }
-#endif
 
 void transport_mapper_inet_init_instance(TransportMapperInet *self, const gchar *transport);
 TransportMapper *transport_mapper_tcp_new(void);

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -37,9 +37,7 @@
 
 #include <string.h>
 
-#if ENABLE_SSL
 #include <openssl/md5.h>
-#endif
 
 static gboolean dbi_initialized = FALSE;
 static const char *s_oracle = "oracle";
@@ -421,7 +419,6 @@ afsql_dd_create_index(AFSqlDestDriver *self, const gchar *table, const gchar *co
       if ((strlen(table) + strlen(column)) > 25)
         {
 
-#if ENABLE_SSL
           guchar hash[MD5_DIGEST_LENGTH];
           gchar hash_str[31];
           gchar *cat = g_strjoin("_", table, column, NULL);
@@ -433,12 +430,6 @@ afsql_dd_create_index(AFSqlDestDriver *self, const gchar *table, const gchar *co
           hash_str[0] = 'i';
           g_string_printf(query_string, "CREATE INDEX %s ON %s (%s)",
               hash_str, table, column);
-#else
-          msg_warning("The name of the index would be too long for Oracle to handle and OpenSSL was not detected which would be used to generate a shorter name. Please enable SSL support in order to use this combination.",
-                      evt_tag_str("table", table),
-                      evt_tag_str("column", column),
-                      NULL);
-#endif
         }
       else
         g_string_printf(query_string, "CREATE INDEX %s_%s_idx ON %s (%s)",

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -27,10 +27,7 @@
 #include "uuid.h"
 #include "str-format.h"
 #include "plugin-types.h"
-
-#if ENABLE_SSL
 #include <openssl/evp.h>
-#endif
 
 static void
 tf_uuid(LogMessage *msg, gint argc, GString *argv[], GString *result)
@@ -43,7 +40,6 @@ tf_uuid(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
 TEMPLATE_FUNCTION_SIMPLE(tf_uuid);
 
-#if ENABLE_SSL
 /*
  * $($hash_method [opts] $arg1 $arg2 $arg3...)
  *
@@ -147,19 +143,16 @@ tf_hash_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs 
 
 TEMPLATE_FUNCTION(TFHashState, tf_hash, tf_hash_prepare, tf_simple_func_eval, tf_hash_call, tf_simple_func_free_state, NULL);
 
-#endif
 
 static Plugin cryptofuncs_plugins[] =
 {
   TEMPLATE_FUNCTION_PLUGIN(tf_uuid, "uuid"),
-#if ENABLE_SSL
   TEMPLATE_FUNCTION_PLUGIN(tf_hash, "hash"),
   TEMPLATE_FUNCTION_PLUGIN(tf_hash, "sha1"),
   TEMPLATE_FUNCTION_PLUGIN(tf_hash, "sha256"),
   TEMPLATE_FUNCTION_PLUGIN(tf_hash, "sha512"),
   TEMPLATE_FUNCTION_PLUGIN(tf_hash, "md4"),
   TEMPLATE_FUNCTION_PLUGIN(tf_hash, "md5"),
-#endif
 };
 
 gboolean

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -5,7 +5,6 @@
 void
 test_hash(void)
 {
-#if ENABLE_SSL
   assert_template_format("$(sha1 foo)", "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
   assert_template_format("$(sha1 bar)", "62cdb7020ff920e5aa642c3d4066950dd1f01f4d");
   assert_template_format("$(md5 foo)", "acbd18db4cc2f85cedef654fccc4a4d8");
@@ -22,7 +21,6 @@ test_hash(void)
   assert_template_format("$(sha1 foo bar)", "8843d7f92416211de9ebb963ff4ce28125932878");
   assert_template_format("$(sha1 \"foo bar\")", "3773dea65156909838fa6c22825cafe090ff8030");
   assert_template_format("$(md5 $(sha1 foo) bar)", "196894290a831b2d2755c8de22619a97");
-#endif
 }
 
 int

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -16,13 +16,11 @@
 #include <glib.h>
 #include <signal.h>
 
-#if ENABLE_SSL
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
-#endif
 
 #include <unistd.h>
 
@@ -103,13 +101,11 @@ send_plain(void *user_data, void *buf, size_t length)
   return (cc);
 }
 
-#if ENABLE_SSL
 static ssize_t
 send_ssl(void *user_data, void *buf, size_t length)
 {
   return SSL_write((SSL *)user_data, buf, length);
 }
-#endif
 
 static unsigned long
 time_val_diff_in_usec(struct timeval *t1, struct timeval *t2)
@@ -507,7 +503,6 @@ gen_messages(send_data_t send_func, void *send_func_ud, int thread_id, FILE *rea
   return count;
 }
 
-#if ENABLE_SSL
 static guint64
 gen_messages_ssl(int sock, int id, FILE *readfrom)
 {
@@ -546,9 +541,6 @@ gen_messages_ssl(int sock, int id, FILE *readfrom)
 
   return ret;
 }
-#else
-#define gen_messages_ssl gen_messages_plain
-#endif
 
 static guint64
 gen_messages_plain(int sock, int id, FILE *readfrom)
@@ -681,9 +673,7 @@ static GOptionEntry loggen_options[] = {
   { "no-framing", 'F', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &framing, "Don't use syslog-protocol style framing, even if syslog-proto is set", NULL },
   { "active-connections", 0, 0, G_OPTION_ARG_INT, &active_connections, "Number of active connections to the server (default = 1)", "<number>" },
   { "idle-connections", 0, 0, G_OPTION_ARG_INT, &idle_connections, "Number of inactive connections to the server (default = 0)", "<number>" },
-#if ENABLE_SSL
   { "use-ssl", 'U', 0, G_OPTION_ARG_NONE, &usessl, "Use ssl layer", NULL },
-#endif
   { "read-file", 'R', 0, G_OPTION_ARG_STRING, &read_file, "Read log messages from file", "<filename>" },
   { "loop-reading", 'l', 0, G_OPTION_ARG_NONE, &loop_reading, "Read the file specified in read-file option in loop (it will restart the reading if reached the end of the file)", NULL },
   { "skip-tokens", 0, 0, G_OPTION_ARG_INT, &skip_tokens, "Skip the given number of tokens (delimined by a space) at the beginning of each line (default value: 3)", "<number>" },

--- a/tgz2build/rules
+++ b/tgz2build/rules
@@ -3,7 +3,7 @@ STAMPDIR=tgz2build/stamps
 DOCDIR=$(PREFIX)/doc
 
 CC:=gcc
-CONFIGURE_OPTS := --prefix $(ZBS_PREFIX) --enable-ssl --enable-dynamic-linking --enable-sql \
+CONFIGURE_OPTS := --prefix $(ZBS_PREFIX) --enable-dynamic-linking --enable-sql \
 	--enable-spoof-source --enable-pcre --disable-tcp-wrapper --with-ld-library-path=$(ZBS_PREFIX)/lib \
 	--with-pidfile-dir=$(ZBS_PREFIX)/var/run \
 	--with-module-dir=$(ZBS_PREFIX)/lib \


### PR DESCRIPTION
This patch also enables all SSL-dependent features by default.

Signed-off-by: Budai Laszlo <Laszlo.Budai@balabit.com>