### PR TITLE
make install fails to install patterndb xsds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,9 +106,7 @@ include syslog-ng/Makefile.am
 include syslog-ng-ctl/Makefile.am
 include scripts/Makefile.am
 include tests/Makefile.am
-if ENABLE_MANPAGES
 include doc/Makefile.am
-endif
 include contrib/Makefile.am
 include scl/Makefile.am
 include debian/Makefile.am

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,17 +1,9 @@
-man_MANS	+= \
-		doc/man/syslog-ng.8 \
-		doc/man/syslog-ng.conf.5 \
-		doc/man/pdbtool.1 \
-		doc/man/loggen.1 \
-		doc/man/syslog-ng-ctl.1
-
 EXTRA_DIST	+=  \
 		doc/man/syslog-ng.8.xml \
 		doc/man/syslog-ng.conf.5.xml \
 		doc/man/pdbtool.1.xml \
 		doc/man/loggen.1.xml \
 		doc/man/syslog-ng-ctl.1.xml \
-		$(man_MANS) \
 		doc/security/bof-2002-09-27.txt \
 		doc/security/dos-2000-11-22.txt \
 		doc/xsd/patterndb-1.xsd \
@@ -26,6 +18,16 @@ xsd_DATA	= \
 		doc/xsd/patterndb-3.xsd \
 		doc/xsd/patterndb-4.xsd
 
+if ENABLE_MANPAGES
+man_MANS	+= \
+		doc/man/syslog-ng.8 \
+		doc/man/syslog-ng.conf.5 \
+		doc/man/pdbtool.1 \
+		doc/man/loggen.1 \
+		doc/man/syslog-ng-ctl.1
+
+EXTRA_DIST	+= $(man_MANS)
+
 # NOTE: this uses a hard-coded path for the XSL stylesheets, but the
 # end-result is also included in the tarball. If so need be, this can
 # be overridden from the make command line or via the environment.
@@ -36,3 +38,4 @@ prefix_e = $(shell echo "${prefix}" | sed -e "s,-,\\\\\\\\-,g")
 doc/man/%: doc/man/%.xml
 	$(AM_V_GEN)xsltproc --xinclude --output $@ ${XSL_STYLESHEET} $<
 	$(AM_V_at)sed -e 's,/opt/syslog\\*-ng/etc,$(sysconfdir_e),g' -e 's,/opt/syslog\\*-ng/,$(prefix_e)/,g' <$@ >$@.tmp && mv $@.tmp $@
+endif


### PR DESCRIPTION
I recently started to update my Debian packaging, and noticed that when using the [tarball release](https://github.com/balabit/syslog-ng/releases/download/syslog-ng-3.7.1/syslog-ng-3.7.1.tar.gz), after a ./configure && make && make install, the xsd files are not installed for some odd reason.

I have not tried building from a git checkout yet.