### PR TITLE
python: passing arguments from `syslog-ng.conf`

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #include "misc.h"
 #include "dnscache.h"
 #include "messages.h"
@@ -97,7 +97,7 @@ g_fd_set_cloexec(int fd, gboolean enable)
   return TRUE;
 }
 
-gboolean 
+gboolean
 resolve_user(const char *user, gint *uid)
 {
   struct passwd *pw;
@@ -119,7 +119,7 @@ resolve_user(const char *user, gint *uid)
   return TRUE;
 }
 
-gboolean 
+gboolean
 resolve_group(const char *group, gint *gid)
 {
   struct group *gr;
@@ -128,7 +128,7 @@ resolve_group(const char *group, gint *gid)
   *gid = 0;
   if (!(*group))
     return FALSE;
-    
+
   *gid = strtol(group, &endptr, 0);
   if (*endptr)
     {
@@ -141,7 +141,7 @@ resolve_group(const char *group, gint *gid)
   return TRUE;
 }
 
-gboolean 
+gboolean
 resolve_user_group(char *arg, gint *uid, gint *gid)
 {
   char *user, *group;
@@ -149,7 +149,7 @@ resolve_user_group(char *arg, gint *uid, gint *gid)
   *uid = 0;
   user = strtok(arg, ":.");
   group = strtok(NULL, "");
-  
+
   if (user && !resolve_user(user, uid))
     return FALSE;
   if (group && !resolve_group(group, gid))
@@ -208,30 +208,30 @@ find_cr_or_lf(gchar *s, gsize n)
       else if (*char_ptr == 0)
         return NULL;
     }
-    
+
   longword_ptr = (gulong *) char_ptr;
 
 #if GLIB_SIZEOF_LONG == 8
   magic_bits = 0x7efefefefefefeffL;
 #elif GLIB_SIZEOF_LONG == 4
-  magic_bits = 0x7efefeffL; 
+  magic_bits = 0x7efefeffL;
 #else
   #error "unknown architecture"
 #endif
   memset(&cr_charmask, CR, sizeof(cr_charmask));
   memset(&lf_charmask, LF, sizeof(lf_charmask));
-    
+
   while (n > sizeof(longword))
     {
       longword = *longword_ptr++;
       if ((((longword + magic_bits) ^ ~longword) & ~magic_bits) != 0 ||
-          ((((longword ^ cr_charmask) + magic_bits) ^ ~(longword ^ cr_charmask)) & ~magic_bits) != 0 || 
+          ((((longword ^ cr_charmask) + magic_bits) ^ ~(longword ^ cr_charmask)) & ~magic_bits) != 0 ||
           ((((longword ^ lf_charmask) + magic_bits) ^ ~(longword ^ lf_charmask)) & ~magic_bits) != 0)
         {
           gint i;
 
           char_ptr = (gchar *) (longword_ptr - 1);
-          
+
           for (i = 0; i < sizeof(longword); i++)
             {
               if (*char_ptr == CR || *char_ptr == LF)
@@ -263,12 +263,12 @@ string_array_to_list(const gchar *strlist[])
 {
   gint i;
   GList *l = NULL;
-  
+
   for (i = 0; strlist[i]; i++)
     {
       l = g_list_prepend(l, g_strdup(strlist[i]));
     }
-  
+
   return g_list_reverse(l);
 }
 

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -320,25 +320,23 @@ utf8_escape_string(const gchar *str, gssize len)
   return res;
 }
 
-gchar *
-replace_char(gchar *buffer,gchar from,gchar to,gboolean in_place)
+static gchar *
+str_replace_char(const gchar* str, const gchar from, const gchar to)
 {
-  gchar *convert;
   gchar *p;
-  if (in_place)
-    {
-      convert = buffer;
-    }
-  else
-    {
-      convert = g_strdup(buffer);
-    }
-  p = convert;
+  gchar *ret = g_strdup(str);
+  p = ret;
   while (*p)
     {
       if (*p == from)
         *p = to;
       p++;
     }
-  return convert;
+  return ret;
+}
+
+gchar *
+__normalize_key(const gchar* buffer)
+{
+  return str_replace_char(buffer, '-', '_');
 }

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -83,7 +83,7 @@ void string_list_free(GList *l);
     dest = __buf; \
   } while (0)
 
-gchar *replace_char(gchar *buffer,gchar from,gchar to,gboolean in_place);
 gchar *utf8_escape_string(const gchar *str, gssize len);
+gchar *__normalize_key(const gchar* buffer);
 
 #endif

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef MISC_H_INCLUDED
 #define MISC_H_INCLUDED
 
@@ -53,7 +53,7 @@ init_sequence_number(gint32 *seqnum)
   *seqnum = 1;
 }
 
-static inline void 
+static inline void
 step_sequence_number(gint32 *seqnum)
 {
   (*seqnum)++;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -41,7 +41,7 @@ Java_org_syslog_1ng_LogDestination_getOption(JNIEnv *env, jobject obj, jlong s, 
       return NULL;
     }
   gchar *normalized_key = g_strdup(key_str);
-  normalized_key = replace_char(normalized_key, '-', '_', TRUE);
+  normalized_key = __normalize_key(normalized_key);
   value = g_hash_table_lookup(self->options, normalized_key);
   (*env)->ReleaseStringUTFChars(env, key, key_str);  // release resources
   g_free(normalized_key);
@@ -74,7 +74,7 @@ void java_dd_set_option(LogDriver *s, const gchar *key, const gchar *value)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;
   gchar *normalized_key = g_strdup(key);
-  normalized_key = replace_char(normalized_key, '-', '_', TRUE);
+  normalized_key = __normalize_key(normalized_key);
   g_hash_table_insert(self->options, g_strdup(normalized_key), g_strdup(value));
 }
 

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -33,7 +33,7 @@ LogDriver *python_dd_new(GlobalConfig *cfg);
 void python_dd_set_imports(LogDriver *d, GList *imports);
 void python_dd_set_class(LogDriver *d, gchar *class_name);
 void python_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
-
+void python_dd_set_option(LogDriver*  d, gchar* key, gchar* value);
 LogTemplateOptions *python_dd_get_template_options(LogDriver *d);
 
 #endif

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -49,6 +49,7 @@
 %token KW_PYTHON
 %token KW_CLASS
 %token KW_IMPORTS
+%token KW_OPTIONS
 
 %%
 
@@ -85,6 +86,7 @@ python_option
           {
             python_dd_set_imports(last_driver, $3);
           }
+        | KW_OPTIONS '(' python_dest_custom_options ')'
         | value_pair_option
           {
             python_dd_set_value_pairs(last_driver, $1);
@@ -92,6 +94,14 @@ python_option
         | dest_driver_option
         | { last_template_options = python_dd_get_template_options(last_driver); } template_option
         ;
+
+python_dest_custom_options
+        : python_dest_custom_option python_dest_custom_options
+        |
+        ;
+
+python_dest_custom_option
+        : LL_IDENTIFIER '(' string ')'{ python_dd_set_option(last_driver, $1, $3); free($1); free($3);  }
 
 python_globals
         : python_global python_globals

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -33,6 +33,7 @@ static CfgLexerKeyword python_keywords[] = {
   { "python",                   KW_PYTHON  },
   { "class",                    KW_CLASS   },
   { "imports",                  KW_IMPORTS },
+  { "options",                  KW_OPTIONS },
   { NULL }
 };
 

--- a/modules/python/sngexample.py
+++ b/modules/python/sngexample.py
@@ -12,7 +12,7 @@ class LogDestination(object):
         """Check if the connection to the target is able to receive messages"""
         return True
 
-    def init(self):
+    def init(self, args):
         """This method is called at initialization time"""
         return True
 


### PR DESCRIPTION
Arguments can be passed to python destinations
using `options` token in the config file.

Example:
```
log {
  source { tcp(port(12345));  };
  destination {
  python(
    class("sngexample.DummyPythonDest")
    options(
      key1("value for key1")
      key2("value for key2")
    )
  );
  };
};
```

Fixes #535

Created-with: Arsenault Adam <adam.arsenault@balabit.com>
Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>