### PR TITLE
python: Fix the automake warnings in the Python module

### DIFF
--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -50,10 +50,11 @@ BUILT_SOURCES					+= \
 	modules/python/python-grammar.h
 
 modules/python mod-python: modules/python/libmod-python.la
-include modules/python/pylib/Makefile.am
 else
 modules/python mod-python:
 endif
+
+include modules/python/pylib/Makefile.am
 
 EXTRA_DIST					+= \
 	modules/python/python-grammar.ym	   \

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_PYTHON
+
 EXTRA_DIST += \
 	modules/python/pylib/syslogng/__init__.py				\
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
@@ -46,24 +48,18 @@ INSTALL_EXEC_HOOKS += install-pylib
 UNINSTALL_HOOKS += uninstall-pylib
 CLEAN_HOOKS += clean-pylib
 
-.PHONY: install-pylib
 install-pylib:
 	(cd $(PYLIB_SRCDIR) && $(PYTHON) setup.py \
 		build --build-base="$(PYLIB_BUILDDIR)/build" \
 		install --record=$(SETUPPY_MANIFEST) --root="$(PYTHON_ROOT)" --prefix="$(prefix)")
 
-.PHONY: uninstall-pylib
 uninstall-pylib:
 	sed -e 's,^,$(PYTHON_ROOT),g' $(SETUPPY_MANIFEST) | tr '\n' '\0' | xargs -0 rm -f
 
-
-.PHONY: clean-pylib
 clean-pylib:
 	rm -rf "$(PYLIB_BUILDDIR)/build"
 	rm -rf "$(SETUPPY_MANIFEST)"
 
-
-.PHONY: python-checks python-unit python-pep8 python-pylint
 python-checks: python-unit python-pep8 python-pylint
 
 python-unit:
@@ -85,3 +81,10 @@ modules/python/pylib/test_pylib$(EXEEXT): Makefile
 	chmod +x "$@"
 
 modules_python_pylib_test_pylib_SOURCES = modules/python/pylib/test_pylib$(EXEEXT)
+
+endif
+
+.PHONY: install-pylib
+.PHONY: uninstall-pylib
+.PHONY: clean-pylib
+.PHONY: python-checks python-unit python-pep8 python-pylint


### PR DESCRIPTION
Conditionally setting .PHONY makes automake very sad. Instead of doing
that, include modules/python/pylib/Makefile.am unconditionally, and add
ENABLE_PYTHON guards there, with the .PHONY dependencies moved out into
an unconditional part.

Signed-off-by: Gergely Nagy <algernon@madhouse-project.org>