### PR TITLE
file: avoid change file permission if file is device

### DIFF
--- a/lib/pathutils.c
+++ b/lib/pathutils.c
@@ -24,6 +24,7 @@
  */
 
 #include "pathutils.h"
+#include <sys/stat.h>
 
 gboolean
 is_file_directory(const char *filename)
@@ -36,3 +37,14 @@ is_file_regular(const char *filename)
 {
   return g_file_test(filename, G_FILE_TEST_EXISTS) && g_file_test(filename, G_FILE_TEST_IS_REGULAR);
 };
+
+gboolean
+is_file_device(const gchar *name)
+{
+  struct stat st;
+
+  if (stat(name, &st) >= 0)
+    return S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode);
+  else
+    return FALSE;
+}

--- a/lib/pathutils.h
+++ b/lib/pathutils.h
@@ -29,5 +29,6 @@
 
 gboolean is_file_regular(const char *filename);
 gboolean is_file_directory(const char *filename);
+gboolean is_file_device(const gchar *name);
 
 #endif

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -24,6 +24,7 @@
 #include "messages.h"
 #include "gprocess.h"
 #include "misc.h"
+#include "pathutils.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -158,7 +159,8 @@ affile_open_file(gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_
 
   *fd = _open_fd(name, open_opts, perm_opts);
 
-  _set_fd_permission(perm_opts, *fd);
+  if (!is_file_device(name))
+    _set_fd_permission(perm_opts, *fd);
 
   g_process_cap_restore(saved_caps);
 


### PR DESCRIPTION
It could be changed only if the file (source or destination) is not
a device because all devices are system entity in filesystem. 
Fixes #383 

Signed-off-by: Fried Zoltan <zoltan.fried@balabit.com>