### PR TITLE
configure.ac: fix compilation where the monolitic libsystemd is not avai...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1167,7 +1167,7 @@ if test "x$enable_systemd" = "xyes"; then
                 AC_MSG_ERROR[Detecting system releted systemd-journal library failed])
             fi
             libsystemd_CFLAGS="${LIBSYSTEMD_JOURNAL_CFLAGS} ${libsystemd_daemon_CFLAGS}"
-            libsystemd_LDFLAGS="${LIBSYSTEMD_JOURNAL_LIBS} ${libsystemd_daemon_LIBS}"
+            libsystemd_LIBS="${LIBSYSTEMD_JOURNAL_LIBS} ${libsystemd_daemon_LIBS}"
             AC_SUBST(libsystemd_CFLAGS)
             AC_SUBST(libsystemd_LIBS)
         else


### PR DESCRIPTION
...lable

Due to a typo, the LIBS for libsystemd-daemon was not exported properly.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>