### PR TITLE
timeutils: Fix the cached_gmtime error

### DIFF
--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -212,7 +212,7 @@ cached_gmtime(time_t *when, struct tm *tm)
   guchar i = 0;
 
   i = *when & 0x3F;
-  if (G_LIKELY(*when == gm_time_cache[i].when))
+  if (G_LIKELY(*when == gm_time_cache[i].when && *when != 0))
     {
       *tm = gm_time_cache[i].tm;
       return;

--- a/tests/unit/test_zone.c
+++ b/tests/unit/test_zone.c
@@ -765,6 +765,13 @@ test_logstamp(void)
   TEST_ASSERT(strcmp(target->str, "2005-10-14T18:47:37.123-01:00") == 0);
   log_stamp_format(&stamp, target, TS_FMT_ISO, -5400, 3);
   TEST_ASSERT(strcmp(target->str, "2005-10-14T18:17:37.123-01:30") == 0);
+
+  /* boundary testing */
+  stamp.tv_sec = 0;
+  stamp.tv_usec = 0;
+
+  log_stamp_format(&stamp, target, TS_FMT_ISO, -1, 0);
+  TEST_ASSERT(strcmp(target->str, "1970-01-01T00:00:00+00:00") == 0);
   g_string_free(target, TRUE);
   return rc;
 }


### PR DESCRIPTION
when we run the command `date 010100001970.00` after the
syslog-ng daemon restart. The timestamp in the log file
have the wrong value to be record:
	1900-01-00T00:00:00+00:00 localhost syslog-ng[18736]: ....
	1900-01-00T00:00:00+00:00 localhost syslog-ng[18736]: ....
        ....
        ....
	1970-01-01T00:00:01+00:00 localhost syslog-ng[18736]: ....
	1970-01-01T00:00:01+00:00 localhost syslog-ng[18736]: ....
after one second later, it becomes ok.

This reason for this error is the improper initialization for
gm_time_cache. so this patch fix that and add the testcase.

Signed-off-by: Wang Long <long.wanglong@huawei.com>