### PR TITLE
java: set GRADLE_USER_HOME in Makefile.am for java-modules

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -4,7 +4,7 @@ JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar')
 
 java-modules:
-	 $(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs build > "$(abs_top_srcdir)/modules/java-modules/gradle-java-modules.log"
+	 $(AM_V_GEN) $(GRADLE) -g $(abs_top_builddir)/modules/java -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs build
 
 all-local: java-modules
 
@@ -17,7 +17,7 @@ java-modules-uninstall-exec-hook:
 
 java-modules-clean-hook:
 	rm -rf $(abs_top_builddir)/modules/java-modules/*.log
-	$(GRADLE) -q -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs clean
+	$(GRADLE) -q -g $(abs_top_builddir)/modules/java -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs clean
 
 eclipse:
 	$(AM_V_GEN) $(GRADLE) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs eclipse > "$(abs_top_scrdir)/modules/java-modules/gradle-eclipse.log"


### PR DESCRIPTION
Without setting GRADLE_USER_HOME (via -g option), build fails on OBS.

Redirection of gradle log also eliminated in order to make available build logs
in OBS log (and to provide feedback to users who build syslog-ng from source,
see #585 ).

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>