### PR TITLE
configure.ac: docbook dir option name corrected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,10 +229,10 @@ AC_ARG_WITH(systemd-journal,
 AC_ARG_WITH(python,
               [  --with-python=VERSION    Build with a specific version of python])
 
-AC_ARG_WITH(docbook,
+AC_ARG_WITH(docbook-dir,
             AC_HELP_STRING([--with-docbook-dir=DIR],
                            [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net]),
-            [ XSL_STYLESHEET=$with_docbook ],
+            [ XSL_STYLESHEET=$with_docbook_dir ],
             [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl ]
             )
 


### PR DESCRIPTION
The name of the `--with-docbook-dir` parameter was wrong. (Wrong documentation string.)

fixes #572 

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>