### PR TITLE
dbparser: handle NULL value for the match parameter in r_parser_email()

### DIFF
--- a/modules/dbparser/radix.c
+++ b/modules/dbparser/radix.c
@@ -218,7 +218,8 @@ r_parser_email(guint8 *str, gint *len, const gchar *param, gpointer state, RPars
     while (strchr(param, str[*len]))
       (*len)++;
 
-  match->ofs = *len;
+  if (match)
+      match->ofs = *len;
 
   /* first character of e-mail can not be a period */
   if (str[*len] == '.')


### PR DESCRIPTION
Fixes #658

I'm not the original author I just copied the diff into this commit.

Author: Balazs Scheidler <balazs.scheidler@balabit.com>