### PR TITLE
afstomp: don't run tests when disabled

### DIFF
--- a/modules/afstomp/tests/Makefile.am
+++ b/modules/afstomp/tests/Makefile.am
@@ -1,4 +1,4 @@
-
+if ENABLE_STOMP
 modules_afstomp_tests_test_stomp_proto_CFLAGS = \
     $(TEST_CFLAGS) \
     -I$(top_srcdir)/modules/afstomp
@@ -14,3 +14,4 @@ modules_afstomp_tests_TESTS =   \
 
 check_PROGRAMS +=   \
     $(modules_afstomp_tests_TESTS)
+endif


### PR DESCRIPTION
Tests should not be run if the user didn't request its
support. Otherwise, we get the following error during compilation:

    libtool: link: cannot find the library `./modules/afstomp/libafstomp.la' or unhandled argument `./modules/afstomp/libafstomp.la'
    Makefile:6141: recipe for target 'modules/afstomp/tests/test_stomp_proto' failed
    make[3]: *** [modules/afstomp/tests/test_stomp_proto] Error 1

Signed-off-by: Vincent Bernat <vincent@bernat.im>