### PR TITLE
scl: add mbox() source

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,4 +1,4 @@
-SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris
+SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris mbox
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/mbox/mbox.conf
+++ b/scl/mbox/mbox.conf
@@ -1,0 +1,34 @@
+#############################################################################
+# Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2015 Fabien Wernli
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+block source mbox(filename()) {
+    file(
+        "`filename`"
+        log-msg-size(10000000)
+        log-fetch-limit(1)
+        flags(no-parse)
+        multi-line-mode(prefix-suffix)
+        multi-line-prefix('^From ')
+      );
+};


### PR DESCRIPTION
This source can be used to fetch emails from local mbox files:

source { mbox("/var/spool/mail/root"); };

This will fetch root emails and parse them into a multiline $MSG.
Original implementation by Fabien Wernli, I only converted it into
an SCL.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>