### PR TITLE
afsmtp: fix grammar inconsistencies in the grammar

### DIFF
--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -65,63 +65,106 @@ start
             last_driver = *instance = afsmtp_dd_new(configuration);
           }
           '(' afsmtp_options ')'         { YYACCEPT; }
-	;
+        ;
 
 afsmtp_options
         : afsmtp_option afsmtp_options
-	|
-	;
+        |
+        ;
 
 afsmtp_option
-        : KW_HOST '(' string ')'		{ afsmtp_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' LL_NUMBER ')'		{ afsmtp_dd_set_port(last_driver, $3); }
-	| KW_SUBJECT '(' template_content ')'	 	{ afsmtp_dd_set_subject(last_driver, $3); log_template_unref($3); }
-	| KW_BODY '(' template_content ')'		{ afsmtp_dd_set_body(last_driver, $3); log_template_unref($3); }
-	| KW_HEADER '(' string template_content ')'	{
-		afsmtp_dd_add_header(last_driver, $3, $4);
-		free($3); log_template_unref($4); 
-	}
-
-	| KW_FROM '(' template_content ')'		{ afsmtp_dd_set_from(last_driver, $3, $3);
-    log_template_unref($3); 
-  }
-	| KW_FROM '(' template_content template_content ')'		{ afsmtp_dd_set_from(last_driver, $3, $4);
-    log_template_unref($3); log_template_unref($4);
-  }
-	| KW_SENDER '(' template_content ')'		{ afsmtp_dd_set_from(last_driver, $3, $3);
-    log_template_unref($3);
-  }
-	| KW_SENDER '(' template_content template_content ')'	{ afsmtp_dd_set_from(last_driver, $3, $4);
-    log_template_unref($3); log_template_unref($4);
-  }
-	| KW_TO '(' template_content ')'			{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_TO, $3, $3);
-    log_template_unref($3); 
-  }
-	| KW_TO '(' template_content template_content ')'		{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_TO, $3, $4);
-    log_template_unref($3); log_template_unref($4); 
-  }
-	| KW_CC '(' template_content ')'			{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_CC, $3, $3);
-    log_template_unref($3);
-  }
-	| KW_CC '(' template_content template_content ')'		{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_CC, $3, $4);
-    log_template_unref($3); log_template_unref($4);
-  }
-	| KW_BCC '(' template_content ')'			{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_BCC, $3, $3);
-    log_template_unref($3);
-  }
-	| KW_BCC '(' template_content template_content ')'		{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_BCC, $3, $4); 
-    log_template_unref($3); log_template_unref($4);
-  }
-	| KW_REPLY_TO '(' template_content ')'		{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_REPLY_TO, $3, $3);
-    log_template_unref($3);
-  } 
-	| KW_REPLY_TO '(' template_content template_content ')'	{ afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_REPLY_TO, $3, $4); 
-    log_template_unref($3); log_template_unref($4);
-  }
-	| threaded_dest_driver_option
-	| dest_driver_option
-	| { last_template_options = afsmtp_dd_get_template_options(last_driver); } template_option
-	;
+        : KW_HOST '(' string ')'
+          {
+            afsmtp_dd_set_host(last_driver, $3);
+            free($3);
+          }
+        | KW_PORT '(' LL_NUMBER ')' { afsmtp_dd_set_port(last_driver, $3); }
+        | KW_SUBJECT '(' template_content ')'
+          {
+            afsmtp_dd_set_subject(last_driver, $3);
+            log_template_unref($3);
+          }
+        | KW_BODY '(' template_content ')'
+          {
+            afsmtp_dd_set_body(last_driver, $3);
+            log_template_unref($3);
+          }
+        | KW_HEADER '(' string template_content ')'
+          {
+            afsmtp_dd_add_header(last_driver, $3, $4);
+            free($3);
+            log_template_unref($4);
+          }
+        | KW_FROM '(' template_content ')'
+          {
+            afsmtp_dd_set_from(last_driver, $3, $3);
+            log_template_unref($3);
+          }
+        | KW_FROM '(' template_content template_content ')'
+          {
+            afsmtp_dd_set_from(last_driver, $3, $4);
+            log_template_unref($3);
+            log_template_unref($4);
+          }
+        | KW_SENDER '(' template_content ')'
+          {
+            afsmtp_dd_set_from(last_driver, $3, $3);
+            log_template_unref($3);
+          }
+        | KW_SENDER '(' template_content template_content ')'
+          {
+            afsmtp_dd_set_from(last_driver, $3, $4);
+            log_template_unref($3);
+            log_template_unref($4);
+          }
+        | KW_TO '(' template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_TO, $3, $3);
+            log_template_unref($3);
+          }
+        | KW_TO '(' template_content template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_TO, $3, $4);
+            log_template_unref($3);
+            log_template_unref($4);
+          }
+        | KW_CC '(' template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_CC, $3, $3);
+            log_template_unref($3);
+          }
+        | KW_CC '(' template_content template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_CC, $3, $4);
+            log_template_unref($3);
+            log_template_unref($4);
+          }
+        | KW_BCC '(' template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_BCC, $3, $3);
+            log_template_unref($3);
+          }
+        | KW_BCC '(' template_content template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_BCC, $3, $4);
+            log_template_unref($3);
+            log_template_unref($4);
+          }
+        | KW_REPLY_TO '(' template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_REPLY_TO, $3, $3);
+            log_template_unref($3);
+          }
+        | KW_REPLY_TO '(' template_content template_content ')'
+          {
+            afsmtp_dd_add_rcpt(last_driver, AFSMTP_RCPT_TYPE_REPLY_TO, $3, $4);
+            log_template_unref($3);
+            log_template_unref($4);
+          }
+        | threaded_dest_driver_option
+        | dest_driver_option
+        | { last_template_options = afsmtp_dd_get_template_options(last_driver); } template_option
+        ;
 
 /* INCLUDE_RULES */
 


### PR DESCRIPTION
PR #419 introduced some inconsistencies in the grammar. I took the
chance to eliminate all tabs and use the same convention through the
whole file.

Fixes #638

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>