### PR TITLE
Docbook: there was a hardcoded path that caused build to fail if docbook is not on that path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 before_script:
   - ./autogen.sh
 script:
-  - ./configure --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct
+  - ./configure --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
   - make
   - make distcheck VERBOSE=1
   - make func-test VERBOSE=1

--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,15 @@ AC_ARG_WITH(systemd-journal,
 AC_ARG_WITH(python,
               [  --with-python=VERSION    Build with a specific version of python])
 
+AC_ARG_WITH(docbook,
+            AC_HELP_STRING([--with-docbook-dir=DIR],
+                           [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net]),
+            [ XSL_STYLESHEET=$with_docbook ],
+            [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/ ]
+            )
+
+AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation of manpages (default: no)]), ,[ XSL_STYLESHEET=""])
+
 AC_ARG_ENABLE(java, [ --enable-java  Enable java destination (default: auto)],, enable_java="auto")
 
 AC_ARG_ENABLE(all-modules,
@@ -1437,6 +1446,8 @@ AC_SUBST(with_ivykis)
 AC_SUBST(INTERNAL_IVYKIS_CFLAGS)
 AC_SUBST(LIBSYSTEMD_JOURNAL_CFLAGS)
 AC_SUBST(LIBSYSTEMD_JOURNAL_LIBS)
+AC_SUBST(XSL_STYLESHEET)
+
 
 AC_OUTPUT(dist.conf
           Makefile

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -29,7 +29,6 @@ xsd_DATA	= \
 # NOTE: this uses a hard-coded path for the XSL stylesheets, but the
 # end-result is also included in the tarball. If so need be, this can
 # be overridden from the make command line or via the environment.
-XSL_STYLESHEET = /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
 
 sysconfdir_e = $(shell echo "${sysconfdir}" | sed -e "s,-,\\\\\\\\-,g")
 prefix_e = $(shell echo "${prefix}" | sed -e "s,-,\\\\\\\\-,g")


### PR DESCRIPTION
It was not a problem on Debian based platforms. This topic was mentioned more times but the elegant solution was hard to find. Now a new option was created for `./configure` that is `--enable-manpages` that enables the generation of manpages using docbook from online source. `--with-docbook=PATH` gives you the opportunity to specify the path for your own installed docbook.

**Examples**
- `./configure --enable-manpages`: generation from online source
- `./configure --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl`: generation of manpdocsages using the path given
- `./configure`: no docs will be generated

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>