### PR TITLE
AFInter: Proper wakeup function handling for deinitialized AFInterSou…

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -152,7 +152,19 @@ afinter_source_wakeup(LogSource *s)
 {
   AFInterSource *self = (AFInterSource *) s;
 
-  iv_event_post(&self->schedule_wakeup);
+  /*
+   * We might get called even after this AFInterSource has been
+   * deinitialized, in which case we must not do anything (since the
+   * iv_event triggered here is not registered).
+   *
+   * This happens when log_writer_deinit() flushes its output queue
+   * after the internal source which produced the message has already been
+   * deinited. Since init/deinit calls are made in the main thread, no
+   * locking is needed.
+   *
+   */
+  if (self->super.super.flags & PIF_INITIALIZED)
+    iv_event_post(&self->schedule_wakeup);
 }
 
 static void


### PR DESCRIPTION
…rces

The wakeup() callback can be called even if a AFInterSource is
deinitialized (when the Writer is deinitialized _after_ the internal source, and
some messages are flushed out in the deinit path), in
which case we shouldn't trigger the schedule_wakeup event.

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>