### PR TITLE
jave: Makefile.am fixed

### DIFF
--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -29,8 +29,7 @@ modules_java_libmod_java_la_SOURCES = \
     modules/java/native/java-parser.c \
     modules/java/native/java-parser.h \
     modules/java/native/java_machine.c \
-    modules/java/native/java_machine.h \
-    $(JAVA_HEADER_FILES)
+    modules/java/native/java_machine.h
 
 modules_java_libmod_java_la_LIBADD = \
     $(JNI_LIBS) $(INCUBATOR_LIBS)


### PR DESCRIPTION
This patch fixes the following build error (make dist, make distcheck)
on machines without java support:

make: *** No rule to make target `modules/java/LogDestination.h',
needed by `distdir'.

$(JAVA_HEADER_FILES) are generated files which will be generated only
when java is enabled, however `make dist` (or `make distcheck`) 'uses'
`modules_java_libmod_java_la_SOURCES`.

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>