### PR TITLE
cfg-grammar: fix template_fn memory leak

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -778,6 +778,8 @@ template_stmt
         | template_fn
           {
             user_template_function_register(configuration, last_template->name, last_template);
+            log_template_unref(last_template);
+            last_template = NULL;
           }
         ;
 


### PR DESCRIPTION
Reported by valgrind.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>