### PR TITLE
Make the default for RLIMIT_NOFILE equal to the current system limits.

### DIFF
--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -133,11 +133,7 @@ static struct
   .argv = NULL,
   .argv_start = NULL,
   .argv_env_len = 0,
-#ifdef __CYGWIN__
-  .fd_limit_min = 256,
-#else
-  .fd_limit_min = 4096,
-#endif
+  .fd_limit_min = 0,
   .check_period = -1,
   .check_fn = NULL,
   .uid = -1,
@@ -628,7 +624,16 @@ g_process_change_limits(void)
 {
   struct rlimit limit;
 
-  limit.rlim_cur = limit.rlim_max = process_opts.fd_limit_min;
+  getrlimit(RLIMIT_NOFILE, &limit);
+#ifdef __CYGWIN__
+  limit.rlim_cur = limit.rlim_max = 256;
+#else
+  limit.rlim_cur = limit.rlim_max;
+  if (process_opts.fd_limit_min)
+    {
+      limit.rlim_cur = limit.rlim_max = process_opts.fd_limit_min;
+    }
+#endif
   
   if (setrlimit(RLIMIT_NOFILE, &limit) < 0)
     g_process_message("Error setting file number limit; limit='%d'; error='%s'", process_opts.fd_limit_min, g_strerror(errno));

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -625,15 +625,11 @@ g_process_change_limits(void)
   struct rlimit limit;
 
   getrlimit(RLIMIT_NOFILE, &limit);
-#ifdef __CYGWIN__
-  limit.rlim_cur = limit.rlim_max = 256;
-#else
   limit.rlim_cur = limit.rlim_max;
   if (process_opts.fd_limit_min)
     {
       limit.rlim_cur = limit.rlim_max = process_opts.fd_limit_min;
     }
-#endif
   
   if (setrlimit(RLIMIT_NOFILE, &limit) < 0)
     g_process_message("Error setting file number limit; limit='%d'; error='%s'", process_opts.fd_limit_min, g_strerror(errno));


### PR DESCRIPTION
--fd-limit can still override this, but the default will be configured based on
existing system limits.

Issue: https://github.com/balabit/syslog-ng/issues/646

Signed-off-by: Avleen Vig <avleen@gmail.com>