### PR TITLE
logthreadeddestination: add connect function to make the interface sy…

### DIFF
--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -59,9 +59,11 @@ struct _LogThrDestDriver
   /* Worker stuff */
   struct
   {
+    gboolean connected;
     void (*thread_init) (LogThrDestDriver *s);
     void (*thread_deinit) (LogThrDestDriver *s);
     worker_insert_result_t (*insert) (LogThrDestDriver *s, LogMessage *msg);
+    gboolean (*connect) (LogThrDestDriver *s);
     void (*worker_message_queue_empty)(LogThrDestDriver *s);
     void (*disconnect) (LogThrDestDriver *s);
   } worker;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -251,6 +251,8 @@ java_dd_new(GlobalConfig *cfg)
 
   self->super.worker.thread_deinit = java_worker_thread_deinit;
   self->super.worker.insert = java_worker_insert;
+  self->super.worker.connect = java_dd_open;
+  self->super.worker.disconnect = java_dd_close;
   self->super.worker.worker_message_queue_empty = java_worker_message_queue_empty;
 
   self->super.format.stats_instance = java_dd_format_stats_instance;


### PR DESCRIPTION
…mmetric,

and give chance to connect before the first message arrives.
We need this, because the connecting method can take seconds,
and in this case the queue could be full causing message loss
without flow-control.
Java destination use this functionality.

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>

We missed somehow this patch, please merge it.