### PR TITLE
cfg: initialize global options

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -260,6 +260,7 @@ cfg_init(GlobalConfig *cfg)
   dns_cache_set_params(cfg->dns_cache_size, cfg->dns_cache_expire, cfg->dns_cache_expire_failed, cfg->dns_cache_hosts);
   hostname_reinit(cfg->custom_domain);
   host_resolve_options_init(&cfg->host_resolve_options, cfg);
+  log_template_options_init(&cfg->template_options, cfg);
   if (!cfg_init_modules(cfg))
     return FALSE;
   return cfg_tree_start(&cfg->tree);


### PR DESCRIPTION
The global template options were not properly initialized as the
log_template_options_init() call was missing.  This meant that the few call
sites that use GlobalConfig->template_options directly (for instance the
debugger), didn't use the time-zone related parameters, as the TimeZoneInfo
pointers were not initialized.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>