### PR TITLE
affile: reopen timer added to logwriter

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -38,6 +38,7 @@
 #define NC_FILE_MOVED  4
 #define NC_FILE_EOF    5
 #define NC_FILE_SKIP   6
+#define NC_REOPEN_REQUIRED 7
 
 /* indicates that the LogPipe was initialized */
 #define PIF_INITIALIZED       0x0001

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -161,6 +161,17 @@ affile_dw_reopen(AFFileDestWriter *self)
 {
   int fd;
   struct stat st;
+  GlobalConfig *cfg;
+  LogProtoClient *proto = NULL;
+
+  cfg = log_pipe_get_config(&self->super);
+  if (cfg)
+    self->time_reopen = cfg->time_reopen;
+
+   msg_verbose("Initializing destination file writer",
+              evt_tag_str("template", self->owner->filename_template->template),
+              evt_tag_str("filename", self->filename),
+              NULL);
 
   self->last_open_stamp = self->last_msg_stamp;
   if (self->owner->overwrite_if_older > 0 && 
@@ -176,12 +187,11 @@ affile_dw_reopen(AFFileDestWriter *self)
 
   if (_affile_dw_reopen_file(self, self->filename, &fd))
     {
-      log_writer_reopen(self->writer,
-                        self->owner->file_open_options.is_pipe
-                        ? log_proto_text_client_new(log_transport_pipe_new(fd), &self->owner->writer_options.proto_options.super)
-                        : log_proto_file_writer_new(log_transport_file_new(fd), &self->owner->writer_options.proto_options.super,
-                                                    self->owner->writer_options.flush_lines,
-                                                    self->owner->use_fsync));
+      proto =  self->owner->file_open_options.is_pipe
+                           ? log_proto_text_client_new(log_transport_pipe_new(fd), &self->owner->writer_options.proto_options.super)
+                           : log_proto_file_writer_new(log_transport_file_new(fd), &self->owner->writer_options.proto_options.super,
+                                                       self->owner->writer_options.flush_lines,
+                                                       self->owner->use_fsync);
 
       main_loop_call((void * (*)(void *)) affile_dw_arm_reaper, self, TRUE);
     }
@@ -191,8 +201,10 @@ affile_dw_reopen(AFFileDestWriter *self)
                 evt_tag_str("filename", self->filename),
                 evt_tag_errno(EVT_TAG_OSERROR, errno),
                 NULL);
-      return self->owner->super.super.optional;
     }
+
+  log_writer_reopen(self->writer, proto);
+
   return TRUE;
 }
 
@@ -201,14 +213,6 @@ affile_dw_init(LogPipe *s)
 {
   AFFileDestWriter *self = (AFFileDestWriter *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
-
-  if (cfg)
-    self->time_reopen = cfg->time_reopen;
-
-  msg_verbose("Initializing destination file writer",
-              evt_tag_str("template", self->owner->filename_template->template),
-              evt_tag_str("filename", self->filename),
-              NULL);
 
   if (!self->writer)
     {
@@ -328,6 +332,19 @@ affile_dw_free(LogPipe *s)
   log_pipe_free_method(s);
 }
 
+static void
+affile_dw_notify(LogPipe *s, gint notify_code, gpointer user_data)
+{
+  switch(notify_code)
+    {
+      case NC_REOPEN_REQUIRED:
+          affile_dw_reopen((AFFileDestWriter *)s);
+          break;
+      default:
+          break;
+    }
+}
+
 static AFFileDestWriter *
 affile_dw_new(const gchar *filename, GlobalConfig *cfg)
 {
@@ -339,6 +356,7 @@ affile_dw_new(const gchar *filename, GlobalConfig *cfg)
   self->super.deinit = affile_dw_deinit;
   self->super.free_fn = affile_dw_free;  
   self->super.queue = affile_dw_queue;
+  self->super.notify = affile_dw_notify;
   self->time_reopen = 60;
 
   IV_TIMER_INIT(&self->reap_timer);


### PR DESCRIPTION
When a not writeable file becomes writeable later, syslog-ng recognize it and
delivers messages to the file without dropping the messages received during
the file was not available.

Some technical details:
AFFileDestDriver owns one(single file) or more(templated filenames)
AFFileDestWriter objects.

Each AFFileDestWriter is responsible for writing logs to the associated file
via its LogWriter object.

LogWriter object has a LogProtoClient which actually writing the logs.

When a file is not available, proto construction is failed, but it is possible
to create the LogWriter object with empty proto. This is what we are doing.
And the LogWriter object handles a timer (reopen_timer). If the timer is
elapsed, it notifies(NC_REOPEN_REQUEST) the AFFileDestWriter who will
reopen itself by retrying to create a proto object.
This is repeating until not able to create a valid proto object (or
the file become writeable to syslog-ng).

fixes #138
(and hopefully also fixes #464)

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>

This patch is forward port from 3.6/master.