### PR TITLE
logmsg: make log_msg_values_foreach() take the receiver as const pointer

### DIFF
--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -582,7 +582,7 @@ log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handl
 }
 
 gboolean
-log_msg_values_foreach(LogMessage *self, NVTableForeachFunc func, gpointer user_data)
+log_msg_values_foreach(const LogMessage *self, NVTableForeachFunc func, gpointer user_data)
 {
   return nv_table_foreach(self->payload, logmsg_registry, func, user_data);
 }

--- a/lib/logmsg.h
+++ b/lib/logmsg.h
@@ -247,7 +247,7 @@ typedef gboolean (*LogMessageTagsForeachFunc)(const LogMessage *self, LogTagId t
 
 void log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *new_value, gssize length);
 void log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
-gboolean log_msg_values_foreach(LogMessage *self, NVTableForeachFunc func, gpointer user_data);
+gboolean log_msg_values_foreach(const LogMessage *self, NVTableForeachFunc func, gpointer user_data);
 void log_msg_set_match(LogMessage *self, gint index, const gchar *value, gssize value_len);
 void log_msg_set_match_indirect(LogMessage *self, gint index, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
 void log_msg_clear_matches(LogMessage *self);


### PR DESCRIPTION
I need this change for my Rust bindings. I have to use `&mut LogMessage` references every time I call this function and that prohibits of using other read only references till the mutable one goes out of scope.

Signed-off-by: Tibor Benke <ihrwein@gmail.com>