### PR TITLE
Allow overriding the python setup.py options

### DIFF
--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -48,10 +48,12 @@ INSTALL_EXEC_HOOKS += install-pylib
 UNINSTALL_HOOKS += uninstall-pylib
 CLEAN_HOOKS += clean-pylib
 
+PYSETUP_OPTIONS ?= --root="$(PYTHON_ROOT)" --prefix="$(prefix)"
+
 install-pylib:
 	(cd $(PYLIB_SRCDIR) && $(PYTHON) setup.py \
 		build --build-base="$(PYLIB_BUILDDIR)/build" \
-		install --record=$(SETUPPY_MANIFEST) --root="$(PYTHON_ROOT)" --prefix="$(prefix)")
+		install --record=$(SETUPPY_MANIFEST) ${PYSETUP_OPTIONS})
 
 uninstall-pylib:
 	sed -e 's,^,$(PYTHON_ROOT),g' $(SETUPPY_MANIFEST) | tr '\n' '\0' | xargs -0 rm -f


### PR DESCRIPTION
When installing the python modules, allow overriding the options. This is useful for distributions that want to pass extra options. For example, on Debian, we want `--install-layout="deb"` instead of the `--prefix` and `--root` options.

With this change, the previous behaviour remains the default, but one can supply `PYSETUP_OPTIONS` on the make command-line to override it.