### PR TITLE
F/debugger cli in python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
   - curl http://packages.madhouse-project.org/debian/add-release.sh | sudo sh
   - sudo apt-get update -qq
   - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev
+  - sudo pip install nose ply pep8 pylint
 before_script:
   - ./autogen.sh
 script:

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -53,7 +53,7 @@ _display_msg_details(Debugger *self, LogMessage *msg)
 {
   GString *output = g_string_sized_new(128);
 
-  log_msg_nv_table_foreach(msg->payload, _format_nvpair, NULL);
+  log_msg_values_foreach(msg, _format_nvpair, NULL);
   g_string_truncate(output, 0);
   log_msg_print_tags(msg, output);
   printf("TAGS=%s\n", output->str);

--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -581,7 +581,11 @@ log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handl
     log_msg_update_sdata(self, handle, name, name_len);
 }
 
-
+gboolean
+log_msg_values_foreach(LogMessage *self, NVTableForeachFunc func, gpointer user_data)
+{
+  return nv_table_foreach(self->payload, logmsg_registry, func, user_data);
+}
 
 void
 log_msg_set_match(LogMessage *self, gint index, const gchar *value, gssize value_len)
@@ -1095,7 +1099,7 @@ log_msg_merge_context(LogMessage *self, LogMessage **context, gsize context_len)
     {
       LogMessage *msg_to_be_merged = context[i];
 
-      log_msg_nv_table_foreach(msg_to_be_merged->payload, _merge_value, self);
+      log_msg_values_foreach(msg_to_be_merged, _merge_value, self);
     }
 }
 
@@ -1655,12 +1659,6 @@ const gchar *
 log_msg_get_handle_name(NVHandle handle, gssize *length)
 {
   return nv_registry_get_handle_name(logmsg_registry, handle, length);
-}
-
-gboolean
-log_msg_nv_table_foreach(NVTable *self, NVTableForeachFunc func, gpointer user_data)
-{
-  return nv_table_foreach(self, logmsg_registry, func, user_data);
 }
 
 void

--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -1645,6 +1645,12 @@ log_msg_registry_deinit(void)
 }
 
 void
+log_msg_registry_foreach(GHFunc func, gpointer user_data)
+{
+  nv_registry_foreach(logmsg_registry, func, user_data);
+}
+
+void
 log_msg_global_init(void)
 {
   log_msg_registry_init();

--- a/lib/logmsg.h
+++ b/lib/logmsg.h
@@ -299,5 +299,6 @@ void log_msg_registry_init();
 void log_msg_registry_deinit();
 void log_msg_global_init();
 void log_msg_global_deinit(void);
+void log_msg_registry_foreach(GHFunc func, gpointer user_data);
 
 #endif

--- a/lib/logmsg.h
+++ b/lib/logmsg.h
@@ -247,6 +247,7 @@ typedef gboolean (*LogMessageTagsForeachFunc)(LogMessage *self, LogTagId tag_id,
 
 void log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *new_value, gssize length);
 void log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
+gboolean log_msg_values_foreach(LogMessage *self, NVTableForeachFunc func, gpointer user_data);
 void log_msg_set_match(LogMessage *self, gint index, const gchar *value, gssize value_len);
 void log_msg_set_match_indirect(LogMessage *self, gint index, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
 void log_msg_clear_matches(LogMessage *self);
@@ -298,7 +299,5 @@ void log_msg_registry_init();
 void log_msg_registry_deinit();
 void log_msg_global_init();
 void log_msg_global_deinit(void);
-
-gboolean log_msg_nv_table_foreach(NVTable *self, NVTableForeachFunc func, gpointer user_data);
 
 #endif

--- a/lib/nvtable.c
+++ b/lib/nvtable.c
@@ -115,6 +115,12 @@ nv_registry_set_handle_flags(NVRegistry *self, NVHandle handle, guint16 flags)
   stored->flags = flags;
 }
 
+void
+nv_registry_foreach(NVRegistry *self, GHFunc callback, gpointer user_data)
+{
+  g_hash_table_foreach(self->name_map, callback, user_data);
+}
+
 NVRegistry *
 nv_registry_new(const gchar **static_names)
 {

--- a/lib/nvtable.h
+++ b/lib/nvtable.h
@@ -63,6 +63,7 @@ void nv_registry_add_alias(NVRegistry *self, NVHandle handle, const gchar *alias
 NVHandle nv_registry_get_handle(NVRegistry *self, const gchar *name);
 NVHandle nv_registry_alloc_handle(NVRegistry *self, const gchar *name);
 void nv_registry_set_handle_flags(NVRegistry *self, NVHandle handle, guint16 flags);
+void nv_registry_foreach(NVRegistry *self, GHFunc callback, gpointer user_data);
 NVRegistry *nv_registry_new(const gchar **static_names);
 void nv_registry_free(NVRegistry *self);
 

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -36,6 +36,7 @@
 
 #include <amqp.h>
 #include <amqp_framing.h>
+#include <amqp_tcp_socket.h>
 
 typedef struct
 {
@@ -261,7 +262,7 @@ afamqp_is_ok(AMQPDestDriver *self, gchar *context, amqp_rpc_reply_t ret)
 
     case AMQP_RESPONSE_LIBRARY_EXCEPTION:
       {
-        gchar *errstr = amqp_error_string2(ret.library_error);
+        const gchar *errstr = amqp_error_string2(ret.library_error);
         msg_error(context,
                   evt_tag_str("driver", self->super.super.super.id),
                   evt_tag_str("error", errstr),
@@ -353,7 +354,7 @@ afamqp_dd_connect(AMQPDestDriver *self, gboolean reconnect)
 
   if (sockfd_ret != AMQP_STATUS_OK)
     {
-      gchar *errstr = amqp_error_string2(-sockfd_ret);
+      const gchar *errstr = amqp_error_string2(-sockfd_ret);
       msg_error("Error connecting to AMQP server",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("error", errstr),
@@ -402,7 +403,6 @@ afamqp_dd_connect(AMQPDestDriver *self, gboolean reconnect)
     amqp_channel_close(self->conn, 1, AMQP_REPLY_SUCCESS);
   exception_amqp_dd_connect_failed_channel:
 
-  exception_amqp_dd_connect_failed_login:
     amqp_connection_close(self->conn, AMQP_REPLY_SUCCESS);
   exception_amqp_dd_connect_failed_init:
     _amqp_connection_deinit(self);

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -3,9 +3,11 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
 	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
+	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
 	modules/python/pylib/setup.py
 
 PYLIB_PATH = modules/python/pylib

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -4,11 +4,13 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/commandlinelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
+	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
 	modules/python/pylib/setup.py
 

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -11,6 +11,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
+	modules/python/pylib/syslogng/debuggercli/templatelang.py		\
 ,	modules/python/pylib/syslogng/debuggercli/templatelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -7,6 +7,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/completerlang.py		\
 	modules/python/pylib/syslogng/debuggercli/debuglang.py			\
 	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
+	modules/python/pylib/syslogng/debuggercli/langcompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -1,6 +1,8 @@
 EXTRA_DIST += \
 	modules/python/pylib/syslogng/__init__.py				\
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
+	modules/python/pylib/syslogng/debuggercli/completer.py			\
+	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/setup.py
 
 PYLIB_PATH = modules/python/pylib

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -11,6 +11,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
+,	modules/python/pylib/syslogng/debuggercli/templatelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py	\
@@ -18,6 +19,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
 	modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py	\
 	modules/python/pylib/setup.py
 
 PYLIB_PATH = modules/python/pylib

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -25,7 +25,8 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
 	modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py	\
-	modules/python/pylib/setup.py
+	modules/python/pylib/setup.py						\
+	modules/python/pylib/pylintrc
 
 PYLIB_PATH = modules/python/pylib
 PYLIB_BUILDDIR = $(abs_builddir)/$(PYLIB_PATH)
@@ -39,8 +40,6 @@ CLEAN_HOOKS += clean-pylib
 
 .PHONY: install-pylib
 install-pylib:
-
-
 	(cd $(PYLIB_SRCDIR) && $(PYTHON) setup.py \
 		build --build-base="$(PYLIB_BUILDDIR)/build" \
 		install --record=$(SETUPPY_MANIFEST) --root="$(PYTHON_ROOT)" --prefix="$(prefix)")
@@ -54,3 +53,27 @@ uninstall-pylib:
 clean-pylib:
 	rm -rf "$(PYLIB_BUILDDIR)/build"
 	rm -rf "$(SETUPPY_MANIFEST)"
+
+
+.PHONY: python-checks python-unit python-pep8 python-pylint
+python-checks: python-unit python-pep8 python-pylint
+
+python-unit:
+	nosetests $(PYLIB_SRCDIR)/syslogng
+
+python-pep8:
+	pep8 --ignore=E501 $(PYLIB_SRCDIR)/syslogng
+
+python-pylint:
+	pylint -r n --rcfile=$(PYLIB_SRCDIR)/pylintrc $(PYLIB_SRCDIR)/syslogng
+
+modules_python_pylib_TESTS = modules/python/pylib/test_pylib
+
+check_PROGRAMS += $(modules_python_pylib_TESTS)
+
+modules/python/pylib/test_pylib$(EXEEXT): Makefile
+	mkdir -p modules/python/pylib
+	echo "$(MAKE) MAKEFLAGS= python-checks" > "$@"
+	chmod +x "$@"
+
+modules_python_pylib_test_pylib_SOURCES = modules/python/pylib/test_pylib$(EXEEXT)

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -4,12 +4,14 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/commandlinelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
+	modules/python/pylib/syslogng/debuggercli/completerlang.py		\
 	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -2,10 +2,12 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/__init__.py				\
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
 	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
+	modules/python/pylib/syslogng/debuggercli/commandlinelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
 	modules/python/pylib/setup.py

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -3,6 +3,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
 	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
+	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
 	modules/python/pylib/setup.py

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -11,6 +11,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/langcompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
+	modules/python/pylib/syslogng/debuggercli/readline.py			\
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
 	modules/python/pylib/syslogng/debuggercli/templatelang.py		\
 ,	modules/python/pylib/syslogng/debuggercli/templatelexer.py		\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/commandlinelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
 	modules/python/pylib/syslogng/debuggercli/completerlang.py		\
+	modules/python/pylib/syslogng/debuggercli/debuglang.py			\
 	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -7,11 +7,13 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
+	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
+	modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py	\
 	modules/python/pylib/setup.py
 
 PYLIB_PATH = modules/python/pylib

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
 	modules/python/pylib/syslogng/debuggercli/completerlang.py		\
 	modules/python/pylib/syslogng/debuggercli/debuglang.py			\
+	modules/python/pylib/syslogng/debuggercli/debuggercli.py		\
 	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
 	modules/python/pylib/syslogng/debuggercli/langcompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
@@ -18,6 +19,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_debuggercli.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
 	modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py	\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -1,8 +1,10 @@
 EXTRA_DIST += \
 	modules/python/pylib/syslogng/__init__.py				\
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
+	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/completer.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
 	modules/python/pylib/setup.py
 
 PYLIB_PATH = modules/python/pylib

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
 	modules/python/pylib/syslogng/debuggercli/templatelang.py		\
 ,	modules/python/pylib/syslogng/debuggercli/templatelexer.py		\
+	modules/python/pylib/syslogng/debuggercli/tflang.py			\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py	\

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -11,20 +11,28 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/langcompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\
 	modules/python/pylib/syslogng/debuggercli/lexertoken.py			\
+	modules/python/pylib/syslogng/debuggercli/macrocompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/readline.py			\
+	modules/python/pylib/syslogng/debuggercli/syslognginternals.py		\
 	modules/python/pylib/syslogng/debuggercli/tablexer.py			\
 	modules/python/pylib/syslogng/debuggercli/templatelang.py		\
-,	modules/python/pylib/syslogng/debuggercli/templatelexer.py		\
+	modules/python/pylib/syslogng/debuggercli/templatelexer.py		\
 	modules/python/pylib/syslogng/debuggercli/tflang.py			\
+	modules/python/pylib/syslogng/debuggercli/tests/__init__.py		\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completer.py    	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_debuglang.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_debuggercli.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_langcompleter.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py		\
+	modules/python/pylib/syslogng/debuggercli/tests/test_macrocompleter.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py	\
 	modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_templatelang.py	\
+	modules/python/pylib/syslogng/debuggercli/tests/test_tflang.py		\
 	modules/python/pylib/setup.py						\
 	modules/python/pylib/pylintrc
 

--- a/modules/python/pylib/pylintrc
+++ b/modules/python/pylib/pylintrc
@@ -1,0 +1,300 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=.git,doc,
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#disable=
+
+disable=C0111,W0613,R0903,I0011,W0142,E1101,R0921,R0922,R0801,C0330
+
+# C0111     missing-docstring       Our priority is to make the code document
+#                                   itself. Docstring is required only when
+#                                   the signature is not enough to tell
+#                                   everything important.
+#
+# C0330
+#
+# W0613     unused-argument         Methods of test doubles, for example stubs,
+#                                   often return canned values, not using any
+#                                   of their arguments.
+#
+# R0903     too-few-public-methods  Node classes often have no methods at all.
+#
+# I0011     locally-disabled        Disabling a Pylint warning is always the
+#                                   result of a decision, no additional notification
+#                                   is required to tell us what we did.
+#
+# W0142     star-args               Using * or ** is not magic, rather it is a very
+#                                   useful Python feature.
+#
+# E1101     no-member               Gives false positives on numpy dynamic module
+#                                   functions.
+#
+# R0921     abstract-class-not-used Due to a pylint bug (#111138), this cannot be
+#                                   disabled inline. The warning itself is invalid,
+#                                   as the class is used by addons, which is not
+#                                   visible to pylint.
+#
+# R0922     abstract-class-little-used Probably due to a pylint bug, this cannot be
+#                                   disabled inline. The warning itself is invalid,
+#                                   as the class is used by addons, which is not
+#                                   visible to pylint.
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+#output-format=parseable
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=5
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the beginning of the name of dummy variables
+# (i.e. not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input
+
+# Regular expression which should only match correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match correct module level names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression which should only match correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match correct function names
+# Private and Protected functions are allowed to have nice explanatory names
+function-rgx=(([a-z][a-z0-9_]{2,30})|(__?[a-z_0-9]{2,70})|(_?[a-z_0-9]{2,70}))$
+
+# Regular expression which should only match correct method names
+# Private and Protected methods and BDD-style xUnit test methods and data_provider methods
+# are allowed to have nice explanatory names
+method-rgx=((_?[a-z][a-z0-9_]{2,70})|((__|provide_)[a-z_0-9]{2,70})|(test[a-z0-9_]{2,100}))$
+
+# Regular expression which should only match correct instance attribute names
+# Private instance attribute names are allowed to have nice explanatory names
+# The unittest module uses camelCase for some useful properties, they are allowed
+attr-rgx=((_?[a-z][a-z0-9_]{1,50})|(__[a-z_0-9]{2,70})|maxDiff)$
+
+# Regular expression which should only match correct argument names
+# Type annotated short argument names are okay
+argument-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-z_][a-z0-9_]{1,30}$
+
+# Regular expression which should only match correct attribute names in class
+# bodies
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{1,30}|(__.*__))$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_,f
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata,tmp,tmp2
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+# Classes inheriting from unittest.TestCase may have more than 50 methods
+max-public-methods=80
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/modules/python/pylib/setup.py
+++ b/modules/python/pylib/setup.py
@@ -8,5 +8,4 @@ setup(name='syslogng',
       author='Balazs Scheidler',
       author_email='balazs.scheidler@balabit.com',
       url='https://www.syslog-ng.org',
-      packages=['syslogng', 'syslogng.debuggercli'],
-     )
+      packages=['syslogng', 'syslogng.debuggercli'])

--- a/modules/python/pylib/syslogng/debuggercli/__init__.py
+++ b/modules/python/pylib/syslogng/debuggercli/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
-import readline
+from syslogng.debuggercli.readline import setup_readline
 
 
 def fetch_command():
+    setup_readline()
     return raw_input("(syslog-ng) ")

--- a/modules/python/pylib/syslogng/debuggercli/choicecompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/choicecompleter.py
@@ -30,8 +30,5 @@ class ChoiceCompleter(Completer):
     def _chop_prefixes(self, entire_input, word_to_be_completed):
         if word_to_be_completed == entire_input:
             word_to_be_completed = word_to_be_completed[len(self._prefix):]
-            self._completing_at_the_beginning_of_the_grammar = True
-        else:
-            self._completing_at_the_beginning_of_the_grammar = False
         entire_input = entire_input[len(self._prefix):]
         return entire_input, word_to_be_completed

--- a/modules/python/pylib/syslogng/debuggercli/choicecompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/choicecompleter.py
@@ -1,0 +1,37 @@
+from __future__ import print_function, absolute_import
+from .completer import Completer
+
+
+class ChoiceCompleter(Completer):
+    def __init__(self, choices, prefix=None, suffix=None):
+        self._choices = choices
+        self._prefix = prefix or ''
+        self._suffix = suffix if suffix is not None else ' '
+
+    def complete(self, entire_input, word_to_be_completed):
+        if entire_input.startswith(self._prefix):
+            return self._handle_input_with_prefix(entire_input, word_to_be_completed)
+        else:
+            return self._handle_input_without_prefix(entire_input)
+
+    def _handle_input_without_prefix(self, entire_input):
+        if self._prefix.startswith(entire_input) or entire_input == '':
+            return [self._prefix]
+        else:
+            return []
+
+    def _handle_input_with_prefix(self, entire_input, word_to_be_completed):
+        entire_input, word_to_be_completed = self._chop_prefixes(entire_input, word_to_be_completed)
+
+        return sorted([self._prefix + choice + self._suffix
+                       for choice in self._choices
+                       if len(word_to_be_completed) == 0 or choice.startswith(word_to_be_completed)])
+
+    def _chop_prefixes(self, entire_input, word_to_be_completed):
+        if word_to_be_completed == entire_input:
+            word_to_be_completed = word_to_be_completed[len(self._prefix):]
+            self._completing_at_the_beginning_of_the_grammar = True
+        else:
+            self._completing_at_the_beginning_of_the_grammar = False
+        entire_input = entire_input[len(self._prefix):]
+        return entire_input, word_to_be_completed

--- a/modules/python/pylib/syslogng/debuggercli/commandlinelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/commandlinelexer.py
@@ -11,10 +11,15 @@ class CommandLineLexer(Lexer):
     """This an inperfect lexer for both the debug language and template functions"""
     def __init__(self):
         self._tokens = []
+        self._input = ''
         self._current_token = 0
+        self._current_state = CLL_NORMAL
+        self._paren_balance = 0
+        self._current_position = 0
+        self._quote_open_character = ''
 
-    def input(self, input):
-        self._input = input
+    def input(self, text):
+        self._input = text
         self._current_position = 0
         self._current_state = CLL_NORMAL
         self._paren_balance = 0

--- a/modules/python/pylib/syslogng/debuggercli/commandlinelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/commandlinelexer.py
@@ -1,0 +1,111 @@
+from __future__ import print_function, absolute_import
+from .lexertoken import LexerToken
+from .lexer import Lexer
+
+CLL_NORMAL = 0
+CLL_QUOTED_STRING = 1
+CLL_QUOTED_CHAR = 2
+
+
+class CommandLineLexer(Lexer):
+    """This an inperfect lexer for both the debug language and template functions"""
+    def __init__(self):
+        self._tokens = []
+        self._current_token = 0
+
+    def input(self, input):
+        self._input = input
+        self._current_position = 0
+        self._current_state = CLL_NORMAL
+        self._paren_balance = 0
+
+    def token(self):
+        token = self._get_next_token()
+        return token
+
+    def get_position(self):
+        return self._current_position
+
+    def _get_next_token(self):
+        self._skip_whitespace()
+        self._current_token = ''
+        self._paren_balance = 0
+        start_position = self._current_position
+        token = None
+
+        while self._current_position < len(self._input):
+            current_char = self._input[self._current_position]
+
+            if self._current_state == CLL_NORMAL:
+                token = self._process_normal_character(current_char)
+            elif self._current_state == CLL_QUOTED_STRING:
+                token = self._process_string_character(current_char)
+            elif self._current_state == CLL_QUOTED_CHAR:
+                token = self._process_escaped_character(current_char)
+
+            self._current_position += 1
+            if token is not None:
+                return token
+
+        if start_position != self._current_position:
+            partial = False
+            if self._current_state != CLL_NORMAL:
+                partial = True
+            if self._paren_balance != 0:
+                partial = True
+            return LexerToken('ARG', value=self._current_token, partial=partial, lexpos=start_position)
+
+    def _skip_whitespace(self):
+        while self._current_position < len(self._input) and self._input[self._current_position].isspace():
+            self._current_position += 1
+
+    def _process_normal_character(self, current_char):
+        if current_char == '"' or current_char == "'":
+            return self._open_quoted_string(current_char)
+        elif current_char.isspace():
+            return self._close_current_token(current_char)
+        elif current_char == '(':
+            return self._open_paren(current_char)
+        elif current_char == ')':
+            return self._close_paren(current_char)
+        else:
+            self._current_token += current_char
+
+    def _open_paren(self, current_char):
+        self._paren_balance += 1
+        self._current_token += current_char
+
+    def _close_paren(self, current_char):
+        self._paren_balance -= 1
+        if self._paren_balance <= 0:
+            self._current_token += current_char
+            return LexerToken('ARG', value=self._current_token)
+        self._current_token += current_char
+
+    def _close_current_token(self, current_char):
+        if self._paren_balance == 0:
+            return LexerToken('ARG', value=self._current_token)
+        self._current_token += current_char
+
+    def _process_string_character(self, current_char):
+        if current_char == '\\':
+            self._current_state = CLL_QUOTED_CHAR
+        elif current_char == self._quote_open_character:
+            self._close_quoted_string(current_char)
+        else:
+            self._current_token += current_char
+
+    def _process_escaped_character(self, current_char):
+        self._current_token += current_char
+        self._current_state = CLL_QUOTED_STRING
+
+    def _open_quoted_string(self, current_char):
+        self._quote_open_character = current_char
+        self._current_state = CLL_QUOTED_STRING
+        if self._paren_balance > 0:
+            self._current_token += current_char
+
+    def _close_quoted_string(self, current_char):
+        if self._paren_balance > 0:
+            self._current_token += current_char
+        self._current_state = CLL_NORMAL

--- a/modules/python/pylib/syslogng/debuggercli/completer.py
+++ b/modules/python/pylib/syslogng/debuggercli/completer.py
@@ -1,0 +1,11 @@
+from __future__ import print_function, absolute_import
+from abc import abstractmethod, ABCMeta
+
+
+class Completer(object):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def complete(self, entire_text, word_to_be_completed):
+        """Function to return the list of potential completion for a word"""
+        raise NotImplementedError

--- a/modules/python/pylib/syslogng/debuggercli/completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/completerlang.py
@@ -15,7 +15,7 @@ class CompleterLang(object):
 
     def __init__(self):
         self._initialize_rules()
-        self._parser = yacc.yacc(module=self, write_tables=False)
+        self._parser = yacc.yacc(module=self, write_tables=False, debug=False, errorlog=yacc.NullLogger())
         self._lexer = TabLexer(self._construct_lexer())
         self._expected_tokens = []
         self._token_position = -1

--- a/modules/python/pylib/syslogng/debuggercli/completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/completerlang.py
@@ -27,9 +27,9 @@ class CompleterLang(object):
     def _initialize_rules(self):
         pass
 
-    def get_expected_tokens(self, input, drop_last_token):
+    def get_expected_tokens(self, text, drop_last_token):
         self._lexer.set_drop_last_token(drop_last_token)
-        self._parser.parse(input, lexer=self._lexer)
+        self._parser.parse(text, lexer=self._lexer)
         return self._expected_tokens, self._lexer.get_replaced_token(), self._token_position
 
     def p_error(self, p):
@@ -47,6 +47,7 @@ class CompleterLang(object):
             # this is the very function that is close enough to the caller, moving this information
             # deeper would probably improve readability at the cost of increasing fragility.
 
+            # pylint: disable=protected-access
             parser_state = sys._getframe(1).f_locals['state']
 
             # now handle the error that the TAB token caused
@@ -78,7 +79,7 @@ class CompleterLang(object):
                 self._collect_expected_productions(next_state)
 
     def _collect_expected_productions(self, state):
-        for token, next_state in self._iter_parser_actions(state):
+        for _, next_state in self._iter_parser_actions(state):
             if next_state < 0:
                 # production shift, we care about production shifts which would translate the
                 # next_state token
@@ -89,7 +90,8 @@ class CompleterLang(object):
     def _iter_parser_actions(self, parser_state):
         return self._parser.action[parser_state].items()
 
-    def _are_we_shifting_a_production(self, state):
+    @staticmethod
+    def _are_we_shifting_a_production(state):
         return state < 0
 
     def _shift_production(self, production, token):

--- a/modules/python/pylib/syslogng/debuggercli/completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/completerlang.py
@@ -1,0 +1,117 @@
+from __future__ import print_function, absolute_import
+import ply.yacc as yacc
+import sys
+from .tablexer import TabLexer
+from abc import abstractmethod, ABCMeta
+
+
+class CompleterLang(object):
+    """Class encapsulating a language (or grammar) used by tab completion
+
+    Derived classes should define their ply.yacc rules in their body, which is
+    then translated at instantiation time.
+    """
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        self._initialize_rules()
+        self._parser = yacc.yacc(module=self, write_tables=False)
+        self._lexer = TabLexer(self._construct_lexer())
+        self._expected_tokens = []
+        self._token_position = -1
+
+    @abstractmethod
+    def _construct_lexer(self):
+        raise NotImplementedError
+
+    def _initialize_rules(self):
+        pass
+
+    def get_expected_tokens(self, input, drop_last_token):
+        self._lexer.set_drop_last_token(drop_last_token)
+        self._parser.parse(input, lexer=self._lexer)
+        return self._expected_tokens, self._lexer.get_replaced_token(), self._token_position
+
+    def p_error(self, p):
+        if p is None:
+            # EOF
+            return None
+        elif p.type == 'TAB':
+            # We look up the current grammar state from the local variables of the caller,
+            # as it doesn't publish this information in self.
+            #
+            # This is somewhat fragile, however I don't really expect this variable to change
+            # too frequently.
+            #
+            # I don't want to hide this call within the _handle_injected_tab_token() call, as
+            # this is the very function that is close enough to the caller, moving this information
+            # deeper would probably improve readability at the cost of increasing fragility.
+
+            parser_state = sys._getframe(1).f_locals['state']
+
+            # now handle the error that the TAB token caused
+            self._token_position = p.lexpos
+            self._collect_expected_tokens_and_productions(parser_state)
+            self._parser.errok()
+
+    def _collect_expected_tokens_and_productions(self, parser_state):
+        self._expected_tokens = []
+        self._collect_expected_tokens_for_a_given_state(parser_state)
+
+    def _collect_expected_tokens_for_a_given_state(self, state):
+        for token, next_state in self._iter_parser_actions(state):
+            if token != '$end':
+                self._expected_tokens.append(token)
+
+            next_state = self._shift_production_if_needed(next_state, token)
+
+            # negative next_state value means one of two things:
+            #
+            #    1) there's a syntax error and the current token does not match
+            #       the rule we are evaluating right now
+            #
+            #    2) this token would trigger another rule shift, which we don't
+            #       support right now.
+            #
+
+            if next_state >= 0:
+                self._collect_expected_productions(next_state)
+
+    def _collect_expected_productions(self, state):
+        for token, next_state in self._iter_parser_actions(state):
+            if next_state < 0:
+                # production shift, we care about production shifts which would translate the
+                # next_state token
+                production = self._lookup_production(next_state)
+                if production.len and production.name not in self._expected_tokens:
+                    self._expected_tokens.append(production.name)
+
+    def _iter_parser_actions(self, parser_state):
+        return self._parser.action[parser_state].items()
+
+    def _are_we_shifting_a_production(self, state):
+        return state < 0
+
+    def _shift_production(self, production, token):
+        translated_state = self._get_target_state_after_shifting_production(production)
+        try:
+            # this might be negative (e.g. indicate a production shift).
+            return self._parser.action[self._parser.goto[translated_state][production.name]][token]
+        except KeyError:
+            # this indicates a syntax error, the current token
+            # does not match any rules where this production
+            # is referenced from
+            return -1
+
+    def _shift_production_if_needed(self, state, token):
+        if self._are_we_shifting_a_production(state):
+            production = self._lookup_production(state)
+            return self._shift_production(production, token)
+        else:
+            return state
+
+    def _lookup_production(self, state):
+        return self._parser.productions[-state]
+
+    def _get_target_state_after_shifting_production(self, production):
+        return self._parser.statestack[-production.len - 1]

--- a/modules/python/pylib/syslogng/debuggercli/debuggercli.py
+++ b/modules/python/pylib/syslogng/debuggercli/debuggercli.py
@@ -18,7 +18,8 @@ class DebuggerCLI(object):
         self.tflang_completers['name_value_name'] = ChoiceCompleter(get_nv_registry())
         self.tflang_completers['value_pairs_scope'] = ChoiceCompleter(get_value_pairs_scopes())
         self.tflang_completers['OPT'] = ChoiceCompleter(TemplateFunctionLang.known_options)
-        self.tflang_completers['template'] = LangBasedCompleter(parser=TemplateLang(), completers=self.template_completers)
+        self.tflang_completers['template'] = LangBasedCompleter(parser=TemplateLang(),
+                                                                completers=self.template_completers)
 
     def _setup_template_completers(self):
         self.template_completers['MACRO'] = MacroCompleter()

--- a/modules/python/pylib/syslogng/debuggercli/debuggercli.py
+++ b/modules/python/pylib/syslogng/debuggercli/debuggercli.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, print_function
+from .langcompleter import LangBasedCompleter
+from .debuglang import DebugLang
+from .templatelang import TemplateLang
+from .tflang import TemplateFunctionLang
+from .choicecompleter import ChoiceCompleter
+from .macrocompleter import MacroCompleter
+from .syslognginternals import get_debugger_commands, get_template_functions, get_nv_registry, get_value_pairs_scopes
+
+
+class DebuggerCLI(object):
+    debug_completers = {}
+    template_completers = {}
+    tflang_completers = {}
+
+    def _setup_tflang_completers(self):
+        self.tflang_completers['COMMAND'] = ChoiceCompleter(get_template_functions())
+        self.tflang_completers['name_value_name'] = ChoiceCompleter(get_nv_registry())
+        self.tflang_completers['value_pairs_scope'] = ChoiceCompleter(get_value_pairs_scopes())
+        self.tflang_completers['OPT'] = ChoiceCompleter(TemplateFunctionLang.known_options)
+        self.tflang_completers['template'] = LangBasedCompleter(parser=TemplateLang(), completers=self.template_completers)
+
+    def _setup_template_completers(self):
+        self.template_completers['MACRO'] = MacroCompleter()
+        self.template_completers['TEMPLATE_FUNC'] = LangBasedCompleter(
+            parser=TemplateFunctionLang(),
+            completers=self.tflang_completers,
+            prefix="$(")
+
+    def _setup_debug_completers(self):
+        self.debug_completers['COMMAND'] = ChoiceCompleter(get_debugger_commands())
+        self.debug_completers['template'] = LangBasedCompleter(parser=TemplateLang(),
+                                                               completers=self.template_completers)
+
+    def get_root_completer(self):
+        self._setup_debug_completers()
+        self._setup_template_completers()
+        self._setup_tflang_completers()
+        return LangBasedCompleter(parser=DebugLang(),
+                                  completers=self.debug_completers)

--- a/modules/python/pylib/syslogng/debuggercli/debuglang.py
+++ b/modules/python/pylib/syslogng/debuggercli/debuglang.py
@@ -1,0 +1,53 @@
+from .completerlang import CompleterLang
+from .commandlinelexer import CommandLineLexer
+from .getoptlexer import GetoptLexer
+
+
+class DebugLang(CompleterLang):
+    # we only need to list commands we want to automatically complete arguments.
+    # Commands that have no arguments don't need to be listed as they wouldn't really
+    # have rules anyway.
+    _known_commands = (
+        "print",
+        "display",
+    )
+    _aliases = {
+        'p': 'print',
+    }
+    tokens = [
+        "COMMAND_PRINT", "COMMAND_DISPLAY",
+        "COMMAND",
+        "ARG",
+    ]
+
+    def p_statement(self, p):
+        '''statement : print_command
+                    | display_command
+                    | generic_command'''
+        pass
+
+    def p_args(self, p):
+        '''args : ARG args
+               | '''
+        pass
+
+    def p_print_command(self, p):
+        '''print_command : COMMAND_PRINT template'''
+        pass
+
+    def p_display_command(self, p):
+        '''display_command : COMMAND_DISPLAY template'''
+        pass
+
+    def p_generic_command(self, p):
+        '''generic_command : COMMAND args'''
+        pass
+
+    def p_template(self, p):
+        '''template : ARG'''
+        pass
+
+    def _construct_lexer(self):
+        return GetoptLexer(CommandLineLexer(),
+                           known_commands=self._known_commands,
+                           aliases=self._aliases)

--- a/modules/python/pylib/syslogng/debuggercli/getoptlexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/getoptlexer.py
@@ -10,8 +10,8 @@ class GetoptLexer(Lexer):
         self._known_options = known_options or {}
         self._aliases = aliases or {}
 
-    def input(self, input):
-        self._lexer.input(input)
+    def input(self, text):
+        self._lexer.input(text)
         self._current_token = 0
 
     def token(self):

--- a/modules/python/pylib/syslogng/debuggercli/getoptlexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/getoptlexer.py
@@ -1,0 +1,36 @@
+from __future__ import print_function, absolute_import
+from .lexer import Lexer
+
+
+class GetoptLexer(Lexer):
+    def __init__(self, lexer, known_commands, known_options=None, aliases=None):
+        self._lexer = lexer
+        self._current_token = 0
+        self._known_commands = known_commands
+        self._known_options = known_options or {}
+        self._aliases = aliases or {}
+
+    def input(self, input):
+        self._lexer.input(input)
+        self._current_token = 0
+
+    def token(self):
+        token = self._lexer.token()
+        if token is not None:
+            if self._current_token == 0:
+                translated_token = self._translate_alias(token.value)
+                if translated_token in self._known_commands:
+                    token.type = 'COMMAND_{}'.format(translated_token.upper().replace('-', '_'))
+                else:
+                    token.type = 'COMMAND'
+            else:
+                if token.value in self._known_options:
+                    token.type = "OPT{}".format(token.value.upper().replace('-', '_'))
+            self._current_token += 1
+        return token
+
+    def get_position(self):
+        return self._lexer.get_position()
+
+    def _translate_alias(self, token):
+        return self._aliases.get(token, token)

--- a/modules/python/pylib/syslogng/debuggercli/langcompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/langcompleter.py
@@ -1,0 +1,79 @@
+from __future__ import print_function, absolute_import
+from .completer import Completer
+
+
+class LangBasedCompleter(Completer):
+
+    def __init__(self, parser, completers, prefix=None):
+        self._parser = parser
+        self._completers = completers
+        self._prefix = prefix or ''
+
+    def complete(self, entire_input, word_to_be_completed):
+        if entire_input.startswith(self._prefix):
+            return self._handle_input_with_prefix(entire_input, word_to_be_completed)
+        else:
+            return self._handle_input_without_prefix(entire_input)
+
+    def _handle_input_without_prefix(self, entire_input):
+        if self._prefix.startswith(entire_input) or entire_input == '':
+            return [self._prefix]
+        else:
+            return []
+
+    def _handle_input_with_prefix(self, entire_input, word_to_be_completed):
+        entire_input, word_to_be_completed = self._chop_prefixes(entire_input, word_to_be_completed)
+        expected_tokens, last_token, completion_prefix, word_to_be_completed = self._evaluate_language(entire_input, word_to_be_completed)
+        completers = self._find_applicable_completers(expected_tokens)
+        completions = self._collect_completions(completers, last_token, completion_prefix, word_to_be_completed)
+        return completions
+
+    def _chop_prefixes(self, entire_input, word_to_be_completed):
+        if word_to_be_completed == entire_input:
+            word_to_be_completed = word_to_be_completed[len(self._prefix):]
+            self._completing_at_the_beginning_of_the_grammar = True
+        else:
+            self._completing_at_the_beginning_of_the_grammar = False
+        entire_input = entire_input[len(self._prefix):]
+        return entire_input, word_to_be_completed
+
+    def _evaluate_language(self, entire_input, word_to_be_completed):
+        expected_tokens, replaced_token, token_position = self._parser.get_expected_tokens(entire_input, drop_last_token=(word_to_be_completed != ''))
+
+        if token_position >= 0:
+            word_position = len(entire_input) - len(word_to_be_completed)
+            if word_position <= token_position:
+                completion_prefix = entire_input[word_position:token_position]
+                word_to_be_completed = entire_input[token_position:]
+            else:
+                completion_prefix = ''
+        else:
+            completion_prefix = ''
+
+        if replaced_token is None:
+            replaced_token = ''
+        else:
+            replaced_token = replaced_token.value or ''
+
+        return expected_tokens, replaced_token, completion_prefix, word_to_be_completed
+
+    def _find_applicable_completers(self, expected_tokens):
+        completers = []
+        for token in expected_tokens:
+            try:
+                completers.append(self._completers[token])
+            except KeyError:
+                pass
+        return completers
+
+    def _collect_completions(self, completers, last_token, completion_prefix, word_to_be_completed):
+        if self._completing_at_the_beginning_of_the_grammar:
+            prefix = self._prefix + completion_prefix
+        else:
+            prefix = completion_prefix
+        completions = []
+        for completer in completers:
+            completions.extend(
+                (prefix + completion for completion in completer.complete(last_token, word_to_be_completed)))
+        completions = sorted(completions)
+        return completions

--- a/modules/python/pylib/syslogng/debuggercli/langcompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/langcompleter.py
@@ -8,6 +8,7 @@ class LangBasedCompleter(Completer):
         self._parser = parser
         self._completers = completers
         self._prefix = prefix or ''
+        self._completing_at_the_beginning_of_the_grammar = False
 
     def complete(self, entire_input, word_to_be_completed):
         if entire_input.startswith(self._prefix):
@@ -23,7 +24,10 @@ class LangBasedCompleter(Completer):
 
     def _handle_input_with_prefix(self, entire_input, word_to_be_completed):
         entire_input, word_to_be_completed = self._chop_prefixes(entire_input, word_to_be_completed)
-        expected_tokens, last_token, completion_prefix, word_to_be_completed = self._evaluate_language(entire_input, word_to_be_completed)
+
+        expected_tokens, last_token, completion_prefix, word_to_be_completed = (
+            self._evaluate_language(entire_input, word_to_be_completed))
+
         completers = self._find_applicable_completers(expected_tokens)
         completions = self._collect_completions(completers, last_token, completion_prefix, word_to_be_completed)
         return completions
@@ -38,7 +42,8 @@ class LangBasedCompleter(Completer):
         return entire_input, word_to_be_completed
 
     def _evaluate_language(self, entire_input, word_to_be_completed):
-        expected_tokens, replaced_token, token_position = self._parser.get_expected_tokens(entire_input, drop_last_token=(word_to_be_completed != ''))
+        expected_tokens, replaced_token, token_position = (
+            self._parser.get_expected_tokens(entire_input, drop_last_token=(word_to_be_completed != '')))
 
         if token_position >= 0:
             word_position = len(entire_input) - len(word_to_be_completed)

--- a/modules/python/pylib/syslogng/debuggercli/lexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/lexer.py
@@ -1,0 +1,18 @@
+from __future__ import print_function, absolute_import
+from abc import ABCMeta, abstractmethod
+
+
+class Lexer(object):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def token(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def input(self, input):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_position(self):
+        raise NotImplementedError

--- a/modules/python/pylib/syslogng/debuggercli/lexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/lexer.py
@@ -10,7 +10,7 @@ class Lexer(object):
         raise NotImplementedError
 
     @abstractmethod
-    def input(self, input):
+    def input(self, text):
         raise NotImplementedError
 
     @abstractmethod

--- a/modules/python/pylib/syslogng/debuggercli/lexertoken.py
+++ b/modules/python/pylib/syslogng/debuggercli/lexertoken.py
@@ -1,0 +1,11 @@
+from __future__ import print_function, absolute_import
+import ply.lex
+
+
+class LexerToken(ply.lex.LexToken):
+    def __init__(self, type, value=None, partial=False, lexpos=-1):
+        self.type = type
+        self.value = value
+        self.partial = partial
+        self.lineno = 0
+        self.lexpos = lexpos

--- a/modules/python/pylib/syslogng/debuggercli/lexertoken.py
+++ b/modules/python/pylib/syslogng/debuggercli/lexertoken.py
@@ -3,6 +3,7 @@ import ply.lex
 
 
 class LexerToken(ply.lex.LexToken):
+    # pylint: disable=redefined-builtin
     def __init__(self, type, value=None, partial=False, lexpos=-1):
         self.type = type
         self.value = value

--- a/modules/python/pylib/syslogng/debuggercli/macrocompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/macrocompleter.py
@@ -1,0 +1,182 @@
+from __future__ import absolute_import, print_function
+from .completer import Completer
+from .syslognginternals import get_nv_registry
+
+
+class MacroCompleter(Completer):
+    _date_wildcards = {
+        'R_': 'received time',
+        'S_': 'stamp in message',
+        'C_': 'current time'
+    }
+
+    def __init__(self, macros=None):
+        super(MacroCompleter, self).__init__()
+        self._macros = macros
+        self._completions = []
+
+    def complete(self, entire_input, word):
+        if not self._looks_like_a_macro_prefix(entire_input):
+            return []
+        self._collect_completions(word)
+        return sorted([completion
+                       for completion in self._completions
+                       if len(word) == 0 or completion.startswith(word)])
+
+    def _looks_like_a_macro_prefix(self, entire_input):
+        if entire_input == '':
+            return True
+        if entire_input == '$':
+            return True
+        if entire_input[0] == '$' and self._is_valid_macro(entire_input[1:]):
+            return True
+        if entire_input == '${':
+            return True
+        if entire_input[:2] == '${':
+            return True
+        return False
+
+    def _is_valid_macro(self, macro):
+        return all(map(self._is_valid_macro_char, macro))
+
+    def _is_valid_macro_char(self, macro_char):
+        if macro_char >= 'A' and macro_char <= 'Z':
+            return True
+        if macro_char >= 'a' and macro_char <= 'z':
+            return True
+        if macro_char >= '0' and macro_char <= '9':
+            return True
+        if macro_char == '_':
+            return True
+        return False
+
+    def _collect_completions(self, word):
+        self._reset_completions()
+        if word == '':
+            self._add_completion('$')
+            self._add_completion('${')
+        elif word == '$':
+            self._extend_completions(self._collect_unqualified_macros())
+            self._extend_completions(self._collect_qualified_macros_with_brace())
+            self._extend_completions(self._collect_small_numbered_matches())
+            self._extend_completions(self._collect_date_wildcards())
+            self._add_completion('${')
+        elif self._is_word_a_numbered_match_prefix(word):
+            self._extend_completions(self._collect_all_numbered_matches())
+        elif self._is_word_a_nonbraced_prefix(word):
+            if self._is_word_a_date_prefix(word):
+                self._extend_completions(self._collect_date_macros())
+            else:
+                self._extend_completions(self._collect_unqualified_macros())
+                self._extend_completions(self._collect_date_wildcards())
+        elif word == '${':
+            self._extend_completions(self._collect_small_numbered_matches_with_brace())
+            self._extend_completions(self._collect_all_macros_with_brace())
+            self._extend_completions(self._collect_date_wildcard_with_brace())
+        elif self._is_word_a_numbered_match_prefix_with_brace(word):
+            self._extend_completions(self._collect_all_numbered_matches_with_brace())
+        elif self._is_word_a_braced_prefix(word):
+            if self._is_word_a_date_prefix_with_brace(word):
+                self._extend_completions(self._collect_date_macros_with_brace())
+            else:
+                self._extend_completions(self._collect_all_macros_with_brace())
+                self._extend_completions(self._collect_date_wildcard_with_brace())
+
+        return self._completions
+
+    def _is_word_a_date_prefix(self, word):
+        return word[:3] in map(lambda x: '$' + x, self._date_wildcards.keys())
+
+    def _is_word_a_numbered_match_prefix(self, word):
+        return word[0] == '$' and word[1:2].isdigit()
+
+    def _is_word_a_nonbraced_prefix(self, word):
+        return word[0] == '$' and word[1] != '{'
+
+    def _is_word_a_numbered_match_prefix_with_brace(self, word):
+        return word[0:2] == '${' and word[2:3].isdigit()
+
+    def _is_word_a_date_prefix_with_brace(self, word):
+        return word[:4] in map(lambda x: '${' + x, self._date_wildcards.keys())
+
+    def _is_word_a_braced_prefix(self, word):
+        return word[0:2] == '${'
+
+    @staticmethod
+    def _is_macro_qualified(macro):
+        return '.' in macro
+
+    @classmethod
+    def _is_macro_unqualified(cls, macro):
+        return (not cls._is_macro_qualified(macro) and
+                not cls._is_macro_a_numbered_match(macro) and
+                not cls._is_macro_a_date_macro(macro))
+
+    @staticmethod
+    def _is_macro_a_numbered_match(macro):
+        return macro.isdigit()
+
+    @staticmethod
+    def _is_macro_a_date_macro(macro):
+        return macro[0:2] in {'R_', 'S_', 'C_'}
+
+    @classmethod
+    def _is_macro_a_small_numbered_match(cls, macro):
+        return cls._is_macro_a_numbered_match(macro) and int(macro) < 10
+
+    def _collect_macros_generic(self, predicate, format):
+        for macro in self._macros or get_nv_registry():
+            if predicate(macro):
+                yield format.format(macro)
+
+    def _collect_macros(self, predicate):
+        return self._collect_macros_generic(predicate, '${}')
+
+    def _collect_macros_with_brace(self, predicate):
+        return self._collect_macros_generic(predicate, '${{{}}}')
+
+    def _collect_unqualified_macros(self):
+        return self._collect_macros(self._is_macro_unqualified)
+
+    def _collect_qualified_macros_with_brace(self):
+        return self._collect_macros_with_brace(self._is_macro_qualified)
+
+    def _collect_date_macros(self):
+        return self._collect_macros(self._is_macro_a_date_macro)
+
+    def _collect_date_macros_with_brace(self):
+        return self._collect_macros_with_brace(self._is_macro_a_date_macro)
+
+    def _collect_small_numbered_matches(self):
+        return self._collect_macros(self._is_macro_a_small_numbered_match)
+
+    def _collect_small_numbered_matches_with_brace(self):
+        return self._collect_macros_with_brace(self._is_macro_a_small_numbered_match)
+
+    def _collect_all_numbered_matches(self):
+        return self._collect_macros(self._is_macro_a_numbered_match)
+
+    def _collect_all_numbered_matches_with_brace(self):
+        return self._collect_macros_with_brace(self._is_macro_a_numbered_match)
+
+    def _collect_all_macros_with_brace(self):
+        return self._collect_macros_with_brace(
+            lambda macro: (not self._is_macro_a_numbered_match(macro) and
+                           not self._is_macro_a_date_macro(macro)))
+
+    def _collect_date_wildcards(self):
+        for (wildcard, description) in self._date_wildcards.items():
+            yield '${}* ({})'.format(wildcard, description)
+
+    def _collect_date_wildcard_with_brace(self):
+        for (wildcard, description) in self._date_wildcards.items():
+            yield '${{{}*}} ({})'.format(wildcard, description)
+
+    def _reset_completions(self):
+        self._completions = []
+
+    def _extend_completions(self, iterable):
+        self._completions.extend(iterable)
+
+    def _add_completion(self, value):
+        self._completions.append(value)

--- a/modules/python/pylib/syslogng/debuggercli/macrocompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/macrocompleter.py
@@ -37,9 +37,10 @@ class MacroCompleter(Completer):
         return False
 
     def _is_valid_macro(self, macro):
-        return all(map(self._is_valid_macro_char, macro))
+        return all(self._is_valid_macro_char(c) for c in macro)
 
-    def _is_valid_macro_char(self, macro_char):
+    @staticmethod
+    def _is_valid_macro_char(macro_char):
         if macro_char >= 'A' and macro_char <= 'Z':
             return True
         if macro_char >= 'a' and macro_char <= 'z':
@@ -85,21 +86,25 @@ class MacroCompleter(Completer):
         return self._completions
 
     def _is_word_a_date_prefix(self, word):
-        return word[:3] in map(lambda x: '$' + x, self._date_wildcards.keys())
+        return word[:3] in ['$' + x for x in self._date_wildcards.keys()]
 
-    def _is_word_a_numbered_match_prefix(self, word):
+    @staticmethod
+    def _is_word_a_numbered_match_prefix(word):
         return word[0] == '$' and word[1:2].isdigit()
 
-    def _is_word_a_nonbraced_prefix(self, word):
+    @staticmethod
+    def _is_word_a_nonbraced_prefix(word):
         return word[0] == '$' and word[1] != '{'
 
-    def _is_word_a_numbered_match_prefix_with_brace(self, word):
+    @staticmethod
+    def _is_word_a_numbered_match_prefix_with_brace(word):
         return word[0:2] == '${' and word[2:3].isdigit()
 
     def _is_word_a_date_prefix_with_brace(self, word):
-        return word[:4] in map(lambda x: '${' + x, self._date_wildcards.keys())
+        return word[:4] in ['${' + x for x in self._date_wildcards.keys()]
 
-    def _is_word_a_braced_prefix(self, word):
+    @staticmethod
+    def _is_word_a_braced_prefix(word):
         return word[0:2] == '${'
 
     @staticmethod
@@ -124,10 +129,10 @@ class MacroCompleter(Completer):
     def _is_macro_a_small_numbered_match(cls, macro):
         return cls._is_macro_a_numbered_match(macro) and int(macro) < 10
 
-    def _collect_macros_generic(self, predicate, format):
+    def _collect_macros_generic(self, predicate, template):
         for macro in self._macros or get_nv_registry():
             if predicate(macro):
-                yield format.format(macro)
+                yield template.format(macro)
 
     def _collect_macros(self, predicate):
         return self._collect_macros_generic(predicate, '${}')

--- a/modules/python/pylib/syslogng/debuggercli/readline.py
+++ b/modules/python/pylib/syslogng/debuggercli/readline.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, print_function
+from .debuggercli import DebuggerCLI
+import readline
+import traceback
+
+
+class ReadlineCompleteHook(object):
+    def __init__(self, completer):
+        self._completer = completer
+        self._last_contents = (None, None)
+
+    def complete(self, text, state):
+        try:
+            entire_text = readline.get_line_buffer()[:readline.get_endidx()]
+            completions = self._get_completions(entire_text, text)
+            return completions[state]
+        except Exception as exc:
+            traceback.print_exc()
+
+    def _get_completions(self, entire_text, text):
+        if (self._last_contents == (entire_text, text)):
+            return self._last_completions
+        self._last_completions = self._completer.complete(entire_text, text)
+        self._last_completions.append(None)
+        self._last_contents = (entire_text, text)
+        return self._last_completions
+
+
+_setup_performed = False
+
+
+def setup_readline():
+    global _setup_performed
+
+    if _setup_performed:
+        return
+
+    debuggercli = DebuggerCLI()
+    readline.parse_and_bind("tab: complete")
+    readline.set_completer(ReadlineCompleteHook(debuggercli.get_root_completer()).complete)
+    readline.set_completer_delims(' \t\n\"\'`@><=;|&')
+    _setup_performed = True

--- a/modules/python/pylib/syslogng/debuggercli/readline.py
+++ b/modules/python/pylib/syslogng/debuggercli/readline.py
@@ -8,17 +8,19 @@ class ReadlineCompleteHook(object):
     def __init__(self, completer):
         self._completer = completer
         self._last_contents = (None, None)
+        self._last_completions = []
 
     def complete(self, text, state):
+        # pylint: disable=broad-except
         try:
             entire_text = readline.get_line_buffer()[:readline.get_endidx()]
             completions = self._get_completions(entire_text, text)
             return completions[state]
-        except Exception as exc:
+        except Exception:
             traceback.print_exc()
 
     def _get_completions(self, entire_text, text):
-        if (self._last_contents == (entire_text, text)):
+        if self._last_contents == (entire_text, text):
             return self._last_completions
         self._last_completions = self._completer.complete(entire_text, text)
         self._last_completions.append(None)
@@ -26,17 +28,18 @@ class ReadlineCompleteHook(object):
         return self._last_completions
 
 
-_setup_performed = False
+__setup_performed__ = False
 
 
 def setup_readline():
-    global _setup_performed
+    # pylint: disable=global-statement
+    global __setup_performed__
 
-    if _setup_performed:
+    if __setup_performed__:
         return
 
     debuggercli = DebuggerCLI()
     readline.parse_and_bind("tab: complete")
     readline.set_completer(ReadlineCompleteHook(debuggercli.get_root_completer()).complete)
     readline.set_completer_delims(' \t\n\"\'`@><=;|&')
-    _setup_performed = True
+    __setup_performed__ = True

--- a/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
+++ b/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
@@ -1,0 +1,18 @@
+#
+# This module contains a stub for all functions exported by syslog-ng, so when
+# the module is imported from within syslog-ng it uses the exported functions,
+# in case we are running outside of syslog-ng we are using the stubs that is
+# enough for testing.
+#
+from __future__ import print_function, absolute_import
+
+
+def get_nv_registry():
+    return ('0', '1', '2', '3', '4', "DATE", "HOST", "MSGHDR", "PROGRAM", "PID", "MSG", '.unix.uid', '.unix.gid')
+
+
+# override implementations from the module supplied by the C implementation.
+try:
+    from _syslogngdbg import *
+except ImportError:
+    pass

--- a/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
+++ b/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
@@ -60,6 +60,23 @@ def get_template_functions():
     )
 
 
+def get_value_pairs_scopes():
+    return (
+        "nv-pairs",
+        "dot-nv-pairs",
+        "all-nv-pairs",
+        "rfc3164",
+        "core",
+        "base",
+        "rfc5424",
+        "syslog-proto",
+        "all-macros",
+        "selected-macros",
+        "sdata",
+        "everything",
+    )
+
+
 # override implementations from the module supplied by the C implementation.
 try:
     from _syslogngdbg import *

--- a/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
+++ b/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
@@ -22,6 +22,44 @@ def get_debugger_commands():
     )
 
 
+def get_template_functions():
+    return (
+        "geoip",
+        "python",
+        "graphite-output",
+        "uuid",
+        "hash",
+        "sha1",
+        "sha256",
+        "sha512",
+        "md4",
+        "md5",
+        "format-json",
+        "grep",
+        "if",
+        "or",
+        "echo",
+        "length",
+        "substr",
+        "strip",
+        "sanitize",
+        "lowercase",
+        "uppercase",
+        "replace-delimiter",
+        "padding",
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "ipv4-to-int",
+        "indent-multi-line",
+        "context-length",
+        "env",
+        "template"
+    )
+
+
 # override implementations from the module supplied by the C implementation.
 try:
     from _syslogngdbg import *

--- a/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
+++ b/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
@@ -79,6 +79,7 @@ def get_value_pairs_scopes():
 
 # override implementations from the module supplied by the C implementation.
 try:
+    # pylint: disable=import-error,wildcard-import
     from _syslogngdbg import *
 except ImportError:
     pass

--- a/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
+++ b/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
@@ -11,6 +11,17 @@ def get_nv_registry():
     return ('0', '1', '2', '3', '4', "DATE", "HOST", "MSGHDR", "PROGRAM", "PID", "MSG", '.unix.uid', '.unix.gid')
 
 
+def get_debugger_commands():
+    return (
+        "help",
+        "continue",
+        "print",
+        "display",
+        "drop",
+        "quit"
+    )
+
+
 # override implementations from the module supplied by the C implementation.
 try:
     from _syslogngdbg import *

--- a/modules/python/pylib/syslogng/debuggercli/tablexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tablexer.py
@@ -10,9 +10,10 @@ class TabLexer(Lexer):
         self._replaced_token = None
         self._buffered_tokens = None
         self._buffer_count = 0
+        self._is_last_token = False
 
-    def input(self, input):
-        self._lexer.input(input)
+    def input(self, text):
+        self._lexer.input(text)
         self._end_of_tokens = False
         self._buffered_tokens = None
         self._replaced_token = None

--- a/modules/python/pylib/syslogng/debuggercli/tablexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tablexer.py
@@ -1,0 +1,88 @@
+from .lexertoken import LexerToken
+from .lexer import Lexer
+
+
+class TabLexer(Lexer):
+    def __init__(self, lexer):
+        self._lexer = lexer
+        self._current_token = None
+        self._end_of_tokens = False
+        self._replaced_token = None
+        self._buffered_tokens = None
+        self._buffer_count = 0
+
+    def input(self, input):
+        self._lexer.input(input)
+        self._end_of_tokens = False
+        self._buffered_tokens = None
+        self._replaced_token = None
+
+    def get_replaced_token(self):
+        return self._replaced_token
+
+    def set_drop_last_token(self, value):
+        if value:
+            self._buffer_count = 1
+        else:
+            self._buffer_count = 0
+
+    def token(self):
+        if self._end_of_tokens:
+            return None
+        if not self._is_buffer_initialized():
+            self._fill_buffer()
+
+        self._shift_and_inject_tab()
+        return self._current_token
+
+    def get_position(self):
+        # This method is not implemented as it would require to look ahead
+        # to the next token we may or may not have, making the code more
+        # difficult. We are not using this anyway.
+        raise NotImplementedError
+
+    def _shift_and_inject_tab(self):
+        self._shift_from_buffer()
+
+        if self._is_last_token or self._is_current_token_partial():
+            self._end_of_tokens = True
+            self._replaced_token = self._current_token
+            self._current_token = self._constuct_tab_token()
+
+    def _is_current_token_partial(self):
+        return (self._current_token is not None and
+                (hasattr(self._current_token, 'partial') and
+                 self._current_token.partial))
+
+    def _is_buffer_initialized(self):
+        return self._buffered_tokens is not None
+
+    def _constuct_tab_token(self):
+        if self._replaced_token is not None:
+            lexpos = self._replaced_token.lexpos
+        else:
+            lexpos = self._lexer.get_position()
+        return LexerToken(type="TAB", lexpos=lexpos)
+
+    def _shift_from_buffer(self):
+        self._fetch_token_to_buffer()
+        self._is_last_token = len(self._buffered_tokens) <= self._buffer_count
+        self._current_token = self._get_token_from_buffer()
+
+    def _fill_buffer(self):
+        self._buffered_tokens = []
+        for _ in range(self._buffer_count):
+            self._fetch_token_to_buffer()
+
+    def _fetch_token_to_buffer(self):
+        token = self._lexer.token()
+        if token is not None:
+            self._buffered_tokens.append(token)
+
+    def _get_token_from_buffer(self):
+        try:
+            token = self._buffered_tokens[0]
+            self._buffered_tokens = self._buffered_tokens[1:]
+            return token
+        except IndexError:
+            return None

--- a/modules/python/pylib/syslogng/debuggercli/templatelang.py
+++ b/modules/python/pylib/syslogng/debuggercli/templatelang.py
@@ -1,0 +1,32 @@
+from __future__ import print_function, absolute_import
+from .completerlang import CompleterLang
+from .templatelexer import TemplateLexer
+
+
+class TemplateLang(CompleterLang):
+
+    tokens = [
+        "LITERAL", "MACRO", "TEMPLATE_FUNC"
+    ]
+
+    @staticmethod
+    def p_template_string(p):
+        '''template_string : template_elems'''
+        pass
+
+    @staticmethod
+    def p_template_elems(p):
+        '''template_elems : template_elem template_elems
+                          |'''
+        pass
+
+    @staticmethod
+    def p_template_elem(p):
+        '''template_elem : LITERAL
+                         | MACRO
+                         | TEMPLATE_FUNC
+        '''
+        pass
+
+    def _construct_lexer(self):
+        return TemplateLexer()

--- a/modules/python/pylib/syslogng/debuggercli/templatelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/templatelexer.py
@@ -8,17 +8,21 @@ class LexBasedLexer(Lexer):
     def __init__(self):
         self._lexer = lex.lex(object=self)
         self._lexer.current_token = ''
+        self._lexer.current_token_pos = -1
 
     def token(self):
         token = self._lexer.token()
         if token is None and self._lexer.lexstate != 'INITIAL':
-            return LexerToken('LITERAL', value=self._lexer.current_token, partial=True, lexpos=self._lexer.current_token_pos)
+            return LexerToken('LITERAL',
+                              value=self._lexer.current_token,
+                              partial=True,
+                              lexpos=self._lexer.current_token_pos)
         return token
 
-    def input(self, input):
+    def input(self, text):
         while len(self._lexer.lexstatestack) > 0:
             self._lexer.pop_state()
-        return self._lexer.input(input)
+        return self._lexer.input(text)
 
     def get_position(self):
         return self._lexer.lexpos
@@ -29,7 +33,7 @@ class TemplateLexerError(Exception):
 
 
 class TemplateLexer(LexBasedLexer):
-
+    # pylint: disable=no-self-use,invalid-name
     tokens = (
         'LITERAL', 'MACRO', "TEMPLATE_FUNC"
     )
@@ -88,11 +92,6 @@ class TemplateLexer(LexBasedLexer):
         t.lexer.paren_count = 1
         t.lexer.current_token = '$('
         t.lexer.current_token_pos = t.lexpos - 1
-
-        #t.partial = True
-        #t.type = 'TEMPLATE_FUNC'
-        #t.value = '$('
-        #return t
 
     def t_dollarparen_PAREN_OPEN(self, t):
         r'\('

--- a/modules/python/pylib/syslogng/debuggercli/templatelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/templatelexer.py
@@ -1,0 +1,170 @@
+from __future__ import print_function, absolute_import
+import ply.lex as lex
+from .lexertoken import LexerToken
+from .lexer import Lexer
+
+
+class LexBasedLexer(Lexer):
+    def __init__(self):
+        self._lexer = lex.lex(object=self)
+        self._lexer.current_token = ''
+
+    def token(self):
+        token = self._lexer.token()
+        if token is None and self._lexer.lexstate != 'INITIAL':
+            return LexerToken('LITERAL', value=self._lexer.current_token, partial=True, lexpos=self._lexer.current_token_pos)
+        return token
+
+    def input(self, input):
+        while len(self._lexer.lexstatestack) > 0:
+            self._lexer.pop_state()
+        return self._lexer.input(input)
+
+    def get_position(self):
+        return self._lexer.lexpos
+
+
+class TemplateLexerError(Exception):
+    pass
+
+
+class TemplateLexer(LexBasedLexer):
+
+    tokens = (
+        'LITERAL', 'MACRO', "TEMPLATE_FUNC"
+    )
+
+    states = (
+        ('dollar', 'exclusive'),
+        ('dollarbrace', 'exclusive'),
+        ('dollarparen', 'exclusive'),
+        ('string', 'exclusive'),
+        ('qstring', 'exclusive'),
+    )
+
+    # Tokens
+
+    def t_LITERAL(self, t):
+        r'[^\$]+'
+        t.type = "LITERAL"
+        return t
+
+    def t_DOLLAR(self, t):
+        r'\$'
+        t.lexer.push_state('dollar')
+        t.lexer.current_token = '$'
+        t.lexer.current_token_pos = t.lexpos
+
+    def t_dollar_MACRO(self, t):
+        r'[a-zA-Z0-9_]+'
+        t.lexer.pop_state()
+        t.value = '$' + t.value
+        t.lexpos = t.lexer.current_token_pos
+        return t
+
+    def t_dollar_BRACE_OPEN(self, t):
+        r'{'
+        t.lexer.push_state('dollarbrace')
+        t.lexer.current_token = '$' + t.value
+
+    def t_dollarbrace_MACRO(self, t):
+        r'[^}]+'
+        t.lexer.current_token += t.value
+
+    def t_dollarbrace_BRACE_CLOSE(self, t):
+        r'}'
+        t.lexer.current_token += t.value
+        # go back to INITIAL
+        t.lexer.pop_state()
+        t.lexer.pop_state()
+        t.type = 'MACRO'
+        t.value = t.lexer.current_token
+        t.lexpos = t.lexer.current_token_pos
+        return t
+
+    def t_dollar_PAREN_OPEN(self, t):
+        r'\('
+        t.lexer.push_state('dollarparen')
+        t.lexer.paren_count = 1
+        t.lexer.current_token = '$('
+        t.lexer.current_token_pos = t.lexpos - 1
+
+        #t.partial = True
+        #t.type = 'TEMPLATE_FUNC'
+        #t.value = '$('
+        #return t
+
+    def t_dollarparen_PAREN_OPEN(self, t):
+        r'\('
+        t.lexer.paren_count += 1
+        t.lexer.current_token += '('
+
+    def t_dollarparen_TEMPLATE_FUNC(self, t):
+        r'''[^()'"]+'''
+        t.lexer.current_token += t.value
+
+    def t_dollarparen_PAREN_CLOSE(self, t):
+        r'\)'
+        t.lexer.current_token += ')'
+        t.lexer.paren_count -= 1
+        if t.lexer.paren_count == 0:
+            t.type = 'TEMPLATE_FUNC'
+            t.value = t.lexer.current_token
+            t.lexpos = t.lexer.current_token_pos
+            t.lexer.pop_state()
+            t.lexer.pop_state()
+            return t
+
+    def t_dollarparen_QUOTE(self, t):
+        r'"'
+        t.lexer.current_token += t.value
+        t.lexer.push_state('string')
+
+    def t_dollarparen_APOSTROPHE(self, t):
+        r"'"
+        t.lexer.current_token += t.value
+        t.lexer.push_state('qstring')
+
+    def t_string_CHARS(self, t):
+        r'[^"\\]'
+        t.lexer.current_token += t.value
+
+    def t_string_backslash_plus_character(self, t):
+        r'\\.'
+        t.lexer.current_token += t.value
+
+    def t_string_QUOTE(self, t):
+        r'"'
+
+        # closing quote character
+        t.lexer.current_token += t.value
+        t.lexer.pop_state()
+
+    def t_qstring_CHARS(self, t):
+        r"[^']"
+        t.lexer.current_token += t.value
+
+    def t_qstring_APOSTROPHE(self, t):
+        r"'"
+
+        # closing apostrophe
+        t.lexer.current_token += t.value
+        t.lexer.pop_state()
+
+    def t_error(self, t):
+        raise TemplateLexerError("Illegal character {} in state {}".format(t.value, self._lexer.lexstate))
+
+    def t_dollar_error(self, t):
+        return self.t_error(t)
+
+    def t_dollarbrace_error(self, t):
+        return self.t_error(t)
+
+    def t_dollarparen_error(self, t):
+        return self.t_error(t)
+
+    def t_string_error(self, t):
+        return self.t_error(t)
+
+    def t_qstring_error(self, t):
+        return self.t_error(t)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py
@@ -4,6 +4,7 @@ from ..choicecompleter import ChoiceCompleter
 
 
 class TestChoiceCompleter(CompleterTestCase):
+    # pylint: disable=arguments-differ
     def _construct_completer(self, choices=None, prefix=None, suffix=None):
         return ChoiceCompleter(choices or ['foo', 'bar', 'baz'],
                                prefix=prefix,

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_choicecompleter.py
@@ -1,0 +1,40 @@
+from __future__ import print_function, absolute_import
+from .test_completer import CompleterTestCase
+from ..choicecompleter import ChoiceCompleter
+
+
+class TestChoiceCompleter(CompleterTestCase):
+    def _construct_completer(self, choices=None, prefix=None, suffix=None):
+        return ChoiceCompleter(choices or ['foo', 'bar', 'baz'],
+                               prefix=prefix,
+                               suffix=suffix)
+
+    def test_all_choices_are_offered_for_an_empty_string(self):
+        self._completer = self._construct_completer(suffix='')
+        self._assert_completions_offered('', ['foo', 'bar', 'baz'])
+
+    def test_only_completions_that_start_with_word_are_listed_as_completions(self):
+        for word in ('f', 'b'):
+            self._assert_completions_start_with_word(word)
+
+    def test_suffix_is_attached_to_all_potential_matches(self):
+        self._completer = self._construct_completer(suffix=' ')
+        self._assert_completions_offered('b', ['bar ', 'baz '])
+        self._assert_completions_not_offered('b', ['bar', 'baz'])
+
+    def test_prefix_is_attached_to_all_potential_matches(self):
+        self._completer = self._construct_completer(prefix='$', suffix='')
+        self._assert_completions_offered('$b', ['$bar', '$baz'])
+        self._assert_completions_not_offered('$b', ['bar', 'baz'])
+
+    def test_only_prefix_is_offered_if_entire_input_is_shorter(self):
+        self._completer = self._construct_completer(prefix='$@', suffix='@')
+        self._assert_completion_offered('', '$@')
+        self._assert_completion_offered('$', '$@')
+        self._assert_completion_not_offered('', '$@bar@')
+        self._assert_completion_not_offered('$', '$@bar@')
+        self._assert_completions_offered('$@', ['$@foo@', '$@bar@', '$@baz@'])
+
+    def test_not_even_the_prefix_is_offered_if_the_entire_input_diverged_already(self):
+        self._completer = self._construct_completer(prefix='$@', suffix='@')
+        self._assert_completions_not_offered('q', ['$', '$@', '$@foo@'])

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_commandlinelexer.py
@@ -1,0 +1,133 @@
+from __future__ import absolute_import, print_function
+from .test_lexer import TestLexer
+from .. import commandlinelexer
+
+
+class TestCommandLineLexer(TestLexer):
+
+    def _construct_lexer(self):
+        return commandlinelexer.CommandLineLexer()
+
+    def test_lexer_returns_none_for_empty_string(self):
+        self._lexer.input("")
+        self._assert_next_token_is_none()
+
+    def test_single_quote_character_is_returned_as_a_partial_token(self):
+        for quote in ('"', "'"):
+            self._lexer.input(quote)
+            self._assert_next_token_is_partial()
+
+    def test_pair_of_quotes_is_returned_as_an_empty_string(self):
+        self._lexer.input("''")
+        self._next_token()
+        self._assert_current_token_is_not_partial()
+        self._assert_current_token_value_equals('')
+
+    def test_quoted_character_is_returned_as_the_character(self):
+        self._lexer.input("'a'")
+        self._next_token()
+        self._assert_current_token_is_not_partial()
+        self._assert_current_token_value_equals('a')
+
+    def test_quoted_string_is_returned_as_the_string(self):
+        self._lexer.input('"foo bar"')
+        self._assert_next_token_value_equals('foo bar')
+
+    def test_unquoted_string_is_returned_as_the_string(self):
+        self._lexer.input('foo')
+        self._assert_next_token_value_equals('foo')
+
+    def test_unquoted_prefix_and_then_a_quoted_string_is_concatenated(self):
+        self._lexer.input('foo"bar"')
+        self._assert_next_token_value_equals('foobar')
+
+    def test_double_quotes_allow_backslash_as_a_single_char_escape(self):
+        self._lexer.input(r'"foo\""')
+        self._assert_next_token_value_equals('foo"')
+
+    def test_white_space_separates_tokens(self):
+        self._lexer.input("""'foo'  "bar"  baz  """)
+        self._assert_next_token_value_equals('foo')
+        self._assert_next_token_value_equals('bar')
+        self._assert_next_token_value_equals('baz')
+        self._assert_next_token_is_none()
+
+    def test_unclosed_string_is_returned_as_a_partial_token(self):
+        self._lexer.input("""'foo' "bar" 'baz""")
+        self._next_token()
+        self._assert_current_token_value_equals('foo')
+        self._assert_current_token_is_not_partial()
+
+        self._next_token()
+        self._assert_current_token_value_equals('bar')
+        self._assert_current_token_is_not_partial()
+
+        self._next_token()
+        self._assert_current_token_value_equals('baz')
+        self._assert_current_token_is_partial()
+
+    def test_single_opened_paren_is_returned_as_a_partial_token(self):
+        self._lexer.input("(")
+        self._next_token()
+        self._assert_current_token_value_equals('(')
+        self._assert_current_token_is_partial()
+
+    def test_pair_of_parens_is_returned_as_a_pair_of_parens(self):
+        self._lexer.input("()")
+
+        self._next_token()
+        self._assert_current_token_value_equals('()')
+        self._assert_current_token_is_not_partial()
+
+    def test_token_enclosed_in_parens_is_returned_as_a_token_in_parens(self):
+        self._lexer.input("(foo)")
+        self._next_token()
+        self._assert_current_token_value_equals('(foo)')
+        self._assert_current_token_is_not_partial()
+
+    def test_whitespace_in_parens_doesnt_terminate_the_token(self):
+        self._lexer.input("(foo bar)")
+        self._next_token()
+        self._assert_current_token_value_equals('(foo bar)')
+        self._assert_current_token_is_not_partial()
+
+    def test_closing_paren_terminates_the_token_only_if_properly_paired(self):
+        self._lexer.input("(foo bar (baz bax)) next-token")
+        self._next_token()
+        self._assert_current_token_value_equals('(foo bar (baz bax))')
+        self._assert_current_token_is_not_partial()
+
+        self._next_token()
+        self._assert_current_token_value_equals('next-token')
+        self._assert_current_token_is_not_partial()
+
+    def test_one_too_many_closing_parens_is_interpreted_as_a_separate_token(self):
+        self._lexer.input("(foo bar )) next-token")
+
+        self._next_token()
+        self._assert_current_token_value_equals('(foo bar )')
+        self._assert_current_token_is_not_partial()
+
+        self._next_token()
+        self._assert_current_token_value_equals(')')
+        self._assert_current_token_is_not_partial()
+
+        self._next_token()
+        self._assert_current_token_value_equals('next-token')
+        self._assert_current_token_is_not_partial()
+
+    def test_quotes_within_parens_are_left_intact_so_a_recursive_parsing_will_find_them(self):
+        self._lexer.input("(foo 'bar baz') next-token")
+        self._next_token()
+        self._assert_current_token_value_equals("(foo 'bar baz')")
+        self._assert_current_token_is_not_partial()
+
+    def test_parens_in_quotes_are_not_counted_against_the_paren_balance(self):
+        self._lexer.input("(foo 'bar )')    next-token")
+        self._next_token()
+        self._assert_current_token_value_equals("(foo 'bar )')")
+        self._assert_current_token_is_not_partial()
+
+        self._next_token()
+        self._assert_current_token_value_equals("next-token")
+        self._assert_current_token_is_not_partial()

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_completer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_completer.py
@@ -1,0 +1,40 @@
+from __future__ import print_function, absolute_import
+import unittest
+
+
+class CompleterTestCase(unittest.TestCase):
+    def setUp(self):
+        self._completer = self._construct_completer()
+
+    def _construct_completer(self):
+        raise NotImplementedError
+
+    def _get_completions(self, word, entire_input=None):
+        return self._completer.complete(entire_input or word, word)
+
+    def _assert_completion_offered(self, word, completion):
+        self._assert_completions_offered(word, [completion])
+
+    def _assert_completion_not_offered(self, word, completion):
+        self._assert_completions_not_offered(word, [completion])
+
+    def _assert_no_completions_are_offered(self, word, entire_input=None):
+        completions = self._get_completions(word, entire_input=entire_input)
+        self.assertEquals(completions, [])
+
+    def _assert_completions_offered(self, word, expected_completions, entire_input=None):
+        completions = self._get_completions(word, entire_input=entire_input)
+        for completion in expected_completions:
+            self.assertIn(completion, completions)
+        self.assertEqual(completions, sorted(completions))
+
+    def _assert_completions_not_offered(self, word, unexpected_completions, entire_input=None):
+        completions = self._get_completions(word, entire_input=entire_input)
+        for completion in unexpected_completions:
+            self.assertNotIn(completion, completions)
+
+    def _assert_completions_start_with_word(self, word):
+        completions = self._get_completions(word)
+        for completion in completions:
+            self.assertTrue(completion.startswith(word),
+                            msg="Completion {} does not start with the word to be completed {}".format(completion, word))

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_completer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_completer.py
@@ -37,4 +37,5 @@ class CompleterTestCase(unittest.TestCase):
         completions = self._get_completions(word)
         for completion in completions:
             self.assertTrue(completion.startswith(word),
-                            msg="Completion {} does not start with the word to be completed {}".format(completion, word))
+                            msg="Completion {} does not start with the word to be completed {}"
+                                .format(completion, word))

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_completerlang.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, print_function
+import unittest
+from ..debuglang import DebugLang
+
+
+class CompleterLangTestCase(unittest.TestCase):
+    def _get_expected_tokens(self, text):
+        drop_last_token = not text[-1:].isspace()
+        return self._parser.get_expected_tokens(text, drop_last_token=drop_last_token)
+
+    def _assert_token_follows(self, text, tokens, pos=None, replaced_token=None):
+        (expected_tokens, rtoken, rtoken_pos) = self._get_expected_tokens(text)
+        if pos is not None:
+            self.assertEquals(pos, rtoken_pos)
+        if replaced_token is not None:
+            self.assertEquals(rtoken.value if rtoken is not None else '', replaced_token)
+        self.assertLessEqual(set(tokens), set(expected_tokens))
+
+
+class TestCompleterLang(CompleterLangTestCase):
+    """This testcase intends to test the CompleterLang base class by
+    an example grammar, which happens to be DebugLang. The DebugLang grammar
+    itself is tested in a separate testcase."""
+
+    def setUp(self):
+        self._parser = DebugLang()
+
+    def test_all_tokens_are_found_that_would_match_rules_in_the_grammar(self):
+        self._assert_command_token_follows("", pos=0, replaced_token="")
+        self._assert_command_token_follows(" ", pos=1, replaced_token="")
+        self._assert_command_token_follows("foo", pos=0, replaced_token="foo")
+
+        self._assert_token_follows("foo ", ["ARG"], pos=4, replaced_token="")
+        self._assert_token_follows("foo bar", ["ARG"], pos=4, replaced_token="bar")
+        self._assert_token_follows("foo bar ", ["ARG"], pos=8, replaced_token="")
+        self._assert_token_follows("print ", ["template", "ARG"], pos=6, replaced_token="")
+        self._assert_token_follows("print $MSG", ["template", "ARG"], pos=6, replaced_token="$MSG")
+        self._assert_token_follows("print $MSG ", [], pos=11, replaced_token="")
+
+    def _get_command_tokens(self):
+        return [token for token in self._parser.tokens if token.startswith("COMMAND")]
+
+    def _assert_command_token_follows(self, text, pos=None, replaced_token=None):
+        self._assert_token_follows(text, set(self._get_command_tokens()), pos, replaced_token)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_debuggercli.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_debuggercli.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import, print_function
+from .test_completer import CompleterTestCase
+from ..debuggercli import DebuggerCLI
+
+
+class TestDebuggerCLI(CompleterTestCase):
+    def setUp(self):
+        self._completer = DebuggerCLI().get_root_completer()
+
+    def test_no_text_offers_the_potential_prefixes_of_a_template_expr(self):
+        self._assert_completions_offered(entire_input="print ", word="", expected_completions=['$', '$(', '${'])
+
+    def test_literal_text_offers_potential_prefixes_of_a_template_expr(self):
+        self._assert_completions_offered(entire_input="print 'foobar ", word="", expected_completions=['$', '$(', '${'])
+
+    def test_dollar_offers_possible_macro_completions(self):
+        self._assert_completions_offered(entire_input="print $", word="$",
+                                         expected_completions=['$MSG', '$MSGHDR', '$DATE', '${', '$('])
+
+    def test_dollar_brace_offers_possible_macro_completions(self):
+        self._assert_completions_offered(entire_input="print ${", word="${",
+                                         expected_completions=["${MSG}", "${DATE}"])
+
+    def test_dollar_paren_offers_template_functions(self):
+        self._assert_completions_offered(entire_input="print $(", word="$(",
+                                         expected_completions=["$(echo "])
+
+    def test_literal_text_plus_dollar_offers_macros_using_the_literal_as_prefix(self):
+        self._assert_completions_offered(entire_input="print foobar$", word="foobar$",
+                                         expected_completions=["foobar$("])
+
+    def test_literal_text_plus_dollar_paren_offers_template_functions_using_the_literal_as_prefix(self):
+        self._assert_completions_offered(entire_input="print foobar$(", word="foobar$(",
+                                         expected_completions=["foobar$(echo ", 'foobar$(format-json '])
+
+    def test_literal_text_plus_dollar_brace_offers_macros_using_the_literal_as_prefix(self):
+        self._assert_completions_offered(entire_input="print foobar${", word="foobar${",
+                                         expected_completions=["foobar${MSG}"])
+
+    def test_template_function_offers_potential_opts(self):
+        self._assert_completions_offered(entire_input="print 'foobar$(format-json ", word="",
+                                         expected_completions=['--pair '])
+        self._assert_completions_offered(entire_input="print 'foobar$(echo ", word="",
+                                         expected_completions=['$', '$(', '${'])
+
+    def test_complex_cases(self):
+        self._assert_completions_offered(entire_input="print 'foo$(format-json --key *)bar", word="",
+                                         expected_completions=['$(', '${', '$'])
+        self._assert_completions_offered(entire_input="print 'foo$(format-json --key *)bar$(echo ", word="",
+                                         expected_completions=['$(', '${', '$'])
+        self._assert_completions_offered(entire_input="print 'foo$(format-json --key *)${MSG}$(echo ", word="",
+                                         expected_completions=['$(', '${', '$'])
+        self._assert_completions_offered(entire_input="print 'foo$(format-json --key *)${MSG}$(echo $MSGHDR)", word="",
+                                         expected_completions=['$(', '${', '$'])

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_debuggercli.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_debuggercli.py
@@ -4,8 +4,8 @@ from ..debuggercli import DebuggerCLI
 
 
 class TestDebuggerCLI(CompleterTestCase):
-    def setUp(self):
-        self._completer = DebuggerCLI().get_root_completer()
+    def _construct_completer(self):
+        return DebuggerCLI().get_root_completer()
 
     def test_no_text_offers_the_potential_prefixes_of_a_template_expr(self):
         self._assert_completions_offered(entire_input="print ", word="", expected_completions=['$', '$(', '${'])

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_debuglang.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_debuglang.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, print_function
+from ..debuglang import DebugLang
+from .test_completerlang import CompleterLangTestCase
+
+
+class TestDebugLang(CompleterLangTestCase):
+    def setUp(self):
+        self._parser = DebugLang()
+
+    def test_first_token_is_a_command(self):
+        self._assert_command_token_follows("")
+        self._assert_command_token_follows(" ")
+        self._assert_command_token_follows("foo")
+
+    def test_print_expects_a_template_arg(self):
+        self._assert_token_follows("print ", ["template", "ARG"])
+        self._assert_token_follows("print $MSG ", [])
+
+    def test_display_expects_a_template_arg(self):
+        self._assert_token_follows("display ", ["template", "ARG"])
+        self._assert_token_follows("display $MSG ", [])
+
+    def test_generic_command_expects_a_series_of_args(self):
+        self._assert_token_follows("foo ", ["ARG"])
+        self._assert_token_follows("foo arg ", ["ARG"])
+        self._assert_token_follows("foo arg arg ", ["ARG"])
+
+    def _get_command_tokens(self):
+        return [token for token in self._parser.tokens if token.startswith("COMMAND")]
+
+    def _assert_command_token_follows(self, text, pos=None, replaced_token=None):
+        self._assert_token_follows(text, set(self._get_command_tokens()), pos, replaced_token)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py
@@ -1,0 +1,107 @@
+from __future__ import absolute_import, print_function
+from .test_lexer import TestLexer
+from ..getoptlexer import GetoptLexer
+from ..commandlinelexer import CommandLineLexer
+
+
+class TestGetoptLexer(TestLexer):
+    def setUp(self):
+        self._known_commands = ['print', 'foo-bar']
+        self._aliases = {
+            'p': 'print',
+            'fb': 'foo-bar'
+        }
+        self._lexer = self._construct_lexer()
+
+    def _construct_lexer(self, known_commands=None, known_options=None, aliases=None):
+        return GetoptLexer(CommandLineLexer(),
+                           known_commands=known_commands or self._known_commands,
+                           known_options=known_options,
+                           aliases=aliases or self._aliases)
+
+    def test_lexer_returns_command_token_for_an_unknown_command_as_the_first_token(self):
+        self._lexer.input("unknown-cmd")
+        token = self._next_token()
+        self.assertEquals(token.type, "COMMAND")
+
+    def test_lexer_returns_specific_token_for_known_commands(self):
+        for command in self._known_commands:
+            self._lexer.input(command)
+            self._assert_next_token_type_equals('COMMAND_{}'.format(command.upper().replace('-', '_')))
+
+    def test_lexer_translates_aliases(self):
+        for (alias, command) in self._aliases.items():
+            self._lexer.input(alias)
+            self._assert_next_token_type_equals('COMMAND_{}'.format(command.upper().replace('-', '_')))
+
+    def test_known_commands_are_not_returned_as_tokens_for_non_first_arguments(self):
+        self._lexer.input("print print")
+        self.assertEquals(self._next_token().type, "COMMAND_PRINT")
+        self.assertEquals(self._next_token().type, "ARG")
+
+    def test_double_quoted_arguments_are_returned_as_a_single_token(self):
+        self._lexer.input('print "foo bar"')
+        self.assertEquals(self._next_token().type, "COMMAND_PRINT")
+        token = self._next_token()
+        self.assertEquals(token.type, "ARG")
+        self.assertEquals(token.value, "foo bar")
+
+    def test_lexer_returns_token_in_a_sequence(self):
+        self._lexer.input('''print foo bar''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals('foo')
+        self._assert_next_arg_equals('bar')
+        self._assert_last_token_reached()
+
+    def test_lexer_handles_quoted_args_by_unqouting_them(self):
+        self._lexer.input('''print "foo bar" 'bar foo' ''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals('foo bar')
+        self._assert_next_arg_equals('bar foo')
+        self._assert_last_token_reached()
+
+    def test_lexer_handles_parenthesized_expression_as_a_single_token(self):
+        self._lexer.input('''print (''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals("(")
+
+        self._lexer.input('''print ( )''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals("( )")
+
+        self._lexer.input('''print (1 + 1)''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals("(1 + 1)")
+
+        self._lexer.input('''print ) )''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals(")")
+        self._assert_next_arg_equals(")")
+
+        self._lexer.input('''print ($MSG == foobar)''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_arg_equals("($MSG == foobar)")
+
+    def test_lexer_translates_args_to_option_tokens_if_they_are_known(self):
+        self._lexer = self._construct_lexer(known_options=("--foo", "--bar", "-a", "-b", "abc"))
+        self._lexer.input('''print --foo --bar -a -b abc''')
+        self._assert_next_token_type_equals("COMMAND_PRINT")
+        self._assert_next_token_type_equals("OPT__FOO")
+        self._assert_next_token_type_equals("OPT__BAR")
+        self._assert_next_token_type_equals("OPT_A")
+        self._assert_next_token_type_equals("OPT_B")
+        self._assert_next_token_type_equals("OPTABC")
+
+    def test_lexer_doesnt_translate_command_token_as_an_option(self):
+        self._lexer = self._construct_lexer(known_options=("--foo", "--bar", "-a", "-b"))
+        self._lexer.input('''--foo --bar -a -b''')
+        self._assert_next_token_equals("COMMAND", value="--foo")
+
+    def _assert_last_token_reached(self):
+        token = self._next_token()
+        self.assertIsNone(token)
+
+    def _assert_next_arg_equals(self, token_value):
+        token = self._next_token()
+        self.assertEquals(token.type, "ARG")
+        self.assertEquals(token.value, token_value)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_getoptlexer.py
@@ -13,6 +13,7 @@ class TestGetoptLexer(TestLexer):
         }
         self._lexer = self._construct_lexer()
 
+    # pylint: disable=arguments-differ
     def _construct_lexer(self, known_commands=None, known_options=None, aliases=None):
         return GetoptLexer(CommandLineLexer(),
                            known_commands=known_commands or self._known_commands,

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_langcompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_langcompleter.py
@@ -7,6 +7,7 @@ from ..lexertoken import LexerToken
 
 
 class DummyLang(CompleterLang):
+    # pylint: disable=super-init-not-called
     def __init__(self, expected_tokens, replaced_token=None, replaced_token_pos=-1):
         self._expected_tokens = expected_tokens
         self._replaced_token = replaced_token
@@ -15,7 +16,7 @@ class DummyLang(CompleterLang):
     def _construct_lexer(self):
         pass
 
-    def get_expected_tokens(self, input, drop_last_token):
+    def get_expected_tokens(self, text, drop_last_token):
         if self._replaced_token is not None:
             replaced_token = LexerToken(type=self._expected_tokens,
                                         value=self._replaced_token,
@@ -34,6 +35,7 @@ class TestLangCompleter(CompleterTestCase):
         'PARTIAL_TOKEN': ChoiceCompleter(("tokenP-a", "tokenP-b"), prefix='@', suffix='')
     }
 
+    # pylint: disable=arguments-differ,too-many-arguments
     def _construct_completer(self, expected_token=None, expected_tokens=None,
                              replaced_token=None, replaced_token_pos=-1,
                              completers=None, prefix="<!--"):

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_langcompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_langcompleter.py
@@ -1,0 +1,129 @@
+from __future__ import print_function, absolute_import
+from .test_completer import CompleterTestCase
+from ..langcompleter import LangBasedCompleter
+from ..completerlang import CompleterLang
+from ..choicecompleter import ChoiceCompleter
+from ..lexertoken import LexerToken
+
+
+class DummyLang(CompleterLang):
+    def __init__(self, expected_tokens, replaced_token=None, replaced_token_pos=-1):
+        self._expected_tokens = expected_tokens
+        self._replaced_token = replaced_token
+        self._replaced_token_pos = replaced_token_pos
+
+    def _construct_lexer(self):
+        pass
+
+    def get_expected_tokens(self, input, drop_last_token):
+        if self._replaced_token is not None:
+            replaced_token = LexerToken(type=self._expected_tokens,
+                                        value=self._replaced_token,
+                                        lexpos=self._replaced_token_pos)
+        else:
+            replaced_token = None
+        return (self._expected_tokens, replaced_token, self._replaced_token_pos)
+
+
+class TestLangCompleter(CompleterTestCase):
+    default_expectation = "1ST_TOKEN"
+    default_completers = {
+        '1ST_TOKEN': ChoiceCompleter(("token1-a", "token1-b"), suffix=''),
+        '2ND_TOKEN': ChoiceCompleter(("token2-a", "token2-b"), suffix=''),
+        '3RD_TOKEN': ChoiceCompleter(("token3-a", "token3-b"), suffix=''),
+        'PARTIAL_TOKEN': ChoiceCompleter(("tokenP-a", "tokenP-b"), prefix='@', suffix='')
+    }
+
+    def _construct_completer(self, expected_token=None, expected_tokens=None,
+                             replaced_token=None, replaced_token_pos=-1,
+                             completers=None, prefix="<!--"):
+        if expected_tokens is None:
+            expected_tokens = [expected_token or self.default_expectation]
+        return LangBasedCompleter(parser=DummyLang(expected_tokens=expected_tokens,
+                                                   replaced_token=replaced_token,
+                                                   replaced_token_pos=replaced_token_pos),
+                                  completers=completers or self.default_completers,
+                                  prefix=prefix)
+
+    def test_completing_on_the_first_characters_of_prefix_offers_the_prefix(self):
+        self._assert_completions_offered("", expected_completions=["<!--"])
+        self._assert_completions_offered("<", expected_completions=["<!--"])
+        self._assert_completions_offered("<!", expected_completions=["<!--"])
+        self._assert_completions_offered("<!-", expected_completions=["<!--"])
+
+    def test_completing_on_an_input_with_a_mismatching_prefix(self):
+        self._assert_no_completions_are_offered("mismatch")
+
+    def test_completing_on_prefix_only_offers_the_completions_of_the_first_token_with_prefix_prepended(self):
+        self._assert_completions_offered("<!--", expected_completions=["<!--token1-a", "<!--token1-b"])
+
+    def test_completing_the_1st_empty_token_offers_completions_on_the_token(self):
+        self._completer = self._construct_completer(expected_token="1ST_TOKEN")
+        self._assert_completions_offered(entire_input="<!-- ", word="", expected_completions=["token1-a", "token1-b"])
+
+    def test_completing_the_2nd_empty_token_offers_completions_on_the_token(self):
+        self._completer = self._construct_completer(expected_token="2ND_TOKEN")
+        self._assert_completions_offered(entire_input="<!-- foo ", word="",
+                                         expected_completions=['token2-a', 'token2-b'])
+
+    def test_completing_the_3rd_empty_token_offers_completions_on_the_token(self):
+        self._completer = self._construct_completer(expected_token="3RD_TOKEN")
+        self._assert_completions_offered(entire_input="<!-- foo bar ", word="",
+                                         expected_completions=['token3-a', 'token3-b'])
+
+    def test_completing_a_partial_token_with_an_empty_word_produces_choices_with_the_partial_prefix(self):
+        self._completer = self._construct_completer(expected_token="PARTIAL_TOKEN")
+        self._assert_completions_offered(entire_input="<!-- foo ", word="",
+                                         expected_completions=['@'])
+
+    def test_completing_a_partial_token_with_only_the_prefix_produces_choices_with_the_partial_prefix(self):
+        # NOTE: replaced_token_pos is calculated after the language prefix (<!--) is chopped!
+        self._completer = self._construct_completer(expected_token="PARTIAL_TOKEN",
+                                                    replaced_token="@",
+                                                    replaced_token_pos=5)
+        self._assert_completions_offered(entire_input="<!-- foo @", word="@",
+                                         expected_completions=['@tokenP-a', '@tokenP-b'])
+
+    def test_completing_a_partial_token_with_a_few_matching_characters_produces_choices_with_the_partial_prefix(self):
+        # NOTE: replaced_token_pos is calculated after the language prefix (<!--) is chopped!
+        self._completer = self._construct_completer(expected_token="PARTIAL_TOKEN",
+                                                    replaced_token="@tok",
+                                                    replaced_token_pos=5)
+        self._assert_completions_offered(entire_input="<!-- foo @tok", word="@tok",
+                                         expected_completions=['@tokenP-a', '@tokenP-b'])
+
+    def test_completing_a_partial_token_with_unmatching_characters_produces_no_completions(self):
+        # NOTE: replaced_token_pos is calculated after the language prefix (<!--) is chopped!
+        self._completer = self._construct_completer(expected_token="PARTIAL_TOKEN",
+                                                    replaced_token="@unmatching",
+                                                    replaced_token_pos=5)
+        self._assert_no_completions_are_offered(entire_input="<!-- foo @unmatching", word="@unmatching")
+
+    def test_completing_a_partial_token_that_is_longer_than_a_word_produces_no_matches(self):
+
+        # This is pretty much a corner case, as this would mean that the word
+        # splitting features of readline is not in-line with the tokenization
+        # rules of the language. A sample is encoded below in the testcase,
+        # the word itself is shorter than the token, which means that we
+        # basically can't complete on the entire token as readline would only replace
+        # stuff partially.
+        #
+        # The best we can do here is to offer no completions, the syntax we wanted
+        # to extend didn't have such a case, fortunately.
+
+        # NOTE: replaced_token_pos is calculated after the language prefix (<!--) is chopped!
+        self._completer = self._construct_completer(expected_token="PARTIAL_TOKEN",
+                                                    replaced_token="@token tail",
+                                                    replaced_token_pos=5)
+        self._assert_no_completions_are_offered(entire_input="<!-- foo @token tail", word="tail")
+
+    def test_completing_a_token_where_multiple_tokens_could_match_collects_all_matches(self):
+        self._completer = self._construct_completer(expected_tokens=["1ST_TOKEN", "2ND_TOKEN", "3RD_TOKEN"])
+        self._assert_completions_offered(entire_input="<!-- ", word="",
+                                         expected_completions=["token1-a", "token2-b", "token3-a"])
+        self._assert_completions_not_offered(entire_input="<!-- ", word="",
+                                             unexpected_completions=["@tokenP-a"])
+
+    def test_completing_a_token_that_has_no_registered_completer_results_in_no_matches(self):
+        self._completer = self._construct_completer(expected_token="NOSUCHCOMPLETER")
+        self._assert_no_completions_are_offered("<!-- ")

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py
@@ -7,7 +7,7 @@ class TestLexer(unittest.TestCase):
         self._lexer = self._construct_lexer()
         self._current_token = None
 
-    def _construct_lexer(self):
+    def _construct_lexer(self, *args, **kwargs):
         raise NotImplementedError
 
     def _next_token(self):

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_lexer.py
@@ -1,0 +1,62 @@
+import unittest
+
+
+class TestLexer(unittest.TestCase):
+
+    def setUp(self):
+        self._lexer = self._construct_lexer()
+        self._current_token = None
+
+    def _construct_lexer(self):
+        raise NotImplementedError
+
+    def _next_token(self):
+        self._current_token = self._lexer.token()
+        return self._current_token
+
+    def _assert_current_token_type_equals(self, token_type):
+        self.assertEquals(self._current_token.type, token_type)
+
+    def _assert_current_token_value_equals(self, value):
+        self.assertEquals(self._current_token.value, value)
+
+    def _assert_current_token_pos_equals(self, pos):
+        self.assertEquals(self._current_token.lexpos, pos)
+
+    def _assert_current_token_is_partial(self):
+        self.assertTrue(self._current_token.partial)
+
+    def _assert_current_token_is_not_partial(self):
+        self.assertFalse(self._current_token.partial)
+
+    def _assert_current_token_equals(self, token_type=None, value=None, pos=None, partial=None):
+        if token_type is not None:
+            self._assert_current_token_type_equals(token_type)
+        if value is not None:
+            self._assert_current_token_value_equals(value)
+        if pos is not None:
+            self._assert_current_token_pos_equals(pos)
+        if partial is not None:
+            if partial:
+                self._assert_current_token_is_partial()
+            else:
+                self._assert_current_token_is_not_partial()
+
+    def _assert_next_token_equals(self, *args, **kwargs):
+        self._next_token()
+        self._assert_current_token_equals(*args, **kwargs)
+
+    def _assert_next_token_type_equals(self, token_type):
+        self._next_token()
+        self._assert_current_token_type_equals(token_type)
+
+    def _assert_next_token_is_partial(self):
+        self._next_token()
+        self._assert_current_token_is_partial()
+
+    def _assert_next_token_is_none(self):
+        self.assertIsNone(self._next_token())
+
+    def _assert_next_token_value_equals(self, value):
+        self._next_token()
+        self._assert_current_token_value_equals(value)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_macrocompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_macrocompleter.py
@@ -1,0 +1,102 @@
+from .test_completer import CompleterTestCase
+from ..macrocompleter import MacroCompleter
+
+
+class TestMacroCompleter(CompleterTestCase):
+    def _construct_completer(self, macros=None):
+        return MacroCompleter(macros=macros or ['MSG', 'MSGHDR', 'HOST',
+                                                '.unix.uid', '.unix.gid',
+                                                'S_DATE', 'R_MONTH', 'C_WEEK', 'DATE',
+                                                'smallcaps',
+                                                '0', '1', '2', '10', '100'])
+
+    def test_only_a_dollar_is_offered_for_an_empty_string(self):
+        self._assert_completions_offered('', ('$', '${'))
+
+    def test_dollar_brace_is_offered_for_a_dollar(self):
+        self._assert_completion_offered('$', '${')
+
+    def test_unqualified_macros_are_offered_for_a_dollar(self):
+        self._assert_completions_offered('$', ('$MSG', '$HOST'))
+
+    def test_qualified_macros_are_offered_with_a_brace_for_a_dollar(self):
+        self._assert_completion_offered('$', '${.unix.uid}')
+        self._assert_completion_not_offered('$', '$.unix.uid')
+
+    def test_small_numbered_matches_are_offered_for_a_dollar(self):
+        # small means < 10
+        self._assert_completion_offered('$', '$0')
+
+    def test_large_numbered_matches_are_not_offered_for_a_dollar(self):
+        # large means > 10
+        self._assert_completions_not_offered('$', ('$10', '$100'))
+
+    def test_all_numbered_matches_are_offered_for_dollar_plus_digit(self):
+        # ${1 ... lists all numbered macros
+        self._assert_completions_offered('$1', ('$1', '$10', '$100'))
+
+    def test_all_macros_except_large_numbered_matches_are_offered_for_a_dollar_brace(self):
+        # ${ }
+        self._assert_completions_offered('${', ('${HOST}', '${MSG}', '${.unix.uid}', '${0}', '${1}'))
+        self._assert_completions_not_offered('${', ('${10}', '${100}'))
+
+    def test_all_numbered_matches_are_offered_for_dollar_brace_digit(self):
+        self._assert_completions_offered('${1', ('${1}', '${10}', '${100}'))
+
+    def test_date_macros_are_not_offered_for_a_dollar(self):
+        self._assert_completions_not_offered('$', ('$S_DATE', '$R_MONTH'))
+
+    def test_date_shortcuts_are_offered_for_a_dollar(self):
+        self._assert_completions_offered('$', ['$R_* (received time)',
+                                               '$S_* (stamp in message)',
+                                               '$C_* (current time)'])
+
+    def test_date_shortcuts_are_offered_for_a_dollar_brace(self):
+        self._assert_completions_offered('${', ['${R_*} (received time)',
+                                                '${S_*} (stamp in message)',
+                                                '${C_*} (current time)'])
+
+    def test_date_macros_are_offered_if_the_prefix_is_correct(self):
+        self._assert_completions_offered('$R_', ['$R_MONTH'])
+        self._assert_completions_offered('${R_', ['${R_MONTH}'])
+        self._assert_completions_offered('$S_', ['$S_DATE'])
+        self._assert_completions_offered('${S_', ['${S_DATE}'])
+        self._assert_completions_offered('$C_', ['$C_WEEK'])
+        self._assert_completions_offered('${C_', ['${C_WEEK}'])
+
+    def test_date_macros_are_not_offered_if_the_prefix_doesnot_match(self):
+        self._assert_completion_not_offered('$R', '$R_MONTH')
+        self._assert_completion_not_offered('$S', '$S_DATE')
+        self._assert_completion_not_offered('$C', '$C_DATE')
+
+    def test_date_wildcards_are_not_offered_if_the_prefix_is_correct(self):
+        self._assert_completions_not_offered('$R_', '$R_* (received time)')
+        self._assert_completions_not_offered('${R_', '${R_*} (received time)')
+        self._assert_completions_not_offered('$S_', '$S_* (stamp in message)')
+        self._assert_completions_not_offered('${S_}', '${S_*} (stamp in message)')
+        self._assert_completions_not_offered('$C_', '$C_* (current time)')
+        self._assert_completions_not_offered('${C_', '${C_*} (current time)')
+
+    def test_prefix_is_as_good_as_the(self):
+        # $ + number as prefix
+        self._assert_completions_offered('$10', ('$10', '$100'))
+        # $ + macro first character
+        self._assert_completions_offered('$M', ('$MSGHDR', '$MSG'))
+        # $ + macro first character (small caps)
+        self._assert_completions_offered('$s', ('$smallcaps',))
+        # $ + brace + number
+        self._assert_completions_offered('${10', ('${10}', '${100}'))
+        # $ + brace + unqualified macro first character
+        self._assert_completions_offered('${M', ('${MSGHDR}', '${MSG}'))
+        # $ + brace + qualified macro first character
+        self._assert_completions_offered('${.', ('${.unix.uid}', '${.unix.gid}'))
+
+    def test_only_completions_that_start_with_word_are_listed_as_completions(self):
+        for word in ('$', '$1', '$M'):
+            self._assert_completions_start_with_word(word)
+
+    def test_nothing_is_offered_if_the_entire_input_diverged_already(self):
+        completions = self._get_completions('', entire_input='$(echo ')
+        self.assertEquals(completions, [])
+        completions = self._get_completions('', entire_input='almafa ')
+        self.assertEquals(completions, [])

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_macrocompleter.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_macrocompleter.py
@@ -3,6 +3,7 @@ from ..macrocompleter import MacroCompleter
 
 
 class TestMacroCompleter(CompleterTestCase):
+    # pylint: disable=arguments-differ
     def _construct_completer(self, macros=None):
         return MacroCompleter(macros=macros or ['MSG', 'MSGHDR', 'HOST',
                                                 '.unix.uid', '.unix.gid',

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py
@@ -1,0 +1,125 @@
+from __future__ import absolute_import, print_function
+from ..lexertoken import LexerToken
+from ..tablexer import TabLexer
+from ..lexer import Lexer
+from .test_lexer import TestLexer
+
+
+class GenNumbersLexer(Lexer):
+    def __init__(self, num_tokens, mark_last_partial=False):
+        self._token_count = 0
+        self._num_tokens = num_tokens
+        self._mark_last_partial = mark_last_partial
+        self._current_position = 0
+
+    def token(self):
+        if self._token_count < self._num_tokens:
+            lexpos = self._current_position
+            self._token_count += 1
+            self._current_position = self._token_count * 2
+
+            return LexerToken(type="NUMBER",
+                              value=str(self._token_count),
+                              partial=self._mark_last_partial and self._token_count == self._num_tokens,
+                              lexpos=lexpos)
+        return None
+
+    def input(self, input):
+        self._current_position = 0
+        self._token_count = 0
+
+    def get_position(self):
+        return self._current_position
+
+
+class TestTabLexer(TestLexer):
+    def setUp(self):
+        self._lexer = self._construct_lexer()
+
+    def _construct_lexer(self, num_tokens=5, mark_last_partial=False):
+        lexer = TabLexer(GenNumbersLexer(num_tokens, mark_last_partial=mark_last_partial))
+        self._consume_all_tokens(lexer)
+        lexer.input('')
+        return lexer
+
+    def _consume_all_tokens(self, lexer):
+        while lexer.token() is not None:
+            pass
+
+    def test_tab_lexer_token_returns_none_if_the_underlying_lexer_is_empty(self):
+        self._lexer = self._construct_lexer(0)
+        self._assert_next_token_is_tab(tab_position=0)
+        self.assertEquals(self._lexer.token(), None)
+
+    def test_tab_lexer_token_returns_token_if_the_underlying_lexer_has_elements(self):
+        self._lexer = self._construct_lexer(2)
+        self.assertEquals(self._lexer.token().value, '1')
+        self.assertEquals(self._lexer.token().value, '2')
+        self._assert_next_token_is_tab(tab_position=4)
+        self.assertIsNone(self._lexer.token())
+
+    def test_partial_is_replaced_by_tab(self):
+        self._lexer = self._construct_lexer(2, mark_last_partial=True)
+        self.assertEquals(self._lexer.token().value, '1')
+        self._assert_next_token_is_tab(tab_position=2)
+        self.assertIsNone(self._lexer.token())
+        self.assertEquals(self._lexer.get_replaced_token().value, '2')
+
+    def test_tab_is_appended_if_no_partial_token(self):
+        self._lexer = self._construct_lexer(2, mark_last_partial=False)
+        self._lexer.set_drop_last_token(False)
+        self.assertEquals(self._lexer.token().value, '1')
+        self.assertEquals(self._lexer.token().value, '2')
+        self._assert_next_token_is_tab(tab_position=4)
+        self.assertIsNone(self._lexer.token())
+        self.assertIsNone(self._lexer.get_replaced_token())
+
+    def test_last_token_is_replaced_by_a_tab_if_theres_no_partial_and_after_last_insertion_is_not_requested(self):
+        self._lexer = self._construct_lexer(2, mark_last_partial=False)
+        self._lexer.set_drop_last_token(True)
+        self.assertEquals(self._lexer.token().value, '1')
+        self._assert_next_token_is_tab(tab_position=2)
+        self.assertIsNone(self._lexer.token())
+        self.assertEquals(self._lexer.get_replaced_token().value, '2')
+
+    def test_tab_lexer_returns_tab_token_at_the_end_of_the_sequence(self):
+        self._lexer = self._construct_lexer(2)
+        self._assert_n_numbered_tokens_available(2)
+        self._assert_next_token_is_tab(tab_position=4)
+        self.assertIsNone(self._lexer.token())
+
+    def test_tab_lexer_can_replace_last_token_to_a_tab(self):
+        self._lexer = self._construct_lexer(0)
+        self._lexer.set_drop_last_token(True)
+        self._assert_next_token_is_tab(tab_position=0)
+        self.assertIsNone(self._lexer.token())
+
+        self._lexer = self._construct_lexer(1)
+        self._lexer.set_drop_last_token(True)
+        self._assert_next_token_is_tab(tab_position=0)
+        self.assertIsNone(self._lexer.token())
+
+        self._lexer = self._construct_lexer(2)
+        self._lexer.set_drop_last_token(True)
+        self._assert_n_numbered_tokens_available(1)
+        self._assert_next_token_is_tab(tab_position=2)
+        self.assertIsNone(self._lexer.token())
+
+        self._lexer = self._construct_lexer(3)
+        self._lexer.set_drop_last_token(True)
+        self._assert_n_numbered_tokens_available(2)
+        self._assert_next_token_is_tab(tab_position=4)
+        self.assertIsNone(self._lexer.token())
+
+    def _assert_n_numbered_tokens_available(self, n):
+        for i in range(1, n + 1):
+            self.assertEquals(self._lexer.token().value, str(i))
+
+    def _assert_current_token_position_equals(self, lexpos):
+        self.assertEquals(self._current_token.lexpos, lexpos)
+
+    def _assert_next_token_is_tab(self, tab_position=None):
+        self._next_token()
+        self._assert_current_token_type_equals("TAB")
+        if tab_position is not None:
+            self._assert_current_token_position_equals(tab_position)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_tablexer.py
@@ -24,7 +24,7 @@ class GenNumbersLexer(Lexer):
                               lexpos=lexpos)
         return None
 
-    def input(self, input):
+    def input(self, text):
         self._current_position = 0
         self._token_count = 0
 
@@ -36,13 +36,15 @@ class TestTabLexer(TestLexer):
     def setUp(self):
         self._lexer = self._construct_lexer()
 
+    # pylint: disable=arguments-differ
     def _construct_lexer(self, num_tokens=5, mark_last_partial=False):
         lexer = TabLexer(GenNumbersLexer(num_tokens, mark_last_partial=mark_last_partial))
         self._consume_all_tokens(lexer)
         lexer.input('')
         return lexer
 
-    def _consume_all_tokens(self, lexer):
+    @staticmethod
+    def _consume_all_tokens(lexer):
         while lexer.token() is not None:
             pass
 

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_templatelang.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_templatelang.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, print_function
+from ..templatelang import TemplateLang
+from .test_completerlang import CompleterLangTestCase
+
+
+class TestTemplateLang(CompleterLangTestCase):
+    def setUp(self):
+        self._parser = TemplateLang()
+
+    def test_template_is_a_series_of_literal_macro_and_template_funcs(self):
+        self._assert_token_follows("", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])
+        self._assert_token_follows(" ", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])
+        self._assert_token_follows("foo ", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])
+        self._assert_token_follows("$MSG ", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])
+        self._assert_token_follows("${MSG} ", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])
+        self._assert_token_follows("$(echo $MSG) ", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])
+        self._assert_token_follows("foo$MSG${MSG}$(echo $MSG)bar ", ["LITERAL", "MACRO", "TEMPLATE_FUNC"])

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py
@@ -6,7 +6,7 @@ from .test_lexer import TestLexer
 class TestTemplateLexer(TestLexer):
 
     def _construct_lexer(self):
-        return templatelexer.construct_lexer()
+        return templatelexer.TemplateLexer()
 
     def test_template_literals_are_returned_as_literal_tokens(self):
         self._lexer.input("foobar barfoo")

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_templatelexer.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import, print_function
+from .. import templatelexer
+from .test_lexer import TestLexer
+
+
+class TestTemplateLexer(TestLexer):
+
+    def _construct_lexer(self):
+        return templatelexer.construct_lexer()
+
+    def test_template_literals_are_returned_as_literal_tokens(self):
+        self._lexer.input("foobar barfoo")
+        self._assert_next_token_equals("LITERAL", value="foobar barfoo", pos=0)
+
+    def test_template_unbraced_macros_are_returned_as_macros(self):
+        self._lexer.input("$MSG")
+        self._assert_next_token_equals("MACRO", value="$MSG", pos=0)
+
+    def test_template_braced_macros_are_returned_as_macros(self):
+        self._lexer.input("${MSG}")
+        self._assert_next_token_equals("MACRO", value="${MSG}", pos=0)
+
+    def test_template_simple_template_functions_are_returned_as_template_funcs(self):
+        self._lexer.input("$(echo $MSG)")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$(echo $MSG)", pos=0)
+
+    def test_template_complex_template_functions_are_returned_as_template_funcs(self):
+        self._lexer.input("$(echo $(echo $MSG))")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$(echo $(echo $MSG))", pos=0)
+
+    def test_template_even_more_complex_template_functions_are_returned_as_template_funcs(self):
+        self._lexer.input("$(grep ('$COUNT' == 5) $MSG)")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$(grep ('$COUNT' == 5) $MSG)", pos=0)
+
+    def test_stray_dollar_at_the_end_of_input_is_returned_as_a_literal_token_with_partial_set(self):
+        self._lexer.input("$")
+        self._assert_next_token_equals("LITERAL", value="$", pos=0, partial=True)
+
+    def test_stray_dollar_brace_at_the_end_of_input_is_returned_as_a_literal_token_with_partial_set(self):
+        self._lexer.input("${")
+        self._assert_next_token_equals("LITERAL", value="${", pos=0, partial=True)
+
+    def test_stray_dollar_paren_at_the_end_of_input_is_returned_as_a_literal_token_with_partial_set(self):
+        self._lexer.input("$(")
+        self._assert_next_token_equals("LITERAL", value="$(", pos=0, partial=True)
+
+    def test_unfinished_template_function_at_the_end_of_input_is_returned_as_a_literal_token_with_partial_set(self):
+        self._lexer.input("$(echo")
+        self._assert_next_token_equals("LITERAL", value="$(echo", pos=0, partial=True)
+
+        self._lexer.input("$(echo $(echo $MSG)")
+        self._assert_next_token_equals("LITERAL", value="$(echo $(echo $MSG)", pos=0, partial=True)
+
+    def test_string_within_parens_returned_intact(self):
+        self._lexer.input("""$("foobar")""")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value='$("foobar")', pos=0)
+
+        self._lexer.input("""$("foo\\"bar")""")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="""$("foo\\"bar")""", pos=0)
+        self._lexer.input("""$("foo\\")bar")""")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="""$("foo\\")bar")""", pos=0)
+
+        self._lexer.input("""$('foobar')""")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$('foobar')", pos=0)
+
+        self._lexer.input("""$('foo"bar')""")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="""$('foo"bar')""", pos=0)
+
+    def test_quoted_parens_dont_close_the_template_function(self):
+        self._lexer.input("$(echo ')'")
+        self._assert_next_token_equals("LITERAL", value="$(echo ')'", pos=0, partial=True)
+
+        self._lexer.input("$(echo ')')")
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$(echo ')')", pos=0)
+
+    def test_quotes_outside_template_functions_are_returned_literally(self):
+        self._lexer.input("'$(echo $MSG)'")
+        self._assert_next_token_equals("LITERAL", value="'", pos=0)
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$(echo $MSG)", pos=1)
+        self._assert_next_token_equals("LITERAL", value="'", pos=13)
+
+    def test_braced_macro_splits_literals_in_half(self):
+        self._lexer.input("foobar${MSG}barfoo")
+        self._assert_next_token_equals("LITERAL", value="foobar", pos=0)
+        self._assert_next_token_equals("MACRO", value="${MSG}", pos=6)
+        self._assert_next_token_equals("LITERAL", value="barfoo", pos=12)
+
+    def test_unbraced_macros_split_literals_in_half(self):
+        self._lexer.input("foobar $MSG barfoo")
+        self._assert_next_token_equals("LITERAL", value="foobar ", pos=0)
+        self._assert_next_token_equals("MACRO", value="$MSG", pos=7)
+        self._assert_next_token_equals("LITERAL", value=" barfoo", pos=11)
+
+    def test_template_function_splits_literals_in_half(self):
+        self._lexer.input("foobar$(echo $MSG)barfoo")
+        self._assert_next_token_equals("LITERAL", value="foobar", pos=0)
+        self._assert_next_token_equals("TEMPLATE_FUNC", value="$(echo $MSG)", pos=6)
+        self._assert_next_token_equals("LITERAL", value="barfoo", pos=18)

--- a/modules/python/pylib/syslogng/debuggercli/tests/test_tflang.py
+++ b/modules/python/pylib/syslogng/debuggercli/tests/test_tflang.py
@@ -1,0 +1,29 @@
+from .test_completerlang import CompleterLangTestCase
+from ..tflang import TemplateFunctionLang
+
+
+class TestTFLang(CompleterLangTestCase):
+    def setUp(self):
+        self._parser = TemplateFunctionLang()
+
+    def test_template_func_is_a_command_and_a_sequence_of_arguments(self):
+        self._assert_token_follows("", ["COMMAND"])
+        self._assert_token_follows("foo ", ["ARG"])
+        self._assert_token_follows("foo bar ", ["ARG"])
+        self._assert_token_follows("foo bar baz", ["ARG"])
+
+    def test_format_json_arguments(self):
+        self._assert_token_follows("format-json", ["COMMAND_FORMAT_JSON"])
+        self._assert_token_follows("format-json ", ["ARG", "OPT__KEY", "OPT__PAIR"])
+        self._assert_token_follows("format-json --key ", ["name_value_name"])
+        self._assert_token_follows("format-json --pair ", ["name_value_pair"])
+        self._assert_token_follows("format-json --scope ", ["value_pairs_scope"])
+        self._assert_token_follows("format-json --key * --pair a=$b --scope ", ["value_pairs_scope"])
+
+    def test_geoip_arguments(self):
+        self._assert_token_follows("geoip ", ["ipaddress", "ARG"])
+
+    def test_echo_arguments(self):
+        self._assert_token_follows("echo ", ["template", "ARG"])
+        self._assert_token_follows("echo $MSG ", ["template", "ARG"])
+        self._assert_token_follows("echo $MSG $MSG ", ["template", "ARG"])

--- a/modules/python/pylib/syslogng/debuggercli/tflang.py
+++ b/modules/python/pylib/syslogng/debuggercli/tflang.py
@@ -1,0 +1,110 @@
+from __future__ import print_function, absolute_import
+from .completerlang import CompleterLang
+from .commandlinelexer import CommandLineLexer
+from .getoptlexer import GetoptLexer
+
+
+class TemplateFunctionLang(CompleterLang):
+    tokens_base = [
+        "COMMAND", "ARG", "OPT"
+    ]
+    known_commands = ("format-json", "echo", "geoip")
+    known_options = (
+        # value-pairs
+        "--scope", "--exclude", "--key", "--rekey", "--pair",
+        "--shift", "--add-prefix", "--replace-prefix", "--replace")
+
+    def p_template_func(self, p):
+        '''template_func : tf_format_json
+                         | tf_echo
+                         | tf_geoip
+                         | tf_generic'''
+        pass
+
+    def p_tf_format_json(self, p):
+        '''tf_format_json : COMMAND_FORMAT_JSON tf_format_json_args'''
+        pass
+
+    def p_tf_format_json_args(self, p):
+        '''tf_format_json_args : tf_format_json_arg tf_format_json_args
+                               | '''
+        pass
+
+    def p_tf_format_json_arg(self, p):
+        '''tf_format_json_arg  : OPT__SCOPE value_pairs_scope
+                               | OPT__EXCLUDE ARG
+                               | OPT__KEY name_value_name
+                               | OPT__REKEY ARG
+                               | OPT__PAIR name_value_pair
+                               | OPT__SHIFT ARG
+                               | OPT__ADD_PREFIX ARG
+                               | OPT__REPLACE_PREFIX ARG
+                               | OPT__REPLACE ARG
+                               | OPT
+                               | ARG'''
+        pass
+
+    def p_name_value_name(self, p):
+        '''name_value_name : ARG'''
+        pass
+
+    def p_name_value_pair(self, p):
+        '''name_value_pair : ARG'''
+        pass
+
+    def p_value_pairs_scope(self, p):
+        '''value_pairs_scope : ARG'''
+        pass
+
+    def p_tf_echo(self, p):
+        '''tf_echo : COMMAND_ECHO templates'''
+        pass
+
+    def p_tf_geoip(self, p):
+        '''tf_geoip : COMMAND_GEOIP ipaddress'''
+        pass
+
+    def p_tf_generic(self, p):
+        '''tf_generic : COMMAND args'''
+        pass
+
+    def p_args(self, p):
+        '''args : ARG args
+                |
+        '''
+        pass
+
+    def p_templates(self, p):
+        '''templates : template templates
+                     | '''
+        pass
+
+    def p_template(self, p):
+        '''template : ARG'''
+        pass
+
+    def p_ipaddress(self, p):
+        '''ipaddress : ARG'''
+        pass
+
+    def _initialize_rules(self):
+        tokens = list(self.tokens_base)
+        self._convert_known_commands_to_tokens(tokens)
+        self._convert_known_options_to_tokens(tokens)
+        self.tokens = tokens
+
+    def _construct_lexer(self):
+        return GetoptLexer(CommandLineLexer(),
+                           known_commands=self.known_commands,
+                           known_options=self.known_options)
+
+    def _tokenize_argument(self, arg):
+        return arg.upper().replace('-', '_')
+
+    def _convert_known_commands_to_tokens(self, tokens):
+        for command in self.known_commands:
+            tokens.append("COMMAND_{}".format(self._tokenize_argument(command)))
+
+    def _convert_known_options_to_tokens(self, tokens):
+        for option in self.known_options:
+            tokens.append("OPT{}".format(self._tokenize_argument(option)))

--- a/modules/python/pylib/syslogng/debuggercli/tflang.py
+++ b/modules/python/pylib/syslogng/debuggercli/tflang.py
@@ -5,6 +5,7 @@ from .getoptlexer import GetoptLexer
 
 
 class TemplateFunctionLang(CompleterLang):
+    tokens = []
     tokens_base = [
         "COMMAND", "ARG", "OPT"
     ]
@@ -98,7 +99,8 @@ class TemplateFunctionLang(CompleterLang):
                            known_commands=self.known_commands,
                            known_options=self.known_options)
 
-    def _tokenize_argument(self, arg):
+    @staticmethod
+    def _tokenize_argument(arg):
         return arg.upper().replace('-', '_')
 
     def _convert_known_commands_to_tokens(self, tokens):

--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -26,6 +26,42 @@
 #include "python-helpers.h"
 #include "messages.h"
 #include "debugger/debugger.h"
+#include "logmsg.h"
+
+static void
+_add_nv_keys_to_list(gpointer key, gpointer value, gpointer user_data)
+{
+  PyObject *list = (PyObject *) user_data;
+  const gchar *name = (const gchar *) key;
+
+  PyList_Append(list, PyString_FromString(name));
+}
+
+static PyObject *
+_py_get_nv_registry(PyObject *s, PyObject *args)
+{
+  PyObject *list;
+
+  if (!PyArg_ParseTuple(args, ""))
+    return NULL;
+
+  list = PyList_New(0);
+  log_msg_registry_foreach(_add_nv_keys_to_list, list);
+  return list;
+}
+
+static PyMethodDef _syslogngdbg_functions[] =
+{
+  { "get_nv_registry",  _py_get_nv_registry, METH_VARARGS, "Get the list of registered name-value pairs in syslog-ng" },
+  { NULL,            NULL, 0, NULL }   /* sentinel*/
+};
+
+
+static void
+python_debugger_export_internals(void)
+{
+  Py_InitModule("_syslogngdbg", _syslogngdbg_functions);
+}
 
 #define DEBUGGER_FETCH_COMMAND "syslogng.debuggercli.fetch_command"
 
@@ -75,5 +111,6 @@ python_fetch_debugger_command(void)
 void
 python_debugger_init(void)
 {
+  python_debugger_export_internals();
   debugger_register_command_fetcher(python_fetch_debugger_command);
 }

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -403,7 +403,7 @@ __check_value_len(NVHandle handle, const gchar *name, const gchar *value, gssize
 void
 _test_field_size_test(TestCase *self, TestSource *src, LogMessage *msg)
 {
-  log_msg_nv_table_foreach(msg->payload, __check_value_len, self);
+  log_msg_values_foreach(msg, __check_value_len, self);
   test_source_finish_tc(src);
 }
 

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -40,7 +40,7 @@ static const gchar *control_name;
 static ControlClient *control_client;
 
 static gboolean
-slng_send_cmd(gchar *cmd)
+slng_send_cmd(const gchar *cmd)
 {
   if (!control_client_connect(control_client))
     {


### PR DESCRIPTION
This branch actually completes the initial batch to support command completion in the syslog-ng interactive debugger.

Right now it is able to use completion on:
 * the debug commands themselves
 * in the template string argument to various debug commands (print and display)

The support for template strings is pretty comprehensive, it understands macros (both with and without braces, e.g. ${MSG} and $MSG), template functions and literal strings. It understands three template functions a bit deeper: format-json, echo and geoip

The support for format-json goes as far as understanding all its keyword arguments and providing completion for macros within the command line.

The entire implementation is based on the Python work I did earlier and I intend to add support for further completions as I see this functionality of becoming really useful for interactive syslog-ng configuration development.

The code itself is pep8 and pylint warning free, has a pretty good unit test coverage (96%, with most of the unsupported portions is in hooking into the readline subsystem).

It could still be improved, but I feel it is good enough to integrate it. I am going to deal with further development in subsequent patches.

Please merge.
