### PR TITLE
syslog-ng not parsing java destinations with empty options in blocks

### DIFF
--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -77,6 +77,7 @@ java_dest_option
           }
 		| KW_TEMPLATE '(' string ')' { java_dd_set_template_string(last_driver, $3); free($3); }
 		| KW_OPTION '(' java_dest_custom_options ')'
+		| KW_OPTION '(' java_dest_empty_options ')'
 		| threaded_dest_driver_option
         | dest_driver_option
         ;
@@ -85,6 +86,14 @@ java_dest_custom_options
   : java_dest_custom_option java_dest_custom_options
   |
   ;
+
+java_dest_empty_options
+  : java_dest_empty_option java_dest_empty_options
+  |
+  ;
+
+java_dest_empty_option
+  : LL_STRING { ;  }
 
 java_dest_custom_option
   : LL_STRING LL_STRING { java_dd_set_option(last_driver, $1, $2); free($1); free($2); }


### PR DESCRIPTION
When writing scl configuration snippets for java destinations, there was no way to granularly control which optional arguments were sent to java. 

If you didn't enclose the value of an argument in quotes: The blocks would fail to be parsed no value for the option would be provided.

Example:
```
block destination test_block(test_option()){
  java(
    class_name("sampleclass")
    class_path("/home/user/sampleclass/")
    option("test_option",`test_option`)
  );
};
#Syslog-ng would fail to parse this because a value wasn't given to test_option
```

If you did enclose the value of an argument in quotes: If no value was actually given when that block was later used, the value of the argument would be the empty string.
Example:
```
block destination test_block(test_option()){
  java(
    class_name("sampleclass")
    class_path("/home/user/sampleclass/")
    option("test_option","`test_option`")
  );
};
destination s_test{
       test_block(
       );
};

#Java would see the "test_option" option having an empty string as its value
```
I don't think adding default values to the options in the blocks would fix the issue, as all java destinations would simply get default values for all parameters, and I can easily imagine situations in which destinations might not function properly if they always receive optional parameters.

I don't know if my proposed fix is a good one though, because its result is that those improper option declarations in Java destinations - ones with a name but no value - will be silently ignored.