### PR TITLE
transport-mapper-unix: remove the second typedef of _TransportMapperUnix

### DIFF
--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -30,12 +30,12 @@
 #include <sys/un.h>
 
 
-typedef struct _TransportMapperUnix
+struct _TransportMapperUnix
 {
   TransportMapper super;
   gchar *filename;
   gboolean pass_unix_credentials;
-} TransportMapperUnix;
+};
 
 static LogTransport*
 _create_log_transport(TransportMapper *s, gint fd)


### PR DESCRIPTION
Fixes #645

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>