### PR TITLE
affile: reopen timer added to logwriter

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -38,6 +38,7 @@
 #define NC_FILE_MOVED  4
 #define NC_FILE_EOF    5
 #define NC_FILE_SKIP   6
+#define NC_REOPEN_REQUIRED 7
 
 /* indicates that the LogPipe was initialized */
 #define PIF_INITIALIZED       0x0001


### PR DESCRIPTION
When a not writeable file becomes writeable later, syslog-ng recognize it and
delivers messages to the file without dropping the messages received during
the file was not available.

Some technical details:
AFFileDestDriver owns one(single file) or more(templated filenames)
AFFileDestWriter objects.

Each AFFileDestWriter is responsible for writing logs to the associated file
via its LogWriter object.

LogWriter object has a LogProtoClient which actually writing the logs.

When a file is not available, proto construction is failed, but it is possible
to create the LogWriter object with empty proto. This is what we are doing.
And the LogWriter object handles a timer (reopen_timer). If the timer is
elapsed, it notifies(NC_REOPEN_REQUEST) the AFFileDestWriter who will
reopen itself by retrying to create a proto object.
This is repeating until not able to create a valid proto object (or
the file become writeable to syslog-ng).

fixes #138
(and hopefully also fixes #464)

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>