### PR TITLE
completerlang: quick fix for PLY-3.6

### DIFF
--- a/modules/python/pylib/syslogng/debuggercli/completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/completerlang.py
@@ -48,7 +48,12 @@ class CompleterLang(object):
             # deeper would probably improve readability at the cost of increasing fragility.
 
             # pylint: disable=protected-access
-            parser_state = sys._getframe(1).f_locals['state']
+            if 'state' in sys._getframe(1).f_locals:
+                parser_state = sys._getframe(1).f_locals['state']
+            elif 'state' in sys._getframe(2).f_locals:
+                parser_state = sys._getframe(2).f_locals['state']
+            else:
+                return None
 
             # now handle the error that the TAB token caused
             self._token_position = p.lexpos


### PR DESCRIPTION
Local variable 'state' is not in frame 1 anymore, it is in frame 2 in
PLY-3.6 (there is a callback which calls our function this is the reason why
the state variable is in frame 2).

Note that this is an ugly-ugly hack :-)
We have to eliminate this sitation somehow.

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>