### PR TITLE
riemann: also exclude "tags" as attribute which conflicts with reserved

### DIFF
--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -242,7 +242,7 @@ static void
 _value_pairs_always_exclude_properties(RiemannDestDriver *self)
 {
   static const gchar *properties[] = {"host", "service", "description", "state",
-                                      "ttl", "metric", NULL};
+                                      "ttl", "metric", "tags", NULL};
   gint i;
 
   for (i = 0; properties[i]; i++)


### PR DESCRIPTION
keyword

See 5ea764d6 and [corresponding riemann issue](/aphyr/riemann/issues/545)