### PR TITLE
F/debugger cli delegated to python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -875,7 +875,7 @@ enable_json="no"
 if test "x$with_jsonc" = "xsystem" -o "x$with_jsonc" = "xauto"; then
    enable_json="yes"
    PKG_CHECK_EXISTS(json-c, json_module_name="json-c",
-    PKG_CHECK_EXISTS(json, json_module_name="json"))
+   PKG_CHECK_EXISTS(json, json_module_name="json"))
    PKG_CHECK_MODULES(JSON, $json_module_name >= $JSON_C_MIN_VERSION,[with_jsonc="system"], [JSON_LIBS=""; enable_json="no"])
    if test "x$with_jsonc" = "xsystem" -a "x$enable_json" = "xno"; then
      AC_MSG_ERROR([json-c library development files cannot be not found on system!])

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,7 @@ AM_PROG_LEX
 AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
 LT_INIT([dlopen disable-static])
+AC_PATH_PROG(PYTHON, python)
 
 dnl ***************************************************************************
 dnl Validate yacc
@@ -996,11 +997,10 @@ dnl rabbitmq-c headers/libraries
 dnl ***************************************************************************
 
 if test "x$with_librabbitmq_client" = "xinternal"; then
-    AC_CHECK_PROG(HAVE_PYTHON, python, 1, 0)
     PYTHON_VERSION=`python -V 2>&1 | cut -d ' ' -f 2`
     PYTHON_MAJOR=`echo $PYTHON_VERSION | cut -d '.' -f 1`
     PYTHON_MINOR=`echo $PYTHON_VERSION | cut -d '.' -f 2`
-    if test ${HAVE_PYTHON} = 0 || test $PYTHON_MAJOR -eq 2 && test $PYTHON_MINOR -lt 5; then
+    if test ${PYTHON} = "" || test $PYTHON_MAJOR -eq 2 && test $PYTHON_MINOR -lt 5; then
         AC_MSG_WARN([Was about to execute rabbitmq configure script, but that requires Python >= 2.5, which you don't seem to have, disabling rabbitmq])
         with_librabbitmq_client=no
     fi

--- a/lib/debugger/Makefile.am
+++ b/lib/debugger/Makefile.am
@@ -7,3 +7,5 @@ debuggerinclude_HEADERS = \
 debugger_sources = \
 	lib/debugger/debugger.c		\
 	lib/debugger/tracer.c
+
+include lib/debugger/tests/Makefile.am

--- a/lib/debugger/Makefile.am
+++ b/lib/debugger/Makefile.am
@@ -2,10 +2,12 @@ debuggerincludedir			= ${pkgincludedir}/debugger
 
 debuggerinclude_HEADERS = \
 	lib/debugger/debugger.h		\
-	lib/debugger/tracer.h
+	lib/debugger/tracer.h		\
+	lib/debugger/debugger-main.h
 
 debugger_sources = \
 	lib/debugger/debugger.c		\
-	lib/debugger/tracer.c
+	lib/debugger/tracer.c		\
+	lib/debugger/debugger-main.c
 
 include lib/debugger/tests/Makefile.am

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -1,0 +1,20 @@
+#include "debugger/debugger.h"
+#include "logpipe.h"
+
+static Debugger *current_debugger;
+
+static gboolean
+_pipe_hook(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  return debugger_stop_at_breakpoint(current_debugger, s, msg);
+}
+
+void
+debugger_start(GlobalConfig *cfg)
+{
+  /* we don't support threaded mode (yet), force it to non-threaded */
+  cfg->threaded = FALSE;
+  current_debugger = debugger_new(cfg);
+  pipe_single_step_hook = _pipe_hook;
+  debugger_start_console(current_debugger);
+}

--- a/lib/debugger/debugger-main.h
+++ b/lib/debugger/debugger-main.h
@@ -21,22 +21,12 @@
  * COPYING for details.
  *
  */
-#ifndef DEBUGGER_DEBUGGER_H_INCLUDED
-#define DEBUGGER_DEBUGGER_H_INCLUDED 1
+#ifndef DEBUGGER_DEBUGGER_MAIN_H_INCLUDED
+#define DEBUGGER_DEBUGGER_MAIN_H_INCLUDED 1
 
-#include "syslog-ng.h"
+#include "debugger/debugger.h"
 #include "cfg.h"
 
-typedef struct _Debugger Debugger;
-
-typedef gchar *(*FetchCommandFunc)(void);
-
-Debugger *debugger_new(GlobalConfig *cfg);
-void debugger_free(Debugger *self);
-
-gchar *debugger_builtin_fetch_command(void);
-void debugger_register_command_fetcher(FetchCommandFunc fetcher);
-void debugger_start_console(Debugger *self);
-gboolean debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe, LogMessage *msg);
+void debugger_start(GlobalConfig *cfg);
 
 #endif

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -41,7 +41,6 @@ struct _Debugger
   gboolean drop_current_message;
 };
 
-
 static gboolean
 _format_nvpair(NVHandle handle, const gchar *name, const gchar *value, gssize length, gpointer user_data)
 {
@@ -250,7 +249,6 @@ _fetch_command(Debugger *self)
         g_free(command);
     }
 }
-
 
 static gboolean
 _handle_command(Debugger *self)

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-typedef struct _Debugger
+struct _Debugger
 {
   Tracer *tracer;
   GlobalConfig *cfg;
@@ -39,7 +39,7 @@ typedef struct _Debugger
   LogMessage *current_msg;
   LogPipe *current_pipe;
   gboolean drop_current_message;
-} Debugger;
+};
 
 
 static gboolean
@@ -332,6 +332,14 @@ debugger_new(GlobalConfig *cfg)
   self->command_buffer = g_strdup("help");
   log_template_compile(self->display_template, "$DATE $HOST $MSGHDR$MSG", NULL);
   return self;
+}
+
+void
+debugger_free(Debugger *self)
+{
+  log_template_unref(self->display_template);
+  tracer_free(self->tracer);
+  g_free(self);
 }
 
 static Debugger *current_debugger;

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -94,7 +94,7 @@ _display_source_line(LogExprNode *expr_node)
   gint lineno = 1;
   gchar buf[1024];
 
-  if (!expr_node->filename)
+  if (!expr_node || !expr_node->filename)
     return;
 
   f = fopen(expr_node->filename, "r");

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -305,6 +305,7 @@ debugger_new(GlobalConfig *cfg)
   self->tracer = tracer_new(cfg);
   self->cfg = cfg;
   self->display_template = log_template_new(cfg, NULL);
+  self->command_buffer = g_strdup("help");
   log_template_compile(self->display_template, "$DATE $HOST $MSGHDR$MSG", NULL);
   return self;
 }

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -34,7 +34,7 @@ typedef struct _Debugger
 {
   Tracer *tracer;
   GlobalConfig *cfg;
-  gchar command_buffer[1024];
+  gchar *command_buffer;
   LogTemplate *display_template;
   LogMessage *current_msg;
   LogPipe *current_pipe;
@@ -132,8 +132,9 @@ _fetch_command(Debugger *self)
     }
   if (strlen(buf) > 0)
     {
-      strncpy(self->command_buffer, buf, sizeof(self->command_buffer));
-      self->command_buffer[sizeof(self->command_buffer) - 1] = 0;
+      if (self->command_buffer)
+        g_free(self->command_buffer);
+      self->command_buffer = g_strdup(buf);
     }
 }
 
@@ -237,7 +238,7 @@ _handle_command(Debugger *self)
   gboolean result = TRUE;
   DebuggerCommandFunc command = NULL;
 
-  if (!g_shell_parse_argv(self->command_buffer, &argc, &argv, &error))
+  if (!g_shell_parse_argv(self->command_buffer ? : "", &argc, &argv, &error))
     {
       printf("%s\n", error->message);
       g_clear_error(&error);

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -27,7 +27,12 @@
 #include "syslog-ng.h"
 #include "cfg.h"
 
+typedef struct _Debugger Debugger;
+
 typedef gchar *(*FetchCommandFunc)(void);
+
+Debugger *debugger_new(GlobalConfig *cfg);
+void debugger_free(Debugger *self);
 
 gchar *debugger_builtin_fetch_command(void);
 void debugger_register_command_fetcher(FetchCommandFunc fetcher);

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -27,6 +27,10 @@
 #include "syslog-ng.h"
 #include "cfg.h"
 
+typedef gchar *(*FetchCommandFunc)(void);
+
+gchar *debugger_builtin_fetch_command(void);
+void debugger_register_command_fetcher(FetchCommandFunc fetcher);
 void debugger_start(GlobalConfig *cfg);
 
 #endif

--- a/lib/debugger/tests/Makefile.am
+++ b/lib/debugger/tests/Makefile.am
@@ -1,0 +1,10 @@
+lib_debugger_tests_TESTS		 = \
+	lib/debugger/tests/test_debugger
+
+check_PROGRAMS				+= ${lib_debugger_tests_TESTS}
+
+lib_debugger_tests_test_debugger_CFLAGS  = $(TEST_CFLAGS) \
+	-I${top_srcdir}/lib/debugger/tests
+lib_debugger_tests_test_debugger_LDADD	 = $(TEST_LDADD)
+lib_debugger_tests_test_debugger_SOURCES = 			\
+	lib/debugger/tests/test-debugger.c

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -1,0 +1,18 @@
+#include "debugger/debugger.h"
+#include "apphook.h"
+
+void
+test_debugger(void)
+{
+  Debugger *debugger = debugger_new(configuration);
+  debugger_free(debugger);
+}
+
+int
+main()
+{
+  app_startup();
+  configuration = cfg_new(VERSION_VALUE);
+  test_debugger();
+  cfg_free(configuration);
+}

--- a/lib/debugger/tracer.c
+++ b/lib/debugger/tracer.c
@@ -69,3 +69,12 @@ tracer_new(GlobalConfig *cfg)
 
   return self;
 }
+
+void
+tracer_free(Tracer *self)
+{
+  g_mutex_free(self->breakpoint_mutex);
+  g_cond_free(self->breakpoint_cond);
+  g_cond_free(self->resume_cond);
+  g_free(self);
+}

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -40,5 +40,6 @@ void tracer_wait_for_breakpoint(Tracer *self);
 void tracer_resume_after_breakpoint(Tracer *self);
 
 Tracer *tracer_new(GlobalConfig *cfg);
+void tracer_free(Tracer *self);
 
 #endif

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -36,7 +36,7 @@
 #include "persist-state.h"
 #include "run-id.h"
 #include "host-id.h"
-#include "debugger/debugger.h"
+#include "debugger/debugger-main.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/lib/template/repr.c
+++ b/lib/template/repr.c
@@ -47,11 +47,13 @@ log_template_elem_free(LogTemplateElem *e)
 }
 
 void
-log_template_elem_free_list(GList *el)
+log_template_elem_free_list(GList *l)
 {
+  GList *el = l;
+
   for (; el; el = el->next)
     {
       log_template_elem_free((LogTemplateElem *) el->data);
     }
-  g_list_free(el);
+  g_list_free(l);
 }

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -35,7 +35,9 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-parser.c		  \
 	modules/python/python-parser.h	          \
 	modules/python/python-logmsg.h		  \
-	modules/python/python-logmsg.c
+	modules/python/python-logmsg.c	          \
+	modules/python/python-debugger.c	  \
+	modules/python/python-debugger.h
 
 
 modules_python_libmod_python_la_LDFLAGS		 = \
@@ -58,3 +60,5 @@ EXTRA_DIST					+= \
 	modules/python/sngexample.py
 
 .PHONY: modules/python mod-python
+
+include modules/python/pylib/Makefile.am

--- a/modules/python/pylib/.gitignore
+++ b/modules/python/pylib/.gitignore
@@ -1,0 +1,3 @@
+build/
+parser.out
+.idea

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -1,0 +1,32 @@
+EXTRA_DIST += \
+	modules/python/pylib/syslogng/__init__.py				\
+	modules/python/pylib/syslogng/debuggercli/__init__.py			\
+	modules/python/pylib/setup.py
+
+PYLIB_PATH = modules/python/pylib
+PYLIB_BUILDDIR = $(abs_builddir)/$(PYLIB_PATH)
+PYLIB_SRCDIR = $(top_srcdir)/modules/python/pylib
+SETUPPY_MANIFEST = $(PYLIB_BUILDDIR)/install-manifest.txt
+PYTHON_ROOT = $(if $(DESTDIR),$(DESTDIR),/)
+
+INSTALL_EXEC_HOOKS += install-pylib
+UNINSTALL_HOOKS += uninstall-pylib
+CLEAN_HOOKS += clean-pylib
+
+.PHONY: install-pylib
+install-pylib:
+
+
+	(cd $(PYLIB_SRCDIR) && $(PYTHON) setup.py \
+		build --build-base="$(PYLIB_BUILDDIR)/build" \
+		install --record=$(SETUPPY_MANIFEST) --root="$(PYTHON_ROOT)" --prefix="$(prefix)")
+
+.PHONY: uninstall-pylib
+uninstall-pylib:
+	sed -e 's,^,$(PYTHON_ROOT),g' $(SETUPPY_MANIFEST) | tr '\n' '\0' | xargs -0 rm -f
+
+
+.PHONY: clean-pylib
+clean-pylib:
+	rm -rf "$(PYLIB_BUILDDIR)/build"
+	rm -rf "$(SETUPPY_MANIFEST)"

--- a/modules/python/pylib/setup.py
+++ b/modules/python/pylib/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='syslogng',
+      version='1.0',
+      description='syslog-ng Python extensions',
+      author='Balazs Scheidler',
+      author_email='balazs.scheidler@balabit.com',
+      url='https://www.syslog-ng.org',
+      packages=['syslogng', 'syslogng.debuggercli'],
+     )

--- a/modules/python/pylib/syslogng/debuggercli/__init__.py
+++ b/modules/python/pylib/syslogng/debuggercli/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import
+import readline
+
+
+def fetch_command():
+    return raw_input("(syslog-ng) ")

--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-debugger.h"
+#include "python-module.h"
+#include "python-helpers.h"
+#include "messages.h"
+#include "debugger/debugger.h"
+
+#define DEBUGGER_FETCH_COMMAND "syslogng.debuggercli.fetch_command"
+
+static gchar *
+python_fetch_debugger_command(void)
+{
+  PyObject *fetch_command;
+  PyObject *ret;
+  gchar *command = NULL;
+
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  fetch_command = _py_resolve_qualified_name(DEBUGGER_FETCH_COMMAND);
+  if (!fetch_command)
+    goto exit;
+
+  ret = PyObject_CallFunctionObjArgs(fetch_command, NULL);
+  if (!ret)
+    {
+      gchar buf[256];
+
+      msg_error("Error calling debugger fetch_command",
+                evt_tag_str("function", DEBUGGER_FETCH_COMMAND),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))),
+                NULL);
+      goto exit;
+    }
+  if (!PyString_Check(ret))
+    {
+      msg_error("Return value from debugger fetch_command is not a string",
+                evt_tag_str("function", DEBUGGER_FETCH_COMMAND),
+                evt_tag_str("type", ret->ob_type->tp_name),
+                NULL);
+      Py_DECREF(ret);
+      goto exit;
+    }
+  command = g_strdup(PyString_AsString(ret));
+  Py_DECREF(ret);
+ exit:
+  PyGILState_Release(gstate);
+  if (!command)
+    return debugger_builtin_fetch_command();
+  return command;
+}
+
+void
+python_debugger_init(void)
+{
+  debugger_register_command_fetcher(python_fetch_debugger_command);
+}

--- a/modules/python/python-debugger.h
+++ b/modules/python/python-debugger.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef PYTHON_DEBUGGER_H_INCLUDED
+#define PYTHON_DEBUGGER_H_INCLUDED 1
+
+void python_debugger_init(void);
+
+#endif

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -27,6 +27,7 @@
 #include "python-dest.h"
 #include "python-tf.h"
 #include "python-logmsg.h"
+#include "python-debugger.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -68,6 +69,7 @@ gboolean
 python_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 {
   _py_init_interpreter();
+  python_debugger_init();
   plugin_register(cfg, python_plugins, G_N_ELEMENTS(python_plugins));
   return TRUE;
 }


### PR DESCRIPTION
This branch contains some improvements to the code in lib/debugger and also makes it possible to change the function that the debugger console uses to fetch a command.

This functionality is in turn used to delegate the fetch_command() to a Python function.

A subsequent branch (WIP is available in f/debugger-cli-in-python) is using this functionality to implement tab-completion for the debugger language, with proper support for template strings.

Please merge.