### PR TITLE
grammar: apply configured mark mode on options section

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -904,6 +904,7 @@ options_item
         | KW_MARK_MODE '(' string ')'
           {
             CHECK_ERROR(cfg_lookup_mark_mode($3) > 0 && cfg_lookup_mark_mode($3) != MM_GLOBAL, @3, "illegal global mark-mode");
+            cfg_set_mark_mode(configuration, $3);
             free($3);
           }
 	| KW_FLUSH_TIMEOUT '(' LL_NUMBER ')'	{ configuration->flush_timeout = $3; }


### PR DESCRIPTION
Mark mode setting is set and used from options section.
Fixes #547 

Signed-off-by: Fried Zoltan <zoltan.fried@balabit.com>