### PR TITLE
afamqp: fix in the connect process

### DIFF
--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -364,8 +364,6 @@ afamqp_dd_connect(AMQPDestDriver *self, gboolean reconnect)
       goto exception_amqp_dd_connect_failed_init;
     }
 
-  amqp_tcp_socket_set_sockfd(self->sockfd, sockfd_ret);
-
   ret = amqp_login(self->conn, self->vhost, 0, 131072, 0,
                    AMQP_SASL_METHOD_PLAIN, self->user, self->password);
   if (!afamqp_is_ok(self, "Error during AMQP login", ret))


### PR DESCRIPTION
This removes the faulty file descriptor set, and should fix the "socket
error" problem.