### PR TITLE
Make it possible to override persist id

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -229,6 +229,8 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_THREADED                    10171
 %token KW_PASS_UNIX_CREDENTIALS       10231
 
+%token KW_PERSIST_NAME                10302
+
 /* log statement options */
 %token KW_FLAGS                       10190
 
@@ -336,6 +338,7 @@ extern struct _StatsOptions *last_stats_options;
 #include "template/templates.h"
 #include "template/user-function.h"
 #include "logreader.h"
+#include "logpipe.h"
 #include "parser/parser-expr.h"
 #include "rewrite/rewrite-expr.h"
 #include "rewrite/rewrite-expr-parser.h"
@@ -1016,6 +1019,7 @@ source_option
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ last_source_options->keep_timestamp = $3; }
         | KW_TAGS '(' string_list ')'		{ log_source_options_set_tags(last_source_options, $3); }
         | { last_host_resolve_options = &last_source_options->host_resolve_options; } host_resolve_option
+        | driver_option
         ;
 
 source_proto_option
@@ -1076,6 +1080,10 @@ source_reader_option_flags
 	|
 	;
 
+driver_option
+    : KW_PERSIST_NAME '(' string ')' { log_pipe_set_persist_name(&last_driver->super, g_strdup($3)); free($3); }
+    ;
+
 threaded_dest_driver_option
 	: KW_RETRIES '(' LL_NUMBER ')'
         {
@@ -1105,6 +1113,7 @@ dest_driver_option
               }
             log_driver_add_plugin(last_driver, (LogDriverPlugin *) value);
           }
+    | driver_option
         ;
 
 dest_writer_options

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -149,7 +149,8 @@ static CfgLexerKeyword main_keywords[] = {
   { "dns_cache_size",     KW_DNS_CACHE_SIZE },
   { "dns_cache_expire",   KW_DNS_CACHE_EXPIRE },
   { "dns_cache_expire_failed", KW_DNS_CACHE_EXPIRE_FAILED },
-  { "pass_unix_credentials", KW_PASS_UNIX_CREDENTIALS },
+  { "pass_unix_credentials",   KW_PASS_UNIX_CREDENTIALS },
+  { "persist_name",            KW_PERSIST_NAME, 0x0308 },
 
   { "retries",            KW_RETRIES },
 

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -24,6 +24,7 @@
 
 #include "cfg-tree.h"
 #include "logmpx.h"
+#include "logpipe.h"
 
 #include <string.h>
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -497,8 +497,9 @@ cfg_persist_config_move(GlobalConfig *src, GlobalConfig *dest)
 }
 
 void
-cfg_persist_config_add(GlobalConfig *cfg, gchar *name, gpointer value, GDestroyNotify destroy, gboolean force)
-{ 
+cfg_persist_config_add(GlobalConfig *cfg, const gchar *name, gpointer value, GDestroyNotify destroy,
+                       gboolean force)
+{
   PersistConfigEntry *p;
   
   if (cfg->persist && value)
@@ -530,7 +531,7 @@ cfg_persist_config_add(GlobalConfig *cfg, gchar *name, gpointer value, GDestroyN
 }
 
 gpointer
-cfg_persist_config_fetch(GlobalConfig *cfg, gchar *name)
+cfg_persist_config_fetch(GlobalConfig *cfg, const gchar *name)
 {
   gpointer res = NULL;
   gchar *orig_key;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -143,8 +143,8 @@ gboolean cfg_deinit(GlobalConfig *cfg);
 PersistConfig *persist_config_new(void);
 void persist_config_free(PersistConfig *self);
 void cfg_persist_config_move(GlobalConfig *src, GlobalConfig *dest);
-void cfg_persist_config_add(GlobalConfig *cfg, gchar *name, gpointer value, GDestroyNotify destroy, gboolean force);
-gpointer cfg_persist_config_fetch(GlobalConfig *cfg, gchar *name);
+void cfg_persist_config_add(GlobalConfig *cfg, const gchar *name, gpointer value, GDestroyNotify destroy, gboolean force);
+gpointer cfg_persist_config_fetch(GlobalConfig *cfg, const gchar *name);
 
 static inline gboolean
 cfg_is_config_version_older(GlobalConfig *cfg, gint req)

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -190,7 +190,8 @@ log_src_driver_free(LogPipe *s)
 
 /* returns a reference */
 static LogQueue *
-log_dest_driver_acquire_queue_method(LogDestDriver *self, gchar *persist_name, gpointer user_data)
+log_dest_driver_acquire_queue_method(LogDestDriver *self, const gchar *persist_name,
+                                     gpointer user_data)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
   LogQueue *queue = NULL;

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -151,7 +151,7 @@ struct _LogDestDriver
   LogDriver super;
 
   gpointer acquire_queue_data;
-  LogQueue *(*acquire_queue)(LogDestDriver *s, gchar *persist_name, gpointer user_data);
+  LogQueue *(*acquire_queue)(LogDestDriver *s, const gchar *persist_name, gpointer user_data);
   gpointer release_queue_data;
   void (*release_queue)(LogDestDriver *s, LogQueue *q, gpointer user_data);
 
@@ -166,7 +166,7 @@ struct _LogDestDriver
 
 /* returns a reference */
 static inline LogQueue *
-log_dest_driver_acquire_queue(LogDestDriver *self, gchar *persist_name)
+log_dest_driver_acquire_queue(LogDestDriver *self, const gchar *persist_name)
 {
   LogQueue *q;
 

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -39,6 +39,7 @@ log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
   g_atomic_counter_set(&self->ref_cnt, 1);
   self->cfg = cfg;
   self->pipe_next = NULL;
+  self->persist_name = NULL;
 
   /* NOTE: queue == NULL means that this pipe simply forwards the
    * message along the pipeline, e.g. like it has called
@@ -93,6 +94,13 @@ void
 log_pipe_forward_notify(LogPipe *self, gint notify_code, gpointer user_data)
 {
   log_pipe_notify(self->pipe_next, notify_code, user_data);
+}
+
+void
+log_pipe_set_persist_name(LogPipe *self, const gchar *persist_name)
+{
+  g_free(self->persist_name);
+  self->persist_name = persist_name;
 }
 
 #ifdef __linux__

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -99,8 +99,15 @@ log_pipe_forward_notify(LogPipe *self, gint notify_code, gpointer user_data)
 void
 log_pipe_set_persist_name(LogPipe *self, const gchar *persist_name)
 {
-  g_free(self->persist_name);
+  g_free((gpointer)self->persist_name);
   self->persist_name = persist_name;
+}
+
+const gchar *
+log_pipe_get_persist_name(const LogPipe *self)
+{
+  return (self->generate_persist_name != NULL) ? self->generate_persist_name(self)
+                                               : self->persist_name;
 }
 
 #ifdef __linux__

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -222,6 +222,8 @@ struct _LogPipe
   gboolean (*init)(LogPipe *self);
   gboolean (*deinit)(LogPipe *self);
 
+  const gchar *(*generate_persist_name)(const LogPipe *self);
+
   /* clone this pipe when used in multiple locations in the processing
    * pipe-line. If it contains state, it should behave as if it was
    * the same instance, otherwise it can be a copy.

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -213,6 +213,7 @@ struct _LogPipe
   GlobalConfig *cfg;
   LogExprNode *expr_node;
   LogPipe *pipe_next;
+  const gchar *persist_name;
 
   /* user_data pointer of the "queue" method in case it is overridden
      by a plugin, see the explanation in the comment on the top. */
@@ -361,6 +362,9 @@ log_pipe_append(LogPipe *s, LogPipe *next)
 {
   s->pipe_next = next;
 }
+
+void
+log_pipe_set_persist_name(LogPipe *self, const gchar *persist_name);
 
 void log_pipe_free_method(LogPipe *s);
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -368,6 +368,9 @@ log_pipe_append(LogPipe *s, LogPipe *next)
 void
 log_pipe_set_persist_name(LogPipe *self, const gchar *persist_name);
 
+const gchar *
+log_pipe_get_persist_name(const LogPipe *self);
+
 void log_pipe_free_method(LogPipe *s);
 
 #endif

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -32,8 +32,8 @@ log_threaded_dest_driver_format_seqnum_for_persist(LogThrDestDriver *self)
 {
   static gchar persist_name[256];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "%s.seqnum", self->format.persist_name(self));
+  g_snprintf(persist_name, sizeof(persist_name), "%s.seqnum",
+             self->super.super.super.generate_persist_name((const LogPipe *)self));
 
   return persist_name;
 }
@@ -319,8 +319,8 @@ log_threaded_dest_driver_start(LogPipe *s)
   if (cfg && self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
-  self->queue = log_dest_driver_acquire_queue(&self->super,
-                                              self->format.persist_name(self));
+  self->queue = log_dest_driver_acquire_queue(
+      &self->super, self->super.super.super.generate_persist_name((const LogPipe *)self));
 
   if (self->queue == NULL)
     {

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -76,7 +76,6 @@ struct _LogThrDestDriver
   struct
   {
     gchar *(*stats_instance) (LogThrDestDriver *s);
-    gchar *(*persist_name) (LogThrDestDriver *s);
   } format;
   gint stats_source;
   gint32 seq_num;

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -203,10 +203,10 @@ afamqp_dd_format_stats_instance(LogThrDestDriver *s)
   return persist_name;
 }
 
-static gchar *
-afamqp_dd_format_persist_name(LogThrDestDriver *s)
+static const gchar *
+afamqp_dd_format_persist_name(const LogPipe *s)
 {
-  AMQPDestDriver *self = (AMQPDestDriver *) s;
+  const AMQPDestDriver *self = (const AMQPDestDriver *)s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name), "afamqp(%s,%s,%u,%s,%s)",

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -583,6 +583,7 @@ afamqp_dd_new(GlobalConfig *cfg)
 
   self->super.super.super.super.init = afamqp_dd_init;
   self->super.super.super.super.free_fn = afamqp_dd_free;
+  self->super.super.super.super.generate_persist_name = afamqp_dd_format_persist_name;
 
   self->super.worker.thread_init = afamqp_worker_thread_init;
   self->super.worker.disconnect = afamqp_dd_disconnect;

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -583,7 +583,6 @@ afamqp_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = afamqp_worker_insert;
 
   self->super.format.stats_instance = afamqp_dd_format_stats_instance;
-  self->super.format.persist_name = afamqp_dd_format_persist_name;
   self->super.stats_source = SCS_AMQP;
 
   self->routing_key_template = log_template_new(cfg, NULL);

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -197,9 +197,12 @@ afamqp_dd_format_stats_instance(LogThrDestDriver *s)
   AMQPDestDriver *self = (AMQPDestDriver *) s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "amqp,%s,%s,%u,%s,%s",
-             self->vhost, self->host, self->port, self->exchange,
-             self->exchange_type);
+  if (s->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "amqp,%s", s->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "amqp,%s,%s,%u,%s,%s", self->vhost, self->host,
+               self->port, self->exchange, self->exchange_type);
+
   return persist_name;
 }
 

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -209,9 +209,12 @@ afamqp_dd_format_persist_name(const LogPipe *s)
   const AMQPDestDriver *self = (const AMQPDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "afamqp(%s,%s,%u,%s,%s)",
-             self->vhost, self->host, self->port, self->exchange,
-             self->exchange_type);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "afamqp.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "afamqp(%s,%s,%u,%s,%s)", self->vhost,
+               self->host, self->port, self->exchange, self->exchange_type);
+
   return persist_name;
 }
 

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -389,9 +389,10 @@ affile_dd_set_fsync(LogDriver *s, gboolean use_fsync)
   self->use_fsync = use_fsync;
 }
 
-static inline gchar *
-affile_dd_format_persist_name(AFFileDestDriver *self)
+static inline const gchar *
+affile_dd_format_persist_name(const LogPipe *s)
 {
+  const AFFileDestDriver *self = (const AFFileDestDriver *)s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name), "affile_dd_writers(%s)", self->filename_template->template);
@@ -470,13 +471,13 @@ affile_dd_init(LogPipe *s)
               
   if (self->filename_is_a_template)
     {
-      self->writer_hash = cfg_persist_config_fetch(cfg, affile_dd_format_persist_name(self));
+      self->writer_hash = cfg_persist_config_fetch(cfg, affile_dd_format_persist_name(s));
       if (self->writer_hash)
         g_hash_table_foreach(self->writer_hash, affile_dd_reuse_writer, self);
     }
   else
     {
-      self->single_writer = cfg_persist_config_fetch(cfg, affile_dd_format_persist_name(self));
+      self->single_writer = cfg_persist_config_fetch(cfg, affile_dd_format_persist_name(s));
       if (self->single_writer)
         {
           affile_dw_set_owner(self->single_writer, self);
@@ -550,7 +551,8 @@ affile_dd_deinit(LogPipe *s)
       g_assert(self->writer_hash == NULL);
 
       log_pipe_deinit(&self->single_writer->super);
-      cfg_persist_config_add(cfg, affile_dd_format_persist_name(self), self->single_writer, affile_dd_destroy_writer, FALSE);
+      cfg_persist_config_add(cfg, affile_dd_format_persist_name(s), self->single_writer,
+                             affile_dd_destroy_writer, FALSE);
       self->single_writer = NULL;
     }
   else if (self->writer_hash)
@@ -558,7 +560,8 @@ affile_dd_deinit(LogPipe *s)
       g_assert(self->single_writer == NULL);
       
       g_hash_table_foreach(self->writer_hash, affile_dd_deinit_writer, NULL);
-      cfg_persist_config_add(cfg, affile_dd_format_persist_name(self), self->writer_hash, affile_dd_destroy_writer_hash, FALSE);
+      cfg_persist_config_add(cfg, affile_dd_format_persist_name(s), self->writer_hash,
+                             affile_dd_destroy_writer_hash, FALSE);
       self->writer_hash = NULL;
     }
 

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -751,6 +751,7 @@ affile_dd_new_instance(gchar *filename, GlobalConfig *cfg)
   self->super.super.super.deinit = affile_dd_deinit;
   self->super.super.super.queue = affile_dd_queue;
   self->super.super.super.free_fn = affile_dd_free;
+  self->super.super.super.generate_persist_name = affile_dd_format_persist_name;
   self->filename_template = log_template_new(cfg, NULL);
   log_template_compile(self->filename_template, filename, NULL);
   log_writer_options_defaults(&self->writer_options);

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -395,7 +395,12 @@ affile_dd_format_persist_name(const LogPipe *s)
   const AFFileDestDriver *self = (const AFFileDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "affile_dd_writers(%s)", self->filename_template->template);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "affile_dd.%s.writers", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "affile_dd_writers(%s)",
+               self->filename_template->template);
+
   return persist_name;
 }
 

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -473,6 +473,7 @@ affile_sd_new_instance(gchar *filename, GlobalConfig *cfg)
   self->super.super.super.deinit = affile_sd_deinit;
   self->super.super.super.notify = affile_sd_notify;
   self->super.super.super.free_fn = affile_sd_free;
+  self->super.super.super.generate_persist_name = affile_sd_format_persist_name;
   log_reader_options_defaults(&self->reader_options);
   file_perm_options_defaults(&self->file_perm_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -135,9 +135,10 @@ affile_sd_open_file(AFFileSourceDriver *self, gchar *name, gint *fd)
   return affile_open_file(name, &self->file_open_options, &self->file_perm_options, fd);
 }
 
-static inline gchar *
-affile_sd_format_persist_name(AFFileSourceDriver *self)
+static inline const gchar *
+affile_sd_format_persist_name(const LogPipe *s)
 {
+  const AFFileSourceDriver *self = (const AFFileSourceDriver *)s;
   static gchar persist_name[1024];
   
   g_snprintf(persist_name, sizeof(persist_name), "affile_sd_curpos(%s)", self->filename->str);
@@ -152,7 +153,7 @@ affile_sd_recover_state(LogPipe *s, GlobalConfig *cfg, LogProtoServer *proto)
   if (self->file_open_options.is_pipe || self->follow_freq <= 0)
     return;
 
-  if (!log_proto_server_restart_with_state(proto, cfg->state, affile_sd_format_persist_name(self)))
+  if (!log_proto_server_restart_with_state(proto, cfg->state, affile_sd_format_persist_name(s)))
     {
       msg_error("Error converting persistent state from on-disk format, losing file position information",
                 evt_tag_str("filename", self->filename->str));

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -140,8 +140,12 @@ affile_sd_format_persist_name(const LogPipe *s)
 {
   const AFFileSourceDriver *self = (const AFFileSourceDriver *)s;
   static gchar persist_name[1024];
-  
-  g_snprintf(persist_name, sizeof(persist_name), "affile_sd_curpos(%s)", self->filename->str);
+
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "affile_sd.%s.curpos", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "affile_sd_curpos(%s)", self->filename->str);
+
   return persist_name;
 }
  

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -95,32 +95,32 @@ _format_instance_id(LogThrDestDriver *d, const gchar *format)
   static gchar args[1024];
   static gchar id[1024];
 
-  const mongoc_host_list_t *hosts = mongoc_uri_get_hosts(self->uri_obj);
-  const gchar *first_host = "";
-  if (hosts)
+  if (((LogPipe *)d)->persist_name)
     {
-      if (hosts->family == AF_UNIX)
-        first_host = hosts->host;
-      else
-        first_host = hosts->host_and_port;
+      g_snprintf(args, sizeof(args), "%s", ((LogPipe *)d)->persist_name);
     }
+  else
+    {
+      const mongoc_host_list_t *hosts = mongoc_uri_get_hosts(self->uri_obj);
+      const gchar *first_host = "";
+      if (hosts)
+        {
+          if (hosts->family == AF_UNIX)
+            first_host = hosts->host;
+          else
+            first_host = hosts->host_and_port;
+        }
 
-  const gchar *db = self->const_db ? self->const_db : "";
+      const gchar *db = self->const_db ? self->const_db : "";
 
-  const gchar *replica_set = mongoc_uri_get_replica_set(self->uri_obj);
-  if (!replica_set)
-    replica_set = "";
+      const gchar *replica_set = mongoc_uri_get_replica_set(self->uri_obj);
+      if (!replica_set)
+        replica_set = "";
 
-  const gchar *coll = self->coll ? self->coll : "";
+      const gchar *coll = self->coll ? self->coll : "";
 
-  g_snprintf(args,
-             sizeof(args),
-             "%s,%s,%s,%s",
-             first_host,
-             db,
-             replica_set,
-             coll);
-
+      g_snprintf(args, sizeof(args), "%s,%s,%s,%s", first_host, db, replica_set, coll);
+    }
   g_snprintf(id, sizeof(id), format, args);
   return id;
 }
@@ -134,7 +134,8 @@ _format_stats_instance(LogThrDestDriver *d)
 static const gchar *
 _format_persist_name(const LogPipe *s)
 {
-  return _format_instance_id(d, "afmongodb(%s)");
+  return s->persist_name ? _format_instance_id(s, "afmongodb.%s")
+                         : _format_instance_id(s, "afmongodb(%s)");
 }
 
 static void

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -89,9 +89,9 @@ afmongodb_dd_set_value_pairs(LogDriver *d, ValuePairs *vp)
  */
 
 static gchar *
-_format_instance_id(LogThrDestDriver *d, const gchar *format)
+_format_instance_id(const LogThrDestDriver *d, const gchar *format)
 {
-  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+  const MongoDBDestDriver *self = (const MongoDBDestDriver *)d;
   static gchar args[1024];
   static gchar id[1024];
 
@@ -134,8 +134,10 @@ _format_stats_instance(LogThrDestDriver *d)
 static const gchar *
 _format_persist_name(const LogPipe *s)
 {
-  return s->persist_name ? _format_instance_id(s, "afmongodb.%s")
-                         : _format_instance_id(s, "afmongodb(%s)");
+  const LogThrDestDriver *self = (const LogThrDestDriver *)s;
+
+  return s->persist_name ? _format_instance_id(self, "afmongodb.%s")
+                         : _format_instance_id(self, "afmongodb(%s)");
 }
 
 static void

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -588,6 +588,7 @@ afmongodb_dd_new(GlobalConfig *cfg)
 
   self->super.super.super.super.init = _init;
   self->super.super.super.super.free_fn = _free;
+  self->super.super.super.super.generate_persist_name = _format_persist_name;
   self->super.queue_method = _logthrdest_queue_method;
 
   self->super.worker.thread_init = _worker_thread_init;

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -592,7 +592,6 @@ afmongodb_dd_new(GlobalConfig *cfg)
   self->super.worker.disconnect = _worker_disconnect;
   self->super.worker.insert = _worker_insert;
   self->super.format.stats_instance = _format_stats_instance;
-  self->super.format.persist_name = _format_persist_name;
   self->super.stats_source = SCS_MONGODB;
   self->super.messages.retry_over = _worker_retry_over_message;
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -131,8 +131,8 @@ _format_stats_instance(LogThrDestDriver *d)
   return _format_instance_id(d, "mongodb,%s");
 }
 
-static gchar *
-_format_persist_name(LogThrDestDriver *d)
+static const gchar *
+_format_persist_name(const LogPipe *s)
 {
   return _format_instance_id(d, "afmongodb(%s)");
 }

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -131,7 +131,7 @@ static gboolean
 _execute_compare_persist_name(const gchar *expected_name)
 {
   LogThrDestDriver *self = (LogThrDestDriver *)mongodb;
-  const gchar *name = self->format.persist_name(self);
+  const gchar *name = log_pipe_get_persist_name((const LogPipe *)self);
   return assert_nstring_non_fatal(name, -1, expected_name, -1, "mismatch");
 }
 

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -330,8 +330,11 @@ afprogram_dd_format_persist_name(const LogPipe *s)
   const AFProgramDestDriver *self = (const AFProgramDestDriver *)s;
   static gchar persist_name[256];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "afprogram_dd_name(%s,%s)", self->process_info.cmdline->str, self->super.super.id);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "afprogram_dd_name.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "afprogram_dd_name(%s,%s)",
+               self->process_info.cmdline->str, self->super.super.id);
 
   return persist_name;
 }

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -324,9 +324,10 @@ afprogram_dd_format_queue_persist_name(AFProgramDestDriver *self)
   return persist_name;
 }
 
-static gchar *
-afprogram_dd_format_persist_name(AFProgramDestDriver *self)
+static const gchar *
+afprogram_dd_format_persist_name(const LogPipe *s)
 {
+  const AFProgramDestDriver *self = (const AFProgramDestDriver *)s;
   static gchar persist_name[256];
 
   g_snprintf(persist_name, sizeof(persist_name),
@@ -402,7 +403,9 @@ afprogram_dd_exit(pid_t pid, int status, gpointer s)
 static gboolean
 afprogram_dd_restore_reload_store_item(AFProgramDestDriver *self, GlobalConfig *cfg)
 {
-  AFProgramReloadStoreItem *restored_info = (AFProgramReloadStoreItem *)cfg_persist_config_fetch(cfg, afprogram_dd_format_persist_name(self));
+  const gchar *persist_name = afprogram_dd_format_persist_name((const LogPipe *)self);
+  AFProgramReloadStoreItem *restored_info =
+      (AFProgramReloadStoreItem *)cfg_persist_config_fetch(cfg, persist_name);
 
   if (restored_info)
     {
@@ -459,7 +462,8 @@ afprogram_dd_store_reload_store_item(AFProgramDestDriver *self, GlobalConfig *cf
   reload_info->pid = self->process_info.pid;
   reload_info->writer = self->writer;
 
-  cfg_persist_config_add(cfg, afprogram_dd_format_persist_name(self), reload_info, afprogram_reload_store_item_destroy_notify, FALSE);
+  cfg_persist_config_add(cfg, afprogram_dd_format_persist_name((const LogPipe *)self), reload_info,
+                         afprogram_reload_store_item_destroy_notify, FALSE);
 }
 
 static gboolean

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -535,6 +535,7 @@ afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg)
   self->super.super.super.deinit = afprogram_dd_deinit;
   self->super.super.super.free_fn = afprogram_dd_free;
   self->super.super.super.notify = afprogram_dd_notify;
+  self->super.super.super.generate_persist_name = afprogram_dd_format_persist_name;
   self->process_info.cmdline = g_string_new(cmdline);
   self->process_info.pid = -1;
   afprogram_set_inherit_environment(&self->process_info, TRUE);

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -675,6 +675,7 @@ afsmtp_dd_new(GlobalConfig *cfg)
   log_threaded_dest_driver_init_instance(&self->super, cfg);
   self->super.super.super.super.init = afsmtp_dd_init;
   self->super.super.super.super.free_fn = afsmtp_dd_free;
+  self->super.super.super.super.generate_persist_name = afsmtp_dd_format_persist_name;
 
   self->super.worker.thread_init = afsmtp_worker_thread_init;
   self->super.worker.thread_deinit = afsmtp_worker_thread_deinit;

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -215,8 +215,11 @@ afsmtp_dd_format_persist_name(const LogPipe *s)
   const AFSMTPDriver *self = (const AFSMTPDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "smtp(%s,%u)", self->host, self->port);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "smtp.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "smtp(%s,%u)", self->host, self->port);
+
   return persist_name;
 }
 

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -209,10 +209,10 @@ afsmtp_dd_format_stats_instance(LogThrDestDriver *d)
   return persist_name;
 }
 
-static gchar *
-afsmtp_dd_format_persist_name(LogThrDestDriver *d)
+static const gchar *
+afsmtp_dd_format_persist_name(const LogPipe *s)
 {
-  AFSMTPDriver *self = (AFSMTPDriver *)d;
+  const AFSMTPDriver *self = (const AFSMTPDriver *)s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name),

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -675,7 +675,6 @@ afsmtp_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = afsmtp_worker_insert;
 
   self->super.format.stats_instance = afsmtp_dd_format_stats_instance;
-  self->super.format.persist_name = afsmtp_dd_format_persist_name;
   self->super.stats_source = SCS_SMTP;
 
   self->super.messages.retry_over = __worker_message_retry_over;

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -204,8 +204,11 @@ afsmtp_dd_format_stats_instance(LogThrDestDriver *d)
   AFSMTPDriver *self = (AFSMTPDriver *)d;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "smtp,%s,%u", self->host, self->port);
+  if (d->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "smtp,%s", d->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "smtp,%s,%u", self->host, self->port);
+
   return persist_name;
 }
 

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -134,7 +134,7 @@ afinet_dd_construct_writer(AFSocketDestDriver *s)
 }
 
 static const gint
-_determine_port(AFInetDestDriver *self)
+_determine_port(const AFInetDestDriver *self)
 {
   gint port = 0;
 

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -183,9 +183,9 @@ afinet_dd_setup_addresses(AFSocketDestDriver *s)
 }
 
 static const gchar *
-afinet_dd_get_dest_name(AFSocketDestDriver *s)
+afinet_dd_get_dest_name(const AFSocketDestDriver *s)
 {
-  AFInetDestDriver *self = (AFInetDestDriver *) s;
+  const AFInetDestDriver *self = (const AFInetDestDriver *)s;
   static gchar buf[256];
 
   if (strchr(self->hostname, ':') != NULL)

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -556,6 +556,7 @@ afsocket_dd_init_instance(AFSocketDestDriver *self,
   self->super.super.super.queue = NULL;
   self->super.super.super.free_fn = afsocket_dd_free;
   self->super.super.super.notify = afsocket_dd_notify;
+  self->super.super.super.generate_persist_name = afsocket_dd_format_name;
   self->setup_addresses = afsocket_dd_setup_addresses;
   self->construct_writer = afsocket_dd_construct_writer_method;
   self->transport_mapper = transport_mapper;

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -82,16 +82,56 @@ afsocket_dd_set_keep_alive(LogDriver *s, gboolean enable)
   self->connections_kept_alive_accross_reloads = enable;
 }
 
+static const gchar *_module_name = "afsocket_dd";
+
+static const gchar *
+_get_module_identifier(const AFSocketDestDriver *self)
+{
+  static gchar module_identifier[128];
+
+  g_snprintf(module_identifier, sizeof(module_identifier), "%s,%s",
+             (self->transport_mapper->sock_type == SOCK_STREAM) ? "stream" : "dgram",
+             afsocket_dd_get_dest_name(self));
+
+  return self->super.super.super.persist_name ? self->super.super.super.persist_name
+                                              : module_identifier;
+}
+
+static const gchar *
+afsocket_dd_format_name(const LogPipe *s)
+{
+  const AFSocketDestDriver *self = (const AFSocketDestDriver *)s;
+  static gchar persist_name[1024];
+  g_snprintf(persist_name, sizeof(persist_name), "%s.(%s)", _module_name,
+             _get_module_identifier(self));
+
+  return persist_name;
+}
+
+static const gchar *
+afsocket_dd_format_qfile_name(const AFSocketDestDriver *self)
+{
+  static gchar persist_name[1024];
+  g_snprintf(persist_name, sizeof(persist_name), "%s_qfile(%s)", _module_name,
+             _get_module_identifier(self));
+
+  return persist_name;
+}
+
+static const gchar *
+afsocket_dd_format_connections_name(const AFSocketDestDriver *self)
+{
+  static gchar persist_name[1024];
+  g_snprintf(persist_name, sizeof(persist_name), "%s_connections(%s)", _module_name,
+             _get_module_identifier(self));
+
+  return persist_name;
+}
+
 static gchar *
 afsocket_dd_format_persist_name(AFSocketDestDriver *self, gboolean qfile)
 {
-  static gchar persist_name[256];
-
-  g_snprintf(persist_name, sizeof(persist_name),
-             qfile ? "afsocket_dd_qfile(%s,%s)" : "afsocket_dd_connection(%s,%s)",
-             (self->transport_mapper->sock_type == SOCK_STREAM) ? "stream" : "dgram",
-             afsocket_dd_get_dest_name(self));
-  return persist_name;
+  return qfile ? afsocket_dd_format_qfile_name(self) : afsocket_dd_format_connections_name(self);
 }
 
 static gchar *

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -56,7 +56,7 @@ struct _AFSocketDestDriver
 
   LogWriter *(*construct_writer)(AFSocketDestDriver *self);
   gboolean (*setup_addresses)(AFSocketDestDriver *s);
-  const gchar *(*get_dest_name)(AFSocketDestDriver *s);
+  const gchar *(*get_dest_name)(const AFSocketDestDriver *s);
 };
 
 static inline LogWriter *
@@ -72,7 +72,7 @@ afsocket_dd_setup_addresses(AFSocketDestDriver *s)
 }
 
 static inline const gchar *
-afsocket_dd_get_dest_name(AFSocketDestDriver *s)
+afsocket_dd_get_dest_name(const AFSocketDestDriver *s)
 {
   return s->get_dest_name(s);
 }

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -713,6 +713,7 @@ afsocket_sd_init_instance(AFSocketSourceDriver *self,
   self->super.super.super.deinit = afsocket_sd_deinit_method;
   self->super.super.super.free_fn = afsocket_sd_free_method;
   self->super.super.super.notify = afsocket_sd_notify;
+  self->super.super.super.generate_persist_name = afsocket_sd_format_name;
   self->setup_addresses = afsocket_sd_setup_addresses_method;
   self->socket_options = socket_options;
   self->transport_mapper = transport_mapper;

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -297,13 +297,6 @@ afsocket_sd_format_connections_name(const AFSocketSourceDriver *self)
   return persist_name;
 }
 
-static inline const gchar *
-afsocket_sd_format_persist_name(const AFSocketSourceDriver *self, gboolean listener_name)
-{
-  return listener_name ? afsocket_sd_format_listener_name(self)
-                       : afsocket_sd_format_connections_name(self);
-}
-
 static gboolean
 afsocket_sd_process_connection(AFSocketSourceDriver *self, GSockAddr *client_addr, GSockAddr *local_addr, gint fd)
 {
@@ -512,7 +505,7 @@ afsocket_sd_restore_kept_alive_connections(AFSocketSourceDriver *self)
   if (self->connections_kept_alive_accross_reloads)
     {
       GList *p = NULL;
-      self->connections = cfg_persist_config_fetch(cfg, afsocket_sd_format_persist_name(self, FALSE));
+      self->connections = cfg_persist_config_fetch(cfg, afsocket_sd_format_connections_name(self));
 
       self->num_connections = 0;
       for (p = self->connections; p; p = p->next)
@@ -549,7 +542,9 @@ afsocket_sd_open_listener(AFSocketSourceDriver *self)
         {
           /* NOTE: this assumes that fd 0 will never be used for listening fds,
            * main.c opens fd 0 so this assumption can hold */
-          sock = GPOINTER_TO_UINT(cfg_persist_config_fetch(cfg, afsocket_sd_format_persist_name(self, TRUE))) - 1;
+          sock = GPOINTER_TO_UINT(
+                     cfg_persist_config_fetch(cfg, afsocket_sd_format_listener_name(self))) -
+                 1;
         }
 
       if (sock == -1)
@@ -618,7 +613,8 @@ afsocket_sd_save_connections(AFSocketSourceDriver *self)
         {
           log_pipe_deinit((LogPipe *) p->data);
         }
-      cfg_persist_config_add(cfg, afsocket_sd_format_persist_name(self, FALSE), self->connections, (GDestroyNotify) afsocket_sd_kill_connection_list, FALSE);
+      cfg_persist_config_add(cfg, afsocket_sd_format_connections_name(self), self->connections,
+                             (GDestroyNotify)afsocket_sd_kill_connection_list, FALSE);
     }
   self->connections = NULL;
 }
@@ -642,7 +638,8 @@ afsocket_sd_save_listener(AFSocketSourceDriver *self)
           /* NOTE: the fd is incremented by one when added to persistent config
            * as persist config cannot store NULL */
 
-          cfg_persist_config_add(cfg, afsocket_sd_format_persist_name(self, TRUE), GUINT_TO_POINTER(self->fd + 1), afsocket_sd_close_fd, FALSE);
+          cfg_persist_config_add(cfg, afsocket_sd_format_listener_name(self),
+                                 GUINT_TO_POINTER(self->fd + 1), afsocket_sd_close_fd, FALSE);
         }
     }
 }

--- a/modules/afsocket/afunix-dest.c
+++ b/modules/afsocket/afunix-dest.c
@@ -34,9 +34,9 @@
 #include <stdlib.h>
 
 static const gchar *
-afunix_dd_get_dest_name(AFSocketDestDriver *s)
+afunix_dd_get_dest_name(const AFSocketDestDriver *s)
 {
-  AFUnixDestDriver *self = (AFUnixDestDriver *) s;
+  const AFUnixDestDriver *self = (const AFUnixDestDriver *)s;
   static gchar buf[256];
 
   g_snprintf(buf, sizeof(buf), "localhost.afunix:%s", self->filename);

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1144,9 +1144,12 @@ afsql_dd_format_persist_name(const LogPipe *s)
   AFSqlDestDriver *self = (AFSqlDestDriver *)s;
   static gchar persist_name[256];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "afsql_dd(%s,%s,%s,%s,%s)",
-             self->type, self->host, self->port, self->database, self->table->template);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "afsql_dd.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "afsql_dd(%s,%s,%s,%s,%s)", self->type,
+               self->host, self->port, self->database, self->table->template);
+
   return persist_name;
 }
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1138,9 +1138,10 @@ afsql_dd_format_stats_instance(AFSqlDestDriver *self)
   return persist_name;
 }
 
-static inline gchar *
-afsql_dd_format_persist_name(AFSqlDestDriver *self)
+static inline const gchar *
+afsql_dd_format_persist_name(const LogPipe *s)
 {
+  AFSqlDestDriver *self = (AFSqlDestDriver *)s;
   static gchar persist_name[256];
 
   g_snprintf(persist_name, sizeof(persist_name),
@@ -1187,7 +1188,8 @@ afsql_dd_init(LogPipe *s)
   if (!self->seq_num)
     init_sequence_number(&self->seq_num);
 
-  self->queue = log_dest_driver_acquire_queue(&self->super, afsql_dd_format_persist_name(self));
+  self->queue = log_dest_driver_acquire_queue(&self->super,
+                                              afsql_dd_format_persist_name((const LogPipe *)self));
   if (self->queue == NULL)
     {
       return FALSE;

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1400,6 +1400,7 @@ afsql_dd_new(GlobalConfig *cfg)
   self->super.super.super.deinit = afsql_dd_deinit;
   self->super.super.super.queue = afsql_dd_queue;
   self->super.super.super.free_fn = afsql_dd_free;
+  self->super.super.super.generate_persist_name = afsql_dd_format_persist_name;
 
   self->type = g_strdup("mysql");
   self->host = g_strdup("");

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -386,6 +386,7 @@ afstomp_dd_new(GlobalConfig *cfg)
   log_threaded_dest_driver_init_instance(&self->super, cfg);
   self->super.super.super.super.init = afstomp_dd_init;
   self->super.super.super.super.free_fn = afstomp_dd_free;
+  self->super.super.super.super.generate_persist_name = afstomp_dd_format_persist_name;
 
   self->super.worker.thread_init = afstomp_worker_thread_init;
   self->super.worker.disconnect = afstomp_dd_disconnect;

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -167,10 +167,10 @@ afstomp_dd_format_stats_instance(LogThrDestDriver *s)
   return persist_name;
 }
 
-static gchar *
-afstomp_dd_format_persist_name(LogThrDestDriver *s)
+static const gchar *
+afstomp_dd_format_persist_name(const LogPipe *s)
 {
-  STOMPDestDriver *self = (STOMPDestDriver *) s;
+  const STOMPDestDriver *self = (const STOMPDestDriver *)s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name), "afstomp(%s,%u,%s)",

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -173,8 +173,12 @@ afstomp_dd_format_persist_name(const LogPipe *s)
   const STOMPDestDriver *self = (const STOMPDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "afstomp(%s,%u,%s)",
-             self->host, self->port, self->destination);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "afstomp.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "afstomp(%s,%u,%s)", self->host, self->port,
+               self->destination);
+
   return persist_name;
 }
 

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -162,8 +162,12 @@ afstomp_dd_format_stats_instance(LogThrDestDriver *s)
   STOMPDestDriver *self = (STOMPDestDriver *) s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "afstomp,%s,%u,%s",
-             self->host, self->port, self->destination);
+  if (s->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "afstomp,%s", s->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "afstomp,%s,%u,%s", self->host, self->port,
+               self->destination);
+
   return persist_name;
 }
 

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -384,7 +384,6 @@ afstomp_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = afstomp_worker_insert;
 
   self->super.format.stats_instance = afstomp_dd_format_stats_instance;
-  self->super.format.persist_name = afstomp_dd_format_persist_name;
   self->super.stats_source = SCS_STOMP;
 
   afstomp_dd_set_host((LogDriver *) self, "127.0.0.1");

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -31,7 +31,7 @@
 #include "persist-state.h"
 
 static LogQueue *
-_acquire_queue(LogDestDriver *dd, gchar *persist_name, gpointer user_data)
+_acquire_queue(LogDestDriver *dd, const gchar *persist_name, gpointer user_data)
 {
   DiskQDestPlugin *self = (DiskQDestPlugin *) user_data;
   GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -334,6 +334,7 @@ http_dd_new(GlobalConfig *cfg)
   self->super.worker.connect = _connect;
   self->super.worker.disconnect = _disconnect;
   self->super.worker.insert = _insert;
+  self->super.super.super.super.generate_persist_name = _format_persist_name;
   self->super.format.stats_instance = _format_stats_instance;
   self->super.stats_source = SCS_HTTP;
   self->super.super.super.super.free_fn = http_dd_free;

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -25,12 +25,11 @@
 #include "syslog-names.h"
 #include "http-plugin.h"
 
-static gchar *
-_format_persist_name(LogThrDestDriver *s)
+static const gchar *
+_format_persist_name(const LogPipe *s)
 {
+  const HTTPDestinationDriver *self = (const HTTPDestinationDriver *)s;
   static gchar persist_name[1024];
-
-  HTTPDestinationDriver *self = (HTTPDestinationDriver *) s;
 
   g_snprintf(persist_name, sizeof(persist_name), "http(%s,)", self->url);
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -332,7 +332,6 @@ http_dd_new(GlobalConfig *cfg)
   self->super.worker.connect = _connect;
   self->super.worker.disconnect = _disconnect;
   self->super.worker.insert = _insert;
-  self->super.format.persist_name = _format_persist_name;
   self->super.format.stats_instance = _format_stats_instance;
   self->super.stats_source = SCS_HTTP;
   self->super.super.super.super.free_fn = http_dd_free;

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -31,7 +31,10 @@ _format_persist_name(const LogPipe *s)
   const HTTPDestinationDriver *self = (const HTTPDestinationDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "http(%s,)", self->url);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "http.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "http(%s,)", self->url);
 
   return persist_name;
 }

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -196,6 +196,21 @@ java_worker_thread_deinit(LogThrDestDriver *d)
   java_machine_detach_thread();
 }
 
+static const gchar *
+java_dd_format_persist_name(const LogPipe *s)
+{
+  const JavaDestDriver *self = (const JavaDestDriver *)s;
+  static gchar persist_name[1024];
+
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "java_dst.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "java_dst(%s)",
+               java_destination_proxy_get_name_by_uniq_options(self->proxy));
+
+  return persist_name;
+}
+
 static gchar *
 java_dd_format_stats_instance(LogThrDestDriver *d)
 {

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -266,6 +266,7 @@ java_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = java_dd_free;
   self->super.super.super.super.init = java_dd_init;
   self->super.super.super.super.deinit = java_dd_deinit;
+  self->super.super.super.super.generate_persist_name = java_dd_format_persist_name;
 
   self->super.worker.thread_deinit = java_worker_thread_deinit;
   self->super.worker.insert = java_worker_insert;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -254,7 +254,6 @@ java_dd_new(GlobalConfig *cfg)
   self->super.worker.worker_message_queue_empty = java_worker_message_queue_empty;
 
   self->super.format.stats_instance = java_dd_format_stats_instance;
-  self->super.format.persist_name = java_dd_format_stats_instance;
   self->super.messages.retry_over = __retry_over_message;
   self->super.stats_source = SCS_JAVA;
 

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -202,8 +202,13 @@ java_dd_format_stats_instance(LogThrDestDriver *d)
   JavaDestDriver *self = (JavaDestDriver *)d;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-            "java_dst(%s)", java_destination_proxy_get_name_by_uniq_options(self->proxy));
+  if (d->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "java_dst,%s",
+               d->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "java_dst,%s",
+               java_destination_proxy_get_name_by_uniq_options(self->proxy));
+
   return persist_name;
 }
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -533,6 +533,7 @@ python_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.init = python_dd_init;
   self->super.super.super.super.deinit = python_dd_deinit;
   self->super.super.super.super.free_fn = python_dd_free;
+  self->super.super.super.super.generate_persist_name = python_dd_format_persist_name;
 
   self->super.worker.thread_init = python_dd_worker_init;
   self->super.worker.thread_deinit = python_dd_worker_deinit;

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -131,10 +131,10 @@ python_dd_format_stats_instance(LogThrDestDriver *d)
   return persist_name;
 }
 
-static gchar *
-python_dd_format_persist_name(LogThrDestDriver *d)
+static const gchar *
+python_dd_format_persist_name(const LogPipe *s)
 {
-  PythonDestDriver *self = (PythonDestDriver *)d;
+  const PythonDestDriver *self = (const PythonDestDriver *)s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name),

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -536,7 +536,6 @@ python_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = python_dd_insert;
 
   self->super.format.stats_instance = python_dd_format_stats_instance;
-  self->super.format.persist_name = python_dd_format_persist_name;
   self->super.stats_source = SCS_PYTHON;
 
   self->options = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -125,9 +125,11 @@ python_dd_format_stats_instance(LogThrDestDriver *d)
   PythonDestDriver *self = (PythonDestDriver *)d;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "python,%s",
-             self->class);
+  if (d->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "python,%s", d->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "python,%s", self->class);
+
   return persist_name;
 }
 
@@ -137,9 +139,11 @@ python_dd_format_persist_name(const LogPipe *s)
   const PythonDestDriver *self = (const PythonDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "python(%s)",
-             self->class);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "python.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "python(%s)", self->class);
+
   return persist_name;
 }
 

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -332,7 +332,6 @@ redis_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = redis_worker_insert;
 
   self->super.format.stats_instance = redis_dd_format_stats_instance;
-  self->super.format.persist_name = redis_dd_format_persist_name;
   self->super.stats_source = SCS_REDIS;
 
   redis_dd_set_host((LogDriver *)self, "127.0.0.1");

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -112,8 +112,11 @@ redis_dd_format_stats_instance(LogThrDestDriver *d)
   RedisDriver *self = (RedisDriver *)d;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "redis,%s,%u", self->host, self->port);
+  if (d->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "redis,%s", d->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "redis,%s,%u", self->host, self->port);
+
   return persist_name;
 }
 

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -123,8 +123,11 @@ redis_dd_format_persist_name(const LogPipe *s)
   const RedisDriver *self = (const RedisDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "redis(%s,%u)", self->host, self->port);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "redis.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "redis(%s,%u)", self->host, self->port);
+
   return persist_name;
 }
 

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -117,10 +117,10 @@ redis_dd_format_stats_instance(LogThrDestDriver *d)
   return persist_name;
 }
 
-static gchar *
-redis_dd_format_persist_name(LogThrDestDriver *d)
+static const gchar *
+redis_dd_format_persist_name(const LogPipe *s)
 {
-  RedisDriver *self = (RedisDriver *)d;
+  const RedisDriver *self = (const RedisDriver *)s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name),

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -331,6 +331,7 @@ redis_dd_new(GlobalConfig *cfg)
   log_threaded_dest_driver_init_instance(&self->super, cfg);
   self->super.super.super.super.init = redis_dd_init;
   self->super.super.super.super.free_fn = redis_dd_free;
+  self->super.super.super.super.generate_persist_name = redis_dd_format_persist_name;
 
   self->super.worker.thread_init = redis_worker_thread_init;
   self->super.worker.thread_deinit = redis_worker_thread_deinit;

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -659,6 +659,7 @@ riemann_dd_new(GlobalConfig *cfg)
 
   self->super.super.super.super.init = riemann_worker_init;
   self->super.super.super.super.free_fn = riemann_dd_free;
+  self->super.super.super.super.generate_persist_name = riemann_dd_format_persist_name;
 
   self->super.worker.disconnect = riemann_dd_disconnect;
   self->super.worker.insert = riemann_worker_insert;

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -240,14 +240,14 @@ riemann_dd_format_stats_instance(LogThrDestDriver *s)
   return persist_name;
 }
 
-static gchar *
-riemann_dd_format_persist_name(LogThrDestDriver *s)
+static const gchar *
+riemann_dd_format_persist_name(const LogPipe *s)
 {
-  RiemannDestDriver *self = (RiemannDestDriver *)s;
+  const RiemannDestDriver *self = (const RiemannDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "riemann(%s,%u)", self->server, self->port);
+  g_snprintf(persist_name, sizeof(persist_name), "riemann(%s,%u)", self->server, self->port);
+
   return persist_name;
 }
 

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -659,7 +659,6 @@ riemann_dd_new(GlobalConfig *cfg)
   self->super.worker.thread_deinit = riemann_worker_thread_deinit;
 
   self->super.format.stats_instance = riemann_dd_format_stats_instance;
-  self->super.format.persist_name = riemann_dd_format_persist_name;
   self->super.stats_source = SCS_RIEMANN;
 
   self->port = -1;

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -246,7 +246,10 @@ riemann_dd_format_persist_name(const LogPipe *s)
   const RiemannDestDriver *self = (const RiemannDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name), "riemann(%s,%u)", self->server, self->port);
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "riemann.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "riemann(%s,%u)", self->server, self->port);
 
   return persist_name;
 }

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -235,8 +235,11 @@ riemann_dd_format_stats_instance(LogThrDestDriver *s)
   RiemannDestDriver *self = (RiemannDestDriver *)s;
   static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "riemann,%s,%u", self->server, self->port);
+  if (s->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "riemann,%s", s->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "riemann,%s,%u", self->server, self->port);
+
   return persist_name;
 }
 


### PR DESCRIPTION
This pull request enables overriding the persist id from the configuration file and performs name collision check between the initialized LogPipes in order to prevent name collision related issues.

At the moment, this is relevant for the `LogDriver`s, but we think it might be useful in the future, if the other `LogPipe` types could save their data to a persistent storage. (Therefore, this could be implemented for the `LogDriver`, but this seems more future-proof.)

Fixes #661.
Workarounds #655.

--
TODOs:
* [ ] Rethink the allocation strategy within persist_name implementations
* [ ] Handle the persist_id != NULL case globally
* [x] Do not change the original format in afsocket-dest

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/balabit/syslog-ng/665)
<!-- Reviewable:end -->
