### PR TITLE
json: accept more characters in `extract-prefix` for `json-parser()`

### DIFF
--- a/modules/json/dot-notation.c
+++ b/modules/json/dot-notation.c
@@ -80,11 +80,11 @@ static gboolean
 _compile_dot_notation_member_ref(const gchar *level, JSONDotNotationElem *elem)
 {
   const gchar *p = level;
-  
-  if (!g_ascii_isalnum(level[0]) && *p != '_')
+
+  if (!g_ascii_isprint(*p) || strchr(".[]", *p) != NULL)
     return FALSE;
 
-  while (g_ascii_isalnum(*p) || *p == '_')
+  while (g_ascii_isprint(*p) && strchr(".[]", *p) == NULL)
     p++;
 
   if (*p != 0)

--- a/modules/json/tests/test_dot_notation.c
+++ b/modules/json/tests/test_dot_notation.c
@@ -139,6 +139,18 @@ test_dot_notation_eval_object_subscript_extracts_the_child_object(void)
 }
 
 static void
+test_dot_notation_eval_object_succeeds_with_odd_or_invalid_js_identifier(void)
+{
+  assert_dot_notation_eval_equals("{'@foo': 'bar'}", "@foo", "'bar'");
+  assert_dot_notation_eval_equals("{'_foo': 'bar'}", "_foo", "'bar'");
+  assert_dot_notation_eval_equals("{'foo+4': 'bar'}", "foo+4", "'bar'");
+  assert_dot_notation_eval_equals("{'foo,bar': 'bar'}", "foo,bar", "'bar'");
+  assert_dot_notation_eval_equals("{'foo bar': 'bar'}", "foo bar", "'bar'");
+  assert_dot_notation_eval_equals("{'foo-bar': 'bar'}", "foo-bar", "'bar'");
+  assert_dot_notation_eval_equals("{'1': 'bar'}", "1", "'bar'");
+}
+
+static void
 test_dot_notation_eval_object_member_from_non_object_fails(void)
 {
   assert_dot_notation_eval_fails("[1, 2, 3]", "foo");
@@ -182,6 +194,7 @@ test_dot_notation_eval(void)
 {
   DOT_NOTATION_TESTCASE(test_dot_notation_eval_empty_subscript_returns_the_object);
   DOT_NOTATION_TESTCASE(test_dot_notation_eval_object_subscript_extracts_the_child_object);
+  DOT_NOTATION_TESTCASE(test_dot_notation_eval_object_succeeds_with_odd_or_invalid_js_identifier);
   DOT_NOTATION_TESTCASE(test_dot_notation_eval_fails_with_an_identifier_that_doesnt_start_with_a_letter);
   DOT_NOTATION_TESTCASE(test_dot_notation_eval_fails_with_an_identifier_that_contains_a_non_alnum_character);
   DOT_NOTATION_TESTCASE(test_dot_notation_eval_fails_with_an_incorrect_array_reference);


### PR DESCRIPTION
When receiving JSON objects whose keys have `@` or `-` characters, it is
currently not possible to extract them with `extract-prefix` since they
are not considered as a valid JS identifier.

In JS, bracket notation should be used instead when accessing such
properties. This is not implemented in syslog-ng as only array indices
can be accessed with this notation.

This commit extends the set of supported characters to `@` and `-`. `-`
can be easily found in the wild while `@` is part of the event log
format of Logstash (`@version` and `@timestamp`).

This commit could be extended to support `$` (which is a valid character
in a JS identifier) but this may conflict with variable expansion. Any
character other than `[` and `.` could be accepted as they don't have a
meaning in the dot notation.

This PR can also be applied on previous versions of syslog-ng (at least 3.6).