### PR TITLE
system-source: Open /proc/kmsg with systemd, too

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -246,11 +246,10 @@ system_sysblock_add_linux(GString *sysblock)
   if (service_management_get_type() == SMT_SYSTEMD)
     system_sysblock_add_systemd_source(sysblock);
   else
-    {
-      system_sysblock_add_unix_dgram(sysblock, "/dev/log", NULL, "8192");
-      if (!_is_running_in_linux_container())
-        system_sysblock_add_linux_kmsg(sysblock);
-    }
+    system_sysblock_add_unix_dgram(sysblock, "/dev/log", NULL, "8192");
+
+  if (!_is_running_in_linux_container())
+    system_sysblock_add_linux_kmsg(sysblock);
 }
 
 static gboolean


### PR DESCRIPTION
Even when used with systemd, the system-source should open /proc/kmsg or
else no kernel messages will get to syslog.

> (BTW, journald is smart enough not to forward the kernel messages it
> gets to you, you should read that on your own, directly from
> /proc/kmsg, as you always did. [...])
             (http://www.freedesktop.org/wiki/Software/systemd/syslog/)

Sure you can add pipe('/proc/kmsg') or something like that by yourself,
but then you loose the flexibility the system-source module gives you.