### PR TITLE
F/csv string delimeter4

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -131,6 +131,7 @@ pkginclude_HEADERS			+= \
 	lib/scratch-buffers.h		\
 	lib/serialize.h			\
 	lib/service-management.h	\
+	lib/stringutils.h	\
 	lib/str-format.h		\
 	lib/syslog-names.h		\
 	lib/syslog-ng.h			\
@@ -213,6 +214,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/scratch-buffers.c		\
 	lib/serialize.c			\
 	lib/service-management.c	\
+	lib/stringutils.c	\
 	lib/str-format.c		\
 	lib/syslog-names.c		\
 	lib/tags.c			\

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -191,6 +191,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_QUOTES                      10051
 %token KW_QUOTE_PAIRS                 10052
 %token KW_NULL                        10053
+%token KW_STRING_DELIMITERS           10054
 
 %token KW_SYSLOG                      10060
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -191,7 +191,8 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_QUOTES                      10051
 %token KW_QUOTE_PAIRS                 10052
 %token KW_NULL                        10053
-%token KW_STRING_DELIMITERS           10054
+%token KW_CHARS                       10054
+%token KW_STRINGS                     10055
 
 %token KW_SYSLOG                      10060
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -53,6 +53,7 @@ static CfgLexerKeyword main_keywords[] = {
   { "delimiters",         KW_DELIMITERS, 0x0300 },
   { "quotes",             KW_QUOTES, 0x0300 },
   { "quote_pairs",        KW_QUOTE_PAIRS, 0x0300},
+  { "string_delimiters",  KW_STRING_DELIMITERS, 0x0300},
   { "null",               KW_NULL, 0x0300 },
 
   /* value pairs */

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -53,7 +53,8 @@ static CfgLexerKeyword main_keywords[] = {
   { "delimiters",         KW_DELIMITERS, 0x0300 },
   { "quotes",             KW_QUOTES, 0x0300 },
   { "quote_pairs",        KW_QUOTE_PAIRS, 0x0300},
-  { "string_delimiters",  KW_STRING_DELIMITERS, 0x0300},
+  { "chars",              KW_CHARS, 0x0300},
+  { "strings",             KW_STRINGS, 0x0300},
   { "null",               KW_NULL, 0x0300 },
 
   /* value pairs */

--- a/lib/stringutils.c
+++ b/lib/stringutils.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stringutils.h"
+
+#include <string.h>
+
+typedef struct _StringSlice {
+  char *start;
+  int length;
+  const char *string;
+} StringSlice;
+
+static void
+_find_string(gpointer data, gpointer u_data)
+{
+  const char *item = (const char*) data;
+  StringSlice *user_data = (StringSlice*) u_data;
+
+  if (!user_data->start)
+  {
+    user_data->start = strstr(user_data->string, item);
+    user_data->length = (user_data->start) ? strlen(item) : 0;
+  }
+}
+
+/* searches for str in list and returns the first occurence, otherwise NULL */
+guchar*
+g_string_list_find_first(GList *list, const char * str, int *result_length)
+{
+  StringSlice user_data = {NULL, 0, str};
+
+  g_list_foreach(list, _find_string, (gpointer) &user_data);
+
+  *result_length = user_data.length;
+
+  return (guchar*) user_data.start;
+}
+

--- a/lib/stringutils.h
+++ b/lib/stringutils.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STRINGUTILS_H_INCLUDED
+#define STRINGUTILS_H_INCLUDED
+
+#include <glib.h>
+
+guchar* g_string_list_find_first(GList *list, const char * str, int *result_length);
+
+#endif

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -87,7 +87,16 @@ parser_csv_opt
         | KW_QUOTES '(' string ')'              { log_csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
         | KW_QUOTE_PAIRS '(' string ')'         { log_csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
         | KW_NULL '(' string ')'                { log_csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_STRING_DELIMITERS '(' parser_csv_string_delimiters ')'
         | parser_column_opt
+        ;
+
+parser_csv_string_delimiters
+        : string parser_csv_string_delimiters
+          {
+            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1);
+          }
+        | 
         ;
 
 parser_csv_flags

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -83,18 +83,31 @@ parser_csv_opt
                                                   guint32 flags = log_csv_parser_normalize_escape_flags((LogColumnParser *) last_parser, $3);
                                                   log_csv_parser_set_flags((LogColumnParser *) last_parser, flags);
                                                 }
-        | KW_DELIMITERS '(' string ')'          { log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_DELIMITERS '(' parser_csv_delimiters ')'
         | KW_QUOTES '(' string ')'              { log_csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
         | KW_QUOTE_PAIRS '(' string ')'         { log_csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
         | KW_NULL '(' string ')'                { log_csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
-        | KW_STRING_DELIMITERS '(' parser_csv_string_delimiters ')'
         | parser_column_opt
         ;
 
-parser_csv_string_delimiters
-        : string parser_csv_string_delimiters
+parser_csv_delimiters
+  : parser_csv_delimiters_chars parser_csv_delimiter_strings
+  ;
+
+parser_csv_delimiters_chars
+  : KW_CHARS '(' string ')' { log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
+  | string {  log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $1); free($1);  }
+  |
+  ;
+
+parser_csv_delimiter_strings
+  : KW_STRINGS '('  parser_csv_delimiter_string  ')'
+  ;
+
+parser_csv_delimiter_string
+        : string parser_csv_delimiter_string
           {
-            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1);
+            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1); free($1);
           }
         | 
         ;

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -185,6 +185,19 @@ _do_drop_invalid(GList *cur_column, const gchar *src, guint32 flags)
   return (cur_column || (src && *src)) && (flags & LOG_CSV_PARSER_DROP_INVALID);
 }
 
+static inline gboolean
+_is_whitespace_char(const gchar* str)
+{
+  return (*str == ' ' || *str == '\t') ? TRUE : FALSE;
+}
+
+static inline void
+_strip_whitespace_left(const gchar** src)
+{
+  while (_is_whitespace_char(*src))
+    (*src)++;
+}
+
 static gboolean
 log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gchar* src)
 {
@@ -217,8 +230,7 @@ log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gcha
 
       if (self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
         {
-          while (*src == ' ' || *src == '\t')
-            src++;
+          _strip_whitespace_left(&src);
         }
 
       // var bezaro quote
@@ -274,7 +286,7 @@ log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gcha
         len--;
       if (len > 0 && self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
         {
-          while (len > 0 && (src[len - 1] == ' ' || src[len - 1] == '\t'))
+          while (len > 0 && (_is_whitespace_char(src + len - 1)))
             len--;
         }
       if (self->null_value && strncmp(src, self->null_value, len) == 0)
@@ -355,7 +367,7 @@ log_csv_parser_process_escaped(LogCSVParser *self, LogMessage *msg, const gchar*
             }
           break;
         case PS_WHITESPACE:
-          if ((self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE) && (*src == ' ' || *src == '\t'))
+          if ((self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE) && _is_whitespace_char(src))
             {
               break;
             }

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -324,6 +324,18 @@ _get_current_quote_unescaped(LogCSVParser *self, const gchar** src)
     }
 }
 
+static inline guchar*
+_find_delim_unescaped(LogCSVParser *self, UnescapedParserState *pstate, const gchar* src, guchar quote)
+{
+  if (quote)
+    {
+      return _find_delim_unescaped_quoted(self, pstate, src, quote);
+    }
+  else
+    {
+      return _find_delim_unescaped_unquoted(self, pstate, src);
+    }
+}
 
 static gboolean
 log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gchar* src)
@@ -344,18 +356,9 @@ log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gcha
         {
           _strip_whitespace_left(&src);
         }
+        
+      delim = _find_delim_unescaped(self, &pstate, src, current_quote);
 
-      // var bezaro quote
-      if (current_quote)
-        {
-          delim = _find_delim_unescaped_quoted(self, &pstate, src, current_quote);
-        }
-      else
-        {
-          delim = _find_delim_unescaped_unquoted(self, &pstate, src);
-        }
-
-      // az oszlop hossza?
       len = _get_column_length_unescaped(self, delim, src, current_quote);
 
       if (self->null_value && strncmp(src, self->null_value, len) == 0)

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -37,8 +37,6 @@ typedef struct _LogCSVParser
   GList *string_delimiters;
 } LogCSVParser;
 
-#define LOG_CSV_PARSER_SINGLE_CHAR_DELIM 0x0100
-
 static inline gint
 _is_escape_flag(guint32 flag)
 {
@@ -93,10 +91,6 @@ log_csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters)
   if (self->delimiters)
     g_free(self->delimiters);
   self->delimiters = g_strdup(delimiters);
-  if (strlen(delimiters) == 1)
-    self->flags |= LOG_CSV_PARSER_SINGLE_CHAR_DELIM;
-  else
-    self->flags &= ~LOG_CSV_PARSER_SINGLE_CHAR_DELIM;
 }
 
 void

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -338,7 +338,7 @@ _find_delim_unescaped(LogCSVParser *self, UnescapedParserState *pstate, const gc
 }
 
 static inline gboolean
-_check_and_handle_greedy_mode(LogCSVParser *self, GList **cur_column, LogMessage *msg, gchar **src)
+_check_and_handle_greedy_mode(LogCSVParser *self, GList **cur_column, LogMessage *msg, const gchar **src)
 {
  if (*cur_column && (*cur_column)->next == NULL && self->flags & LOG_CSV_PARSER_GREEDY)
    {
@@ -411,10 +411,19 @@ _get_current_quote_escaped(LogCSVParser *self, const gchar *src)
     }
 }
 
+enum
+  {
+    PS_COLUMN_START,
+    PS_WHITESPACE,
+    PS_VALUE,
+    PS_DELIMITER,
+    PS_EOS
+  };
+
 typedef struct _EscapedParserState
 {
   LogMessage *msg;
-  gchar *src;
+  const gchar *src;
   gint state;
   GString *current_value;
   GList *current_column;
@@ -422,15 +431,6 @@ typedef struct _EscapedParserState
   gint delim_len;
   gboolean store_value;
 } EscapedParserState;
-
-  enum
-    {
-      PS_COLUMN_START,
-      PS_WHITESPACE,
-      PS_VALUE,
-      PS_DELIMITER,
-      PS_EOS
-    };
 
 static inline void
 _escaped_parser_state_init(EscapedParserState *self, LogMessage *msg, GList *cur_column, const gchar *src)
@@ -548,7 +548,6 @@ log_csv_parser_process_escaped(LogCSVParser *self, LogMessage *msg, const gchar*
           pstate.state = PS_VALUE;
           /* fallthrough */
         case PS_VALUE:
-
           if (pstate.current_quote)
             {
               _process_escaped_VALUE_quoted(self, &pstate);

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -455,6 +455,12 @@ _process_escaped_VALUE_quoted(LogCSVParser *self, EscapedParserState *pstate)
 }
 
 static gboolean
+_is_delimiter_escaped(LogCSVParser *self, EscapedParserState *pstate)
+{
+  return (self->string_delimiters && strlst(pstate->src, self->string_delimiters, &pstate->delim_len) == (guchar*)pstate->src) || strchr(self->delimiters, *pstate->src);
+}
+
+static gboolean
 log_csv_parser_process_escaped(LogCSVParser *self, LogMessage *msg, const gchar* src)
 {
   GList *cur_column = self->super.columns;
@@ -509,7 +515,7 @@ log_csv_parser_process_escaped(LogCSVParser *self, LogMessage *msg, const gchar*
           else
             {
               /* unquoted value */
-              if ((self->string_delimiters && strlst(src, self->string_delimiters, &delim_len) == (guchar*)src) || strchr(self->delimiters, *src) )
+              if (_is_delimiter_escaped(self, &pstate))
                 {
                   state = PS_DELIMITER;
                   continue;

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -381,9 +381,7 @@ log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gcha
         log_msg_set_value_by_name(msg, (gchar *) cur_column->data, src, len);
 
       _move_to_next_column_unescaped(&pstate, &src);
-
       cur_column = cur_column->next;
-      
       _check_and_handle_greedy_mode(self, &cur_column, msg, &src);
     }
 
@@ -498,27 +496,27 @@ _get_column_length_escaped(LogCSVParser *self, GString *current_value)
 }
 
 static inline void
-_store_value_escaped(LogCSVParser *self, LogMessage *msg, GList *current_column, GString *current_value)
+_store_value_escaped(LogCSVParser *self, EscapedParserState *ps)
 {
-  gint len = _get_column_length_escaped(self, current_value);
-  if (self->null_value && strcmp(current_value->str, self->null_value) == 0)
-    log_msg_set_value_by_name(msg, (gchar *) current_column->data, "", 0);
+  gint len = _get_column_length_escaped(self, ps->current_value);
+  if (self->null_value && strcmp(ps->current_value->str, self->null_value) == 0)
+    log_msg_set_value_by_name(ps->msg, (gchar *) ps->current_column->data, "", 0);
   else
-    log_msg_set_value_by_name(msg, (gchar *) current_column->data, current_value->str, len);
+    log_msg_set_value_by_name(ps->msg, (gchar *) ps->current_column->data, ps->current_value->str, len);
 }
 
 static inline void
-_reset_variables(LogCSVParser *self, LogMessage *msg, GList **current_column, GString *current_value, gint *state, gboolean *store_value, gchar **src, gint *delim_len)
+_reset_variables(LogCSVParser *self, EscapedParserState *ps)
 {
-  g_string_truncate(current_value, 0);
-  *current_column = (*current_column)->next;
-  *state = PS_COLUMN_START;
-  *store_value = FALSE;
+  g_string_truncate(ps->current_value, 0);
+  ps->current_column = ps->current_column->next;
+  ps->state = PS_COLUMN_START;
+  ps->store_value = FALSE;
 
-  if (*delim_len > 0)
-    *src += *delim_len - 1;
+  if (ps->delim_len > 0)
+    ps->src += ps->delim_len - 1;
 
-  *delim_len = 0;
+  ps->delim_len = 0;
 }
 
 #define has_more_data(ps) (ps.current_column && *ps.src)
@@ -574,8 +572,8 @@ log_csv_parser_process_escaped(LogCSVParser *self, LogMessage *msg, const gchar*
       pstate.src++;
       if (*pstate.src == 0 || pstate.store_value)
         {
-          _store_value_escaped(self, pstate.msg, pstate.current_column, pstate.current_value);
-          _reset_variables(self, pstate.msg, &pstate.current_column, pstate.current_value, &pstate.state, &pstate.store_value, &pstate.src, &pstate.delim_len);
+          _store_value_escaped(self, &pstate);
+          _reset_variables(self, &pstate);
           _check_and_handle_greedy_mode(self, &pstate.current_column, pstate.msg, &pstate.src);
         }
     }

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -144,7 +144,7 @@ log_csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_d
 {
   LogCSVParser *self = (LogCSVParser *) s;
 
-  self->string_delimiters = g_list_prepend(self->string_delimiters, (gpointer)string_delimiter);
+  self->string_delimiters = g_list_prepend(self->string_delimiters, (gpointer)g_strdup(string_delimiter));
 }
 
 typedef struct _StrLstPrivData {

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -41,6 +41,7 @@ void log_csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters);
 void log_csv_parser_set_quotes(LogColumnParser *s, const gchar *quotes);
 void log_csv_parser_set_quote_pairs(LogColumnParser *s, const gchar *quote_pairs);
 void log_csv_parser_set_null_value(LogColumnParser *s, const gchar *null_value);
+void log_csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_delimiter);
 LogColumnParser *log_csv_parser_new(GlobalConfig *cfg);
 guint32 log_csv_parser_lookup_flag(const gchar *flag);
 guint32 log_csv_parser_normalize_escape_flags(LogColumnParser *s, guint32 new_flag);


### PR DESCRIPTION
This PR includes an extended csvparser, which is capable of handling string delimiters. It solves https://github.com/balabit/syslog-ng/issues/168 issue. 

The config is something like this:

```
parser csv_parser {
    csv-parser(
      columns("A","B", "C", "D", "E")
      delimiters(chars(":"), strings(":,", "//"))
      quotes("'")
      flags(escape-double-char)
    );
};
```

The chars() part is optional.