### PR TITLE
F/scl varargs refined

### DIFF
--- a/lib/cfg-args.c
+++ b/lib/cfg-args.c
@@ -46,6 +46,12 @@ cfg_args_validate_callback(gpointer k, gpointer v, gpointer user_data)
     }
 }
 
+void
+cfg_args_foreach(CfgArgs *self, GHFunc func, gpointer user_data)
+{
+  g_hash_table_foreach(self->args, func, user_data);
+}
+
 gboolean
 cfg_args_validate(CfgArgs *self, CfgArgs *defs, const gchar *context)
 {

--- a/lib/cfg-args.c
+++ b/lib/cfg-args.c
@@ -57,7 +57,7 @@ cfg_args_validate(CfgArgs *self, CfgArgs *defs, const gchar *context)
 {
   gpointer validate_params[] = { defs, NULL, NULL };
 
-  g_hash_table_foreach(self->args, cfg_args_validate_callback, validate_params);
+  cfg_args_foreach(self, cfg_args_validate_callback, validate_params);
 
   if (validate_params[1])
     {

--- a/lib/cfg-args.h
+++ b/lib/cfg-args.h
@@ -33,6 +33,7 @@ typedef struct _CfgArgs CfgArgs;
 gboolean cfg_args_validate(CfgArgs *self, CfgArgs *defs, const gchar *context);
 void cfg_args_set(CfgArgs *self, const gchar *name, const gchar *value);
 const gchar *cfg_args_get(CfgArgs *self, const gchar *name);
+void cfg_args_foreach(CfgArgs *self, GHFunc func, gpointer user_data);
 
 CfgArgs *cfg_args_new(void);
 CfgArgs *cfg_args_ref(CfgArgs *self);

--- a/scl/graphite/plugin.conf
+++ b/scl/graphite/plugin.conf
@@ -24,5 +24,5 @@ block destination graphite(
       host("localhost") port(2003)
       payload("")) {
   network("`host`" port(`port`) transport(tcp)
-          template("$(graphite-output `payload`)"));
+          template("$(graphite-output `payload`)") `__VARARGS__`);
 };

--- a/scl/nodejs/plugin.conf
+++ b/scl/nodejs/plugin.conf
@@ -24,7 +24,7 @@
 block source nodejs(localip(0.0.0.0) port(9003)) {
         channel {
                 log {
-                        source { network(transport(tcp) localip(`localip`) port(`port`) flags(no-parse)); };
+                        source { network(transport(tcp) localip(`localip`) port(`port`) flags(no-parse) `__VARARGS__`); };
                         parser { json-parser(extract-prefix("[1]") prefix(".nodejs.winston.")); };
                         rewrite {
                                 set("${.nodejs.winston.message}" value("MESSAGE")); 

--- a/scl/pacct/plugin.conf
+++ b/scl/pacct/plugin.conf
@@ -23,5 +23,5 @@
 
 block source pacct(file("/var/log/account/pacct") follow-freq(1)) {
 @module pacctformat
-        file("`file`" follow-freq(`follow-freq`) format("pacct") tags(".pacct"));
+        file("`file`" follow-freq(`follow-freq`) format("pacct") tags(".pacct") `__VARARGS__`);
 };


### PR DESCRIPTION
This PR makes possible to dynamically insert options into blocks. The users
just need to use the `...` placeholder in the block definition.

Fixes #679 

Example configuration:

```
@version:3.7
@include "scl.conf"

block destination local_network(port(1999)) {
  network("localhost" port(`port`) `...`);
};

source s_stdin {
  file('/dev/stdin');
};

destination d_local {
  local_network(template("I'm a templated line and came from ...\n"));
};

log {
  source(s_stdin);
  destination(d_local);
};
```

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>
Signed-off-by: Tibor Benke <tibor.benke@balabit.com>