### PR TITLE
periodical-mark-mode: cancel the mark_timer instead of unregister it

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1253,7 +1253,7 @@ log_writer_deinit(LogPipe *s)
   iv_event_unregister(&self->queue_filled);
 
   ml_batched_timer_unregister(&self->suppress_timer);
-  ml_batched_timer_cancel(&self->mark_timer);
+  ml_batched_timer_unregister(&self->mark_timer);
 
   log_queue_set_counters(self->queue, NULL, NULL);
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1253,7 +1253,7 @@ log_writer_deinit(LogPipe *s)
   iv_event_unregister(&self->queue_filled);
 
   ml_batched_timer_unregister(&self->suppress_timer);
-  ml_batched_timer_unregister(&self->mark_timer);
+  ml_batched_timer_cancel(&self->mark_timer);
 
   log_queue_set_counters(self->queue, NULL, NULL);
 

--- a/lib/ml-batched-timer.c
+++ b/lib/ml-batched-timer.c
@@ -141,8 +141,12 @@ ml_batched_timer_cancel(MlBatchedTimer *self)
 void
 ml_batched_timer_unregister(MlBatchedTimer *self)
 {
+  main_loop_assert_main_thread();
+
   if (iv_timer_registered(&self->timer))
     iv_timer_unregister(&self->timer);
+  self->expires.tv_sec = 0;
+  self->expires.tv_nsec = 0;
 }
 
 /* one-time initialization of the MlBatchedTimer structure */


### PR DESCRIPTION
The problem is that if the reload is fast enough (done in 1sec),
then the mark_timer will be unregistered without resetting the expire time in the log_writer_deinit.

In the log_writer_init the mark_timer will be updated, but it won't be updated,
because the new expire time will be the same as the current expire time
and because of the "race condition shield" in the ml_batched_timer_update the timer won't be registered.

In case of deinit we should cancel the mark_timer instead of unregister,
because the cancel reset the expire date to 0.

fixes #701

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>