### PR TITLE
log_threaded_destination: initialize watches before worker_thread_init()

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -232,11 +232,13 @@ log_threaded_dest_driver_worker_thread_main(gpointer arg)
 
   log_queue_set_use_backlog(self->queue, TRUE);
 
-  if (self->worker.thread_init)
-    self->worker.thread_init(self);
   log_threaded_dest_driver_init_watches(self);
 
   log_threaded_dest_driver_start_watches(self);
+
+  if (self->worker.thread_init)
+    self->worker.thread_init(self);
+
   iv_main();
 
   if (self->worker.disconnect)


### PR DESCRIPTION
When syslog-ng got a signal (i.e. SIGTERM) in worker_thread_init(),
it tried to deinitialize itself gracefully, but the watches was not initialized,
so it caused a SIGSEGV.

Signed-off-by: Benke Tibor <tibor.benke@balabit.com>