### PR TITLE
java: modified java modules to allow local caching of jar files

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -4,7 +4,7 @@ JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar')
 
 java-modules:
-	 $(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs build > "$(top_srcdir)/modules/java-modules/gradle-java-modules.log"
+	 $(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs build > "$(abs_top_srcdir)/modules/java-modules/gradle-java-modules.log"
 
 all-local: java-modules
 
@@ -20,7 +20,7 @@ java-modules-clean-hook:
 	$(GRADLE) -q -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs clean
 
 eclipse:
-	$(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs eclipse > "$(top_srcdir)/modules/java-modules/gradle-eclipse.log"
+	$(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs eclipse > "$(abs_top_scrdir)/modules/java-modules/gradle-eclipse.log"
 
 
 INSTALL_EXEC_HOOKS += java-modules-install-exec-hook

--- a/modules/java-modules/common/build.gradle
+++ b/modules/java-modules/common/build.gradle
@@ -6,10 +6,12 @@ project.buildDir = syslogBuildDir + '/common/gradle'
 jar.baseName = 'syslog-ng-common'
 
 repositories {
-  mavenCentral()
   flatDir {
     dirs syslogDepsDir
+    dirs '/usr/lib/syslog-ng-java-module-dependency-jars/jars'
   }
+  mavenCentral()
+
 }
 
 dependencies {
@@ -18,3 +20,4 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-core:1.3'
 }
+

--- a/modules/java-modules/elastic/build.gradle
+++ b/modules/java-modules/elastic/build.gradle
@@ -3,12 +3,14 @@ apply plugin: 'eclipse'
 
 project.buildDir = syslogBuildDir+'/elastic/gradle'
 
+
 repositories {
-    mavenCentral()
     flatDir {
        dirs syslogDepsDir
        dirs syslogBuildDir + '/common/gradle/libs'
+       dirs '/usr/lib/syslog-ng-java-module-dependency-jars/jars'
     }
+  mavenCentral()
 }
 
 dependencies {
@@ -18,5 +20,6 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'org.hamcrest:hamcrest-core:1.3'
     compile 'log4j:log4j:1.2.17'
-
+    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
 }
+

--- a/modules/java-modules/hdfs/build.gradle
+++ b/modules/java-modules/hdfs/build.gradle
@@ -4,20 +4,20 @@ apply plugin: 'eclipse'
 project.buildDir = syslogBuildDir+'/hdfs/gradle'
 
 repositories {
-   mavenCentral()
    flatDir {
        dirs syslogDepsDir
        dirs syslogBuildDir + '/common/gradle/libs'
+       dirs '/usr/lib/syslog-ng-java-module-dependency-jars/jars'
    }
+  mavenCentral()
 }
 
 dependencies {
-    compile "org.apache.hadoop:hadoop-hdfs:2.7.1"
+    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
+    compile 'org.apache.hadoop:hadoop-hdfs:2.7.1'
     compile 'org.apache.hadoop:hadoop-common:2.7.1'
-    compile 'org.apache.hadoop:hadoop-core:1.2.1'
     compile name: 'syslog-ng-common'
     compile name: 'syslog-ng-core'
     compile 'log4j:log4j:1.2.17'
-
-
 }
+

--- a/modules/java-modules/kafka/build.gradle
+++ b/modules/java-modules/kafka/build.gradle
@@ -4,18 +4,23 @@ apply plugin: 'eclipse'
 project.buildDir = syslogBuildDir + '/kafka/gradle'
 
 repositories {
-    mavenCentral()
     flatDir {
         dirs syslogDepsDir
         dirs syslogBuildDir + '/common/gradle/libs'
+        dirs '/usr/lib/syslog-ng-java-module-dependency-jars/jars'
     }
+  mavenCentral()
 }
 
 dependencies {
+  compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
   compile 'org.apache.kafka:kafka_2.10:0.8.2.1'
+  compile 'org.apache.kafka:kafka-clients:0.8.2.1'
   compile name: 'syslog-ng-common'
   compile name: 'syslog-ng-core'
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-core:1.3'
   compile 'log4j:log4j:1.2.17'
+
 }
+

--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -5,13 +5,12 @@ JAVA_DST_DIR=$(DESTDIR)/$(moduledir)
 JARS=$(shell find $(abs_top_builddir)/modules/java -name '*.jar')
 
 java-binaries:
-	$(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java -PsyslogBuildDir=$(abs_top_builddir)/modules/java build > "$(top_srcdir)/modules/java/gradle-java-binaries.log"
+	$(AM_V_GEN) $(GRADLE) -g $(abs_top_builddir)/modules/java build -p $(abs_top_srcdir)/modules/java -PsyslogBuildDir=$(abs_top_builddir)/modules/java build 
 
 java-headers:
-	$(AM_V_GEN) $(GRADLE) -q -p $(abs_top_srcdir)/modules/java -PsyslogBuildDir=$(abs_top_builddir)/modules/java nativeHeaders > "$(top_srcdir)/modules/java/gradle-java-headers.log"
+	$(AM_V_GEN) $(GRADLE) -g $(abs_top_builddir)/modules/java build -q -p $(abs_top_srcdir)/modules/java -PsyslogBuildDir=$(abs_top_builddir)/modules/java nativeHeaders
 
 all-local: java-binaries
-
 
 java-install-exec-hook:
 	$(mkinstalldirs) $(JAVA_DST_DIR)
@@ -25,7 +24,7 @@ java-uninstall-exec-hook:
 	rm -f $(JAVA_DST_DIR)/*.jar
 
 eclipse:
-	$(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java -PsyslogBuildDir=$(abs_top_builddir)/modules/java eclipse > "$(top_srcdir)/modules/java/gradle-eclipse.log"
+	$(AM_V_GEN) $(GRADLE) -g $(abs_top_builddir)/modules/java build -p $(abs_top_srcdir)/modules/java -PsyslogBuildDir=$(abs_top_builddir)/modules/java eclipse
 
 
 INSTALL_EXEC_HOOKS += java-install-exec-hook
@@ -108,5 +107,5 @@ endif
 
 EXTRA_DIST += \
     modules/java/native/java-grammar.ym \
-    modules/java/build.gradle \
-    $(JAVA_FILES)
+    $(JAVA_FILES) \
+    modules/java/build.gradle


### PR DESCRIPTION
For building on OBS, offline jars are necessary because OBS builders don't have
internet access. This patch makes gradle first check a local folder for jars.

Signed-off-by: Arsenault Adam <adam.arsenault@balabit.com>