### PR TITLE
F/linux audit parser

### DIFF
--- a/lib/ml-batched-timer.c
+++ b/lib/ml-batched-timer.c
@@ -143,6 +143,8 @@ ml_batched_timer_unregister(MlBatchedTimer *self)
 {
   if (iv_timer_registered(&self->timer))
     iv_timer_unregister(&self->timer);
+  self->expires.tv_sec = 0;
+  self->expires.tv_nsec = 0;
 }
 
 /* one-time initialization of the MlBatchedTimer structure */

--- a/modules/kvformat/Makefile.am
+++ b/modules/kvformat/Makefile.am
@@ -7,6 +7,8 @@ modules_kvformat_libkvformat_la_SOURCES=	\
 	modules/kvformat/kv-parser.h		\
 	modules/kvformat/kv-scanner.c		\
 	modules/kvformat/kv-scanner.h		\
+	modules/kvformat/linux-audit-scanner.c	\
+	modules/kvformat/linux-audit-scanner.h	\
 	modules/kvformat/kv-parser-grammar.y	\
 	modules/kvformat/kv-parser-parser.c		\
 	modules/kvformat/kv-parser-parser.h		\

--- a/modules/kvformat/kv-parser-grammar.ym
+++ b/modules/kvformat/kv-parser-grammar.ym
@@ -28,6 +28,7 @@
 %code {
 
 #include "kv-parser.h"
+#include "linux-audit-scanner.h"
 #include "cfg-parser.h"
 #include "kv-parser-grammar.h"
 
@@ -48,6 +49,7 @@ extern LogParser *last_parser;
 /* INCLUDE_DECLS */
 
 %token KW_KV_PARSER
+%token KW_LINUX_AUDIT_PARSER
 %token KW_PREFIX
 
 %type	<ptr> parser_expr_kv
@@ -63,6 +65,12 @@ parser_expr_kv
 	: KW_KV_PARSER '('
 	  {
 	    last_parser = *instance = (LogParser *) kv_parser_new(configuration, kv_scanner_new());
+	  }
+	  parser_kv_opts
+	  ')'					{ $$ = last_parser; }
+	| KW_LINUX_AUDIT_PARSER '('
+	  {
+	    last_parser = *instance = (LogParser *) kv_parser_new(configuration, linux_audit_scanner_new());
 	  }
 	  parser_kv_opts
 	  ')'					{ $$ = last_parser; }

--- a/modules/kvformat/kv-parser-grammar.ym
+++ b/modules/kvformat/kv-parser-grammar.ym
@@ -62,7 +62,7 @@ start
 parser_expr_kv
 	: KW_KV_PARSER '('
 	  {
-	    last_parser = *instance = (LogParser *) kv_parser_new(configuration);
+	    last_parser = *instance = (LogParser *) kv_parser_new(configuration, kv_scanner_new());
 	  }
 	  parser_kv_opts
 	  ')'					{ $$ = last_parser; }

--- a/modules/kvformat/kv-parser.h
+++ b/modules/kvformat/kv-parser.h
@@ -23,8 +23,9 @@
 #define KVPARSER_H_INCLUDED
 
 #include "parser/parser-expr.h"
+#include "kv-scanner.h"
 
 void kv_parser_set_prefix(LogParser *p, const gchar *prefix);
-LogParser *kv_parser_new(GlobalConfig *cfg);
+LogParser *kv_parser_new(GlobalConfig *cfg, KVScanner *kv_scanner);
 
 #endif

--- a/modules/kvformat/kv-scanner.c
+++ b/modules/kvformat/kv-scanner.c
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 #include "kv-scanner.h"
 #include "misc.h"
 #include <string.h>

--- a/modules/kvformat/kv-scanner.c
+++ b/modules/kvformat/kv-scanner.c
@@ -86,6 +86,7 @@ _kv_scanner_extract_value(KVScanner *self)
 
   g_string_truncate(self->value, 0);
   self->quote_state = KV_QUOTE_INITIAL;
+  self->value_was_quoted = FALSE;
   cur = &self->input[self->input_pos];
   while (*cur && self->quote_state != KV_QUOTE_FINISH)
     {
@@ -101,6 +102,8 @@ _kv_scanner_extract_value(KVScanner *self)
             {
               self->quote_state = KV_QUOTE_STRING;
               self->quote_char = *cur;
+              if (self->value->len == 0)
+                self->value_was_quoted = TRUE;
               break;
             }
           g_string_append_c(self->value, *cur);

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -32,9 +32,11 @@ struct _KVScanner
   gsize input_len;
   GString *key;
   GString *value;
+  GString *decoded_value;
   gchar quote_char;
   gint quote_state;
   gint next_quote_state;
+  gboolean (*parse_value)(KVScanner *self);
   void (*free_fn)(KVScanner *self);
 };
 

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 #ifndef KV_SCANNER_H_INCLUDED
 #define KV_SCANNER_H_INCLUDED
 

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -33,6 +33,7 @@ struct _KVScanner
   GString *key;
   GString *value;
   GString *decoded_value;
+  gboolean value_was_quoted;
   gchar quote_char;
   gint quote_state;
   gint next_quote_state;

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -24,7 +24,8 @@
 
 #include "syslog-ng.h"
 
-typedef struct _KVScannerState
+typedef struct _KVScanner KVScanner;
+struct _KVScanner
 {
   const gchar *input;
   gsize input_pos;
@@ -34,13 +35,18 @@ typedef struct _KVScannerState
   gchar quote_char;
   gint quote_state;
   gint next_quote_state;
-} KVScannerState;
+  void (*free_fn)(KVScanner *self);
+};
 
-void kv_scanner_init(KVScannerState *self);
-void kv_scanner_destroy(KVScannerState *self);
-void kv_scanner_input(KVScannerState *self, const gchar *input);
-gboolean kv_scanner_scan_next(KVScannerState *self);
-const gchar *kv_scanner_get_current_key(KVScannerState *self);
-const gchar *kv_scanner_get_current_value(KVScannerState *self);
+void kv_scanner_input(KVScanner *self, const gchar *input);
+gboolean kv_scanner_scan_next(KVScanner *self);
+const gchar *kv_scanner_get_current_key(KVScanner *self);
+const gchar *kv_scanner_get_current_value(KVScanner *self);
+KVScanner *kv_scanner_clone(KVScanner *self);
+void kv_scanner_free_method(KVScanner *self);
+void kv_scanner_init(KVScanner *self);
+
+KVScanner *kv_scanner_new(void);
+void kv_scanner_free(KVScanner *self);
 
 #endif

--- a/modules/kvformat/kvformat-plugin.c
+++ b/modules/kvformat/kvformat-plugin.c
@@ -33,6 +33,11 @@ static Plugin kvformat_plugins[] =
     .name = "kv-parser",
     .parser = &kv_parser_parser,
   },
+  {
+    .type = LL_CONTEXT_PARSER,
+    .name = "linux-audit-parser",
+    .parser = &kv_parser_parser,
+  },
   TEMPLATE_FUNCTION_PLUGIN(tf_format_welf, "format-welf"),
 };
 

--- a/modules/kvformat/linux-audit-scanner.c
+++ b/modules/kvformat/linux-audit-scanner.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "kv-scanner.h"
+#include "misc.h"
+#include "utf8utils.h"
+
+#include <string.h>
+#include <ctype.h>
+
+const gchar *hexcoded_fields[] =
+{
+  "name",
+  "proctitle",
+  "path",
+  "dir",
+  "comm",
+  "ocomm",
+  "data",
+  "old",
+  "new",
+  NULL
+};
+
+static gint
+_decode_xdigit(gchar xdigit)
+{
+  if (xdigit >= '0' && xdigit <= '9')
+    return xdigit - '0';
+  xdigit = toupper(xdigit);
+  if (xdigit >= 'A' && xdigit <= 'F')
+    return xdigit - 'A' + 10;
+  return -1;
+}
+
+static gint
+_decode_xbyte(gchar xdigit1, gchar xdigit2)
+{
+  gint nibble_hi, nibble_lo;
+
+  nibble_hi = _decode_xdigit(xdigit1);
+  nibble_lo = _decode_xdigit(xdigit2);
+  if (nibble_hi < 0 || nibble_lo < 0)
+    return -1;
+  return (nibble_hi << 4) + nibble_lo;
+}
+
+static gboolean
+_is_control_char(gint ch)
+{
+  if (ch < 0x21 || ch > 0x7e)
+    return TRUE;
+  return FALSE;
+}
+
+static gboolean
+_parse_linux_audit_hexstring(GString *decoded_value, const gchar *value, gsize len)
+{
+  gint src;
+  gboolean kernel_would_have_encoded_this_as_hex = FALSE;
+
+  for (src = 0; src < len; src += 2)
+    {
+      gint v;
+
+      v = _decode_xbyte(value[src], value[src + 1]);
+
+      if (v < 0)
+        return FALSE;
+
+      if (_is_control_char(v) || v == '"')
+        kernel_would_have_encoded_this_as_hex = TRUE;
+
+      if (v == 0)
+        v = 9;
+
+      g_string_append_c(decoded_value, v);
+    }
+  if (!kernel_would_have_encoded_this_as_hex)
+    return FALSE;
+  return TRUE;
+}
+
+static gboolean
+_is_field_hex_encoded(const gchar *field)
+{
+  gint i;
+
+  for (i = 0; hexcoded_fields[i]; i++)
+    {
+      if (strcmp(hexcoded_fields[i], field) == 0)
+        return TRUE;
+    }
+  return FALSE;
+}
+
+static gboolean
+_parse_linux_audit_style_hexdump(KVScanner *self)
+{
+  if (!self->value_was_quoted &&
+      (self->value->len % 2) == 0 &&
+      isxdigit(self->value->str[0]) &&
+      _is_field_hex_encoded(self->key->str))
+    {
+      if (!_parse_linux_audit_hexstring(self->decoded_value, self->value->str, self->value->len))
+        return FALSE;
+
+      if (!g_utf8_validate(self->decoded_value->str, self->decoded_value->len, NULL))
+        return FALSE;
+
+      return TRUE;
+    }
+  return FALSE;
+}
+
+KVScanner *
+linux_audit_scanner_new(void)
+{
+  KVScanner *self = kv_scanner_new();
+  self->parse_value = _parse_linux_audit_style_hexdump;
+  return self;
+}

--- a/modules/kvformat/linux-audit-scanner.c
+++ b/modules/kvformat/linux-audit-scanner.c
@@ -90,7 +90,7 @@ _parse_linux_audit_hexstring(GString *decoded_value, const gchar *value, gsize l
         kernel_would_have_encoded_this_as_hex = TRUE;
 
       if (v == 0)
-        v = 9;
+        v = '\t';
 
       g_string_append_c(decoded_value, v);
     }

--- a/modules/kvformat/linux-audit-scanner.h
+++ b/modules/kvformat/linux-audit-scanner.h
@@ -17,33 +17,13 @@
  * As an additional exemption you are allowed to compile & link against the
  * OpenSSL libraries as published by the OpenSSL project. See the file
  * COPYING for details.
+ *
  */
+#ifndef LINUX_AUDIT_SCANNER_H_INCLUDED
+#define LINUX_AUDIT_SCANNER_H_INCLUDED
 
-#include "kv-parser.h"
-#include "cfg-parser.h"
-#include "kv-parser-grammar.h"
+#include "kv-scanner.h"
 
-extern int kv_parser_debug;
+KVScanner *linux_audit_scanner_new(void);
 
-int kv_parser_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
-
-static CfgLexerKeyword kv_parser_keywords[] =
-{
-  { "kv_parser",          KW_KV_PARSER,  },
-  { "linux_audit_parser", KW_LINUX_AUDIT_PARSER,  },
-  { "prefix",             KW_PREFIX,  },
-  { NULL }
-};
-
-CfgParser kv_parser_parser =
-{
-#if ENABLE_DEBUG
-  .debug_flag = &kv_parser_debug,
 #endif
-  .name = "kv-parser",
-  .keywords = kv_parser_keywords,
-  .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) kv_parser_parse,
-  .cleanup = (void (*)(gpointer)) log_pipe_unref,
-};
-
-CFG_PARSER_IMPLEMENT_LEXER_BINDING(kv_parser_, LogParser **)

--- a/modules/kvformat/tests/Makefile.am
+++ b/modules/kvformat/tests/Makefile.am
@@ -1,6 +1,7 @@
 modules_kvformat_tests_TESTS		= \
 	modules/kvformat/tests/test_format_welf	\
 	modules/kvformat/tests/test_kv_scanner	\
+	modules/kvformat/tests/test_linux_audit_scanner	\
 	modules/kvformat/tests/test_kv_parser
 
 check_PROGRAMS				+= ${modules_kvformat_tests_TESTS}
@@ -24,3 +25,9 @@ modules_kvformat_tests_test_kv_scanner_LDADD	= $(TEST_LDADD)
 modules_kvformat_tests_test_kv_scanner_LDFLAGS	= \
 	-dlpreopen $(top_builddir)/modules/kvformat/libkvformat.la
 modules_kvformat_tests_test_kv_scanner_DEPENDENCIES = $(top_builddir)/modules/kvformat/libkvformat.la
+
+modules_kvformat_tests_test_linux_audit_scanner_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/kvformat
+modules_kvformat_tests_test_linux_audit_scanner_LDADD	= $(TEST_LDADD)
+modules_kvformat_tests_test_linux_audit_scanner_LDFLAGS	= \
+	-dlpreopen $(top_builddir)/modules/kvformat/libkvformat.la
+modules_kvformat_tests_test_linux_audit_scanner_DEPENDENCIES = $(top_builddir)/modules/kvformat/libkvformat.la

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -27,7 +27,7 @@
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      kv_parser = kv_parser_new(NULL);                      \
+      kv_parser = kv_parser_new(NULL, kv_scanner_new());        \
     }                                                           \
   while (0)
 

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -233,6 +233,21 @@ test_kv_scanner_transforms_values_if_parse_value_is_set(void)
 }
 
 static void
+test_kv_scanner_quotation_is_stored_in_the_was_quoted_value_member(void)
+{
+  kv_scanner_input(kv_scanner, "foo=\"bar\"");
+  assert_next_kv_is("foo", "bar");
+  assert_true(kv_scanner->value_was_quoted, "expected value_was_quoted to be TRUE");
+  assert_no_more_tokens();
+
+  kv_scanner_input(kv_scanner, "foo=bar");
+  assert_next_kv_is("foo", "bar");
+  assert_false(kv_scanner->value_was_quoted, "expected value_was_quoted to be FALSE");
+  assert_no_more_tokens();
+}
+
+
+static void
 test_kv_scanner(void)
 {
   KV_SCANNER_TESTCASE(test_kv_scanner_incomplete_string_returns_no_pairs);
@@ -243,6 +258,7 @@ test_kv_scanner(void)
   KV_SCANNER_TESTCASE(test_kv_scanner_with_comma_separated_values);
   KV_SCANNER_TESTCASE(test_kv_scanner_quoted_values_are_unquoted_like_c_strings);
   KV_SCANNER_TESTCASE(test_kv_scanner_transforms_values_if_parse_value_is_set);
+  KV_SCANNER_TESTCASE(test_kv_scanner_quotation_is_stored_in_the_was_quoted_value_member);
 }
 
 int main(int argc, char *argv[])

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
 #include "kv-scanner.h"
 #include "testutils.h"
 

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -212,6 +212,26 @@ test_kv_scanner_quoted_values_are_unquoted_like_c_strings(void)
   assert_no_more_tokens();
 }
 
+static gboolean
+_parse_value_by_incrementing_all_bytes(KVScanner *self)
+{
+  gint i;
+
+  g_string_assign(self->decoded_value, self->value->str);
+  for (i = 0; i < self->decoded_value->len; i++)
+    self->decoded_value->str[i]++;
+  return TRUE;
+}
+
+static void
+test_kv_scanner_transforms_values_if_parse_value_is_set(void)
+{
+  kv_scanner->parse_value = _parse_value_by_incrementing_all_bytes;
+  kv_scanner_input(kv_scanner, "foo=\"bar\"");
+  assert_next_kv_is("foo", "cbs");
+  assert_no_more_tokens();
+}
+
 static void
 test_kv_scanner(void)
 {
@@ -222,6 +242,7 @@ test_kv_scanner(void)
   KV_SCANNER_TESTCASE(test_kv_scanner_spaces_between_values_are_ignored);
   KV_SCANNER_TESTCASE(test_kv_scanner_with_comma_separated_values);
   KV_SCANNER_TESTCASE(test_kv_scanner_quoted_values_are_unquoted_like_c_strings);
+  KV_SCANNER_TESTCASE(test_kv_scanner_transforms_values_if_parse_value_is_set);
 }
 
 int main(int argc, char *argv[])

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -25,14 +25,14 @@
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      kv_scanner_init(&kv_scanner);                             \
+      kv_scanner = kv_scanner_new();                            \
     }                                                           \
   while (0)
 
 #define kv_scanner_testcase_end()                           \
   do                                                            \
     {                                                           \
-      kv_scanner_destroy(&kv_scanner);                          \
+      kv_scanner_free(kv_scanner);                              \
       testcase_end();                                           \
     }                                                           \
   while (0)
@@ -44,24 +44,24 @@
       kv_scanner_testcase_end();                                \
   } while(0)
 
-KVScannerState kv_scanner;
+KVScanner *kv_scanner;
 
 static void
 assert_no_more_tokens(void)
 {
-  assert_false(kv_scanner_scan_next(&kv_scanner), "kv_scanner is expected to return no more key-value pairs");
+  assert_false(kv_scanner_scan_next(kv_scanner), "kv_scanner is expected to return no more key-value pairs");
 }
 
 static void
 scan_next_token(void)
 {
-  assert_true(kv_scanner_scan_next(&kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
+  assert_true(kv_scanner_scan_next(kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
 }
 
 static void
 assert_current_key_is(const gchar *expected_key)
 {
-  const gchar *key = kv_scanner_get_current_key(&kv_scanner);
+  const gchar *key = kv_scanner_get_current_key(kv_scanner);
 
   assert_string(key, expected_key, "current key mismatch");
 }
@@ -69,7 +69,7 @@ assert_current_key_is(const gchar *expected_key)
 static void
 assert_current_value_is(const gchar *expected_value)
 {
-  const gchar *value = kv_scanner_get_current_value(&kv_scanner);
+  const gchar *value = kv_scanner_get_current_value(kv_scanner);
 
   assert_string(value, expected_value, "current value mismatch");
 }
@@ -91,32 +91,32 @@ assert_next_kv_is(const gchar *expected_key, const gchar *expected_value)
 static void
 test_kv_scanner_incomplete_string_returns_no_pairs(void)
 {
-  kv_scanner_input(&kv_scanner, "");
+  kv_scanner_input(kv_scanner, "");
   assert_no_more_tokens();
-  kv_scanner_input(&kv_scanner, "f");
+  kv_scanner_input(kv_scanner, "f");
   assert_no_more_tokens();
-  kv_scanner_input(&kv_scanner, "fo");
+  kv_scanner_input(kv_scanner, "fo");
   assert_no_more_tokens();
-  kv_scanner_input(&kv_scanner, "foo");
+  kv_scanner_input(kv_scanner, "foo");
   assert_no_more_tokens();
 }
 
 static void
 test_kv_scanner_name_equals_value_returns_a_pair(void)
 {
-  kv_scanner_input(&kv_scanner, "foo=");
+  kv_scanner_input(kv_scanner, "foo=");
   assert_next_kv_is("foo", "");
   assert_no_more_tokens();
 
-  kv_scanner_input(&kv_scanner, "foo=b");
+  kv_scanner_input(kv_scanner, "foo=b");
   assert_next_kv_is("foo", "b");
   assert_no_more_tokens();
 
-  kv_scanner_input(&kv_scanner, "foo=bar");
+  kv_scanner_input(kv_scanner, "foo=bar");
   assert_next_kv_is("foo", "bar");
   assert_no_more_tokens();
 
-  kv_scanner_input(&kv_scanner, "foo=barbar ");
+  kv_scanner_input(kv_scanner, "foo=barbar ");
   assert_next_kv_is("foo", "barbar");
   assert_no_more_tokens();
 }
@@ -124,11 +124,11 @@ test_kv_scanner_name_equals_value_returns_a_pair(void)
 static void
 test_kv_scanner_stray_words_are_ignored(void)
 {
-  kv_scanner_input(&kv_scanner, "lorem ipsum foo=bar");
+  kv_scanner_input(kv_scanner, "lorem ipsum foo=bar");
   assert_next_kv_is("foo", "bar");
   assert_no_more_tokens();
 
-  kv_scanner_input(&kv_scanner, "foo=bar lorem ipsum key=value some more values");
+  kv_scanner_input(kv_scanner, "foo=bar lorem ipsum key=value some more values");
   assert_next_kv_is("foo", "bar");
   assert_next_kv_is("key", "value");
   assert_no_more_tokens();
@@ -137,7 +137,7 @@ test_kv_scanner_stray_words_are_ignored(void)
 static void
 test_kv_scanner_with_multiple_key_values_return_multiple_pairs(void)
 {
-  kv_scanner_input(&kv_scanner, "key1=value1 key2=value2 key3=value3 ");
+  kv_scanner_input(kv_scanner, "key1=value1 key2=value2 key3=value3 ");
   assert_next_kv_is("key1", "value1");
   assert_next_kv_is("key2", "value2");
   assert_next_kv_is("key3", "value3");
@@ -147,7 +147,7 @@ test_kv_scanner_with_multiple_key_values_return_multiple_pairs(void)
 static void
 test_kv_scanner_spaces_between_values_are_ignored(void)
 {
-  kv_scanner_input(&kv_scanner, "key1=value1    key2=value2     key3=value3 ");
+  kv_scanner_input(kv_scanner, "key1=value1    key2=value2     key3=value3 ");
   assert_next_kv_is("key1", "value1");
   assert_next_kv_is("key2", "value2");
   assert_next_kv_is("key3", "value3");
@@ -157,7 +157,7 @@ test_kv_scanner_spaces_between_values_are_ignored(void)
 static void
 test_kv_scanner_with_comma_separated_values(void)
 {
-  kv_scanner_input(&kv_scanner, "key1=value1, key2=value2, key3=value3");
+  kv_scanner_input(kv_scanner, "key1=value1, key2=value2, key3=value3");
   assert_next_kv_is("key1", "value1");
   assert_next_kv_is("key2", "value2");
   assert_next_kv_is("key3", "value3");
@@ -167,47 +167,47 @@ test_kv_scanner_with_comma_separated_values(void)
 static void
 test_kv_scanner_quoted_values_are_unquoted_like_c_strings(void)
 {
-  kv_scanner_input(&kv_scanner, "foo=\"bar\"");
+  kv_scanner_input(kv_scanner, "foo=\"bar\"");
   assert_next_kv_is("foo", "bar");
   assert_no_more_tokens();
 
-  kv_scanner_input(&kv_scanner, "key1=\"value1\", key2=\"value2\"");
+  kv_scanner_input(kv_scanner, "key1=\"value1\", key2=\"value2\"");
   assert_next_kv_is("key1", "value1");
   assert_next_kv_is("key2", "value2");
   assert_no_more_tokens();
 
   /* embedded quote */
-  kv_scanner_input(&kv_scanner, "key1=\"\\\"value1\"");
+  kv_scanner_input(kv_scanner, "key1=\"\\\"value1\"");
   assert_next_kv_is("key1", "\"value1");
   assert_no_more_tokens();
 
   /* control sequences */
-  kv_scanner_input(&kv_scanner, "key1=\"\\b \\f \\n \\r \\t \\\\\"");
+  kv_scanner_input(kv_scanner, "key1=\"\\b \\f \\n \\r \\t \\\\\"");
   assert_next_kv_is("key1", "\b \f \n \r \t \\");
   assert_no_more_tokens();
 
   /* unknown backslash escape is left as is */
-  kv_scanner_input(&kv_scanner, "key1=\"\\p\"");
+  kv_scanner_input(kv_scanner, "key1=\"\\p\"");
   assert_next_kv_is("key1", "\\p");
   assert_no_more_tokens();
 
-  kv_scanner_input(&kv_scanner, "key1='value1', key2='value2'");
+  kv_scanner_input(kv_scanner, "key1='value1', key2='value2'");
   assert_next_kv_is("key1", "value1");
   assert_next_kv_is("key2", "value2");
   assert_no_more_tokens();
 
   /* embedded quote */
-  kv_scanner_input(&kv_scanner, "key1='\\'value1'");
+  kv_scanner_input(kv_scanner, "key1='\\'value1'");
   assert_next_kv_is("key1", "'value1");
   assert_no_more_tokens();
 
   /* control sequences */
-  kv_scanner_input(&kv_scanner, "key1='\\b \\f \\n \\r \\t \\\\'");
+  kv_scanner_input(kv_scanner, "key1='\\b \\f \\n \\r \\t \\\\'");
   assert_next_kv_is("key1", "\b \f \n \r \t \\");
   assert_no_more_tokens();
 
   /* unknown backslash escape is left as is */
-  kv_scanner_input(&kv_scanner, "key1='\\p'");
+  kv_scanner_input(kv_scanner, "key1='\\p'");
   assert_next_kv_is("key1", "\\p");
   assert_no_more_tokens();
 }

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+#include "linux-audit-scanner.h"
+#include "testutils.h"
+
+#define kv_scanner_testcase_begin(func, args)             \
+  do                                                            \
+    {                                                           \
+      testcase_begin("%s(%s)", func, args);                     \
+      kv_scanner = linux_audit_scanner_new();                   \
+    }                                                           \
+  while (0)
+
+#define kv_scanner_testcase_end()                           \
+  do                                                            \
+    {                                                           \
+      kv_scanner_free(kv_scanner);                              \
+      testcase_end();                                           \
+    }                                                           \
+  while (0)
+
+#define KV_SCANNER_TESTCASE(x, ...) \
+  do {                                                          \
+      kv_scanner_testcase_begin(#x, #__VA_ARGS__);  		\
+      x(__VA_ARGS__);                                           \
+      kv_scanner_testcase_end();                                \
+  } while(0)
+
+KVScanner *kv_scanner;
+
+static void
+assert_no_more_tokens(void)
+{
+  assert_false(kv_scanner_scan_next(kv_scanner), "kv_scanner is expected to return no more key-value pairs");
+}
+
+static void
+scan_next_token(void)
+{
+  assert_true(kv_scanner_scan_next(kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
+}
+
+static void
+assert_current_key_is(const gchar *expected_key)
+{
+  const gchar *key = kv_scanner_get_current_key(kv_scanner);
+
+  assert_string(key, expected_key, "current key mismatch");
+}
+
+static void
+assert_current_value_is(const gchar *expected_value)
+{
+  const gchar *value = kv_scanner_get_current_value(kv_scanner);
+
+  assert_string(value, expected_value, "current value mismatch");
+}
+
+static void
+assert_current_kv_is(const gchar *expected_key, const gchar *expected_value)
+{
+  assert_current_key_is(expected_key);
+  assert_current_value_is(expected_value);
+}
+
+static void
+assert_next_kv_is(const gchar *expected_key, const gchar *expected_value)
+{
+  scan_next_token();
+  assert_current_kv_is(expected_key, expected_value);
+}
+
+static void
+test_linux_audit_scanner_audit_style_hex_dump_is_decoded(void)
+{
+  /* not decoded as no characters to be escaped, kernel only escapes stuff below 0x21, above 0x7e and the quote character */
+  kv_scanner_input(kv_scanner, "proctitle=41607E");
+  assert_next_kv_is("proctitle", "41607E");
+  assert_no_more_tokens();
+
+  kv_scanner_input(kv_scanner, "proctitle=412042");
+  assert_next_kv_is("proctitle", "A B");
+  assert_no_more_tokens();
+
+  /* odd number of chars, not decoded */
+  kv_scanner_input(kv_scanner, "proctitle=41204");
+  assert_next_kv_is("proctitle", "41204");
+  assert_no_more_tokens();
+
+  kv_scanner_input(kv_scanner, "proctitle=C3A17276C3AD7A74C5B172C59174C3BC6BC3B67266C3BA72C3B367C3A970");
+  assert_next_kv_is("proctitle", "árvíztűrőtükörfúrógép");
+  assert_no_more_tokens();
+
+  kv_scanner_input(kv_scanner, "proctitle=2F62696E2F7368002D65002F6574632F696E69742E642F706F737466697800737461747573");
+  assert_next_kv_is("proctitle", "/bin/sh\t-e\t/etc/init.d/postfix\tstatus");
+  assert_no_more_tokens();
+}
+
+static void
+test_kv_scanner(void)
+{
+  KV_SCANNER_TESTCASE(test_linux_audit_scanner_audit_style_hex_dump_is_decoded);
+}
+
+int main(int argc, char *argv[])
+{
+  test_kv_scanner();
+}


### PR DESCRIPTION
This adds support for the format used by the Linux Audit subsystem. It properly decodes fields
that are hexdumps (e.g. proctitle and values that might contain spaces or binary garbage)
