### PR TITLE
F/fix logwriter spinning on partial writes

### DIFF
--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -65,16 +65,7 @@ log_proto_file_writer_flush(LogProtoClient *s)
 
   if (rc < 0)
     {
-      if (errno != EINTR)
-        {
-          msg_error("I/O error occurred while writing",
-                    evt_tag_int("fd", self->super.transport->fd),
-                    evt_tag_errno(EVT_TAG_OSERROR, errno),
-                    NULL);
-          return LPS_ERROR;
-        }
-
-      return LPS_SUCCESS;
+      goto write_error;
     }
   else if (rc != self->sum_len)
     {
@@ -112,6 +103,19 @@ log_proto_file_writer_flush(LogProtoClient *s)
   self->sum_len = 0;
 
   return LPS_SUCCESS;
+
+ write_error:
+  if (errno != EINTR && errno != EAGAIN)
+    {
+      msg_error("I/O error occurred while writing",
+                evt_tag_int("fd", self->super.transport->fd),
+                evt_tag_errno(EVT_TAG_OSERROR, errno),
+                NULL);
+      return LPS_ERROR;
+    }
+
+  return LPS_SUCCESS;
+
 }
 
 /*

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -54,8 +54,31 @@ log_proto_file_writer_flush(LogProtoClient *s)
   LogProtoFileWriter *self = (LogProtoFileWriter *)s;
   gint rc, i, i0, sum, ofs, pos;
 
-  /* we might be called from log_writer_deinit() without having a buffer at all */
+  if (self->partial)
+    {
+      /* there is still some data from the previous file writing process */
+      gint len = self->partial_len - self->partial_pos;
 
+      rc = write(self->fd, self->partial + self->partial_pos, len);
+      if (rc > 0 && self->fsync)
+        fsync(self->fd);
+      if (rc < 0)
+        {
+          goto write_error;
+        }
+      else if (rc != len)
+        {
+          self->partial_pos += rc;
+          return LPS_SUCCESS;
+        }
+      else
+        {
+          g_free(self->partial);
+          self->partial = NULL;
+        }
+    }
+
+  /* we might be called from log_writer_deinit() without having a buffer at all */
   if (self->buf_count == 0)
     return LPS_SUCCESS;
 
@@ -133,42 +156,19 @@ static LogProtoStatus
 log_proto_file_writer_post(LogProtoClient *s, guchar *msg, gsize msg_len, gboolean *consumed)
 {
   LogProtoFileWriter *self = (LogProtoFileWriter *)s;
-  gint rc;
+  LogProtoStatus result;
 
   *consumed = FALSE;
-  if (self->buf_count >= self->buf_size)
+  if (self->buf_count >= self->buf_size || self->partial)
     {
-      rc = log_proto_file_writer_flush(s);
-      if (rc != LPS_SUCCESS || self->buf_count >= self->buf_size)
+      result = log_proto_file_writer_flush(s);
+      if (result != LPS_SUCCESS || self->buf_count >= self->buf_size || self->partial)
         {
-          /* don't consume a new message if flush failed, or even after the flush we don't have any free slots */
-          return rc;
-        }
-    }
-
-  if (self->partial)
-    {
-      /* there is still some data from the previous file writing process */
-      gint len = self->partial_len - self->partial_pos;
-
-      rc = write(self->fd, self->partial + self->partial_pos, len);
-      if (rc > 0 && self->fsync)
-        fsync(self->fd);
-      if (rc < 0)
-        {
-          goto write_error;
-        }
-      else if (rc != len)
-        {
-          self->partial_pos += rc;
-          return LPS_SUCCESS;
-        }
-      else
-        {
-          g_free(self->partial);
-          self->partial = NULL;
-          /* NOTE: we return here to give a chance to the framed protocol to send the frame header. */
-          return LPS_SUCCESS;
+          /* don't consume a new message if flush failed OR if we couldn't
+           * progress in flush() to empty the outgoing buffer (either
+           * buffers or partial)
+           */
+          return result;
         }
     }
 
@@ -181,25 +181,13 @@ log_proto_file_writer_post(LogProtoClient *s, guchar *msg, gsize msg_len, gboole
   if (self->buf_count == self->buf_size)
     {
       /* we have reached the max buffer size -> we need to write the messages */
-      LogProtoStatus result = log_proto_file_writer_flush(s);
+      result = log_proto_file_writer_flush(s);
       if (result != LPS_SUCCESS)
         return result;
     }
 
   *consumed = TRUE;
   log_proto_client_msg_ack(&self->super, 1);
-  return LPS_SUCCESS;
-
-write_error:
-  if (errno != EAGAIN && errno != EINTR)
-    {
-      msg_error("I/O error occurred while writing",
-                evt_tag_int("fd", self->super.transport->fd),
-                evt_tag_errno(EVT_TAG_OSERROR, errno),
-                NULL);
-      return LPS_ERROR;
-    }
-
   return LPS_SUCCESS;
 }
 


### PR DESCRIPTION
This branch should fix the issue encountered by @faxm0dem as reported on gitter.

The problems relates to LogProtoFileWriter, e.g. the LogProto implementation that bypasses our LogTransport abstraction and uses writev() to send multiple records to a file with a single system call. That LogProto implementation sometimes fails to progress in flushing the data: more specifically when there are remaining bytes from the last transaction (e.g. partial holds some data), and the queue of the destination is empty, so no new data is post()-ed.

syslog-ng comes out of the loop once a new message is posted to the destination.

Kudos to @faxm0dem for the report and initial analysis.

PS: I forgot to include the Reported-By lines in the commit messages and my internet connection is pretty bad, so if you rebase before merging this, pls add those lines so that we don't forget credits.

