### PR TITLE
journald: If key is NULL, that means, we can not really add the value th...

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -158,6 +158,11 @@ __handle_data(gchar *key, gchar *value, gpointer user_data)
   JournalReaderOptions *options = args[1];
   gssize value_len = MIN(strlen(value), options->max_field_size);
 
+  if (key == NULL)
+    {
+      return;
+    }
+
   if (strcmp(key, "MESSAGE") == 0)
     {
       log_msg_set_value(msg, LM_V_MESSAGE, value, value_len);


### PR DESCRIPTION
...e message,

because at this point we can not create name value pair if we only have the value

References: issue #459

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>