### PR TITLE
F/some polishments

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -603,3 +603,21 @@ cfg_persist_config_fetch(GlobalConfig *cfg, gchar *name)
   return res;
 }
 
+gint
+cfg_get_user_version(const GlobalConfig *cfg)
+{
+  return cfg->user_version;
+}
+
+gint
+cfg_get_parsed_version(const GlobalConfig *cfg)
+{
+  return cfg->parsed_version;
+}
+
+const gchar*
+cfg_get_filename(const GlobalConfig *cfg)
+{
+  return cfg->filename;
+}
+

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -173,4 +173,8 @@ cfg_set_use_uniqid(gboolean flag)
   configuration->use_uniqid = !!flag;
 }
 
+gint cfg_get_user_version(const GlobalConfig *cfg);
+gint cfg_get_parsed_version(const GlobalConfig *cfg);
+const gchar* cfg_get_filename(const GlobalConfig *cfg);
+
 #endif

--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -1668,3 +1668,11 @@ log_msg_global_deinit(void)
 {
   log_msg_registry_deinit();
 }
+
+static const gchar *
+__log_msg_get_value(LogMessage *self, NVHandle handle, gssize *value_len)
+__attribute__((alias("log_msg_get_value")));
+
+static const gchar *
+__log_msg_get_value_by_name(LogMessage *self, const gchar *name, gssize *value_len)
+__attribute__((alias("log_msg_get_value_by_name")));

--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -157,7 +157,7 @@ TLS_BLOCK_END;
  **********************************************************************/
 
 static inline gboolean
-log_msg_chk_flag(LogMessage *self, gint32 flag)
+log_msg_chk_flag(const LogMessage *self, gint32 flag)
 {
   return self->flags & flag;
 }
@@ -206,7 +206,7 @@ static StatsCounterItem *count_sdata_updates;
 static GStaticPrivate priv_macro_value = G_STATIC_PRIVATE_INIT;
 
 static inline gboolean
-log_msg_is_write_protected(LogMessage *self)
+log_msg_is_write_protected(const LogMessage *self)
 {
   return self->protect_cnt > 0;
 }
@@ -382,7 +382,7 @@ __free_macro_value(void *val)
 }
 
 const gchar *
-log_msg_get_macro_value(LogMessage *self, gint id, gssize *value_len)
+log_msg_get_macro_value(const LogMessage *self, gint id, gssize *value_len)
 {
   GString *value;
 
@@ -630,7 +630,7 @@ log_msg_clear_matches(LogMessage *self)
 #endif
 
 static inline void
-log_msg_tags_foreach_item(LogMessage *self, gint base, gulong item, LogMessageTagsForeachFunc callback, gpointer user_data)
+log_msg_tags_foreach_item(const LogMessage *self, gint base, gulong item, LogMessageTagsForeachFunc callback, gpointer user_data)
 {
   gint i;
 
@@ -650,7 +650,7 @@ log_msg_tags_foreach_item(LogMessage *self, gint base, gulong item, LogMessageTa
 
 
 void
-log_msg_tags_foreach(LogMessage *self, LogMessageTagsForeachFunc callback, gpointer user_data)
+log_msg_tags_foreach(const LogMessage *self, LogMessageTagsForeachFunc callback, gpointer user_data)
 {
   guint i;
 
@@ -808,7 +808,7 @@ log_msg_sdata_append_escaped(GString *result, const gchar *sstr, gssize len)
 }
 
 void
-log_msg_append_format_sdata(LogMessage *self, GString *result,  guint32 seq_num)
+log_msg_append_format_sdata(const LogMessage *self, GString *result,  guint32 seq_num)
 {
   const gchar *value;
   const gchar *sdata_name, *sdata_elem, *sdata_param, *cur_elem = NULL, *dot;
@@ -942,14 +942,14 @@ log_msg_append_format_sdata(LogMessage *self, GString *result,  guint32 seq_num)
 }
 
 void
-log_msg_format_sdata(LogMessage *self, GString *result,  guint32 seq_num)
+log_msg_format_sdata(const LogMessage *self, GString *result,  guint32 seq_num)
 {
   g_string_truncate(result, 0);
   log_msg_append_format_sdata(self, result, seq_num);
 }
 
 gboolean
-log_msg_append_tags_callback(LogMessage *self, LogTagId tag_id, const gchar *name, gpointer user_data)
+log_msg_append_tags_callback(const LogMessage *self, LogTagId tag_id, const gchar *name, gpointer user_data)
 {
   GString *result = (GString *) ((gpointer *) user_data)[0];
   gint original_length = GPOINTER_TO_UINT(((gpointer *) user_data)[1]);
@@ -964,7 +964,7 @@ log_msg_append_tags_callback(LogMessage *self, LogTagId tag_id, const gchar *nam
 }
 
 void
-log_msg_print_tags(LogMessage *self, GString *result)
+log_msg_print_tags(const LogMessage *self, GString *result)
 {
   gpointer args[] = { result, GUINT_TO_POINTER(result->len) };
 
@@ -1670,9 +1670,9 @@ log_msg_global_deinit(void)
 }
 
 static const gchar *
-__log_msg_get_value(LogMessage *self, NVHandle handle, gssize *value_len)
+__log_msg_get_value(const LogMessage *self, NVHandle handle, gssize *value_len)
 __attribute__((alias("log_msg_get_value")));
 
 static const gchar *
-__log_msg_get_value_by_name(LogMessage *self, const gchar *name, gssize *value_len)
+__log_msg_get_value_by_name(const LogMessage *self, const gchar *name, gssize *value_len)
 __attribute__((alias("log_msg_get_value_by_name")));

--- a/lib/logmsg.h
+++ b/lib/logmsg.h
@@ -222,10 +222,10 @@ log_msg_is_handle_settable_with_an_indirect_value(NVHandle handle)
   return (handle >= LM_V_MAX);
 }
 
-const gchar *log_msg_get_macro_value(LogMessage *self, gint id, gssize *value_len);
+const gchar *log_msg_get_macro_value(const LogMessage *self, gint id, gssize *value_len);
 
 static inline const gchar *
-log_msg_get_value(LogMessage *self, NVHandle handle, gssize *value_len)
+log_msg_get_value(const LogMessage *self, NVHandle handle, gssize *value_len)
 {
   guint16 flags;
 
@@ -237,13 +237,13 @@ log_msg_get_value(LogMessage *self, NVHandle handle, gssize *value_len)
 }
 
 static inline const gchar *
-log_msg_get_value_by_name(LogMessage *self, const gchar *name, gssize *value_len)
+log_msg_get_value_by_name(const LogMessage *self, const gchar *name, gssize *value_len)
 {
   NVHandle handle = log_msg_get_value_handle(name);
   return log_msg_get_value(self, handle, value_len);
 }
 
-typedef gboolean (*LogMessageTagsForeachFunc)(LogMessage *self, LogTagId tag_id, const gchar *name, gpointer user_data);
+typedef gboolean (*LogMessageTagsForeachFunc)(const LogMessage *self, LogTagId tag_id, const gchar *name, gpointer user_data);
 
 void log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *new_value, gssize length);
 void log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
@@ -258,8 +258,8 @@ log_msg_set_value_by_name(LogMessage *self, const gchar *name, const gchar *valu
   log_msg_set_value(self, handle, value, length);
 }
 
-void log_msg_append_format_sdata(LogMessage *self, GString *result, guint32 seq_num);
-void log_msg_format_sdata(LogMessage *self, GString *result, guint32 seq_num);
+void log_msg_append_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);
+void log_msg_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);
 
 void log_msg_set_tag_by_id_onoff(LogMessage *self, LogTagId id, gboolean on);
 void log_msg_set_tag_by_id(LogMessage *self, LogTagId id);
@@ -268,8 +268,8 @@ void log_msg_clear_tag_by_id(LogMessage *self, LogTagId id);
 void log_msg_clear_tag_by_name(LogMessage *self, const gchar *name);
 gboolean log_msg_is_tag_by_id(LogMessage *self, LogTagId id);
 gboolean log_msg_is_tag_by_name(LogMessage *self, const gchar *name);
-void log_msg_tags_foreach(LogMessage *self, LogMessageTagsForeachFunc callback, gpointer user_data);
-void log_msg_print_tags(LogMessage *self, GString *result);
+void log_msg_tags_foreach(const LogMessage *self, LogMessageTagsForeachFunc callback, gpointer user_data);
+void log_msg_print_tags(const LogMessage *self, GString *result);
 
 LogMessageQueueNode *log_msg_alloc_queue_node(LogMessage *msg, const LogPathOptions *path_options);
 LogMessageQueueNode *log_msg_alloc_dynamic_queue_node(LogMessage *msg, const LogPathOptions *path_options);

--- a/lib/logstamp.c
+++ b/lib/logstamp.c
@@ -28,7 +28,7 @@
 #include "str-format.h"
 
 static void
-log_stamp_append_frac_digits(LogStamp *stamp, GString *target, gint frac_digits)
+log_stamp_append_frac_digits(const LogStamp *stamp, GString *target, gint frac_digits)
 {
   glong usecs;
 
@@ -59,7 +59,7 @@ log_stamp_append_frac_digits(LogStamp *stamp, GString *target, gint frac_digits)
  * @ts_format and @tz_convert. 
  **/
 void
-log_stamp_append_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits)
+log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits)
 {
   glong target_zone_offset = 0;
   struct tm *tm, tm_storage;

--- a/lib/logstamp.h
+++ b/lib/logstamp.h
@@ -43,7 +43,7 @@ typedef struct _LogStamp
 } LogStamp;
 
 void log_stamp_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
-void log_stamp_append_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
+void log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
 
 
 #endif

--- a/lib/messages.c
+++ b/lib/messages.c
@@ -214,6 +214,12 @@ msg_event_create(gint prio, const gchar *desc, EVTTAG *tag1, ...)
   return e;
 }
 
+EVTREC*
+msg_event_create_from_desc(gint prio, const char *desc)
+{
+  return msg_event_create(prio, desc, NULL);
+}
+
 void
 msg_event_free(EVTREC *e)
 {

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -37,6 +37,7 @@ typedef void (*MsgPostFunc)(LogMessage *msg);
 
 void msg_set_context(LogMessage *msg);
 EVTREC *msg_event_create(gint prio, const char *desc, EVTTAG *tag1, ...);
+EVTREC *msg_event_create_from_desc(gint prio, const char *desc);
 void msg_event_free(EVTREC *e);
 void msg_event_send(EVTREC *e);
 void msg_event_suppress_recursions_and_send(EVTREC *e);

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -183,7 +183,7 @@ static GHashTable *macro_hash;
 static LogTemplateOptions template_options_for_macro_expand;
 
 static void
-_result_append_value(GString *result, LogMessage *lm, NVHandle handle, gboolean escape)
+_result_append_value(GString *result, const LogMessage *lm, NVHandle handle, gboolean escape)
 {
   const gchar *str;
   gssize len = 0;
@@ -193,7 +193,7 @@ _result_append_value(GString *result, LogMessage *lm, NVHandle handle, gboolean 
 }
 
 gboolean
-log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, LogMessage *msg)
+log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, const LogMessage *msg)
 {
   switch (id)
     {
@@ -430,7 +430,8 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
         gchar buf[64];
         gint length;
         time_t t;
-        LogStamp *stamp, sstamp;
+        const LogStamp *stamp;
+        LogStamp sstamp;
         glong zone_ofs;
         guint tmp_hour;
 
@@ -570,7 +571,7 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
 }
 
 gboolean
-log_macro_expand_simple(GString *result, gint id, LogMessage *msg)
+log_macro_expand_simple(GString *result, gint id, const LogMessage *msg)
 {
   return log_macro_expand(result, id, FALSE, &template_options_for_macro_expand, LTZ_LOCAL, 0, NULL, msg);
 }

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -111,8 +111,8 @@ extern LogMacroDef macros[];
 
 /* low level macro functions */
 guint log_macro_lookup(gchar *macro, gint len);
-gboolean log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, LogMessage *msg);
-gboolean log_macro_expand_simple(GString *result, gint id, LogMessage *msg);
+gboolean log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, const LogMessage *msg);
+gboolean log_macro_expand_simple(GString *result, gint id, const LogMessage *msg);
 
 void log_macros_global_init(void);
 void log_macros_global_deinit(void);


### PR DESCRIPTION
This PR contains some polishments on different subjects. All of these modifications are needed to a Rust based filter implementation:

* the static inline functions are not exported from `libsyslog-ng.so`
* it makes a lot of sense to use `const` in Rust
* the getter functions hide the inner structure of `GlobalConfig`
* Rust doesn't have variadic functions (just macros) 