### PR TITLE
Gitter integration added to syslog-ng to make it easier to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,9 @@ notifications:
   irc:
     channels:
       - "irc.freenode.org#balabit"
+  webhooks:
+      urls:
+        - https://webhooks.gitter.im/e/1c6e3a6f10348748585a
+      on_success: always  # options: [always|never|change] default: always
+      on_failure: always  # options: [always|never|change] default: always
+      on_start: true     # default: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/balabit/syslog-ng?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
+[![Build Status](https://travis-ci.org/balabit/syslog-ng.svg?branch=master)](https://travis-ci.org/balabit/syslog-ng)
+[![Build Status](https://drone.io/github.com/balabit/syslog-ng/status.png)](https://drone.io/github.com/balabit/syslog-ng/latest)
+
 syslog-ng
 =========
 


### PR DESCRIPTION
sync within the community.
Badges added to check TravisCI and Drone.io state.
Badge added to Gitter room.

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>