### PR TITLE
python: fixed sngexample.py indentation

### DIFF
--- a/modules/python/sngexample.py
+++ b/modules/python/sngexample.py
@@ -1,15 +1,15 @@
 class LogDestination(object):
 
     def open(self):
-	"""Open a connection to the target service"""
+        """Open a connection to the target service"""
         return True
 
     def close(self):
-	"""Close the connection to the target service"""
+        """Close the connection to the target service"""
         pass
 
     def is_opened(self):
-	"""Check if the connection to the target is able to receive messages"""
+        """Check if the connection to the target is able to receive messages"""
         return True
 
     def init(self):
@@ -26,6 +26,7 @@ class LogDestination(object):
         It should return True to indicate success, False will suspend the
         destination for a period specified by the time-reopen() option."""
         pass
+
 
 class DummyPythonDest(LogDestination):
     def send(self, msg):


### PR DESCRIPTION
There are indentation problems in modules/python/sngexample.py file, because 3 lines are indented with tab instead of 4 spaces. This caused an error, when I tried to use this example file. This patch will fix this problem.

Signed-off-by: Botond Borsits <borsits.b@gmail.com>