### PR TITLE
syslog-ng-ctl/Makefile.am: Add _DEPENDENCIES for parallel build

### DIFF
--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -11,4 +11,4 @@ EXTRA_DIST					+=	\
 	syslog-ng-ctl/control-client-unix.c
 
 syslog_ng_ctl_syslog_ng_ctl_LDADD		= lib/libsyslog-ng.la $(CRYPTO_LIBS) @BASE_LIBS@ @GLIB_LIBS@ @RESOLV_LIBS@
-
+syslog_ng_ctl_syslog_ng_ctl_DEPENDENCIES	= lib/libsyslog-ng.la lib/libsyslog-ng-crypto.la


### PR DESCRIPTION
When building in parallel, we need to set _DEPENDENCIES, otherwise make might attempt linking syslog-ng-ctl without having the dependencies fully built. Unfortunately, automake cannot infer the libsyslog-ng-crypto dependency from the $(CRYPTO_LIBS) variable, because that is only available at run-time, while we need this kind of dependency at Makefile.in generation time.

The problem does not affect master, because of the crypto merge.