### PR TITLE
3.6/f/docbook xsl enable option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 before_script:
   - ./autogen.sh
 script:
-  - ./configure --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct
+  - ./configure --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
   - make
   - make distcheck VERBOSE=1
   - make func-test VERBOSE=1

--- a/Makefile.am
+++ b/Makefile.am
@@ -112,7 +112,9 @@ include syslog-ng/Makefile.am
 include syslog-ng-ctl/Makefile.am
 include scripts/Makefile.am
 include tests/Makefile.am
+if ENABLE_MANPAGES
 include doc/Makefile.am
+endif
 include contrib/Makefile.am
 include scl/Makefile.am
 include debian/Makefile.am

--- a/configure.ac
+++ b/configure.ac
@@ -234,10 +234,10 @@ AC_ARG_WITH(docbook,
             AC_HELP_STRING([--with-docbook-dir=DIR],
                            [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net]),
             [ XSL_STYLESHEET=$with_docbook ],
-            [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/ ]
+            [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl ]
             )
 
-AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation of manpages (default: no)]), ,[ XSL_STYLESHEET=""])
+AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation of manpages (default: no)]), , [enable_manpages="no"; XSL_STYLESHEET=""])
 
 AC_ARG_ENABLE(all-modules,
               [  --enable-all-modules    Forcibly enable all modules. (default: auto)]
@@ -1370,6 +1370,7 @@ AM_CONDITIONAL(LIBMONGO_INTERNAL, [test "x$LIBMONGO_SUBDIRS" != "x"])
 AM_CONDITIONAL(LIBRABBITMQ_INTERNAL, [test "x$LIBRABBITMQ_SUBDIRS" != "x"])
 AM_CONDITIONAL(ENABLE_RIEMANN, [test "$enable_riemann" != "no"])
 AM_CONDITIONAL(ENABLE_JOURNALD, [test "$with_systemd_journal" != "no"])
+AM_CONDITIONAL(ENABLE_MANPAGES, [test "$enable_manpages" != "no"])
 
 # substitution into manual pages
 expanded_sysconfdir=[`patheval $sysconfdir | sed -e 's/-/\\\\-/g'`]

--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,15 @@ AC_ARG_WITH(systemd-journal,
                                          Link against the system supplied or the wrapper library. (default: auto)]
               ,,with_systemd_journal="auto")
 
+AC_ARG_WITH(docbook,
+            AC_HELP_STRING([--with-docbook-dir=DIR],
+                           [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net]),
+            [ XSL_STYLESHEET=$with_docbook ],
+            [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/ ]
+            )
+
+AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation of manpages (default: no)]), ,[ XSL_STYLESHEET=""])
+
 AC_ARG_ENABLE(all-modules,
               [  --enable-all-modules    Forcibly enable all modules. (default: auto)]
               ,,enable_all_modules="auto")
@@ -1415,6 +1424,8 @@ AC_SUBST(with_ivykis)
 AC_SUBST(INTERNAL_IVYKIS_CFLAGS)
 AC_SUBST(LIBSYSTEMD_JOURNAL_CFLAGS)
 AC_SUBST(LIBSYSTEMD_JOURNAL_LIBS)
+AC_SUBST(XSL_STYLESHEET)
+
 
 AC_OUTPUT(dist.conf
           Makefile

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -29,7 +29,6 @@ xsd_DATA	= \
 # NOTE: this uses a hard-coded path for the XSL stylesheets, but the
 # end-result is also included in the tarball. If so need be, this can
 # be overridden from the make command line or via the environment.
-XSL_STYLESHEET = /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
 
 sysconfdir_e = $(shell echo "${sysconfdir}" | sed -e "s,-,\\\\\\\\-,g")
 prefix_e = $(shell echo "${prefix}" | sed -e "s,-,\\\\\\\\-,g")


### PR DESCRIPTION
Backported docbook-xsl `--enable-manpages` from `3.7/master`.