### PR TITLE
docs: manpage entry for --control option

### DIFF
--- a/doc/man/syslog-ng.8.xml
+++ b/doc/man/syslog-ng.8.xml
@@ -157,6 +157,15 @@
         </varlistentry>
         <varlistentry>
           <term>
+            <command moreinfo="none">--control &lt;ctlpath&gt;</command> or <command moreinfo="none">-c
+              &lt;ctlpath&gt;</command>
+          </term>
+          <listitem>
+            <para>Set syslog-ng control socket, default=/var/run/syslog-ng.ctl.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
             <command moreinfo="none">--preprocess-into &lt;output-file&gt;</command>
           </term>
           <listitem>


### PR DESCRIPTION
Manpage entry added referring --control option for it was missing
from the docs only mentioned in program help.

fixes #436

Signed-off-by: Gregory Nagy <gergo.nagy@balabit.com>