### PR TITLE
cfg.c: call destroy() only when it is set in cfg_persist_config_add()

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -564,7 +564,8 @@ cfg_persist_config_add(GlobalConfig *cfg, gchar *name, gpointer value, GDestroyN
               msg_error("Internal error, duplicate configuration elements refer to the same persistent config", 
                         evt_tag_str("name", name),
                         NULL);
-              destroy(value);
+              if (destroy)
+                destroy(value);
               return;
             }
         }


### PR DESCRIPTION
When a name-value pair is added to the persist config then the user
can set a destroy function which can be called in two cases:

a) when the key is already added to the hash table
b) config doesn't have PersistConfig

For case b) syslog-ng check whether the destroy function is set or not and
calls only when it is set.

For case a) this patch fix the issue.


Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>