### PR TITLE
stats-counter: json formatter implemented

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -245,7 +245,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(compat_sources)
 
 lib_libsyslog_ng_la_CFLAGS		= @UUID_CFLAGS@ $(libsystemd_CFLAGS)
-lib_libsyslog_ng_la_LIBADD		+= @OPENSSL_LIBS@ @UUID_LIBS@
+lib_libsyslog_ng_la_LIBADD		+= @OPENSSL_LIBS@ @UUID_LIBS@ @JSON_LIBS@
 
 # each line with closely related files (e.g. the ones generated from the same source)
 BUILT_SOURCES += lib/cfg-lex.c lib/cfg-lex.h						\

--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -52,7 +52,10 @@ control_register_command(const gchar *command_name, const gchar *description, Co
 static GString *
 control_connection_send_stats(GString *command)
 {
-  gchar *stats = stats_generate_csv();
+  gchar *stats;
+  if (strcmp(command->str, "CSV_STATS") == 0) stats = stats_generate_csv();
+  if (strcmp(command->str, "JSON_STATS") == 0) stats = stats_generate_json();
+
   GString *result = g_string_new(stats);
   g_free(stats);
   return result;
@@ -129,7 +132,8 @@ control_connection_reload(GString *command)
 }
 
 ControlCommand default_commands[] = {
-  { "STATS", NULL, control_connection_send_stats },
+  { "CSV_STATS", NULL, control_connection_send_stats },
+  { "JSON_STATS", NULL, control_connection_send_stats },
   { "RESET_STATS", NULL, control_connection_reset_stats },
   { "LOG", NULL, control_connection_message_log },
   { "STOP", NULL, control_connection_stop_process },

--- a/lib/stats/Makefile.am
+++ b/lib/stats/Makefile.am
@@ -5,6 +5,7 @@ statsinclude_HEADERS = \
 	lib/stats/stats-counter.h		\
 	lib/stats/stats-cluster.h		\
 	lib/stats/stats-csv.h			\
+	lib/stats/stats-json.h			\
 	lib/stats/stats-log.h			\
 	lib/stats/stats-registry.h		\
 	lib/stats/stats-syslog.h
@@ -14,6 +15,7 @@ stats_sources = \
 	lib/stats/stats-counter.c		\
 	lib/stats/stats-cluster.c		\
 	lib/stats/stats-csv.c			\
+	lib/stats/stats-json.c			\
 	lib/stats/stats-log.c			\
 	lib/stats/stats-registry.c		\
 	lib/stats/stats-syslog.c

--- a/lib/stats/stats-json.c
+++ b/lib/stats/stats-json.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 1998-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "stats/stats-json.h"
+#include "stats/stats-registry.h"
+#include "misc.h"
+
+#include <json/json.h>
+#include <string.h>
+
+typedef struct json_entry
+{
+   gchar* name;
+   json_object* value;
+} json_entry;
+
+static gboolean
+has_json_special_character(const gchar *var)
+{
+  return FALSE;
+}
+
+static gchar *
+stats_format_json_escapevar(const gchar *var)
+{
+  guint32 index;
+  guint32 e_index;
+  guint32 varlen = strlen(var);
+  gchar *result, *escaped_result;
+
+  if (varlen != 0 && has_json_special_character(var))
+    {
+      result = g_malloc(varlen*2);
+
+      result[0] = '"';
+      e_index = 1;
+      for (index = 0; index < varlen; index++)
+        {
+          if (var[index] == '"')
+            {
+              result[e_index] = '\\';
+              e_index++;
+            }
+          result[e_index] = var[index];
+          e_index++;
+        }
+      result[e_index] = '"';
+      result[e_index + 1] = 0;
+
+      escaped_result = utf8_escape_string(result, e_index + 2);
+      g_free(result);
+    }
+  else
+    {
+      escaped_result = utf8_escape_string(var, strlen(var));
+    }
+  return escaped_result;
+}
+
+static json_object*
+stats_json_object_type_with_int(void* value)
+{
+  const int integral_value = *((int*)(value));
+  return json_object_new_int(integral_value);
+}
+
+static json_object*
+stats_json_object_type_with_string(void* value)
+{
+  const gchar* string_value = (const gchar*) value;
+  return json_object_new_string(value);
+}
+
+static json_entry*
+stats_json_entry_new(const gchar* name, void* value, json_object* (*json_object_type_handler)(void*))
+{
+  json_entry* ret = (json_entry*) malloc(sizeof(json_entry));
+  ret->name = (gchar*) malloc(strlen(name) + 1);
+  strcpy(ret->name, name);
+  ret->value = json_object_type_handler(value);
+  return ret;
+}
+
+static void
+stats_json_entry_free(json_entry* entry)
+{
+   free(entry->name);
+}
+
+static void
+stats_json_entry_add_to_root(json_object* root, json_entry* entry)
+{
+  json_object_object_add(root, entry->name, entry->value);
+}
+
+static void
+stats_json_entry_del_from_root(json_object* root, json_entry* entry)
+{
+  json_object_object_del(root, entry->name);
+  stats_json_entry_free(entry);
+}
+
+static void
+stats_format_json(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
+{
+  GString *json = (GString *) user_data;
+  gchar *s_id, *s_instance, *tag_name;
+  gchar buf[32];
+  gchar state[2];
+  int counter_value;
+  const int number_of_entries = 6;
+  json_entry* entries[number_of_entries];
+  json_object* root = json_object_new_object();
+  int i;
+
+  s_id = stats_format_json_escapevar(sc->id);
+  s_instance = stats_format_json_escapevar(sc->instance);
+
+  if (sc->dynamic)
+    state[0] = 'd';
+  else if (sc->use_count == 0)
+    state[0] = 'o';
+  else
+    state[0] = 'a';
+  state[1] = '\0';
+
+  tag_name = stats_format_json_escapevar(stats_cluster_get_type_name(type));
+  counter_value = stats_counter_get(&sc->counters[type]);
+
+  entries[0] = stats_json_entry_new("name",
+                                    stats_cluster_get_component_name(sc, buf, sizeof(buf)),
+                                    stats_json_object_type_with_string);
+
+  entries[1] =  stats_json_entry_new("id",
+                                     s_id,
+                                     stats_json_object_type_with_string);
+
+  entries[2] = stats_json_entry_new("instance",
+                                    s_instance,
+                                    stats_json_object_type_with_string);
+
+  entries[3] = stats_json_entry_new("state",
+                                    state,
+                                    stats_json_object_type_with_string);
+
+  entries[4] = stats_json_entry_new("type",
+                                    tag_name,
+                                    stats_json_object_type_with_string);
+
+  entries[5] = stats_json_entry_new("number",
+                                    &counter_value,
+                                    stats_json_object_type_with_int);
+
+  for (i = 0; i < number_of_entries; ++i)
+     {
+       stats_json_entry_add_to_root(root, entries[i]);
+     }
+
+  g_string_append_printf(json, "%s,\n", json_object_to_json_string(root));
+
+  for (i = 0; i < number_of_entries; ++i)
+     {
+        stats_json_entry_del_from_root(root, entries[i]);
+     }
+
+  g_free(tag_name);
+  g_free(s_id);
+  g_free(s_instance);
+}
+
+static inline
+gboolean has_any_items(GString* json)
+{
+   return json->len > 1;
+}
+
+gchar *
+stats_generate_json(void)
+{
+  GString *json= g_string_sized_new(1024);
+
+  g_string_append_printf(json, "[");
+  stats_lock();
+  stats_foreach_counter(stats_format_json, json);
+  stats_unlock();
+  if (has_any_items(json))
+    {
+      /* removing the ',' and '\n' after the end of the last json structure */
+      g_string_truncate(json, json->len-2);
+    }
+  g_string_append_printf(json, "]");
+
+  return g_string_free(json, FALSE);
+}

--- a/lib/stats/stats-json.h
+++ b/lib/stats/stats-json.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 1998-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef STATS_JSON_H_INCLUDED
+#define STATS_JSON_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+gchar *stats_generate_json(void);
+
+#endif

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -96,9 +96,13 @@ slng_verbose(int argc, char *argv[], const gchar *mode)
 }
 
 static gboolean stats_options_reset_is_set = FALSE;
+static gboolean stats_options_json_format_is_set = FALSE;
+static gboolean stats_options_csv_format_is_set = FALSE;
 
 static GOptionEntry stats_options[] =
 {
+  { "json", 'j', 0, G_OPTION_ARG_NONE, &stats_options_json_format_is_set, "print stats in json format", NULL },
+  { "csv", 'c', 0, G_OPTION_ARG_NONE, &stats_options_csv_format_is_set, "print stats in csv format", NULL },
   { "reset", 'r', 0, G_OPTION_ARG_NONE, &stats_options_reset_is_set, "reset counters", NULL },
   { NULL,    0,   0, G_OPTION_ARG_NONE, NULL,                        NULL,             NULL }
 };
@@ -114,7 +118,10 @@ static GOptionEntry verbose_options[] =
 static const gchar *
 _stats_command_builder()
 {
-  return stats_options_reset_is_set ? "RESET_STATS\n" : "STATS\n";
+  if (stats_options_reset_is_set) return "RESET_STATS\n";
+  if (stats_options_csv_format_is_set) return "CSV_STATS\n";
+  if (stats_options_json_format_is_set) return "JSON_STATS\n";
+  return "CSV_STATS\n";
 }
 
 static gint


### PR DESCRIPTION
Issue #272 mentioned it would be great to be able to
extract queue stats in json format.
The formatter is implemented but there is no option
for changing between csv and json formatters yet.
I'll implement the options and mechanism to do that.

fixes #272

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>