### PR TITLE
F/format welf

### DIFF
--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -27,6 +27,7 @@ include modules/systemd-journal/Makefile.am
 include modules/python/Makefile.am
 include modules/java/Makefile.am
 include modules/java-modules/Makefile.am
+include modules/welf/Makefile.am
 
 SYSLOG_NG_MODULES	=	\
 	mod-afsocket mod-afstreams mod-affile mod-afprog \
@@ -35,7 +36,7 @@ SYSLOG_NG_MODULES	=	\
 	mod-confgen mod-system-source mod-csvparser mod-dbparser \
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
-	mod-python mod-java mod-java-modules
+	mod-python mod-java mod-java-modules mod-welf
 
 modules modules/: ${SYSLOG_NG_MODULES}
 
@@ -48,6 +49,6 @@ modules_test_subdirs	=	\
 	modules_csvparser modules_dbparser modules_basicfuncs \
 	modules_cryptofuncs modules_geoip modules_afstomp \
 	modules_graphite modules_riemann modules_python \
-	modules_systemd_journal
+	modules_systemd_journal modules_welf
 
 .PHONY: modules modules/

--- a/modules/welf/Makefile.am
+++ b/modules/welf/Makefile.am
@@ -1,0 +1,23 @@
+module_LTLIBRARIES				+= modules/welf/libwelf.la
+
+modules_welf_libwelf_la_SOURCES=	\
+	modules/welf/format-welf.c		\
+	modules/welf/format-welf.h		\
+	modules/welf/welf-plugin.c
+
+modules_welf_libwelf_la_CPPFLAGS	=	\
+	$(AM_CPPFLAGS)					\
+	-I$(top_srcdir)/modules/welf			\
+	-I$(top_builddir)/modules/welf
+
+modules_welf_libwelf_la_LDFLAGS	=	\
+	$(MODULE_LDFLAGS)
+modules_welf_libwelf_la_DEPENDENCIES	=	\
+	$(MODULE_DEPS_LIBS)
+
+modules/welf modules/welf/ mod-welf:	\
+	modules/welf/libwelf.la
+
+.PHONY: modules/welf/ mod-welf
+
+include modules/welf/tests/Makefile.am

--- a/modules/welf/format-welf.c
+++ b/modules/welf/format-welf.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "format-welf.h"
+#include "utf8utils.h"
+#include "value-pairs.h"
+
+typedef struct _TFWelfState
+{
+  TFSimpleFuncState super;
+  ValuePairs *vp;
+} TFWelfState;
+
+static gboolean
+tf_format_welf_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
+                       gint argc, gchar *argv[],
+                       GError **error)
+{
+  TFWelfState *state = (TFWelfState *) s;
+
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, argc, argv, error);
+  if (!state->vp)
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
+tf_format_welf_foreach(const gchar *name, TypeHint type, const gchar *value, gpointer user_data)
+{
+  GString *result = (GString *) user_data;
+
+  if (result->len > 0)
+    g_string_append(result, " ");
+  g_string_append(result, name);
+  g_string_append_c(result, '=');
+  if (strchr(value, ' ') == NULL)
+    append_unsafe_utf8_as_escaped_binary(result, value, NULL);
+  else
+    {
+      g_string_append_c(result, '"');
+      append_unsafe_utf8_as_escaped_binary(result, value, "\"");
+      g_string_append_c(result, '"');
+    }
+
+  return FALSE;
+}
+
+static gint
+tf_format_welf_strcmp(gconstpointer a, gconstpointer b)
+{
+  gchar *sa = (gchar *)a, *sb = (gchar *)b;
+  if (strcmp (sa, "id") == 0)
+    return -1;
+  return strcmp(sa, sb);
+}
+
+static void
+tf_format_welf_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
+{
+  TFWelfState *state = (TFWelfState *) s;
+  gint i;
+
+  for (i = 0; i < args->num_messages; i++)
+    {
+      value_pairs_foreach_sorted(state->vp,
+                                 tf_format_welf_foreach, (GCompareDataFunc) tf_format_welf_strcmp,
+                                 args->messages[i], 0, args->tz, args->opts, result);
+    }
+
+}
+
+static void
+tf_format_welf_free_state(gpointer s)
+{
+  TFWelfState *state = (TFWelfState *) s;
+
+  if (state->vp)
+    value_pairs_unref(state->vp);
+  tf_simple_func_free_state(s);
+}
+
+TEMPLATE_FUNCTION(TFWelfState, tf_format_welf, tf_format_welf_prepare, NULL, tf_format_welf_call, tf_format_welf_free_state, NULL);

--- a/modules/welf/format-welf.h
+++ b/modules/welf/format-welf.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef WELF_FORMAT_WELF_H_INCLUDED
+#define WELF_FORMAT_WELF_H_INCLUDED
+
+#include "template/simple-function.h"
+
+TEMPLATE_FUNCTION_DECLARE(tf_format_welf);
+
+#endif

--- a/modules/welf/tests/Makefile.am
+++ b/modules/welf/tests/Makefile.am
@@ -1,0 +1,11 @@
+modules_welf_tests_TESTS		= \
+	modules/welf/tests/test_format_welf
+
+check_PROGRAMS				+= ${modules_welf_tests_TESTS}
+
+modules_welf_tests_test_format_welf_CFLAGS	= $(TEST_CFLAGS)
+modules_welf_tests_test_format_welf_LDADD	= $(TEST_LDADD)
+modules_welf_tests_test_format_welf_LDFLAGS	= \
+	$(PREOPEN_SYSLOGFORMAT)		  \
+	-dlpreopen $(top_builddir)/modules/welf/libwelf.la
+modules_welf_tests_test_format_welf_DEPENDENCIES = $(top_builddir)/modules/welf/libwelf.la

--- a/modules/welf/tests/test_format_welf.c
+++ b/modules/welf/tests/test_format_welf.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "template_lib.h"
+#include "apphook.h"
+#include "plugin.h"
+#include "cfg.h"
+
+void
+test_format_welf(void)
+{
+  assert_template_format("$(format-welf MSG=$MSG)", "MSG=árvíztűrőtükörfúrógép");
+  assert_template_format("$(format-welf MSG=$escaping)", "MSG=\"binary stuff follows \\\"\\xad árvíztűrőtükörfúrógép\"");
+  assert_template_format_with_context("$(format-welf MSG=$MSG)", "MSG=árvíztűrőtükörfúrógép MSG=árvíztűrőtükörfúrógép");
+}
+
+int
+main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+{
+  app_startup();
+  putenv("TZ=UTC");
+  tzset();
+  init_template_tests();
+  plugin_load_module("welf", configuration, NULL);
+
+  test_format_welf();
+
+  deinit_template_tests();
+  app_shutdown();
+}

--- a/modules/welf/welf-plugin.c
+++ b/modules/welf/welf-plugin.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "plugin.h"
+#include "plugin-types.h"
+#include "format-welf.h"
+
+extern CfgParser welf_parser_parser;
+
+static Plugin welf_plugins[] =
+{
+/*  {
+    .type = LL_CONTEXT_PARSER,
+    .name = "welf",
+    .parser = &welf_parser_parser,
+  }, */
+  TEMPLATE_FUNCTION_PLUGIN(tf_format_welf, "format-welf"),
+};
+
+gboolean
+welf_module_init(GlobalConfig *cfg, CfgArgs *args)
+{
+  plugin_register(cfg, welf_plugins, G_N_ELEMENTS(welf_plugins));
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "welf",
+  .version = VERSION,
+  .description = "The welf module provides WebTrends Enhanced Log Format support for syslog-ng.",
+  .core_revision = SOURCE_REVISION,
+  .plugins = welf_plugins,
+  .plugins_len = G_N_ELEMENTS(welf_plugins),
+};


### PR DESCRIPTION
This is a backport of $(format-welf) from the pe-5.3/master to master. WELF is a key-value format:

key1=value key2=value key3=value

It is not really well specified, quote characters are supported, but no mention is made what to do with values where quotes are embedded into a value. $(format-welf) will enclose the value in quotes if it contains a space, and will quote embedded quote/newline/control characters with a backslash in a format similar to how C/JSON quotes string literals.

PS: It currently contains the f/utf8-sanitization branch as a dependency, if you integrate that first, this needs to be rebased.

please merge.
