### PR TITLE
afsocket: initialization phase was refactored.

### DIFF
--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -48,6 +48,7 @@ struct _AFSocketDestDriver
   GSockAddr *bind_addr;
   GSockAddr *dest_addr;
   gint time_reopen;
+  gboolean connection_initialized;
   struct iv_fd connect_fd;
   struct iv_timer reconnect_timer;
   SocketOptions *socket_options;


### PR DESCRIPTION
 If the host cannot be connected during the initialization of `afsocket` destination and it is
possible that it can be done later then we will retry it periodically
scheduled by `time-reopen`.

This patch was written in pair with @dnsjts

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>