### PR TITLE
configure: fix syntax error in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1203,7 +1203,7 @@ if test "x$enable_systemd" = "xyes"; then
                                   with_systemd_journal=system, with_systemd_journal=optional)
             elif test "x$with_systemd_journal" = "xsystem"; then
                 PKG_CHECK_MODULES(LIBSYSTEMD_JOURNAL, libsystemd-journal >= $JOURNALD_MIN_VERSION,,
-                AC_MSG_ERROR[Detecting system releted systemd-journal library failed])
+                                  AC_MSG_ERROR([Detecting system related systemd-journal library failed]))
             fi
             libsystemd_CFLAGS="${LIBSYSTEMD_JOURNAL_CFLAGS} ${libsystemd_daemon_CFLAGS}"
             libsystemd_LIBS="${LIBSYSTEMD_JOURNAL_LIBS} ${libsystemd_daemon_LIBS}"


### PR DESCRIPTION
I think the original notion was to fail in this case.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>