### PR TITLE
afsocket: replace writer only when protocol changed during reload

### DIFF
--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -33,6 +33,48 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+typedef struct _ReloadStoreItem
+{
+  LogProtoClientFactory *proto_factory;
+  LogWriter *writer;
+} ReloadStoreItem;
+
+static ReloadStoreItem*
+_reload_store_item_new(AFSocketDestDriver *afsocket_dd)
+{
+  ReloadStoreItem *item = g_new(ReloadStoreItem, 1);
+  item->proto_factory = afsocket_dd->proto_factory;
+  item->writer = afsocket_dd->writer;
+  return item;
+}
+
+static void
+_reload_store_item_free(ReloadStoreItem *self)
+{
+  if (!self)
+    return;
+
+  if (self->writer)
+    log_pipe_unref((LogPipe *) self->writer);
+
+  g_free(self);
+}
+
+static LogWriter*
+_reload_store_item_release_writer(ReloadStoreItem *self)
+{
+  LogWriter *writer = self->writer;
+  self->writer = NULL;
+
+  return writer;
+}
+
+static inline gboolean
+_is_protocol_type_changed_during_reload(AFSocketDestDriver *self, ReloadStoreItem *item)
+{
+  return (self->proto_factory->construct != item->proto_factory->construct);
+}
+
 void
 afsocket_dd_set_keep_alive(LogDriver *s, gboolean enable)
 {
@@ -40,7 +82,6 @@ afsocket_dd_set_keep_alive(LogDriver *s, gboolean enable)
 
   self->connections_kept_alive_accross_reloads = enable;
 }
-
 
 static gchar *
 afsocket_dd_format_persist_name(AFSocketDestDriver *self, gboolean qfile)
@@ -315,12 +356,18 @@ static void
 afsocket_dd_restore_writer(AFSocketDestDriver *self)
 {
   GlobalConfig *cfg;
+  ReloadStoreItem *item;
 
   g_assert(self->writer == NULL);
-  cfg = log_pipe_get_config(&self->super.super.super);
-  self->writer = cfg_persist_config_fetch(cfg, afsocket_dd_format_persist_name(self, FALSE));
-}
 
+  cfg = log_pipe_get_config(&self->super.super.super);
+  item = cfg_persist_config_fetch(cfg, afsocket_dd_format_persist_name(self, FALSE));
+
+  if (item && !_is_protocol_type_changed_during_reload(self, item))
+    self->writer = _reload_store_item_release_writer(item);
+
+  _reload_store_item_free(item);
+}
 
 LogWriter *
 afsocket_dd_construct_writer_method(AFSocketDestDriver *self)
@@ -410,7 +457,8 @@ afsocket_dd_save_connection(AFSocketDestDriver *self)
 
   if (self->connections_kept_alive_accross_reloads)
     {
-      cfg_persist_config_add(cfg, afsocket_dd_format_persist_name(self, FALSE), self->writer, (GDestroyNotify) log_pipe_unref, FALSE);
+      ReloadStoreItem *item = _reload_store_item_new(self);
+      cfg_persist_config_add(cfg, afsocket_dd_format_persist_name(self, FALSE), item, (GDestroyNotify) _reload_store_item_free, FALSE);
       self->writer = NULL;
     }
 }


### PR DESCRIPTION
And, thus, do not replace writer when protocol not changed during reload.

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>

This is actually a backport.
