### PR TITLE
ssl_options() option inside tls()

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -429,10 +429,10 @@ tls_lookup_verify_mode(const gchar *mode_str)
   return TVM_REQUIRED | TVM_TRUSTED;
 }
 
-TLSSslOptions
+gint
 tls_lookup_options(GList *options)
 {
-  TLSSslOptions ret=TSO_NONE;
+  gint ret=TSO_NONE;
   GList *l;
   for (l=options; l != NULL; l=l->next)
     {

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -432,26 +432,24 @@ TLSSslOptions
 tls_lookup_options(GList *options)
 {
   TLSSslOptions ret=TSO_NONE;
-  GList *option;
-  for(option=options; option != NULL ; option=option->next)
+  GList *l;
+  for(l=options; l != NULL ; l=l->next)
     {
-      msg_debug("ssl-option",evt_tag_str("opt",option->data),NULL);
-      if(strcasecmp(option->data,"none") == 0)
-        ret|=TSO_NONE;
-      else if (strcasecmp(option->data,"no-sslv2") == 0 || strcasecmp(option->data,"no_sslv2") == 0)
+      msg_debug("ssl-option",evt_tag_str("opt",l->data),NULL);
+      if (strcasecmp(l->data,"no-sslv2") == 0 || strcasecmp(l->data,"no_sslv2") == 0)
         ret|=TSO_NOSSLv2;
-      else if (strcasecmp(option->data,"no-sslv3") == 0 || strcasecmp(option->data,"no_sslv3") == 0)
+      else if (strcasecmp(l->data,"no-sslv3") == 0 || strcasecmp(l->data,"no_sslv3") == 0)
         ret|=TSO_NOSSLv3;
-      else if (strcasecmp(option->data,"no-tlsv1") == 0 || strcasecmp(option->data,"no_tlsv1") == 0)
+      else if (strcasecmp(l->data,"no-tlsv1") == 0 || strcasecmp(l->data,"no_tlsv1") == 0)
         ret|=TSO_NOTLSv1;
 #ifdef SSL_OP_NO_TLSv1_2
-      else if (strcasecmp(option->data,"no-tlsv11") == 0 || strcasecmp(option->data,"no_tlsv11") == 0)
+      else if (strcasecmp(l->data,"no-tlsv11") == 0 || strcasecmp(l->data,"no_tlsv11") == 0)
         ret|=TSO_NOTLSv11;
-      else if (strcasecmp(option->data,"no-tlsv12") == 0 || strcasecmp(option->data,"no_tlsv12") == 0)
+      else if (strcasecmp(l->data,"no-tlsv12") == 0 || strcasecmp(l->data,"no_tlsv12") == 0)
         ret|=TSO_NOTLSv12;
 #endif
       else
-        msg_error("Unknown ssl-option",evt_tag_str("option",option->data),NULL);
+        msg_error("Unknown ssl-option",evt_tag_str("option",l->data),NULL);
     }
   msg_debug("ssl-options parsed",evt_tag_printf("parsed value","%d" ,ret),NULL);
   return ret;

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -335,6 +335,7 @@ tls_context_setup_session(TLSContext *self)
         }
 
       SSL_CTX_set_verify(self->ssl_ctx, verify_mode, tls_session_verify_callback);
+
       if (self->ssl_options != TSO_NONE)
         {
           ssl_options=0;
@@ -433,25 +434,25 @@ tls_lookup_options(GList *options)
 {
   TLSSslOptions ret=TSO_NONE;
   GList *l;
-  for(l=options; l != NULL ; l=l->next)
+  for (l=options; l != NULL; l=l->next)
     {
-      msg_debug("ssl-option",evt_tag_str("opt",l->data),NULL);
-      if (strcasecmp(l->data,"no-sslv2") == 0 || strcasecmp(l->data,"no_sslv2") == 0)
+      msg_debug("ssl-option", evt_tag_str("opt", l->data), NULL);
+      if (strcasecmp(l->data, "no-sslv2") == 0 || strcasecmp(l->data, "no_sslv2") == 0)
         ret|=TSO_NOSSLv2;
-      else if (strcasecmp(l->data,"no-sslv3") == 0 || strcasecmp(l->data,"no_sslv3") == 0)
+      else if (strcasecmp(l->data, "no-sslv3") == 0 || strcasecmp(l->data, "no_sslv3") == 0)
         ret|=TSO_NOSSLv3;
-      else if (strcasecmp(l->data,"no-tlsv1") == 0 || strcasecmp(l->data,"no_tlsv1") == 0)
+      else if (strcasecmp(l->data, "no-tlsv1") == 0 || strcasecmp(l->data, "no_tlsv1") == 0)
         ret|=TSO_NOTLSv1;
 #ifdef SSL_OP_NO_TLSv1_2
-      else if (strcasecmp(l->data,"no-tlsv11") == 0 || strcasecmp(l->data,"no_tlsv11") == 0)
+      else if (strcasecmp(l->data, "no-tlsv11") == 0 || strcasecmp(l->data, "no_tlsv11") == 0)
         ret|=TSO_NOTLSv11;
-      else if (strcasecmp(l->data,"no-tlsv12") == 0 || strcasecmp(l->data,"no_tlsv12") == 0)
+      else if (strcasecmp(l->data, "no-tlsv12") == 0 || strcasecmp(l->data, "no_tlsv12") == 0)
         ret|=TSO_NOTLSv12;
 #endif
       else
-        msg_error("Unknown ssl-option",evt_tag_str("option",l->data),NULL);
+        msg_error("Unknown ssl-option", evt_tag_str("option", l->data), NULL);
     }
-  msg_debug("ssl-options parsed",evt_tag_printf("parsed value","%d" ,ret),NULL);
+  msg_debug("ssl-options parsed", evt_tag_printf("parsed value", "%d", ret), NULL);
   return ret;
 }
 

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -344,10 +344,12 @@ tls_context_setup_session(TLSContext *self)
             ssl_options |= SSL_OP_NO_SSLv3;
           if(self->ssl_options & TSO_NOTLSv1)
             ssl_options |= SSL_OP_NO_TLSv1;
+#ifdef SSL_OP_NO_TLSv1_2
           if(self->ssl_options & TSO_NOTLSv11)
             ssl_options |= SSL_OP_NO_TLSv1_1;
           if(self->ssl_options & TSO_NOTLSv12)
             ssl_options |= SSL_OP_NO_TLSv1_2;
+#endif
           SSL_CTX_set_options(self->ssl_ctx, ssl_options);
         }
       else
@@ -430,26 +432,26 @@ TLSSslOptions
 tls_lookup_options(GList *options)
 {
   TLSSslOptions ret=TSO_NONE;
-  GList *l;
-  for(l=options; l != NULL ; l=l->next)
+  GList *option;
+  for(option=options; option != NULL ; option=option->next)
     {
-      msg_debug("ssl-option",evt_tag_str("opt",l->data),NULL);
-      if(strcasecmp(l->data,"none") == 0)
+      msg_debug("ssl-option",evt_tag_str("opt",option->data),NULL);
+      if(strcasecmp(option->data,"none") == 0)
         ret|=TSO_NONE;
-      else if (strcasecmp(l->data,"no-sslv2") == 0 || strcasecmp(l->data,"no_sslv2") == 0)
+      else if (strcasecmp(option->data,"no-sslv2") == 0 || strcasecmp(option->data,"no_sslv2") == 0)
         ret|=TSO_NOSSLv2;
-      else if (strcasecmp(l->data,"no-sslv3") == 0 || strcasecmp(l->data,"no_sslv3") == 0)
+      else if (strcasecmp(option->data,"no-sslv3") == 0 || strcasecmp(option->data,"no_sslv3") == 0)
         ret|=TSO_NOSSLv3;
-      else if (strcasecmp(l->data,"no-tlsv1") == 0 || strcasecmp(l->data,"no_tlsv1") == 0)
+      else if (strcasecmp(option->data,"no-tlsv1") == 0 || strcasecmp(option->data,"no_tlsv1") == 0)
         ret|=TSO_NOTLSv1;
-      else if (strcasecmp(l->data,"no-tlsv11") == 0 || strcasecmp(l->data,"no_tlsv11") == 0)
+#ifdef SSL_OP_NO_TLSv1_2
+      else if (strcasecmp(option->data,"no-tlsv11") == 0 || strcasecmp(option->data,"no_tlsv11") == 0)
         ret|=TSO_NOTLSv11;
-      else if (strcasecmp(l->data,"no-tlsv12") == 0 || strcasecmp(l->data,"no_tlsv12") == 0)
+      else if (strcasecmp(option->data,"no-tlsv12") == 0 || strcasecmp(option->data,"no_tlsv12") == 0)
         ret|=TSO_NOTLSv12;
+#endif
       else
-        msg_error("Unknown ssl-option",evt_tag_str("option",l->data),NULL);
-/* FIXME: If none of above, than we should handle the illegal options string somehow!!!
-*/
+        msg_error("Unknown ssl-option",evt_tag_str("option",option->data),NULL);
     }
   msg_debug("ssl-options parsed",evt_tag_printf("parsed value","%d" ,ret),NULL);
   return ret;

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -44,7 +44,7 @@ typedef enum
   TVM_REQUIRED=0x0020,
 } TLSVerifyMode;
 
-typedef enum
+enum
 {
   TSO_NONE,
   TSO_NOSSLv2=0x0001,
@@ -92,7 +92,7 @@ TLSContext *tls_context_new(TLSMode mode);
 void tls_context_free(TLSContext *s);
 
 TLSVerifyMode tls_lookup_verify_mode(const gchar *mode_str);
-TLSSslOptions tls_lookup_options(GList *options);
+gint tls_lookup_options(GList *options);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -81,7 +81,7 @@ struct _TLSContext
   SSL_CTX *ssl_ctx;
   GList *trusted_fingerpint_list;
   GList *trusted_dn_list;
-  TLSSslOptions ssl_options;
+  gint ssl_options;
 };
 
 

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -44,6 +44,16 @@ typedef enum
   TVM_REQUIRED=0x0020,
 } TLSVerifyMode;
 
+typedef enum
+{
+  TSO_NONE,
+  TSO_NOSSLv2=0x0001,
+  TSO_NOSSLv3=0x0002,
+  TSO_NOTLSv1=0x0004,
+  TSO_NOTLSv11=0x0008,
+  TSO_NOTLSv12=0x0010,
+} TLSSslOptions;
+
 typedef gint (*TLSSessionVerifyFunc)(gint ok, X509_STORE_CTX *ctx, gpointer user_data);
 typedef struct _TLSContext TLSContext;
 
@@ -71,6 +81,7 @@ struct _TLSContext
   SSL_CTX *ssl_ctx;
   GList *trusted_fingerpint_list;
   GList *trusted_dn_list;
+  TLSSslOptions ssl_options;
 };
 
 
@@ -81,6 +92,7 @@ TLSContext *tls_context_new(TLSMode mode);
 void tls_context_free(TLSContext *s);
 
 TLSVerifyMode tls_lookup_verify_mode(const gchar *mode_str);
+TLSSslOptions tls_lookup_options(GList *options);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -166,6 +166,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_TRUSTED_KEYS
 %token KW_TRUSTED_DN
 %token KW_CIPHER_SUITE
+%token KW_SSL_OPTIONS
 
 /* INCLUDE_DECLS */
 
@@ -700,6 +701,10 @@ tls_option
 	  {
             last_tls_context->cipher_suite = g_strdup($3);
             free($3);
+	  }
+	| KW_SSL_OPTIONS '(' string_list ')'
+	  {
+            last_tls_context->ssl_options = tls_lookup_options($3);
 	  }
         | KW_ENDIF {
 }

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -51,6 +51,7 @@ static CfgLexerKeyword afsocket_keywords[] = {
   { "trusted_keys",       KW_TRUSTED_KEYS },
   { "trusted_dn",         KW_TRUSTED_DN },
   { "cipher_suite",       KW_CIPHER_SUITE },
+  { "ssl_options",        KW_SSL_OPTIONS },
 
   { "localip",            KW_LOCALIP },
   { "ip",                 KW_IP },


### PR DESCRIPTION
allowed values: no-sslv2, no-sslv3, no-tlsv1, no-tlsv11, no-tlsv12, none
I think, they are self-explanatory.

Signed-off-by: PÁSZTOR György <gyorgy.pasztor@balabit.com>