### PR TITLE
systemd-journal: ensure tests are run only when enabled

### DIFF
--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -45,6 +45,7 @@ modules_test_subdirs	=	\
 	modules_pacctformat modules_confgen modules_system_source \
 	modules_csvparser modules_dbparser modules_basicfuncs \
 	modules_cryptofuncs modules_geoip modules_afstomp \
-	modules_graphite modules_riemann modules_python
+	modules_graphite modules_riemann modules_python \
+	modules_systemd_journal
 
 .PHONY: modules modules/

--- a/modules/systemd-journal/tests/Makefile.am
+++ b/modules/systemd-journal/tests/Makefile.am
@@ -1,3 +1,4 @@
+if ENABLE_JOURNALD
 modules_systemd_journal_tests_TESTS	= modules/systemd-journal/tests/test_systemd_journal
 
 check_PROGRAMS					+= ${modules_systemd_journal_tests_TESTS}
@@ -11,4 +12,4 @@ modules_systemd_journal_tests_test_systemd_journal_SOURCES = \
 
 modules_systemd_journal_tests_test_systemd_journal_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/systemd-journal
 modules_systemd_journal_tests_test_systemd_journal_LDADD = $(TEST_LDADD)
-
+endif


### PR DESCRIPTION
This was the only module to not have an entry in the top `Makefile.am`
file in `modules_test_subdirs`. Also, ensure tests are not run when the
support is not enabled.

Please note, that I don't fully understand the change I made. This could be a terrible mistake. :)