### PR TITLE
Docbook: the lack of `--enable-manpages` option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,9 @@ include syslog-ng/Makefile.am
 include syslog-ng-ctl/Makefile.am
 include scripts/Makefile.am
 include tests/Makefile.am
+if ENABLE_MANPAGES
 include doc/Makefile.am
+endif
 include contrib/Makefile.am
 include scl/Makefile.am
 include debian/Makefile.am

--- a/configure.ac
+++ b/configure.ac
@@ -233,10 +233,10 @@ AC_ARG_WITH(docbook,
             AC_HELP_STRING([--with-docbook-dir=DIR],
                            [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net]),
             [ XSL_STYLESHEET=$with_docbook ],
-            [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/ ]
+            [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl ]
             )
 
-AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation of manpages (default: no)]), ,[ XSL_STYLESHEET=""])
+AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation of manpages (default: no)]), , [enable_manpages="no"; XSL_STYLESHEET=""])
 
 AC_ARG_ENABLE(java, [ --enable-java  Enable java destination (default: auto)],, enable_java="auto")
 
@@ -1393,6 +1393,7 @@ AM_CONDITIONAL(ENABLE_RIEMANN, [test "$enable_riemann" != "no"])
 AM_CONDITIONAL(ENABLE_JOURNALD, [test "$with_systemd_journal" != "no"])
 AM_CONDITIONAL(ENABLE_PYTHON, [test "$enable_python" != "no"])
 AM_CONDITIONAL(ENABLE_JAVA, [test "$enable_java" = "yes"])
+AM_CONDITIONAL(ENABLE_MANPAGES, [test "$enable_manpages" != "no"])
 
 # substitution into manual pages
 expanded_sysconfdir=[`patheval $sysconfdir | sed -e 's/-/\\\\-/g'`]


### PR DESCRIPTION
 caused `XSL_STYLESHEET` to be empty that's why build failed on Drone.io.

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>