### PR TITLE
requirements: add logilab-common as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ nose==1.3.6
 ply==3.6
 pep8==1.6.2
 pylint==1.4.3
+logilab-common<=0.63.0


### PR DESCRIPTION
This PR fixes the `drone.io` build failures.

There is a version conflict between the installed Python eggs.
This commit solves it by choosing the proper version so the
unit tests are OK again.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>