### PR TITLE
utf8 sanitization

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -145,6 +145,7 @@ pkginclude_HEADERS			+= \
 	lib/tlscontext.h  		\
 	lib/type-hinting.h		\
 	lib/uuid.h			\
+	lib/utf8utils.h			\
 	lib/value-pairs.h		\
 	lib/vptransform.h		\
 	lib/versioning.h		\
@@ -226,6 +227,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/crypto.c			\
 	lib/tlscontext.c		\
 	lib/uuid.c			\
+	lib/utf8utils.c			\
 	$(transport_crypto_sources)	\
 	lib/host-id.c			\
 					\

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -291,35 +291,6 @@ string_list_free(GList *l)
     }
 }
 
-gchar *
-utf8_escape_string(const gchar *str, gssize len)
-{
-  int i;
-  gchar *res, *res_pos;
-
-  /* Check if string is a valid UTF-8 string */
-  if (g_utf8_validate(str, -1, NULL))
-      return g_strndup(str, len);
-
-  /* It contains invalid UTF-8 sequences --> treat input as a
-   * string containing binary data; escape those chars that have
-   * no ASCII representation */
-  res = g_new(gchar, 4 * len + 1);
-  res_pos = res;
-
-  for (i = 0; (i < len) && str[i]; i++)
-    {
-      if (g_ascii_isprint(str[i]))
-        *(res_pos++) = str[i];
-      else
-        res_pos += sprintf(res_pos, "\\x%02x", ((guint8)str[i]));
-    }
-
-  *(res_pos++) = '\0';
-
-  return res;
-}
-
 static gchar *
 str_replace_char(const gchar* str, const gchar from, const gchar to)
 {

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -83,7 +83,7 @@ void string_list_free(GList *l);
     dest = __buf; \
   } while (0)
 
-gchar *utf8_escape_string(const gchar *str, gssize len);
 gchar *__normalize_key(const gchar* buffer);
+gchar *replace_char(gchar *buffer,gchar from,gchar to,gboolean in_place);
 
 #endif

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -109,6 +109,7 @@ CfgFlagHandler msg_format_flag_handlers[] =
   { "syslog-protocol",            CFH_SET, offsetof(MsgFormatOptions, flags), LP_SYSLOG_PROTOCOL },
   { "assume-utf8",                CFH_SET, offsetof(MsgFormatOptions, flags), LP_ASSUME_UTF8 },
   { "validate-utf8",              CFH_SET, offsetof(MsgFormatOptions, flags), LP_VALIDATE_UTF8 },
+  { "sanitize-utf8",              CFH_SET, offsetof(MsgFormatOptions, flags), LP_SANITIZE_UTF8 },
   { "no-multi-line",              CFH_SET, offsetof(MsgFormatOptions, flags), LP_NO_MULTI_LINE },
   { "store-legacy-msghdr",        CFH_SET, offsetof(MsgFormatOptions, flags), LP_STORE_LEGACY_MSGHDR },
   { "dont-store-legacy-msghdr", CFH_CLEAR, offsetof(MsgFormatOptions, flags), LP_STORE_LEGACY_MSGHDR },

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -43,14 +43,16 @@ enum
   LP_ASSUME_UTF8     = 0x0008,
   /* validate that all characters are indeed UTF-8 and mark the message as valid when relaying */
   LP_VALIDATE_UTF8   = 0x0010,
+  /* sanitize input and force it to be valid UTF-8 by escaping */
+  LP_SANITIZE_UTF8   = 0x0020,
   /* the message may not contain NL characters, strip them if it does */
-  LP_NO_MULTI_LINE   = 0x0020,
+  LP_NO_MULTI_LINE   = 0x0040,
   /* don't store MSGHDR in the LEGACY_MSGHDR macro */
-  LP_STORE_LEGACY_MSGHDR = 0x0040,
+  LP_STORE_LEGACY_MSGHDR = 0x0080,
   /* expect a hostname field in the message */
-  LP_EXPECT_HOSTNAME = 0x0080,
+  LP_EXPECT_HOSTNAME = 0x0100,
   /* message is locally generated and should be marked with LF_LOCAL */
-  LP_LOCAL = 0x0100,
+  LP_LOCAL = 0x0200,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -23,20 +23,16 @@
  */
 #include "stats/stats-csv.h"
 #include "stats/stats-registry.h"
-#include "misc.h"
+#include "utf8utils.h"
 
 #include <string.h>
 
 static gboolean
 has_csv_special_character(const gchar *var)
 {
-  gchar *p1 = strchr(var, ';');
-  if (p1)
+  if (strchr(var, ';'))
     return TRUE;
-  p1 = strchr(var, '\n');
-  if (p1)
-    return TRUE;
-  if (var[0] == '"')
+  if (strchr(var, '\"'))
     return TRUE;
   return FALSE;
 }
@@ -44,36 +40,19 @@ has_csv_special_character(const gchar *var)
 static gchar *
 stats_format_csv_escapevar(const gchar *var)
 {
-  guint32 index;
-  guint32 e_index;
-  guint32 varlen = strlen(var);
-  gchar *result, *escaped_result;
+  gchar *escaped_result;
 
-  if (varlen != 0 && has_csv_special_character(var))
+  if (var[0] && has_csv_special_character(var))
     {
-      result = g_malloc(varlen*2);
-
-      result[0] = '"';
-      e_index = 1;
-      for (index = 0; index < varlen; index++)
-        {
-          if (var[index] == '"')
-            {
-              result[e_index] = '\\';
-              e_index++;
-            }
-          result[e_index] = var[index];
-          e_index++;
-        }
-      result[e_index] = '"';
-      result[e_index + 1] = 0;
-
-      escaped_result = utf8_escape_string(result, e_index + 2);
+      gchar *result;
+      /* quote */
+      result = convert_unsafe_utf8_to_escaped_binary(var, "\"");
+      escaped_result = g_strdup_printf("\"%s\"", result);
       g_free(result);
     }
   else
     {
-      escaped_result = utf8_escape_string(var, strlen(var));
+      escaped_result = convert_unsafe_utf8_to_escaped_binary(var, NULL);
     }
   return escaped_result;
 }

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -11,7 +11,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_lexer        \
 	lib/tests/test_str_format   \
 	lib/tests/test_runid        \
-	lib/tests/test_pathutils
+	lib/tests/test_pathutils	\
+	lib/tests/test_utf8utils
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
@@ -85,6 +86,11 @@ lib_tests_test_str_format_LDADD	=	\
 lib_tests_test_pathutils_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_pathutils_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_utf8utils_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_utf8utils_LDADD	=	\
 	$(TEST_LDADD)
 
 CLEANFILES				+= \

--- a/lib/tests/test_utf8utils.c
+++ b/lib/tests/test_utf8utils.c
@@ -1,0 +1,68 @@
+#include "testutils.h"
+#include "utf8utils.h"
+
+
+
+void
+assert_escaped_binary_with_unsafe_chars(const gchar *str, const gchar *expected_escaped_str, const gchar *unsafe_chars)
+{
+  gchar *escaped_str = convert_unsafe_utf8_to_escaped_binary(str, unsafe_chars);
+
+  assert_string(escaped_str, expected_escaped_str, "Escaped UTF-8 string is not expected");
+  g_free(escaped_str);
+}
+
+void
+assert_escaped_binary(const gchar *str, const gchar *expected_escaped_str)
+{
+  assert_escaped_binary_with_unsafe_chars(str, expected_escaped_str, NULL);
+}
+
+void
+assert_escaped_text_with_unsafe_chars(const gchar *str, const gchar *expected_escaped_str, const gchar *unsafe_chars)
+{
+  gchar *escaped_str = convert_unsafe_utf8_to_escaped_text(str, unsafe_chars);
+
+  assert_string(escaped_str, expected_escaped_str, "Escaped UTF-8 string is not expected");
+  g_free(escaped_str);
+}
+
+void
+assert_escaped_text(const gchar *str, const gchar *expected_escaped_str)
+{
+  assert_escaped_text_with_unsafe_chars(str, expected_escaped_str, NULL);
+}
+
+int
+main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+{
+  assert_escaped_binary("", "");
+  assert_escaped_binary("\n", "\\n");
+  assert_escaped_binary("\b \f \n \r \t", "\\b \\f \\n \\r \\t");
+  assert_escaped_binary("\\", "\\\\");
+  assert_escaped_binary("árvíztűrőtükörfúrógép", "árvíztűrőtükörfúrógép");
+  assert_escaped_binary("árvíztűrőtükörfúrógép\n", "árvíztűrőtükörfúrógép\\n");
+  assert_escaped_binary("\x41", "A");
+  assert_escaped_binary("\x7", "\\x07");
+  assert_escaped_binary("\xad", "\\xad");
+  assert_escaped_binary("Á\xadÉ", "Á\\xadÉ");
+
+  assert_escaped_binary_with_unsafe_chars("\"text\"", "\\\"text\\\"", "\"");
+  assert_escaped_binary_with_unsafe_chars("\"text\"", "\\\"te\\xt\\\"", "\"x");
+
+  assert_escaped_text("", "");
+  assert_escaped_text("\n", "\\n");
+  assert_escaped_text("\b \f \n \r \t", "\\b \\f \\n \\r \\t");
+  assert_escaped_text("\\", "\\\\");
+  assert_escaped_text("árvíztűrőtükörfúrógép", "árvíztűrőtükörfúrógép");
+  assert_escaped_text("árvíztűrőtükörfúrógép\n", "árvíztűrőtükörfúrógép\\n");
+  assert_escaped_text("\x41", "A");
+  assert_escaped_text("\x7", "\\u0007");
+  assert_escaped_text("\xad", "\\\\xad");
+  assert_escaped_text("Á\xadÉ", "Á\\\\xadÉ");
+
+  assert_escaped_text_with_unsafe_chars("\"text\"", "\\\"text\\\"", "\"");
+  assert_escaped_text_with_unsafe_chars("\"text\"", "\\\"te\\xt\\\"", "\"x");
+
+  return 0;
+}

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "utf8utils.h"
+#include <string.h>
+
+/**
+ * This function escapes an unsanitized input (e.g. that can contain binary
+ * characters, and produces an escaped format that can be deescaped in need,
+ * which is guaranteed to be utf8 clean.  The major difference between
+ * "binary" and "text" form is that the receiver is able to cope with \xXX
+ * sequences that can incorporate invalid utf8 sequences when decoded.  With
+ * "text" format, we never embed anything that would become not valid utf8
+ * when decoded.
+ *
+ * This is basically meant to be used when sending data to
+ * 8 bit clean receivers, e.g. syslog-ng or WELF.
+ *
+ * Here are the rules that the routine follows:
+ *   - well-known control characters are escaped (0x0a as \n and so on)
+ *   - other control characters as \xXX
+ *   - backslash is escaped as \\
+ *   - any additional characters (only ASCII is supported) as \<char>
+ *   - invalid utf8 sequences are converted to \xXX
+ *   - utf8 characters are reproduced as is
+ */
+void
+append_unsafe_utf8_as_escaped_binary(GString *escaped_string, const gchar *str, const gchar *unsafe_chars)
+{
+  const gchar *char_ptr = str;
+
+  while (*char_ptr)
+    {
+      gunichar uchar = g_utf8_get_char_validated(char_ptr, -1);
+
+      switch (uchar)
+        {
+          case (gunichar) -1:
+            g_string_append_printf(escaped_string, "\\x%02x", *(guint8 *) char_ptr);
+            char_ptr++;
+            continue;
+            break;
+          case '\b':
+            g_string_append(escaped_string, "\\b");
+            break;
+          case '\f':
+            g_string_append(escaped_string, "\\f");
+            break;
+          case '\n':
+            g_string_append(escaped_string, "\\n");
+            break;
+          case '\r':
+            g_string_append(escaped_string, "\\r");
+            break;
+          case '\t':
+            g_string_append(escaped_string, "\\t");
+            break;
+          case '\\':
+            g_string_append(escaped_string, "\\\\");
+            break;
+          default:
+            if (uchar < 32)
+              g_string_append_printf(escaped_string, "\\x%02x", uchar);
+            else if (uchar < 256 && unsafe_chars && strchr(unsafe_chars, (gchar) uchar))
+              g_string_append_printf(escaped_string, "\\%c", (gchar) uchar);
+            else
+              g_string_append_unichar(escaped_string, uchar);
+            break;
+        }
+      char_ptr = g_utf8_next_char(char_ptr);
+    }
+}
+
+gchar *
+convert_unsafe_utf8_to_escaped_binary(const gchar *str, const gchar *unsafe_chars)
+{
+  GString *escaped_string;
+
+  escaped_string = g_string_sized_new(strlen(str));
+  append_unsafe_utf8_as_escaped_binary(escaped_string, str, unsafe_chars);
+  return g_string_free(escaped_string, FALSE);
+}
+
+/**
+ * This function escapes an unsanitized input (e.g. that can contain binary
+ * characters, and produces an escaped format that can be deescaped in need,
+ * which is guaranteed to be utf8 clean.  The major difference between
+ * "binary" and "text" form is that the receiver is able to cope with \xXX
+ * sequences that can incorporate invalid utf8 sequences when decoded.  With
+ * "text" format, we never embed anything that would become not valid utf8
+ * when decoded.
+ *
+ * This is basically meant to be used when sending data to
+ * utf8 only receivers, e.g. JSON.
+ *
+ * Here are the rules that the routine follows:
+ *   - well-known control characters are escaped (0x0a as \n and so on)
+ *   - other control characters as \u00XX
+ *   - backslash is escaped as \\
+ *   - any additional characters (only ASCII is supported) as \<char>
+ *   - invalid utf8 sequences are converted to \\xXX (e.g. double-escaped as a literal \xXX sequence)
+ *   - utf8 characters are reproduced as is
+ **/
+void
+append_unsafe_utf8_as_escaped_text(GString *escaped_string, const gchar *str, const gchar *unsafe_chars)
+{
+  const gchar *char_ptr = str;
+
+  while (*char_ptr)
+    {
+      gunichar uchar = g_utf8_get_char_validated(char_ptr, -1);
+
+      switch (uchar)
+        {
+          case (gunichar) -1:
+            g_string_append_printf(escaped_string, "\\\\x%02x", *(guint8 *) char_ptr);
+            char_ptr++;
+            continue;
+            break;
+          case '\b':
+            g_string_append(escaped_string, "\\b");
+            break;
+          case '\f':
+            g_string_append(escaped_string, "\\f");
+            break;
+          case '\n':
+            g_string_append(escaped_string, "\\n");
+            break;
+          case '\r':
+            g_string_append(escaped_string, "\\r");
+            break;
+          case '\t':
+            g_string_append(escaped_string, "\\t");
+            break;
+          case '\\':
+            g_string_append(escaped_string, "\\\\");
+            break;
+          default:
+            if (uchar < 32)
+              g_string_append_printf(escaped_string, "\\u%04x", uchar);
+            else if (uchar < 256 && unsafe_chars && strchr(unsafe_chars, (gchar) uchar))
+              g_string_append_printf(escaped_string, "\\%c", (gchar) uchar);
+            else
+              g_string_append_unichar(escaped_string, uchar);
+            break;
+        }
+      char_ptr = g_utf8_next_char(char_ptr);
+    }
+}
+
+gchar *
+convert_unsafe_utf8_to_escaped_text(const gchar *str, const gchar *unsafe_chars)
+{
+  GString *escaped_string;
+
+  escaped_string = g_string_sized_new(strlen(str));
+  append_unsafe_utf8_as_escaped_text(escaped_string, str, unsafe_chars);
+  return g_string_free(escaped_string, FALSE);
+}

--- a/lib/utf8utils.h
+++ b/lib/utf8utils.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef UTF8UTILS_H_INCLUDED
+#define UTF8UTILS_H_INCLUDED
+
+#include "syslog-ng.h"
+
+void append_unsafe_utf8_as_escaped_binary(GString *escaped_string, const gchar *str, const gchar *unsafe_chars);
+gchar *convert_unsafe_utf8_to_escaped_binary(const gchar *str, const gchar *additional_unsafe_chars);
+
+void append_unsafe_utf8_as_escaped_text(GString *escaped_string, const gchar *str, const gchar *unsafe_chars);
+gchar *convert_unsafe_utf8_to_escaped_text(const gchar *str, const gchar *additional_unsafe_chars);
+
+#endif

--- a/libtest/template_lib.c
+++ b/libtest/template_lib.c
@@ -62,6 +62,7 @@ create_sample_message(void)
   log_msg_set_value_by_name(msg, ".json.foo", "bar", -1);
   log_msg_set_value_by_name(msg, ".json.sub.value1", "subvalue1", -1);
   log_msg_set_value_by_name(msg, ".json.sub.value2", "subvalue2", -1);
+  log_msg_set_value_by_name(msg, "escaping", "binary stuff follows \"\xad árvíztűrőtükörfúrógép", -1);
   log_msg_set_match(msg, 0, "whole-match", -1);
   log_msg_set_match(msg, 1, "first-match", -1);
   log_msg_set_tag_by_name(msg, "alma");

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -29,6 +29,7 @@ void
 test_format_json(void)
 {
   assert_template_format("$(format-json MSG=$MSG)", "{\"MSG\":\"árvíztűrőtükörfúrógép\"}");
+  assert_template_format("$(format-json MSG=$escaping)", "{\"MSG\":\"binary stuff follows \\\"\\\\xad árvíztűrőtükörfúrógép\"}");
   assert_template_format_with_context("$(format-json MSG=$MSG)", "{\"MSG\":\"árvíztűrőtükörfúrógép\"}{\"MSG\":\"árvíztűrőtükörfúrógép\"}");
   assert_template_format("$(format-json --scope rfc3164)", "{\"PROGRAM\":\"syslog-ng\",\"PRIORITY\":\"err\",\"PID\":\"23323\",\"MESSAGE\":\"árvíztűrőtükörfúrógép\",\"HOST\":\"bzorp\",\"FACILITY\":\"local3\",\"DATE\":\"Feb 11 10:34:56\"}");
   assert_template_format("$(format-json msg.text=$MSG msg.id=42 host=bzorp)", "{\"msg\":{\"text\":\"árvíztűrőtükörfúrógép\",\"id\":\"42\"},\"host\":\"bzorp\"}");


### PR DESCRIPTION
This branch does a couple of things:

1) implements proper utf8 sanitization for untrusted output (two kinds actually, but read those in the patches)
2) migrates stats and format-json to use these
3) implements sanitize-utf8 as an input flag

The last one should probably be a separate branch as it's a new feature, the other two is just refactors. My original intent was to port $(format-welf) that would be using these new functions, but I didn't get there so far.

PS: I know that the syslog-format code that implements sanitize-utf8 is ugly with the GString mockery, however it is a fast path and I wanted to avoid a GString object allocation. I also know that there's a syslog-format refactor en-route, which probably conflicts with this change, so feel free to integrate only the first few patches and not the last one.

Thanks.
