### PR TITLE
pylib: Makefile.am fixed

### DIFF
--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -80,8 +80,8 @@ modules_python_pylib_TESTS = modules/python/pylib/test_pylib
 check_PROGRAMS += $(modules_python_pylib_TESTS)
 
 modules/python/pylib/test_pylib$(EXEEXT): Makefile
-	mkdir -p modules/python/pylib
-	echo "$(MAKE) MAKEFLAGS= python-checks" > "$@"
+	mkdir -p modules/python/pylib && \
+	echo "$(MAKE) MAKEFLAGS= python-checks" > "$@" && \
 	chmod +x "$@"
 
 modules_python_pylib_test_pylib_SOURCES = modules/python/pylib/test_pylib$(EXEEXT)


### PR DESCRIPTION
Run those shell commands in the same subshell.

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>

During Debian packaging execution permission was missing from the test_pylib script
