### PR TITLE
configure.ac: 'with-docbook' option renamed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,10 +231,10 @@ AC_ARG_WITH(systemd-journal,
                                          Link against the system supplied or the wrapper library. (default: auto)]
               ,,with_systemd_journal="auto")
 
-AC_ARG_WITH(docbook,
+AC_ARG_WITH(docbook-dir,
             AC_HELP_STRING([--with-docbook-dir=DIR],
                            [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net]),
-            [ XSL_STYLESHEET=$with_docbook ],
+            [ XSL_STYLESHEET=$with_docbook_dir],
             [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl ]
             )
 


### PR DESCRIPTION
`with-docbook` option was misleading for it showed that you should pass the path to the `.xsl` file not to the directory of `docbook`. This notation was provided by @faxmodem and fixe in `3.7`. The new name shows that you should pass the directory of docbook because that path is different in many distros.

This is only a patchport.

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>