### PR TITLE
afsocket: using msg_control only when credential passing is supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -495,6 +495,10 @@ AC_CHECK_MEMBER(struct tm.tm_gmtoff,AC_DEFINE(HAVE_STRUCT_TM_TM_GMTOFF,1,[Whethe
 #include <time.h>
 #endif])
 
+AC_CHECK_MEMBER(struct msghdr.msg_control,AC_DEFINE(HAVE_CTRLBUF_IN_MSGHDR,1,[Whether you have msg_control field in msghdr in socket.h]),,[
+#include <sys/socket.h>
+])
+
 AC_CACHE_CHECK(for I_CONSLOG, blb_cv_c_i_conslog,
   [AC_EGREP_CPP(I_CONSLOG,
 [

--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -207,8 +207,14 @@ _unix_socket_read(gint fd, gpointer buf, gsize buflen, LogTransportAuxData *aux)
   gint rc;
   struct msghdr msg;
   struct iovec iov[1];
-  gchar ctlbuf[32];
   struct sockaddr_storage ss;
+#if defined(HAVE_CTRLBUF_IN_MSGHDR)
+  gchar ctlbuf[32];
+  msg.msg_control = *ctlbuf;
+  msg.msg_controllen = sizeof(ctlbuf);
+#endif
+
+
 
   msg.msg_name = (struct sockaddr *) &ss;
   msg.msg_namelen = sizeof(ss);
@@ -216,8 +222,6 @@ _unix_socket_read(gint fd, gpointer buf, gsize buflen, LogTransportAuxData *aux)
   msg.msg_iov = iov;
   iov[0].iov_base = buf;
   iov[0].iov_len = buflen;
-  msg.msg_control = ctlbuf;
-  msg.msg_controllen = sizeof(ctlbuf);
   do
     {
       rc = recvmsg(fd, &msg, 0);

--- a/modules/afsocket/unix-credentials.h
+++ b/modules/afsocket/unix-credentials.h
@@ -30,13 +30,13 @@
 #include "syslog-ng.h"
 
 #if defined(__linux__)
-# if HAVE_STRUCT_UCRED
+# if HAVE_STRUCT_UCRED && HAVE_CTRLBUF_IN_MSGHDR
 # define CRED_PASS_SUPPORTED
 # define cred_t struct ucred
 # define cred_get(c,x) (c->x)
 # endif
 #elif defined(__FreeBSD__)
-# if HAVE_STRUCT_CMSGCRED
+# if HAVE_STRUCT_CMSGCRED && HAVE_CTRLBUF_IN_MSGHDR
 #  define CRED_PASS_SUPPORTED
 #  define SCM_CREDENTIALS SCM_CREDS
 #  define cred_t struct cmsgcred


### PR DESCRIPTION
fixes #542

Signed-off-by: Adam Arsenault <adam.arsenault@balabit.com>