### PR TITLE
F/python template functions

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,3 +1,4 @@
+
 DIST_SUBDIRS				= lib/ivykis
 
 include lib/transport/Makefile.am
@@ -109,6 +110,7 @@ pkginclude_HEADERS			+= \
 	lib/mainloop-call.h		\
 	lib/mainloop-worker.h		\
 	lib/mainloop-io-worker.h	\
+	lib/module-config.h		\
 	lib/memtrace.h			\
 	lib/messages.h			\
 	lib/misc.h			\
@@ -189,6 +191,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/mainloop-call.c		\
 	lib/mainloop-worker.c		\
 	lib/mainloop-io-worker.c	\
+	lib/module-config.c		\
 	lib/memtrace.c			\
 	lib/messages.c			\
 	lib/misc.c			\

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -403,6 +403,7 @@ StatsOptions *last_stats_options;
 %type   <ptr> parser_stmt
 %type   <ptr> rewrite_stmt
 %type   <ptr> log_stmt
+%type   <ptr> plugin_stmt
 
 /* START_DECLS */
 
@@ -478,6 +479,7 @@ stmt
 	| template_stmt
 	| options_stmt
 	| block_stmt
+	| plugin_stmt
 	;
 
 expr_stmt
@@ -547,6 +549,24 @@ log_stmt
           }
 
 	;
+
+
+plugin_stmt
+        : LL_IDENTIFIER
+          {
+            Plugin *p;
+            gint context = LL_CONTEXT_ROOT;
+            gpointer result;
+
+            p = plugin_find(configuration, context, $1);
+            CHECK_ERROR(p, @1, "%s plugin %s not found", cfg_lexer_lookup_context_name_by_type(context), $1);
+
+            result = plugin_parse_config(p, configuration, &@1, NULL);
+            free($1);
+            if (!result)
+              YYERROR;
+            $$ = NULL;
+          }
 
 /* START_RULES */
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -116,6 +116,7 @@ struct _GlobalConfig
   
   PersistConfig *persist;
   PersistState *state;
+  GHashTable *module_config;
   
   CfgTree tree;
 

--- a/lib/module-config.c
+++ b/lib/module-config.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "module-config.h"
+
+gboolean
+module_config_init(ModuleConfig *s, GlobalConfig *cfg)
+{
+  if (s->init)
+    return s->init(s, cfg);
+  return TRUE;
+}
+
+void
+module_config_deinit(ModuleConfig *s, GlobalConfig *cfg)
+{
+  if (s->deinit)
+    s->deinit(s, cfg);
+}
+
+void
+module_config_free_method(ModuleConfig *s)
+{
+}
+
+void
+module_config_free(ModuleConfig *s)
+{
+  if (s->free_fn)
+    s->free_fn(s);
+  g_free(s);
+}

--- a/lib/module-config.h
+++ b/lib/module-config.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef MODULE_CONFIG_H_INCLUDED
+#define MODULE_CONFIG_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+typedef struct _ModuleConfig ModuleConfig;
+
+/* This class encapsulates global (e.g. GlobalConfig) level settings for
+ * modules.  It can be used to store state that is not related to a specific
+ * LogPipe instance.  Such an example is the python block embedded in the
+ * configuration used by the Python module.  */
+struct _ModuleConfig
+{
+  /* init/deinit is hooked into configuration init/deinit */
+  gboolean (*init)(ModuleConfig *s, GlobalConfig *cfg);
+  void (*deinit)(ModuleConfig *s, GlobalConfig *cfg);
+  void (*free_fn)(ModuleConfig *s);
+};
+
+gboolean module_config_init(ModuleConfig *s, GlobalConfig *cfg);
+void module_config_deinit(ModuleConfig *s, GlobalConfig *cfg);
+void module_config_free_method(ModuleConfig *s);
+void module_config_free(ModuleConfig *s);
+
+#endif

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -20,6 +20,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-module.h		  \
 	modules/python/python-helpers.h		  \
 	modules/python/python-helpers.c		  \
+	modules/python/python-main.h		  \
+	modules/python/python-main.c		  \
 	modules/python/python-plugin.c		  \
 	modules/python/python-grammar.y		  \
 	modules/python/python-value-pairs.c	  \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -18,6 +18,8 @@ modules_python_libmod_python_la_LIBADD		= \
 
 modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-globals.h		  \
+	modules/python/python-helpers.h		  \
+	modules/python/python-helpers.c		  \
 	modules/python/python-plugin.c		  \
 	modules/python/python-grammar.y		  \
 	modules/python/python-value-pairs.c	  \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -30,6 +30,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-value-pairs.h	  \
 	modules/python/python-dest.c		  \
 	modules/python/python-dest.h		  \
+	modules/python/python-tf.c		  \
+	modules/python/python-tf.h		  \
 	modules/python/python-parser.c		  \
 	modules/python/python-parser.h	          \
 	modules/python/python-logmsg.h		  \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -18,6 +18,8 @@ modules_python_libmod_python_la_LIBADD		= \
 
 modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-module.h		  \
+	modules/python/python-config.h		  \
+	modules/python/python-config.c		  \
 	modules/python/python-helpers.h		  \
 	modules/python/python-helpers.c		  \
 	modules/python/python-main.h		  \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -17,7 +17,7 @@ modules_python_libmod_python_la_LIBADD		= \
 	$(IVYKIS_LIBS)
 
 modules_python_libmod_python_la_SOURCES		= \
-	modules/python/python-globals.h		  \
+	modules/python/python-module.h		  \
 	modules/python/python-helpers.h		  \
 	modules/python/python-helpers.c		  \
 	modules/python/python-plugin.c		  \

--- a/modules/python/python-config.c
+++ b/modules/python/python-config.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-config.h"
+#include "python-main.h"
+#include "cfg.h"
+
+#define MODULE_CONFIG_KEY "python"
+
+static gboolean
+python_config_init(ModuleConfig *s, GlobalConfig *cfg)
+{
+  PythonConfig *self = (PythonConfig *) s;
+
+  PyGILState_STATE gstate;
+
+  gstate = PyGILState_Ensure();
+  _py_switch_main_module(self);
+  PyGILState_Release(gstate);
+  return TRUE;
+}
+
+static void
+python_config_free(ModuleConfig *s)
+{
+  PythonConfig *self = (PythonConfig *) s;
+  PyGILState_STATE gstate;
+
+  gstate = PyGILState_Ensure();
+  Py_XDECREF(self->main_module);
+  PyGILState_Release(gstate);
+  module_config_free_method(s);
+}
+
+PythonConfig *
+python_config_new(void)
+{
+  PythonConfig *self = g_new0(PythonConfig, 1);
+
+  self->super.init = python_config_init;
+  self->super.free_fn = python_config_free;
+  return self;
+}
+
+PythonConfig *
+python_config_get(GlobalConfig *cfg)
+{
+  PythonConfig *pc = g_hash_table_lookup(cfg->module_config, MODULE_CONFIG_KEY);
+  if (!pc)
+    {
+      pc = python_config_new();
+      g_hash_table_insert(cfg->module_config, g_strdup(MODULE_CONFIG_KEY), pc);
+    }
+  return pc;
+}

--- a/modules/python/python-config.h
+++ b/modules/python/python-config.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef PYTHON_GLOBALS_H_INCLUDED
+#define PYTHON_GLOBALS_H_INCLUDED 1
+
+#include "python-module.h"
+#include "module-config.h"
+
+typedef struct _PythonConfig
+{
+  ModuleConfig super;
+  PyObject *main_module;
+} PythonConfig;
+
+PythonConfig *python_config_get(GlobalConfig *cfg);
+
+#endif

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -22,7 +22,7 @@
  */
 
 #include "python-dest.h"
-#include "python-globals.h"
+#include "python-module.h"
 #include "python-value-pairs.h"
 #include "python-logmsg.h"
 #include "python-helpers.h"

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -160,45 +160,13 @@ _py_invoke_bool_function(PythonDestDriver *self, PyObject *func, PyObject *arg)
   return result;
 }
 
-static PyObject *
-_py_do_import(PythonDestDriver *self, const gchar *modname)
-{
-  PyObject *module, *modobj;
-
-  module = PyUnicode_FromString(modname);
-  if (!module)
-    {
-      msg_error("Error allocating Python string",
-                evt_tag_str("driver", self->super.super.super.id),
-                evt_tag_str("string", modname),
-                NULL);
-      return NULL;
-    }
-
-  modobj = PyImport_Import(module);
-  Py_DECREF(module);
-  if (!modobj)
-    {
-      gchar buf[256];
-
-      msg_error("Error loading Python module",
-                evt_tag_str("driver", self->super.super.super.id),
-                evt_tag_str("module", modname),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))),
-                NULL);
-      return NULL;
-    }
-  return modobj;
-}
-
 static void
 _foreach_import(gpointer data, gpointer user_data)
 {
-  PythonDestDriver *self = (PythonDestDriver *) user_data;
   gchar *modname = (gchar *) data;
   PyObject *mod;
 
-  mod = _py_do_import(self, modname);
+  mod = _py_do_import(modname);
   Py_XDECREF(mod);
 }
 
@@ -311,7 +279,7 @@ _split_fully_qualified_name(const gchar *input, gchar **module, gchar **class)
 static gboolean
 _py_init_bindings_from_module_and_class(PythonDestDriver *self, const gchar *module, const gchar *class)
 {
-  self->py.module = _py_do_import(self, module);
+  self->py.module = _py_do_import(module);
   if (!self->py.module)
     return FALSE;
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -483,6 +483,7 @@ python_dd_insert(LogThrDestDriver *d, LogMessage *msg)
                 evt_tag_int("time_reopen", self->super.time_reopen),
                 NULL);
     }
+  Py_DECREF(msg_object);
 
  exit:
   PyGILState_Release(gstate);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 BalaBit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 BalaBit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2014-2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/python/python-globals.h
+++ b/modules/python/python-globals.h
@@ -1,8 +1,0 @@
-
-#ifndef PYTHON_GLOBALS_H_INCLUDED
-#define PYTHON_GLOBALS_H_INCLUDED 1
-
-#include "syslog-ng.h"
-#include <Python.h>
-
-#endif

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -25,6 +25,7 @@
 
 #include "python-parser.h"
 #include "python-dest.h"
+#include "python-main.h"
 #include "value-pairs.h"
 #include "vptransform.h"
 
@@ -57,6 +58,16 @@ start
             last_driver = *instance = python_dd_new(configuration);
           }
           '(' python_options ')'         { YYACCEPT; }
+	| LL_CONTEXT_ROOT KW_PYTHON
+          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "Python code"); }
+          LL_BLOCK
+          { cfg_lexer_pop_context(lexer); }
+          {
+	    python_evaluate_global_code(configuration, $4);
+	    free($4);
+	    *instance = (void *) 1;
+	    YYACCEPT;
+          }
         ;
 
 python_options

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-helpers.h"
+#include "messages.h"
+
+const gchar *
+_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
+{
+  PyObject *name = PyObject_GetAttrString(callable, "__name__");
+
+  if (name)
+    {
+      g_strlcpy(buf, PyString_AsString(name), buf_len);
+    }
+  else
+    {
+      PyErr_Clear();
+      g_strlcpy(buf, "<unknown>", buf_len);
+    }
+  Py_XDECREF(name);
+  return buf;
+}
+
+const gchar *
+_py_format_exception_text(gchar *buf, gsize buf_len)
+{
+  PyObject *exc, *value, *tb, *str;
+
+  PyErr_Fetch(&exc, &value, &tb);
+  if (!exc)
+    {
+      g_strlcpy(buf, "None", buf_len);
+      return buf;
+    }
+  PyErr_NormalizeException(&exc, &value, &tb);
+
+  str = PyObject_Str(value);
+  if (str)
+    {
+      g_snprintf(buf, buf_len, "%s: %s", ((PyTypeObject *) exc)->tp_name, PyString_AsString(str));
+    }
+  else
+    {
+      g_strlcpy(buf, "<unknown>", buf_len);
+    }
+  Py_XDECREF(exc);
+  Py_XDECREF(value);
+  Py_XDECREF(tb);
+  Py_XDECREF(str);
+  return buf;
+}
+
+PyObject *
+_py_get_attr_or_null(PyObject *o, const gchar *attr)
+{
+  PyObject *result;
+
+  if (!attr)
+    return NULL;
+
+  result = PyObject_GetAttrString(o, attr);
+  if (!result)
+    {
+      PyErr_Clear();
+      return NULL;
+    }
+  return result;
+}

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -87,3 +87,32 @@ _py_get_attr_or_null(PyObject *o, const gchar *attr)
     }
   return result;
 }
+
+PyObject *
+_py_do_import(const gchar *modname)
+{
+  PyObject *module, *modobj;
+
+  module = PyUnicode_FromString(modname);
+  if (!module)
+    {
+      msg_error("Error allocating Python string",
+                evt_tag_str("string", modname),
+                NULL);
+      return NULL;
+    }
+
+  modobj = PyImport_Import(module);
+  Py_DECREF(module);
+  if (!modobj)
+    {
+      gchar buf[256];
+
+      msg_error("Error loading Python module",
+                evt_tag_str("module", modname),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))),
+                NULL);
+      return NULL;
+    }
+  return modobj;
+}

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -30,5 +30,6 @@ const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len
 const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
 PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
 PyObject *_py_do_import(const gchar *modname);
+PyObject *_py_resolve_qualified_name(const gchar *name);
 
 #endif

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef PYTHON_HELPERS_H_INCLUDED
+#define PYTHON_HELPERS_H_INCLUDED 1
+
+#include "python-globals.h"
+
+const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
+const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
+PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
+
+#endif

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -29,5 +29,6 @@
 const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
 const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
 PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
+PyObject *_py_do_import(const gchar *modname);
 
 #endif

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 #include "python-logmsg.h"
 #include "logmsg.h"
 

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 
 #ifndef _SNG_PYTHON_LOGMSG_H
 #define _SNG_PYTHON_LOGMSG_H

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -2,7 +2,7 @@
 #ifndef _SNG_PYTHON_LOGMSG_H
 #define _SNG_PYTHON_LOGMSG_H
 
-#include "python-globals.h"
+#include "python-module.h"
 
 PyObject *py_log_message_new(LogMessage *msg);
 void python_log_message_init(void);

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-main.h"
+#include "python-helpers.h"
+#include "messages.h"
+
+/*
+ * Some information about how we embed the Python interpreter:
+ *  - instead of using the __main__ module, we use a separate _syslogng
+ *    module as we want to replace it every time syslog-ng is reloaded
+ *  - hanlding of our separate main module is implemented by this module
+ *  - this separate __main__ module requires some magic though (most of it
+ *    is in _py_construct_main_module(), see below.
+ *  - the PyObject reference to the current main module is stored in the
+ *    GlobalConfig instance (using the ModuleConfig mechanism)
+ *  - the current main module is switched during config initialization, e.g.
+ *    during runtime, _syslogng module refers to the main module of the current
+ *    config
+ *  - since _syslogng is different for each initialized syslog-ng
+ *    configuration, it is not possible to use variables between reloads,
+ *    _except_ by storing them in other, imported modules.
+ *  - it is currently not possible to hook into the init/deinit mechanism in
+ *    the global context (from Python), but it is possible for a DestDriver.
+ *    It is doable also in the global context, but has not yet been done.
+ */
+
+static PyObject *
+_py_construct_main_module(void)
+{
+  PyObject *module;
+  PyObject *module_dict;
+  PyObject *modules = PyImport_GetModuleDict();
+
+  /* make sure the module registry doesn't contain our module */
+  PyDict_DelItemString(modules, "_syslogng");
+
+  /* create a new module */
+  module = PyImport_AddModule("_syslogng");
+
+  /* make sure __builtins__ is there, it is normally automatically done for
+   * __main__ and any imported modules */
+  module_dict = PyModule_GetDict(module);
+  if (PyDict_GetItemString(module_dict, "__builtins__") == NULL)
+    {
+      PyObject *builtins_module = PyImport_ImportModule("__builtin__");
+      if (builtins_module == NULL ||
+          PyDict_SetItemString(module_dict, "__builtins__", builtins_module) < 0)
+        g_assert_not_reached();
+      Py_XDECREF(builtins_module);
+    }
+
+  /* return a reference */
+  Py_INCREF(module);
+  return module;
+}
+
+/* switch the _syslogng main module to the one in a specific configuration */
+void
+_py_switch_main_module(PythonConfig *pc)
+{
+  PyObject *modules = PyImport_GetModuleDict();
+
+  if (pc->main_module)
+    {
+      Py_INCREF(pc->main_module);
+      PyDict_SetItemString(modules, "_syslogng", pc->main_module);
+    }
+  else
+    {
+      PyDict_DelItemString(modules, "_syslogng");
+    }
+}
+
+
+/* get the current main module in a production context by using the Python
+ * module registry instead of the GlobalConfig machinery.  This only works
+ * once _py_switch_to_main_module() has been called (e.g. past init()).
+ *
+ * returns borrowed reference. */
+PyObject *
+_py_get_current_main_module(void)
+{
+  return PyImport_AddModule("_syslogng");
+}
+
+/* get the current main module as stored in the current GlobalConfig.
+ * returns borrowed reference */
+PyObject *
+_py_get_main_module(PythonConfig *pc)
+{
+  if (!pc->main_module)
+    pc->main_module = _py_construct_main_module();
+  return pc->main_module;
+}
+
+gboolean
+_py_evaluate_global_code(PythonConfig *pc, const gchar *code)
+{
+  PyObject *result;
+  PyObject *module;
+  PyObject *dict;
+
+  module = _py_get_main_module(pc);
+  dict = PyModule_GetDict(module);
+  result = PyRun_String(code, Py_file_input, dict, dict);
+
+  if (!result)
+    {
+      gchar buf[256];
+
+      msg_error("Error evaluating global Python block",
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))),
+                NULL);
+      return FALSE;
+    }
+  Py_XDECREF(result);
+  return TRUE;
+}
+
+gboolean
+python_evaluate_global_code(GlobalConfig *cfg, const gchar *code)
+{
+  PyGILState_STATE gstate;
+  PythonConfig *pc = python_config_get(cfg);
+  gboolean result;
+
+  gstate = PyGILState_Ensure();
+  result = _py_evaluate_global_code(pc, code);
+  PyGILState_Release(gstate);
+
+  return result;
+}

--- a/modules/python/python-main.h
+++ b/modules/python/python-main.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef PYTHON_MAIN_H_INCLUDED
+#define PYTHON_MAIN_H_INCLUDED 1
+
+#include "python-config.h"
+
+PyObject *_py_get_current_main_module(void);
+PyObject *_py_get_main_module(PythonConfig *pc);
+void _py_switch_main_module(PythonConfig *pc);
+gboolean python_evaluate_global_code(GlobalConfig *cfg, const gchar *code);
+
+
+#endif

--- a/modules/python/python-module.h
+++ b/modules/python/python-module.h
@@ -21,15 +21,10 @@
  * COPYING for details.
  *
  */
-#ifndef PYTHON_HELPERS_H_INCLUDED
-#define PYTHON_HELPERS_H_INCLUDED 1
+#ifndef PYTHON_MODULE_H_INCLUDED
+#define PYTHON_MODULE_H_INCLUDED 1
 
-#include "python-module.h"
-
-const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
-const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
-PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
-PyObject *_py_do_import(const gchar *modname);
-PyObject *_py_resolve_qualified_name(const gchar *name);
+#include "syslog-ng.h"
+#include <Python.h>
 
 #endif

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 BalaBit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/python/python-parser.h
+++ b/modules/python/python-parser.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 BalaBit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -39,18 +39,27 @@ static Plugin python_plugins[] =
     .parser = &python_parser,
   },
 };
+static gboolean interpreter_initialized = FALSE;
+
+static void
+_py_init_interpreter(void)
+{
+  if (!interpreter_initialized)
+    {
+      Py_Initialize();
+
+      PyEval_InitThreads();
+      python_log_message_init();
+      PyEval_ReleaseLock();
+
+      interpreter_initialized = TRUE;
+    }
+}
 
 gboolean
 python_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 {
-  Py_Initialize();
-
-  if (!PyEval_ThreadsInitialized())
-    {
-      PyEval_InitThreads();
-      PyEval_ReleaseLock();
-    }
-  python_log_message_init();
+  _py_init_interpreter();
   plugin_register(cfg, python_plugins, G_N_ELEMENTS(python_plugins));
   return TRUE;
 }

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -21,7 +21,7 @@
  *
  */
 
-#include "python-globals.h"
+#include "python-module.h"
 #include "python-parser.h"
 #include "python-dest.h"
 #include "python-logmsg.h"

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -38,6 +38,11 @@ static Plugin python_plugins[] =
     .name = "python",
     .parser = &python_parser,
   },
+  {
+    .type = LL_CONTEXT_ROOT,
+    .name = "python",
+    .parser = &python_parser,
+  },
 };
 static gboolean interpreter_initialized = FALSE;
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 BalaBit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -24,6 +24,7 @@
 #include "python-module.h"
 #include "python-parser.h"
 #include "python-dest.h"
+#include "python-tf.h"
 #include "python-logmsg.h"
 
 #include "plugin.h"
@@ -43,6 +44,7 @@ static Plugin python_plugins[] =
     .name = "python",
     .parser = &python_parser,
   },
+  TEMPLATE_FUNCTION_PLUGIN(tf_python, "python"),
 };
 static gboolean interpreter_initialized = FALSE;
 

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-tf.h"
+#include "python-module.h"
+#include "python-helpers.h"
+#include "python-main.h"
+#include "template/simple-function.h"
+#include "python-logmsg.h"
+#include <time.h>
+
+static PyObject *
+_py_construct_args_tuple(LogMessage *msg, gint argc, GString *argv[])
+{
+  PyObject *args;
+  gint i;
+
+  args = PyTuple_New(1 + argc - 1);
+  PyTuple_SetItem(args, 0, py_log_message_new(msg));
+  for (i = 1; i < argc; i++)
+    {
+      PyTuple_SetItem(args, i, PyString_FromString(argv[i]->str));
+    }
+  return args;
+}
+
+/* returns NULL or reference, exception is handled */
+static PyObject *
+_py_invoke_template_function(const gchar *function_name, LogMessage *msg, gint argc, GString *argv[])
+{
+  PyObject *callable, *ret, *args;
+  gchar buf[256];
+
+  callable = _py_resolve_qualified_name(function_name);
+  if (!callable)
+    {
+      msg_error("$(python): Error looking up Python function",
+                evt_tag_str("function", function_name),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))),
+                NULL);
+      return NULL;
+    }
+
+  args = _py_construct_args_tuple(msg, argc, argv);
+  ret = PyObject_CallObject(callable, args);
+  Py_DECREF(args);
+  Py_DECREF(callable);
+
+  if (!ret)
+    {
+      msg_error("$(python): Error invoking Python function",
+                evt_tag_str("function", function_name),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))),
+                NULL);
+      return NULL;
+    }
+  return ret;
+}
+
+/* NOTE: consumes ret */
+static gboolean
+_py_convert_return_value_to_result(const gchar *function_name, PyObject *ret, GString *result)
+{
+  if (!PyString_Check(ret))
+    {
+      msg_error("$(python): The return value is not a string",
+                evt_tag_str("function", function_name),
+                evt_tag_str("type", ret->ob_type->tp_name),
+                NULL);
+      Py_DECREF(ret);
+      return FALSE;
+    }
+  g_string_append(result, PyString_AS_STRING(ret));
+  Py_DECREF(ret);
+  return TRUE;
+}
+
+static void
+tf_python(LogMessage *msg, gint argc, GString *argv[], GString *result)
+{
+  PyGILState_STATE gstate;
+  const gchar *function_name;
+  PyObject *ret;
+
+  if (argc == 0)
+    return;
+  function_name = argv[0]->str;
+
+  gstate = PyGILState_Ensure();
+
+  if (!(ret = _py_invoke_template_function(function_name, msg, argc, argv)) ||
+      !_py_convert_return_value_to_result(function_name, ret, result))
+    {
+      g_string_append(result, "<error>");
+    }
+
+  PyGILState_Release(gstate);
+}
+
+TEMPLATE_FUNCTION_SIMPLE(tf_python);

--- a/modules/python/python-tf.h
+++ b/modules/python/python-tf.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_TF_H
+#define _SNG_PYTHON_TF_H
+
+#include "lib/template/function.h"
+
+TEMPLATE_FUNCTION_PROTOTYPE(tf_python);
+
+#endif

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 #include "python-value-pairs.h"
 
 /** Value pairs **/

--- a/modules/python/python-value-pairs.h
+++ b/modules/python/python-value-pairs.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2014-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 BalaBit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
- * Copyright (c) 2014-2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/python/python-value-pairs.h
+++ b/modules/python/python-value-pairs.h
@@ -25,7 +25,7 @@
 #ifndef PYTHON_VALUE_PAIRS_H_INCLUDED
 #define PYTHON_VALUE_PAIRS_H_INCLUDED 1
 
-#include "python-globals.h"
+#include "python-module.h"
 #include "value-pairs.h"
 
 gboolean py_value_pairs_apply(ValuePairs *vp, const LogTemplateOptions *template_options, guint32 seq_num, LogMessage *msg, PyObject **result);


### PR DESCRIPTION
This series builds on top of f/python (and fixes a couple of bugs there, so the two branches may be merged before integration).

It adds support for template functions implemented in Python and also a python configuration block within the main syslog-ng conf file.

Something like this:
```
@version: 3.7

python {

def template_function_in_python(msg, *args):
    return "hello world from python, args:" + ' '.join(args)
 
}
...

template t_foo {
    template("$(python template_function_in_python $MSG)\n");
};

```