### PR TITLE
json: do not rely on json_object_is_type() accepting NULL

### DIFF
--- a/modules/json/dot-notation.c
+++ b/modules/json/dot-notation.c
@@ -221,6 +221,9 @@ json_dot_notation_eval(JSONDotNotation *self, struct json_object *jso)
   JSONDotNotationElem *compiled;
   gint i;
 
+  if (!jso)
+    goto error;
+
   compiled = self->compiled_elems;
   for (i = 0; compiled && compiled[i].used; i++)
     {

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -185,7 +185,7 @@ json_parser_extract(JSONParser *self, struct json_object *jso, LogMessage *msg)
   if (self->extract_prefix)
     jso = json_extract(jso, self->extract_prefix);
 
-  if (!json_object_is_type(jso, json_type_object))
+  if (!jso || !json_object_is_type(jso, json_type_object))
     {
       return FALSE;
     }


### PR DESCRIPTION
Starting from jsonc 0.10, `json_object_is_type()` started handling NULL
appropriately. With previous versions, calling this function with NULL
would lead to a segfault.

The version embedded in syslog-ng is recent enough. This fix is for
people using `--with-jsonc=system` and having a too old system jsonc
library (like the one in Ubuntu Precise).

I have experienced the "bug" in `json/json-parser.c`. I think that the "bug" could also be triggered in `dot-notation.c` but I can't be sure. The test may be unneeded.

Not using embedded libs is a common culture in distributions and is useful to get security updates (jsonc had several CVE fixes in the past). So, I think the use case is valid, but I can understand if it would be dismissed.