### PR TITLE
afprog: do not send SIGTERM when getpgid() fails

### DIFF
--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -276,12 +276,15 @@ afprogram_dd_kill_child(AFProgramDestDriver *self)
 {
   if (self->pid != -1)
     {
+      pid_t pgid;
       child_manager_unregister(self->pid);
       msg_verbose("Sending destination program a TERM signal",
                   evt_tag_str("cmdline", self->cmdline->str),
                   evt_tag_int("child_pid", self->pid),
                   NULL);
-      killpg(getpgid(self->pid), SIGTERM);
+      pgid = getpgid(self->pid);
+      if (pgid != -1)
+        killpg(pgid, SIGTERM);
       self->pid = -1;
     }
 }


### PR DESCRIPTION
Fixes: #586

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>