### PR TITLE
F/opt in unix creds

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -245,6 +245,7 @@ extern struct _StatsOptions *last_stats_options;
 
 %token KW_THROTTLE                    10170
 %token KW_THREADED                    10171
+%token KW_PASS_UNIX_CREDENTIALS       10231
 
 /* log statement options */
 %token KW_FLAGS                       10190
@@ -916,6 +917,7 @@ options_item
 	| KW_TIME_SLEEP '(' LL_NUMBER ')'	{}
 	| KW_SUPPRESS '(' LL_NUMBER ')'		{ configuration->suppress = $3; }
 	| KW_THREADED '(' yesno ')'		{ configuration->threaded = $3; }
+	| KW_PASS_UNIX_CREDENTIALS '(' yesno ')' { configuration->pass_unix_credentials = $3; }
 	| KW_USE_RCPTID '(' yesno ')'		{ cfg_set_use_uniqid($3); }
 	| KW_USE_UNIQID '(' yesno ')'		{ cfg_set_use_uniqid($3); }
 	| KW_LOG_FIFO_SIZE '(' LL_NUMBER ')'	{ configuration->log_fifo_size = $3; }

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -147,6 +147,7 @@ static CfgLexerKeyword main_keywords[] = {
   { "dns_cache_size",     KW_DNS_CACHE_SIZE },
   { "dns_cache_expire",   KW_DNS_CACHE_EXPIRE },
   { "dns_cache_expire_failed", KW_DNS_CACHE_EXPIRE_FAILED },
+  { "pass_unix_credentials", KW_PASS_UNIX_CREDENTIALS },
 
   { "retries",            KW_RETRIES, 0x0303 },
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -367,6 +367,7 @@ cfg_new(gint version)
   self->dns_cache_expire = 3600;
   self->dns_cache_expire_failed = 60;
   self->threaded = TRUE;
+  self->pass_unix_credentials = TRUE;
   
   log_template_options_defaults(&self->template_options);
   self->template_options.ts_format = TS_FMT_BSD;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -74,6 +74,7 @@ struct _GlobalConfig
   gint mark_mode;
   gint flush_timeout;
   gboolean threaded;
+  gboolean pass_unix_credentials;
   gboolean chain_hostnames;
   gboolean keep_hostname;
   gboolean check_hostname;

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -146,6 +146,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_TCP_KEEPALIVE_PROBES
 %token KW_TCP_KEEPALIVE_INTVL
 %token KW_SPOOF_SOURCE
+%token KW_PASS_UNIX_CREDENTIALS
 
 %token KW_KEEP_ALIVE
 %token KW_MAX_CONNECTIONS
@@ -263,6 +264,11 @@ source_afunix_option
 	| source_reader_option			{}
 	| socket_option				{}
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
+	| KW_PASS_UNIX_CREDENTIALS '(' yesno ')'
+	  {
+	    AFUnixSourceDriver *self = (AFUnixSourceDriver*) last_driver;
+	    afunix_sd_set_pass_unix_credentials(self, $3);
+	  }
 	;
 
 source_afinet

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -116,9 +116,19 @@ afunix_sd_new_instance(TransportMapper *transport_mapper, gchar *filename, Globa
   self->filename = g_strdup(filename);
   file_perm_options_defaults(&self->file_perm_options);
   self->file_perm_options.file_perm = 0666;
+  self->pass_unix_credentials = cfg->pass_unix_credentials;
+  afunix_sd_set_pass_unix_credentials(self, self->pass_unix_credentials);
 
   afunix_sd_adjust_reader_options(self, cfg);
   return self;
+}
+
+void
+afunix_sd_set_pass_unix_credentials(AFUnixSourceDriver *self, gboolean pass)
+{
+  self->pass_unix_credentials = pass;
+
+  transport_mapper_unix_set_pass_unix_credentials(self->super.transport_mapper, pass);
 }
 
 AFUnixSourceDriver *

--- a/modules/afsocket/afunix-source.h
+++ b/modules/afsocket/afunix-source.h
@@ -33,9 +33,11 @@ typedef struct _AFUnixSourceDriver
   AFSocketSourceDriver super;
   gchar *filename;
   FilePermOptions file_perm_options;
+  gboolean pass_unix_credentials;
 } AFUnixSourceDriver;
 
 AFUnixSourceDriver *afunix_sd_new_stream(gchar *filename, GlobalConfig *cfg);
 AFUnixSourceDriver *afunix_sd_new_dgram(gchar *filename, GlobalConfig *cfg);
+void afunix_sd_set_pass_unix_credentials(AFUnixSourceDriver *self, gboolean pass);
 
 #endif

--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -22,6 +22,7 @@
  */
 #include "transport-mapper-unix.h"
 #include "transport-unix-socket.h"
+#include "unix-credentials.h"
 #include "stats/stats-registry.h"
 
 #include <sys/types.h>
@@ -33,15 +34,28 @@ typedef struct _TransportMapperUnix
 {
   TransportMapper super;
   gchar *filename;
+  gboolean pass_unix_credentials;
 } TransportMapperUnix;
 
-static LogTransport *
-transport_mapper_unix_construct_log_transport(TransportMapper *s, gint fd)
+static LogTransport*
+_create_log_transport(TransportMapper *s, gint fd)
 {
   if (s->sock_type == SOCK_DGRAM)
     return log_transport_unix_dgram_socket_new(fd);
   else
     return log_transport_unix_stream_socket_new(fd);
+}
+
+static LogTransport *
+_construct_log_transport(TransportMapper *s, gint fd)
+{
+  TransportMapperUnix *self = (TransportMapperUnix*) s;
+  LogTransport *transport = _create_log_transport(s, fd);
+
+  if (self->pass_unix_credentials)
+    socket_set_pass_credentials(fd);
+
+  return transport;
 }
 
 static TransportMapperUnix *
@@ -50,10 +64,17 @@ transport_mapper_unix_new_instance(const gchar *transport, gint sock_type)
   TransportMapperUnix *self = g_new0(TransportMapperUnix, 1);
 
   transport_mapper_init_instance(&self->super, transport);
-  self->super.construct_log_transport = transport_mapper_unix_construct_log_transport;
+  self->super.construct_log_transport = _construct_log_transport;
   self->super.address_family = AF_UNIX;
   self->super.sock_type = sock_type;
   return self;
+}
+
+void
+transport_mapper_unix_set_pass_unix_credentials(TransportMapper *s, gboolean pass)
+{
+  TransportMapperUnix *self = (TransportMapperUnix*) s;
+  self->pass_unix_credentials = pass;
 }
 
 TransportMapper *

--- a/modules/afsocket/transport-mapper-unix.h
+++ b/modules/afsocket/transport-mapper-unix.h
@@ -25,7 +25,10 @@
 
 #include "transport-mapper.h"
 
+typedef struct _TransportMapperUnix TransportMapperUnix;
+
 TransportMapper *transport_mapper_unix_dgram_new(void);
 TransportMapper *transport_mapper_unix_stream_new(void);
+void transport_mapper_unix_set_pass_unix_credentials(TransportMapper *self, gboolean pass);
 
 #endif

--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -258,8 +258,6 @@ log_transport_unix_dgram_socket_new(gint fd)
   log_transport_dgram_socket_init_instance(self, fd);
   self->super.read = log_transport_unix_dgram_socket_read_method;
 
-  socket_set_pass_credentials(fd);
-
   return &self->super;
 }
 
@@ -276,8 +274,6 @@ log_transport_unix_stream_socket_new(gint fd)
 
   log_transport_stream_socket_init_instance(self, fd);
   self->super.read = log_transport_unix_stream_socket_read_method;
-
-  socket_set_pass_credentials(fd);
 
   return &self->super;
 }


### PR DESCRIPTION
This PR adds support for turning on/off Unix credential passing on Unix domain sockets. It can be slow
that we needed a way to turn it off from config.

The proposed name of the new option is `pass-unix-credentials()`.

The global default value of `pass-unix-credentials()` is `false` but it can be overwritten in the source config.

Fixes #353 