### PR TITLE
java: install all *.jar files under lib/syslog-ng/java-modules

### DIFF
--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -1,7 +1,7 @@
 
 if ENABLE_JAVA
 
-JAVA_DST_DIR=$(DESTDIR)/$(moduledir)
+JAVA_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 JARS=$(shell find $(abs_top_builddir)/modules/java -name '*.jar')
 
 java-binaries:


### PR DESCRIPTION
Syslog-ng's classloader didn't find syslog-ng-core.jar because it only
searched in lib/syslog-ng/java-modules. This commit installs all *.jar files
under lib/syslog-ng/java-modules so the classloader will find them.

Fixes #594
Fixes #595 

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>