### PR TITLE
cfg-lex: exclude the '\r' character from word declaration

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -154,7 +154,7 @@ xdigit	[0-9a-fA-F]
 odigit  [0-7]
 alpha		[a-zA-Z]
 alphanum	[a-zA-Z0-9]
-word	[^ \#'"\(\)\{\}\\;\n\t,|\.@:]
+word	[^ \#'"\(\)\{\}\\;\r\n\t,|\.@:]
 
 /* block related states must be last, as we use this fact in YY_INPUT */
 %x string


### PR DESCRIPTION
syslog-ng parses configuration in an erroneous way when CR characters are present at line endings,
and will give misleading error messages:

Error parsing main, syntax error, unexpected LL_IDENTIFIER, expecting '}' in dos-ending.conf at line 97, column 20:
  facility(local0) and
                   ^^^^

filter f_dp_gwy_app_audit {^M
  facility(local0) and^M
  host("BTESBDPGWYAppAudit");^M
};^M

Steps to reproduce:
[ERROR]
[WILL WORK OK]

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>