### PR TITLE
.travis.yml: Java support added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: c
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq curl
-  - curl http://packages.madhouse-project.org/debian/add-release.sh | sudo sh
+  - curl http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04/Release.key | sudo apt-key add -
+  - echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04 ./" | sudo tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
   - sudo apt-get update -qq
-  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev
+  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev openjdk-7-jdk gradle-2.2.1
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh


### PR DESCRIPTION
Java support requires:
  * gradle-2.2.1
  * openjdk-7-jdk

(gradle-2.2.1 is provided by the OBS repo)

Fixes #612

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>