### PR TITLE
affile: fix crash at the first message delivery when templates are used ...

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -603,6 +603,7 @@ affile_dd_open_writer(gpointer args[])
       if (!next)
 	{
 	  next = affile_dw_new(filename->str, log_pipe_get_config(&self->super.super.super));
+          affile_dw_set_owner(next, self);
           if (!log_pipe_init(&next->super))
 	    {
 	      log_pipe_unref(&next->super);


### PR DESCRIPTION
...in the name

The patch a5c946fa4 omitted a call to affile_dw_set_owner(), causing
a NULL deref during affile_dw_init() as a file is opened. This patch fixes
that.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>