### PR TITLE
systemd service file only half-respects /etc/default/syslog-ng

### DIFF
--- a/contrib/systemd/syslog-ng.service
+++ b/contrib/systemd/syslog-ng.service
@@ -4,7 +4,7 @@ Documentation=man:syslog-ng(8)
 
 [Service]
 Type=notify
-ExecStart=/usr/sbin/syslog-ng -F
+ExecStart=/usr/sbin/syslog-ng -F $SYSLOGNG_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 EnvironmentFile=-/etc/default/syslog-ng
 EnvironmentFile=-/etc/sysconfig/syslog-ng


### PR DESCRIPTION
The systemd service file does read `/etc/default/syslog-ng` and `/etc/sysconfig/syslog-ng`, but doesn't do anything with their contents. The `ExecStart` line should include `$SYSLOGNG_OPTS` and whatever the variable is called on RedHat too.