### PR TITLE
syslog-ng-ctl: added counter reset capability 

### DIFF
--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -39,7 +39,7 @@ static ControlServer *control_server;
 static GList *command_list = NULL;
 
 void
-control_register_command(gchar *command_name, gchar *description, CommandFunction function)
+control_register_command(const gchar *command_name, const gchar *description, CommandFunction function)
 {
   ControlCommand *new_command = g_new0(ControlCommand, 1);
   new_command->command_name = command_name;
@@ -130,10 +130,14 @@ ControlCommand default_commands[] = {
 static void
 register_default_commands()
 {
-  control_register_command("STATS", NULL, control_connection_send_stats);
-  control_register_command("LOG", NULL, control_connection_message_log);
-  control_register_command("STOP", NULL, control_connection_stop_process);
-  control_register_command("RELOAD", NULL, control_connection_reload);
+  int i;
+  ControlCommand *cmd;
+
+  for (i = 0; default_commands[i].command_name != NULL; i++)
+    {
+      cmd = &default_commands[i];
+      control_register_command(cmd->command_name, cmd->description, cmd->func);
+    }
 }
 
 void

--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -27,6 +27,7 @@
 #include "gsocket.h"
 #include "messages.h"
 #include "stats/stats-csv.h"
+#include "stats/stats-counter.h"
 #include "misc.h"
 #include "mainloop.h"
 
@@ -54,6 +55,14 @@ control_connection_send_stats(GString *command)
   gchar *stats = stats_generate_csv();
   GString *result = g_string_new(stats);
   g_free(stats);
+  return result;
+}
+
+static GString *
+control_connection_reset_stats(GString *command)
+{
+  GString *result = g_string_new("The statistics of syslog-ng have been reset to 0.");
+  stats_reset_counters();
   return result;
 }
 
@@ -121,6 +130,7 @@ control_connection_reload(GString *command)
 
 ControlCommand default_commands[] = {
   { "STATS", NULL, control_connection_send_stats },
+  { "RESET_STATS", NULL, control_connection_reset_stats },
   { "LOG", NULL, control_connection_message_log },
   { "STOP", NULL, control_connection_stop_process },
   { "RELOAD", NULL, control_connection_reload },

--- a/lib/control/control.h
+++ b/lib/control/control.h
@@ -31,6 +31,6 @@ typedef GString* (*CommandFunction)(GString *);
 
 void  control_init(const gchar *control_name);
 void control_destroy(void);
-void control_register_command(gchar *command_name, gchar *description, CommandFunction function);
+void control_register_command(const gchar *command_name, const gchar *description, CommandFunction function);
 
 #endif

--- a/lib/stats/Makefile.am
+++ b/lib/stats/Makefile.am
@@ -11,6 +11,7 @@ statsinclude_HEADERS = \
 
 stats_sources = \
 	lib/stats/stats.c			\
+	lib/stats/stats-counter.c		\
 	lib/stats/stats-cluster.c		\
 	lib/stats/stats-csv.c			\
 	lib/stats/stats-log.c			\

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/stats-counter.h"
+#include "stats/stats-cluster.h"
+#include "stats/stats-registry.h"
+
+static void
+_reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
+{
+  stats_counter_set(counter, 0);
+}
+
+void
+stats_reset_counters(void)
+{
+  stats_lock();
+  stats_foreach_counter(_reset_counter, NULL);
+  stats_unlock();
+}
+

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -72,4 +72,6 @@ stats_counter_get(StatsCounterItem *counter)
   return result;
 }
 
+void stats_reset_counters(void);
+
 #endif

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -95,6 +95,14 @@ slng_verbose(int argc, char *argv[], const gchar *mode)
   return ret;
 }
 
+static gboolean stats_options_reset_is_set = FALSE;
+
+static GOptionEntry stats_options[] =
+{
+  { "reset", 'r', 0, G_OPTION_ARG_NONE, &stats_options_reset_is_set, "reset counters", NULL },
+  { NULL,    0,   0, G_OPTION_ARG_NONE, NULL,                        NULL,             NULL }
+};
+
 static GOptionEntry verbose_options[] =
 {
   { "set", 's', 0, G_OPTION_ARG_STRING, &verbose_set,
@@ -102,10 +110,17 @@ static GOptionEntry verbose_options[] =
   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
 };
 
+
+static const gchar *
+_stats_command_builder()
+{
+  return stats_options_reset_is_set ? "RESET_STATS\n" : "STATS\n";
+}
+
 static gint
 slng_stats(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = slng_run_command("STATS\n");
+  GString *rsp = slng_run_command(_stats_command_builder());
 
   if (rsp == NULL)
     return 1;
@@ -186,7 +201,7 @@ static struct
   gint (*main)(gint argc, gchar *argv[], const gchar *mode);
 } modes[] =
 {
-  { "stats", no_options, "Dump syslog-ng statistics", slng_stats },
+  { "stats", stats_options, "Query/reset syslog-ng statistics", slng_stats },
   { "verbose", verbose_options, "Enable/query verbose messages", slng_verbose },
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose },
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose },

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -55,6 +55,15 @@ slng_send_cmd(gchar *cmd)
   return TRUE;
 }
 
+static GString *
+slng_run_command(const gchar *command)
+{
+  if (!slng_send_cmd(command))
+    return NULL;
+
+  return control_client_read_reply(control_client);
+}
+
 static gchar *verbose_set = NULL;
 
 static gint
@@ -72,7 +81,8 @@ slng_verbose(int argc, char *argv[], const gchar *mode)
 
   g_strup(buff);
 
-  if (!(slng_send_cmd(buff) && ((rsp = control_client_read_reply(control_client)) != NULL)))
+  rsp = slng_run_command(buff);
+  if (rsp == NULL)
     return 1;
 
   if (!verbose_set)
@@ -95,9 +105,9 @@ static GOptionEntry verbose_options[] =
 static gint
 slng_stats(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = NULL;
+  GString *rsp = slng_run_command("STATS\n");
 
-  if (!(slng_send_cmd("STATS\n") && ((rsp = control_client_read_reply(control_client)) != NULL)))
+  if (rsp == NULL)
     return 1;
 
   printf("%s\n", rsp->str);
@@ -110,9 +120,9 @@ slng_stats(int argc, char *argv[], const gchar *mode)
 static gint
 slng_stop(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = NULL;
+  GString *rsp = slng_run_command("STOP\n");
 
-  if (!(slng_send_cmd("STOP\n") && ((rsp = control_client_read_reply(control_client)) != NULL)))
+  if (rsp == NULL)
     return 1;
 
   printf("%s\n", rsp->str);
@@ -125,9 +135,9 @@ slng_stop(int argc, char *argv[], const gchar *mode)
 static gint
 slng_reload(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = NULL;
+  GString *rsp = slng_run_command("RELOAD\n");
 
-  if (!(slng_send_cmd("RELOAD\n") && ((rsp = control_client_read_reply(control_client)) != NULL)))
+  if (rsp == NULL)
     return 1;
 
   printf("%s\n", rsp->str);


### PR DESCRIPTION
The statistics counters (see the output of "syslog-ng-ctl stats") now can be reset with syslog-ng-ctl stats --reset.