### PR TITLE
java: Fixed libjvm linking

### DIFF
--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -62,6 +62,7 @@ modules_java_libmod_java_la_SOURCES = \
     modules/java/proxies/java-template-proxy.h \
     modules/java/proxies/internal-message-sender-proxy.c
 
+modules_java_libmod_java_la_LIBADD =  $(JNI_LIBS)
 
 modules_java_libmod_java_la_LDFLAGS = \
     -avoid-version -module -no-undefined


### PR DESCRIPTION
    Included the previously-unincluded JNI_LIBS flags for linking
    libmod-java to libjvm.so.

    Fixes #596

    Signed-off-by: Arsenault Adam <adam.arsenault@balabit.com>