### PR TITLE
afsql: fixed retry_sql_inserts(1) isssue

### DIFF
--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1010,7 +1010,7 @@ afsql_dd_insert_db(AFSqlDestDriver *self)
     }
   else
     {
-      if (self->failed_message_counter < self->num_retries - 1)
+      if (self->failed_message_counter < self->num_retries)
         {
           if (!afsql_dd_handle_insert_row_error_depending_on_connection_availability(self, msg, &path_options))
             return FALSE;


### PR DESCRIPTION
When an insert failed(after retries), syslog-ng didn't drop the connection
and thus an invalid transaction was kept in open state. When a new message
arrived, syslog-ng wanted to append that to the invalid transaction,
which caused failure and the message was dropped.

The problem occured when retries was set to 1.

if (self->failed_message_counter < self->num_retries - 1) // if (0 < 0)
  {
     // retry AND return false, which means to the caller
     // that the connection should be suspended
  }
else
  {
     // drop msg AND return true, which means to the caller
     // that connection should be kept open
  }

This is why a simple workaround (setting reties to 2) could solve this problem.

fixes #469

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>