### PR TITLE
java-modules: http destination improvements

### DIFF
--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
@@ -66,7 +66,7 @@ public class HTTPDestination extends TextLogDestination {
         int responseCode = 0;
         try {
             HttpURLConnection connection = (HttpURLConnection) this.url.openConnection();
-            connection.setRequestMethod("PUT");
+            connection.setRequestMethod(options.getMethod());
             connection.setRequestProperty("content-length", Integer.toString(message.length()));
             connection.setDoOutput(true);
             try (OutputStreamWriter osw = new OutputStreamWriter(connection.getOutputStream())) {

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java
@@ -32,6 +32,10 @@ import org.syslog_ng.options.*;
 public class HTTPDestinationOptions {
 
   public static String URL = "url";
+  public static String METHOD  = "method";
+  public static String METHOD_DEFAULT  = "PUT";
+
+  public static HashSet<String> HTTP_METHODS = new HashSet<String>(Arrays.asList("POST", "PUT", "HEAD", "OPTIONS", "DELETE", "TRACE", "GET"));
 
   private LogDestination owner;
   private Options options;
@@ -58,12 +62,17 @@ public class HTTPDestinationOptions {
     return options.get(URL).getValue();
   }
 
+  public String getMethod() {
+     return options.get(METHOD).getValue();
+  }
+
   private void fillOptions() {
     fillStringOptions();
   }
 
   private void fillStringOptions() {
 		options.put(new RequiredOptionDecorator(new StringOption(owner, URL)));
+		options.put(new EnumOptionDecorator(new StringOption(owner, METHOD, METHOD_DEFAULT), HTTP_METHODS));
   }
 
 }


### PR DESCRIPTION
HTTP destination is now able to receive HTTP method as an option.
The new option can be passed using `method(<METHOD>)`.

valid methods:
* PUT
* POST

fixes #668

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>