### PR TITLE
logthrdestdrv: add new worker_message_queue_empty virtual function.

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -164,6 +164,13 @@ log_threaded_dest_driver_do_insert(LogThrDestDriver *self)
       msg_set_context(NULL);
       log_msg_refcache_stop();
     }
+  if (!self->suspended)
+    {
+      if (self->worker.worker_message_queue_empty)
+        {
+          self->worker.worker_message_queue_empty(self);
+        }
+    }
 }
 
 static void

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -61,6 +61,7 @@ struct _LogThrDestDriver
     void (*thread_init) (LogThrDestDriver *s);
     void (*thread_deinit) (LogThrDestDriver *s);
     worker_insert_result_t (*insert) (LogThrDestDriver *s, LogMessage *msg);
+    void (*worker_message_queue_empty)(LogThrDestDriver *s);
     void (*disconnect) (LogThrDestDriver *s);
   } worker;
 


### PR DESCRIPTION
This will be called if the queue become empty.

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>