### PR TITLE
F/csv string delimeter

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -131,6 +131,7 @@ pkginclude_HEADERS			+= \
 	lib/scratch-buffers.h		\
 	lib/serialize.h			\
 	lib/service-management.h	\
+	lib/stringutils.h	\
 	lib/str-format.h		\
 	lib/syslog-names.h		\
 	lib/syslog-ng.h			\
@@ -213,6 +214,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/scratch-buffers.c		\
 	lib/serialize.c			\
 	lib/service-management.c	\
+	lib/stringutils.c	\
 	lib/str-format.c		\
 	lib/syslog-names.c		\
 	lib/tags.c			\

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -191,6 +191,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_QUOTES                      10051
 %token KW_QUOTE_PAIRS                 10052
 %token KW_NULL                        10053
+%token KW_STRING_DELIMITERS           10054
 
 %token KW_SYSLOG                      10060
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -191,7 +191,8 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_QUOTES                      10051
 %token KW_QUOTE_PAIRS                 10052
 %token KW_NULL                        10053
-%token KW_STRING_DELIMITERS           10054
+%token KW_CHARS                       10054
+%token KW_STRINGS                     10055
 
 %token KW_SYSLOG                      10060
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -53,6 +53,7 @@ static CfgLexerKeyword main_keywords[] = {
   { "delimiters",         KW_DELIMITERS, 0x0300 },
   { "quotes",             KW_QUOTES, 0x0300 },
   { "quote_pairs",        KW_QUOTE_PAIRS, 0x0300},
+  { "string_delimiters",  KW_STRING_DELIMITERS, 0x0300},
   { "null",               KW_NULL, 0x0300 },
 
   /* value pairs */

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -53,7 +53,8 @@ static CfgLexerKeyword main_keywords[] = {
   { "delimiters",         KW_DELIMITERS, 0x0300 },
   { "quotes",             KW_QUOTES, 0x0300 },
   { "quote_pairs",        KW_QUOTE_PAIRS, 0x0300},
-  { "string_delimiters",  KW_STRING_DELIMITERS, 0x0300},
+  { "chars",              KW_CHARS, 0x0300},
+  { "strings",             KW_STRINGS, 0x0300},
   { "null",               KW_NULL, 0x0300 },
 
   /* value pairs */

--- a/lib/stringutils.c
+++ b/lib/stringutils.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stringutils.h"
+
+#include <string.h>
+
+typedef struct _StringSlice {
+  char *start;
+  int length;
+  const char *string;
+} StringSlice;
+
+static void
+_find_string(gpointer data, gpointer u_data)
+{
+  const char *item = (const char*) data;
+  StringSlice *user_data = (StringSlice*) u_data;
+
+  if (!user_data->start)
+  {
+    user_data->start = strstr(user_data->string, item);
+    user_data->length = (user_data->start) ? strlen(item) : 0;
+  }
+}
+
+/* searches for str in list and returns the first occurence, otherwise NULL */
+guchar*
+g_string_list_find_first(GList *list, const char * str, int *result_length)
+{
+  StringSlice user_data = {NULL, 0, str};
+
+  g_list_foreach(list, _find_string, (gpointer) &user_data);
+
+  *result_length = user_data.length;
+
+  return (guchar*) user_data.start;
+}
+

--- a/lib/stringutils.h
+++ b/lib/stringutils.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STRINGUTILS_H_INCLUDED
+#define STRINGUTILS_H_INCLUDED
+
+#include <glib.h>
+
+guchar* g_string_list_find_first(GList *list, const char * str, int *result_length);
+
+#endif

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -87,7 +87,16 @@ parser_csv_opt
         | KW_QUOTES '(' string ')'              { log_csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
         | KW_QUOTE_PAIRS '(' string ')'         { log_csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
         | KW_NULL '(' string ')'                { log_csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_STRING_DELIMITERS '(' parser_csv_string_delimiters ')'
         | parser_column_opt
+        ;
+
+parser_csv_string_delimiters
+        : string parser_csv_string_delimiters
+          {
+            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1);
+          }
+        | 
         ;
 
 parser_csv_flags

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -83,18 +83,31 @@ parser_csv_opt
                                                   guint32 flags = log_csv_parser_normalize_escape_flags((LogColumnParser *) last_parser, $3);
                                                   log_csv_parser_set_flags((LogColumnParser *) last_parser, flags);
                                                 }
-        | KW_DELIMITERS '(' string ')'          { log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_DELIMITERS '(' parser_csv_delimiters ')'
         | KW_QUOTES '(' string ')'              { log_csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
         | KW_QUOTE_PAIRS '(' string ')'         { log_csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
         | KW_NULL '(' string ')'                { log_csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
-        | KW_STRING_DELIMITERS '(' parser_csv_string_delimiters ')'
         | parser_column_opt
         ;
 
-parser_csv_string_delimiters
-        : string parser_csv_string_delimiters
+parser_csv_delimiters
+  : parser_csv_delimiters_chars parser_csv_delimiter_strings
+  ;
+
+parser_csv_delimiters_chars
+  : KW_CHARS '(' string ')' { log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
+  | string {  log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $1); free($1);  }
+  |
+  ;
+
+parser_csv_delimiter_strings
+  : KW_STRINGS '('  parser_csv_delimiter_string  ')'
+  ;
+
+parser_csv_delimiter_string
+        : string parser_csv_delimiter_string
           {
-            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1);
+            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1); free($1);
           }
         | 
         ;

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -23,6 +23,7 @@
 
 #include "csvparser.h"
 #include "parser/parser-expr.h"
+#include "stringutils.h"
 
 #include <string.h>
 
@@ -36,8 +37,6 @@ typedef struct _LogCSVParser
   guint32 flags;
   GList *string_delimiters;
 } LogCSVParser;
-
-#define LOG_CSV_PARSER_SINGLE_CHAR_DELIM 0x0100
 
 static inline gint
 _is_escape_flag(guint32 flag)
@@ -93,10 +92,6 @@ log_csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters)
   if (self->delimiters)
     g_free(self->delimiters);
   self->delimiters = g_strdup(delimiters);
-  if (strlen(delimiters) == 1)
-    self->flags |= LOG_CSV_PARSER_SINGLE_CHAR_DELIM;
-  else
-    self->flags &= ~LOG_CSV_PARSER_SINGLE_CHAR_DELIM;
 }
 
 void
@@ -153,296 +148,457 @@ log_csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_d
   self->string_delimiters = g_list_prepend(self->string_delimiters, (gpointer)string_delimiter);
 }
 
-typedef struct _StrLstPrivData {
-  char *first_occurence;
-  int delim_length;
-  const char *string;
-} StrLstPrivData;
-
-void
-_find_string(gpointer data, gpointer u_data)
+static inline gboolean
+_should_drop_as_invalid(GList *cur_column, const gchar *src, guint32 flags)
 {
-  const char *item = (const char*) data;
-  StrLstPrivData *user_data = (StrLstPrivData*) u_data;
-
-  if (!user_data->first_occurence)
-  {
-    user_data->first_occurence = strstr(user_data->string, item);
-    user_data->delim_length = (user_data->first_occurence) ? strlen(item) : 0;
-  }
+  return (cur_column || (src && *src)) && (flags & LOG_CSV_PARSER_DROP_INVALID);
 }
 
-/* searches for str1 in list and returns the first occurence, otherwise NULL */
-guchar*
-strlst(const char * str1, GList *list, int *delim_length)
+static inline gboolean
+_is_whitespace_char(const gchar* str)
 {
-  StrLstPrivData user_data = {NULL, 0, str1};
+  return (*str == ' ' || *str == '\t') ? TRUE : FALSE;
+}
 
-  g_list_foreach(list, _find_string, (gpointer) &user_data);
+static inline void
+_strip_whitespace_left(const gchar** src)
+{
+  while (_is_whitespace_char(*src))
+    (*src)++;
+}
 
-  *delim_length = user_data.delim_length;
+typedef struct _UnescapedParserState {
+  guchar *next_delim;
+  guchar *next_string_delim;
+  guchar *next_char_delim;
+  gint delim_len;
+  GList *cur_column;
+  guchar current_quote;
+} UnescapedParserState;
 
-  return (guchar*) user_data.first_occurence;
+static void
+unescaped_parser_state_init(UnescapedParserState *self, GList *cur_column)
+{
+  self->next_delim = NULL;
+  self->next_string_delim = NULL;
+  self->next_char_delim = NULL;
+  self->delim_len = 0;
+  self->cur_column = cur_column;
+  self->current_quote = 0;
+}
+
+static void
+unescaped_parser_state_reset_delimiters(UnescapedParserState *self)
+{
+  self->next_delim = NULL;
+  self->next_string_delim = NULL;
+  self->next_char_delim = NULL;
+  self->delim_len = 0;
+}
+
+static inline guchar*
+_unescaped_quoted_find_next_delim(LogCSVParser *self, UnescapedParserState *pstate, const gchar* src)
+{
+  /* search for end of quote */
+  pstate->next_delim = (guchar *) strchr(src, pstate->current_quote);
+
+  if (pstate->next_delim)
+    {
+      pstate->next_string_delim = g_string_list_find_first(self->string_delimiters,
+                                                          (const char *)pstate->next_delim,
+                                                          &pstate->delim_len);
+      if (pstate->next_string_delim == (pstate->next_delim + 1) ||
+          (strchr(self->delimiters, *(pstate->next_delim + 1)) != NULL )
+         )
+        {
+          /* closing quote, and then a delimiter, everything is nice */
+          pstate->next_delim++;
+        }
+    }
+  else if (!pstate->next_delim)
+    {
+      /* complete remaining string */
+      pstate->next_delim = (guchar *) src + strlen(src);
+    }
+
+  return pstate->next_delim;
+}
+
+static inline guchar*
+_unescaped_unquoted_find_next_delim(LogCSVParser *self, UnescapedParserState *pstate, const gchar* src)
+{
+  if (self->string_delimiters)
+    {
+      pstate->next_string_delim =  g_string_list_find_first(self->string_delimiters,
+                                                            src, 
+                                                            &pstate->delim_len);
+    }
+
+  pstate->next_char_delim = (guchar *) src + strcspn(src, self->delimiters);
+
+  if (pstate->next_string_delim && pstate->next_string_delim <= pstate->next_char_delim)
+    {
+      pstate->next_delim = pstate->next_string_delim;
+    }
+  else if (pstate->next_char_delim)
+    {
+      pstate->next_delim = pstate->next_char_delim; 
+    }
+  else
+    {
+      pstate->next_delim = (guchar *) src + strlen(src);
+    }
+  
+  return pstate->next_delim;
+}
+
+static gint
+_unescaped_get_column_length(LogCSVParser *self, UnescapedParserState *ps, const gchar *src)
+{
+  gint len;
+
+  len = ps->next_delim - (guchar *) src;
+  /* move in front of the terminating quote character */
+  if (ps->current_quote && len > 0 && src[len - 1] == ps->current_quote)
+    len--;
+  if (len > 0 && self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
+    {
+      while (len > 0 && (_is_whitespace_char(src + len - 1)))
+        len--;
+    }
+
+  return len;
+}
+
+static inline void
+_unescaped_move_to_next_column(UnescapedParserState *pstate, const gchar** src)
+{
+  *src = (gchar *) pstate->next_delim;
+
+  if (pstate->delim_len && (pstate->next_delim == pstate->next_string_delim))
+    *src += pstate->delim_len;
+  else if (**src)
+    (*src)++;
+
+  pstate->cur_column = pstate->cur_column->next;
+}
+
+static guchar
+_unescaped_get_current_quote(LogCSVParser *self, const gchar** src)
+{
+  guchar *quote = (guchar *) strchr(self->quotes_start, **src);
+
+  if (quote != NULL)
+    {
+      /* ok, quote character found */
+      (*src)++;
+      return self->quotes_end[quote - (guchar *) self->quotes_start];
+    }
+  else
+    {
+      /* we didn't start with a quote character, no need for escaping, delimiter terminates */
+      return  0;
+    }
+}
+
+static inline guchar*
+_unescaped_find_next_delim(LogCSVParser *self, UnescapedParserState *pstate, const gchar* src)
+{
+  if (pstate->current_quote)
+    {
+      return _unescaped_quoted_find_next_delim(self, pstate, src);
+    }
+  else
+    {
+      return _unescaped_unquoted_find_next_delim(self, pstate, src);
+    }
+}
+
+static inline gboolean
+_is_greedy_mode_on(LogCSVParser *self, GList **cur_column)
+{
+  return (*cur_column &&
+         (*cur_column)->next == NULL &&
+         self->flags & LOG_CSV_PARSER_GREEDY
+         ) != 0 ? TRUE : FALSE;
+}
+
+static inline void
+_parse_remaining_message(LogCSVParser *self, GList **cur_column, LogMessage *msg, const gchar **src)
+{
+  /* greedy mode, the last column gets it all, without taking escaping, quotes or anything into account */
+  log_msg_set_value_by_name(msg, (gchar *) (*cur_column)->data, *src, -1);
+  *cur_column = NULL;
+  *src = NULL;
 }
 
 static gboolean
-log_csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input, gsize input_len)
+log_csv_parser_process_unescaped(LogCSVParser *self, LogMessage *msg, const gchar* src)
 {
-  LogCSVParser *self = (LogCSVParser *) s;
-  const gchar *src;
-  GList *cur_column = self->super.columns;
   gint len;
-  LogMessage *msg;
+  UnescapedParserState pstate;
+  unescaped_parser_state_init(&pstate, self->super.columns);
+  /* no escaping, no need to keep state, we split input and trim if necessary */
 
-  src = input;
-  msg = log_msg_make_writable(pmsg, path_options);
-  if ((self->flags & LOG_CSV_PARSER_ESCAPE_NONE) || ((self->flags & LOG_CSV_PARSER_ESCAPE_MASK) == 0))
+  while (pstate.cur_column && *src)
     {
-      /* no escaping, no need to keep state, we split input and trim if necessary */
+      unescaped_parser_state_reset_delimiters(&pstate);
+      pstate.current_quote = _unescaped_get_current_quote(self, &src);
 
-      while (cur_column && *src)
+      if (self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
         {
-          const guchar *delim;
-          const guchar *delim_string=NULL, *delim_char=NULL;
-          guchar *quote;
-          guchar current_quote;
-          gint delim_len = 0;
+          _strip_whitespace_left(&src);
+        }
+        
+      pstate.next_delim = _unescaped_find_next_delim(self, &pstate, src);
 
-          quote = (guchar *) strchr(self->quotes_start, *src);
-          // a jelenlegi karakter egy quote
-          if (quote != NULL)
-            {
-              /* ok, quote character found */
-              // ez a bezaro quote
-              current_quote = self->quotes_end[quote - (guchar *) self->quotes_start];
-              src++;
-            }
-          else
-            {
-              /* we didn't start with a quote character, no need for escaping, delimiter terminates */
-              current_quote = 0;
-            }
+      len = _unescaped_get_column_length(self, &pstate, src);
 
-          if (self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
-            {
-              while (*src == ' ' || *src == '\t')
-                src++;
-            }
+      if (self->null_value && strncmp(src, self->null_value, len) == 0)
+        log_msg_set_value_by_name(msg, (gchar *) pstate.cur_column->data, "", 0);
+      else
+        log_msg_set_value_by_name(msg, (gchar *) pstate.cur_column->data, src, len);
+      _unescaped_move_to_next_column(&pstate, &src);
 
-          // var bezaro quote
-          if (current_quote)
-            {
-              /* search for end of quote */
-              delim = (guchar *) strchr(src, current_quote);
+      if (_is_greedy_mode_on(self, &pstate.cur_column))
+        {
+          _parse_remaining_message(self, &pstate.cur_column, msg, &src);
 
-              if (delim)
-                {
-                  delim_string = strlst((const char *)delim, self->string_delimiters, &delim_len);
-                  if (delim_string == (delim + 1) || (strchr(self->delimiters, *(delim + 1)) != NULL ))
-                    {
-                      /* closing quote, and then a delimiter, everything is nice */
-                      delim++;
-                    }
-                }
-              else if (!delim)
-                {
-                  /* complete remaining string */
-                  delim = (guchar *) src + strlen(src);
-                }
-            }
-          else
-            {
-              if (self->string_delimiters)
-                {
-                  delim_string = strlst(src, self->string_delimiters, &delim_len);
-                }
-
-              delim_char = (guchar *) src + strcspn(src, self->delimiters);
-
-              // string delimeter legalabb a karakter delim helyen kezdodik
-              if (delim_string && delim_string <= delim_char)
-                {
-                  delim = delim_string;
-                }
-              else if (delim_char)
-                {
-                  delim = delim_char; 
-                }
-              else
-                {
-                  delim = (guchar *) src + strlen(src);
-                }
-            }
-
-
-          // az oszlop hossza?
-          len = delim - (guchar *) src;
-          /* move in front of the terminating quote character */
-          if (current_quote && len > 0 && src[len - 1] == current_quote)
-            len--;
-          if (len > 0 && self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
-            {
-              while (len > 0 && (src[len - 1] == ' ' || src[len - 1] == '\t'))
-                len--;
-            }
-          if (self->null_value && strncmp(src, self->null_value, len) == 0)
-            log_msg_set_value_by_name(msg, (gchar *) cur_column->data, "", 0);
-          else
-            log_msg_set_value_by_name(msg, (gchar *) cur_column->data, src, len);
-
-          src = (gchar *) delim;
-
-          if (delim_len && delim == delim_string)
-            src += delim_len;
-          else if (*src)
-            src++;
-          cur_column = cur_column->next;
-
-          if (cur_column && cur_column->next == NULL && self->flags & LOG_CSV_PARSER_GREEDY)
-            {
-              /* greedy mode, the last column gets it all, without taking escaping, quotes or anything into account */
-              log_msg_set_value_by_name(msg, (gchar *) cur_column->data, src, -1);
-              cur_column = NULL;
-              src = NULL;
-              break;
-            }
         }
     }
-  else if (self->flags & (LOG_CSV_PARSER_ESCAPE_BACKSLASH+LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR))
-    {
-      /* stateful parser */
-      gint state;
-      enum
-        {
-          PS_COLUMN_START,
-          PS_WHITESPACE,
-          PS_VALUE,
-          PS_DELIMITER,
-          PS_EOS
-        };
-      gchar current_quote = 0;
-      GString *current_value;
-      gboolean store_value = FALSE;
-      gint delim_len = 0;
-      gchar *quote;
 
-      current_value = g_string_sized_new(128);
-
-      state = PS_COLUMN_START;
-      while (cur_column && *src)
-        {
-          switch (state)
-            {
-            case PS_COLUMN_START:
-              /* check for quote character */
-              state = PS_WHITESPACE;
-              quote = strchr(self->quotes_start, *src);
-              if (quote != NULL)
-                {
-                  /* ok, quote character found */
-                  current_quote = self->quotes_end[quote - self->quotes_start];
-                }
-              else
-                {
-                  /* we didn't start with a quote character, no need for escaping, delimiter terminates */
-                  current_quote = 0;
-                  /* don't skip to the next character */
-                  continue;
-                }
-              break;
-            case PS_WHITESPACE:
-              if ((self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE) && (*src == ' ' || *src == '\t'))
-                {
-                  break;
-                }
-              state = PS_VALUE;
-              /* fallthrough */
-            case PS_VALUE:
-              if (current_quote)
-                {
-                  /* quoted value */
-                  if ((self->flags & LOG_CSV_PARSER_ESCAPE_BACKSLASH) && *src == '\\' && *(src+1))
-                    {
-                      src++;
-                      g_string_append_c(current_value, *src);
-                      break;
-                    }
-                  else if (self->flags & LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR && *src == current_quote && *(src+1) == current_quote)
-                    {
-                      src++;
-                      g_string_append_c(current_value, *src);
-                      break;
-                    }
-                  if (*src == current_quote)
-                    {
-                      /* end of column */
-                      current_quote = 0;
-                      state = PS_DELIMITER;
-
-                      if (self->string_delimiters && strlst(src, self->string_delimiters, &delim_len) != ((guchar*)src + 1))
-                        delim_len = 0;
-
-                      break;
-                    }
-                  g_string_append_c(current_value, *src);
-                }
-              else
-                {
-                  /* unquoted value */
-                  if ((self->string_delimiters && strlst(src, self->string_delimiters, &delim_len) == (guchar*)src) || strchr(self->delimiters, *src) )
-                    {
-                      state = PS_DELIMITER;
-                      continue;
-                    }
-                  g_string_append_c(current_value, *src);
-                }
-              break;
-            case PS_DELIMITER:
-              store_value = TRUE;
-              break;
-            }
-          src++;
-          if (*src == 0 || store_value)
-            {
-              len = current_value->len;
-              if (self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
-                {
-                  while (len > 0 && (current_value->str[len-1] == ' ' || current_value->str[len-1] == '\t'))
-                    len--;
-                }
-              if (self->null_value && strcmp(current_value->str, self->null_value) == 0)
-                log_msg_set_value_by_name(msg, (gchar *) cur_column->data, "", 0);
-              else
-                log_msg_set_value_by_name(msg, (gchar *) cur_column->data, current_value->str, len);
-              g_string_truncate(current_value, 0);
-              cur_column = cur_column->next;
-              state = PS_COLUMN_START;
-              store_value = FALSE;
-
-              if (delim_len > 0)
-                src += delim_len - 1;
-
-              delim_len = 0;
-
-              if (cur_column && cur_column->next == NULL && self->flags & LOG_CSV_PARSER_GREEDY)
-                {
-                  /* greedy mode, the last column gets it all, without taking escaping, quotes or anything into account */
-                  log_msg_set_value_by_name(msg, (gchar *) cur_column->data, src, -1);
-                  cur_column = NULL;
-                  src = NULL;
-                  break;
-                }
-            }
-        }
-      g_string_free(current_value, TRUE);
-    }
-  if ((cur_column || (src && *src)) && (self->flags & LOG_CSV_PARSER_DROP_INVALID))
+  if (_should_drop_as_invalid(pstate.cur_column, src, self->flags))
     {
       /* there are unfilled variables, OR not all of the input was processed
        * and "drop-invalid" flag is specified */
       return FALSE;
     }
   return TRUE;
+}
+
+static inline gchar
+_escaped_get_current_quote(LogCSVParser *self, const gchar *src)
+{
+  gchar *quote = strchr(self->quotes_start, *src);
+
+  if (quote != NULL)
+    {
+      /* ok, quote character found */
+      return self->quotes_end[quote - self->quotes_start];
+    }
+  else
+    {
+      /* we didn't start with a quote character, no need for escaping, delimiter terminates */
+      return 0;
+    }
+}
+
+typedef enum _UnescapedParserFSAState
+  {
+    PS_COLUMN_START,
+    PS_WHITESPACE,
+    PS_VALUE,
+    PS_DELIMITER
+  } UnescapedParserFSAState;
+
+typedef struct _EscapedParserState
+{
+  LogMessage *msg;
+  const gchar *src;
+  UnescapedParserFSAState state;
+  GString *current_value;
+  GList *current_column;
+  gchar current_quote;
+  gint delim_len;
+  gboolean store_value;
+} EscapedParserState;
+
+static inline void
+_escaped_parser_state_init(EscapedParserState *self, LogMessage *msg, GList *cur_column, const gchar *src)
+{
+  self->msg = msg;
+  self->src = src;
+  self->state = PS_COLUMN_START;
+  self->current_value = g_string_sized_new(128);
+  self->current_quote = 0;
+  self->current_column = cur_column;
+  self->delim_len = 0;
+  self->store_value = FALSE;
+}
+
+static inline void
+_escaped_quoted_process_next_char(LogCSVParser *self, EscapedParserState *pstate)
+{
+  /* quoted value */
+  if ((self->flags & LOG_CSV_PARSER_ESCAPE_BACKSLASH) && *pstate->src == '\\' && *(pstate->src+1))
+    {
+      pstate->src++;
+      g_string_append_c(pstate->current_value, *pstate->src);
+      return;
+    }
+  else if (self->flags & LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR && *pstate->src == pstate->current_quote && *(pstate->src+1) == pstate->current_quote)
+    {
+      (pstate->src)++;
+      g_string_append_c(pstate->current_value, *pstate->src);
+      return;
+    }
+  if (*pstate->src == pstate->current_quote)
+    {
+      /* end of column */
+      pstate->current_quote = 0;
+      pstate->state = PS_DELIMITER;
+
+      if (self->string_delimiters &&  g_string_list_find_first(self->string_delimiters, pstate->src, &pstate->delim_len) != ((guchar*)pstate->src + 1))
+        pstate->delim_len = 0;
+
+      return;
+    }
+  g_string_append_c(pstate->current_value, *pstate->src);
+}
+
+static gboolean
+_escaped_is_delimiter(LogCSVParser *self, EscapedParserState *pstate)
+{
+  return (self->string_delimiters &&  g_string_list_find_first(self->string_delimiters, pstate->src, &pstate->delim_len) == (guchar*)pstate->src) || strchr(self->delimiters, *pstate->src);
+}
+
+static inline gint
+_escaped_get_column_length(LogCSVParser *self, GString *current_value)
+{
+  gint len = current_value->len;
+
+  if (self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE)
+    {
+      while (len > 0 && _is_whitespace_char(current_value->str + len -1))
+        len--;
+    }
+
+  return len;
+}
+
+static inline void
+_escaped_store_value(LogCSVParser *self, EscapedParserState *ps)
+{
+  gint len = _escaped_get_column_length(self, ps->current_value);
+  if (self->null_value && strcmp(ps->current_value->str, self->null_value) == 0)
+    log_msg_set_value_by_name(ps->msg, (gchar *) ps->current_column->data, "", 0);
+  else
+    log_msg_set_value_by_name(ps->msg, (gchar *) ps->current_column->data, ps->current_value->str, len);
+}
+
+static inline void
+_escaped_reset_variables(LogCSVParser *self, EscapedParserState *ps)
+{
+  g_string_truncate(ps->current_value, 0);
+  ps->current_column = ps->current_column->next;
+  ps->state = PS_COLUMN_START;
+  ps->store_value = FALSE;
+
+  if (ps->delim_len > 0)
+    ps->src += ps->delim_len - 1;
+
+  ps->delim_len = 0;
+}
+
+#define has_more_data(ps) (ps.current_column && *ps.src)
+
+static gboolean
+log_csv_parser_process_escaped(LogCSVParser *self, LogMessage *msg, const gchar* src)
+{
+  EscapedParserState pstate;
+
+  _escaped_parser_state_init(&pstate, msg, self->super.columns, src);
+
+  while (has_more_data(pstate))
+    {
+      switch (pstate.state)
+        {
+        case PS_COLUMN_START:
+          /* check for quote character */
+          pstate.state = PS_WHITESPACE;
+          pstate.current_quote = _escaped_get_current_quote(self, pstate.src);
+          if (!pstate.current_quote)
+            continue;
+
+          break;
+        case PS_WHITESPACE:
+          if ((self->flags & LOG_CSV_PARSER_STRIP_WHITESPACE) && _is_whitespace_char(pstate.src))
+            {
+              break;
+            }
+          pstate.state = PS_VALUE;
+          /* fallthrough */
+        case PS_VALUE:
+          if (pstate.current_quote)
+            {
+              _escaped_quoted_process_next_char(self, &pstate);
+              break;
+            }
+          else
+            {
+              /* unquoted value */
+              if (_escaped_is_delimiter(self, &pstate))
+                {
+                  pstate.state = PS_DELIMITER;
+                  continue;
+                }
+              g_string_append_c(pstate.current_value, *pstate.src);
+            }
+          break;
+        case PS_DELIMITER:
+          pstate.store_value = TRUE;
+          break;
+        }
+      pstate.src++;
+      if (*pstate.src == 0 || pstate.store_value)
+        {
+          _escaped_store_value(self, &pstate);
+          _escaped_reset_variables(self, &pstate);
+
+          if (_is_greedy_mode_on(self, &pstate.current_column))
+            {
+              _parse_remaining_message(self, &pstate.current_column, pstate.msg, &pstate.src);
+
+            }
+        }
+    }
+
+  g_string_free(pstate.current_value, TRUE);
+
+  if (_should_drop_as_invalid(pstate.current_column, pstate.src, self->flags))
+    {
+      /* there are unfilled variables, OR not all of the input was processed
+       * and "drop-invalid" flag is specified */
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static inline gboolean
+_should_not_escape(guint32 flags)
+{
+  return ((flags & LOG_CSV_PARSER_ESCAPE_NONE) ||
+         ((flags & LOG_CSV_PARSER_ESCAPE_MASK) == 0));
+}
+
+static inline gboolean
+_should_escape(guint32 flags)
+{
+  return flags & (LOG_CSV_PARSER_ESCAPE_BACKSLASH+LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR);
+}
+
+static gboolean
+log_csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input, gsize input_len)
+{
+  LogCSVParser *self = (LogCSVParser *) s;
+  LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  const gchar *src = input;
+
+  if (_should_not_escape(self->flags))
+    return log_csv_parser_process_unescaped(self, msg, src);
+  else if (_should_escape(self->flags))
+    return log_csv_parser_process_escaped(self, msg, src);
+  return FALSE;
 }
 
 static LogPipe *

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -145,7 +145,7 @@ log_csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_d
 {
   LogCSVParser *self = (LogCSVParser *) s;
 
-  self->string_delimiters = g_list_prepend(self->string_delimiters, (gpointer)string_delimiter);
+  self->string_delimiters = g_list_prepend(self->string_delimiters, (gpointer)g_strdup(string_delimiter));
 }
 
 static inline gboolean

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -41,6 +41,7 @@ void log_csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters);
 void log_csv_parser_set_quotes(LogColumnParser *s, const gchar *quotes);
 void log_csv_parser_set_quote_pairs(LogColumnParser *s, const gchar *quote_pairs);
 void log_csv_parser_set_null_value(LogColumnParser *s, const gchar *null_value);
+void log_csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_delimiter);
 LogColumnParser *log_csv_parser_new(GlobalConfig *cfg);
 guint32 log_csv_parser_lookup_flag(const gchar *flag);
 guint32 log_csv_parser_normalize_escape_flags(LogColumnParser *s, guint32 new_flag);


### PR DESCRIPTION
This PR includes an extended csvparser, which is capable of handling string delimiters. It solves #168 issue.

The config is something like this:

parser csv_parser {
    csv-parser(
      columns("A","B", "C", "D", "E")
      delimiters(chars(":"), strings(":,", "//"))
      quotes("'")
      flags(escape-double-char)
    );
};
The chars() part is optional.

I'll close https://github.com/balabit/syslog-ng/pull/370, because it was based on `3.6/master`, not `master`.