### PR TITLE
scl: install cim scl only when syslog-ng is compiled with json support

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,5 +1,9 @@
-SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris
+SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite solaris
 SCL_CONFIGS	= scl.conf syslog-ng.conf
+
+if ENABLE_JSON
+  SCL_SUBDIRS += cim
+endif
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))
 


### PR DESCRIPTION
Fixes #673 

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>