### PR TITLE
SNMP trap parser, as a format plugin

### DIFF
--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -28,6 +28,7 @@ include modules/python/Makefile.am
 include modules/java/Makefile.am
 include modules/java-modules/Makefile.am
 include modules/kvformat/Makefile.am
+include modules/snmp-format/Makefile.am
 
 SYSLOG_NG_MODULES	=	\
 	mod-afsocket mod-afstreams mod-affile mod-afprog \
@@ -36,7 +37,8 @@ SYSLOG_NG_MODULES	=	\
 	mod-confgen mod-system-source mod-csvparser mod-dbparser \
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
-	mod-python mod-java mod-java-modules mod-kvformat
+	mod-python mod-java mod-java-modules mod-kvformat \
+	mod-snmp-format
 
 modules modules/: ${SYSLOG_NG_MODULES}
 
@@ -49,6 +51,6 @@ modules_test_subdirs	=	\
 	modules_csvparser modules_dbparser modules_basicfuncs \
 	modules_cryptofuncs modules_geoip modules_afstomp \
 	modules_graphite modules_riemann modules_python \
-	modules_systemd_journal modules_kvformat
+	modules_systemd_journal modules_kvformat modules_snmp_format
 
 .PHONY: modules modules/

--- a/modules/snmp-format/Makefile.am
+++ b/modules/snmp-format/Makefile.am
@@ -1,0 +1,25 @@
+module_LTLIBRARIES				+= \
+	modules/snmp-format/libsnmp-format.la
+
+modules_snmp_format_libsnmp_format_la_SOURCES	=	\
+	modules/snmp-format/snmp-format.c		\
+	modules/snmp-format/snmp-format.h		\
+	modules/snmp-format/snmp-format-plugin.c
+
+modules_snmp_format_libsnmp_format_la_CPPFLAGS	=	\
+	$(AM_CPPFLAGS)					\
+	-I$(top_srcdir)/modules/snmp-format		\
+	-I$(top_builddir)/modules/snmp-format
+modules_snmp_format_libsnmp_format_la_LIBADD	= 	\
+	$(MODULE_DEPS_LIBS)
+
+modules_snmp_format_libsnmp_format_la_LDFLAGS	=	\
+	$(MODULE_LDFLAGS)
+modules_snmp_format_libsnmp_format_la_DEPENDENCIES =	\
+	$(MODULE_DEPS_LIBS)
+
+modules/snmp-format modules/snmp-format/ mod-snmp: modules/snmp-format/libsnmp-format.la
+
+.PHONY: modules/snmp-format/ mod-snmp-format
+
+include modules/snmp-format/tests/Makefile.am

--- a/modules/snmp-format/snmp-format-plugin.c
+++ b/modules/snmp-format/snmp-format-plugin.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+#include "snmp-format.h"
+#include "messages.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+static MsgFormatHandler snmp_handler =
+{
+  .parse = &snmp_format_handler
+};
+
+static MsgFormatHandler *
+snmp_format_construct(Plugin *self, GlobalConfig *cfg,gint plugin_type,
+                      const gchar *plugin_name)
+{
+  return &snmp_handler;
+}
+
+static Plugin snmp_format_plugin =
+{
+  .type = LL_CONTEXT_FORMAT,
+  .name = "snmp",
+  .construct = (gpointer (*)(Plugin *self, GlobalConfig *cfg, gint plugin_type,
+                             const gchar *plugin_name)) snmp_format_construct,
+};
+
+gboolean
+snmp_format_module_init(GlobalConfig *cfg, CfgArgs *args)
+{
+  plugin_register(cfg, &snmp_format_plugin, 1);
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "snmp-format",
+  .version = VERSION,
+  .description = "The snmp-format module provides SNMP trap parsing support for syslog-ng.",
+  .core_revision = SOURCE_REVISION,
+  .plugins = &snmp_format_plugin,
+  .plugins_len = 1,
+};

--- a/modules/snmp-format/snmp-format.c
+++ b/modules/snmp-format/snmp-format.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2015 Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "snmp-format.h"
+#include "logmsg.h"
+#include "messages.h"
+#include "misc.h"
+#include "cfg.h"
+#include "str-format.h"
+#include "scratch-buffers.h"
+
+#include <string.h>
+#include <ctype.h>
+
+static gboolean
+log_msg_parse_snmp(LogMessage *msg, const gchar *input, gsize input_len)
+{
+  SBGString *key, *value;
+  gboolean parsed = TRUE;
+  gsize pos = 0;
+
+  key = sb_gstring_acquire();
+  value = sb_gstring_acquire();
+
+  while (pos < input_len)
+    {
+      char *assign_pos, *value_pos, *value_end;
+      gsize key_len;
+
+      while ((input[pos] == ' ') && (pos < input_len))
+        pos++;
+
+      assign_pos = strchr(input + pos, '=');
+      if (assign_pos == NULL)
+        {
+          parsed = FALSE;
+          break;
+        }
+
+      key_len = assign_pos - input - pos;
+      if (input[pos + key_len - 1] == ' ')
+        key_len--;
+
+      g_string_assign(sb_gstring_string(key), ".snmp.");
+      g_string_append_len(sb_gstring_string(key), input + pos,
+                          key_len);
+
+      value_pos = strchr(assign_pos, ':');
+      if (value_pos == NULL)
+        {
+          parsed = FALSE;
+          break;
+        }
+      value_pos++;
+
+      if (value_pos[0] == ' ')
+        value_pos++;
+
+      if (value_pos[0] == '"')
+        {
+          value_pos++;
+          value_end = strchr(value_pos, '"');
+          pos = value_end - input + 1;
+        }
+      else
+        {
+          value_end = strchr(value_pos, ' ');
+          if (!value_end)
+            value_end = strchr(value_pos, '\0');
+          if (!value_end)
+            {
+              parsed = FALSE;
+              break;
+            }
+          pos = value_end - input;
+        }
+
+      g_string_assign(sb_gstring_string(value),
+                      value_pos);
+      g_string_truncate(sb_gstring_string(value),
+                        value_end - value_pos);
+
+      log_msg_set_value_by_name(msg,
+                                sb_gstring_string(key)->str,
+                                sb_gstring_string(value)->str,
+                                sb_gstring_string(value)->len);
+    }
+
+  sb_gstring_release(key);
+  sb_gstring_release(value);
+
+  return parsed;
+}
+
+void
+snmp_format_handler(const MsgFormatOptions *parse_options,
+                    const guchar *data, gsize length,
+                    LogMessage *self)
+{
+  gboolean success;
+
+  if (parse_options->flags & LP_NOPARSE)
+    {
+      log_msg_set_value(self, LM_V_MESSAGE, (gchar *) data, length);
+      self->pri = parse_options->default_pri;
+      return;
+    }
+
+  self->flags |= LF_UTF8;
+
+  if (parse_options->flags & LP_LOCAL)
+    self->flags |= LF_LOCAL;
+
+  self->initial_parse = TRUE;
+
+  success = log_msg_parse_snmp(self, (gchar *)data, length);
+
+  self->initial_parse = FALSE;
+
+  if (G_UNLIKELY(!success))
+    {
+      msg_format_inject_parse_error(self, data, length);
+      return;
+    }
+}

--- a/modules/snmp-format/snmp-format.h
+++ b/modules/snmp-format/snmp-format.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#ifndef SNMPFORMAT_H_INCLUDED
+#define SNMPFORMAT_H_INCLUDED
+
+#include "msg-format.h"
+
+void snmp_format_handler(const MsgFormatOptions *parse_options,
+                         const guchar *data, gsize length,
+                         LogMessage *self);
+
+#endif

--- a/modules/snmp-format/tests/Makefile.am
+++ b/modules/snmp-format/tests/Makefile.am
@@ -1,0 +1,13 @@
+modules_snmp_format_tests_TESTS		= \
+	modules/snmp-format/tests/test_snmp_format
+
+check_PROGRAMS				+= ${modules_snmp_format_tests_TESTS}
+
+modules_snmp_format_tests_test_snmp_format_CFLAGS	= \
+	$(TEST_CFLAGS) -I$(top_srcdir)/modules/snmp-format
+modules_snmp_format_tests_test_snmp_format_LDADD	= $(TEST_LDADD)
+modules_snmp_format_tests_test_snmp_format_LDFLAGS	= \
+	$(PREOPEN_SYSLOGFORMAT)		  \
+	-dlpreopen $(top_builddir)/modules/snmp-format/libsnmp-format.la
+modules_snmp_format_tests_test_snmp_format_DEPENDENCIES = \
+	$(top_builddir)/modules/snmp-format/libsnmp-format.la

--- a/modules/snmp-format/tests/test_snmp_format.c
+++ b/modules/snmp-format/tests/test_snmp_format.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2015 Gergely Nagy
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+#include "syslog-ng.h"
+
+#include "testutils.h"
+#include "msg_parse_lib.h"
+#include "apphook.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+static LogMessage *
+snmp_parse_message(const gchar *raw_message_str)
+{
+  LogMessage *message;
+  GSockAddr *addr = g_sockaddr_inet_new("10.10.10.10", 1010);
+
+  message = log_msg_new(raw_message_str, strlen(raw_message_str), addr, &parse_options);
+
+  g_sockaddr_unref(addr);
+  return message;
+}
+
+static void
+assert_log_snmp_value(LogMessage *message, const gchar *key,
+                      const gchar *expected_value)
+{
+  const gchar *actual_value = log_msg_get_value(message,
+                                                log_msg_get_value_handle(key),
+                                                NULL);
+  assert_string(actual_value, expected_value, NULL);
+}
+
+void
+test_snmp_format_parses_well_formed_traps_and_puts_result_in_message(void)
+{
+  LogMessage *parsed_message;
+  gchar msg[] = "foo = STRING: \"blah\"";
+
+  testcase_begin("Testing well formed SNMP trap parsing; msg='%s'", msg);
+
+  parsed_message = snmp_parse_message(msg);
+
+  assert_log_snmp_value(parsed_message, ".snmp.foo", "blah");
+
+  log_msg_unref(parsed_message);
+
+  testcase_end();
+}
+
+static void
+test_snmp_format_parses_well_formed_traps_regardless_of_whitespace(void)
+{
+  LogMessage *parsed_message;
+  gchar msg[] = "foo= STRING: \"blah\"    bar =STRING: \"baz\" baz=STRING:\"hello\"";
+
+  testcase_begin("Testing well formed SNMP trap parsing, regardless of whitespace; msg='%s'", msg);
+
+  parsed_message = snmp_parse_message(msg);
+
+  assert_log_snmp_value(parsed_message, ".snmp.foo", "blah");
+  assert_log_snmp_value(parsed_message, ".snmp.bar", "baz");
+  assert_log_snmp_value(parsed_message, ".snmp.baz", "hello");
+
+  log_msg_unref(parsed_message);
+  testcase_end();
+}
+
+static void
+test_snmp_format_fails_for_invalid_trap_message(void)
+{
+  LogMessage *msg;
+
+  testcase_begin("Testing that invalid SNMP traps produce a parse error");
+
+  msg = snmp_parse_message("not-valid-trap-message");
+  assert_log_snmp_value(msg, "MESSAGE", "Error processing log message: not-valid-trap-message");
+  log_msg_unref(msg);
+
+  msg = snmp_parse_message("not-valid-trap-message = value");
+  assert_log_snmp_value(msg, "MESSAGE", "Error processing log message: not-valid-trap-message = value");
+  log_msg_unref(msg);
+
+  msg = snmp_parse_message("not-valid-trap-message = type value");
+  assert_log_snmp_value(msg, "MESSAGE", "Error processing log message: not-valid-trap-message = type value");
+  log_msg_unref(msg);
+
+  testcase_end();
+}
+
+static void
+test_snmp_format_validate_type_representation(void)
+{
+  LogMessage *parsed_message;
+  gchar msg[] = "string = STRING: \"blah\" int = INT32: 42";
+
+  testcase_begin("Testing SNMP trap type parsing; msg='%s'", msg);
+
+  parsed_message = snmp_parse_message(msg);
+
+  assert_log_snmp_value(parsed_message, ".snmp.int", "42");
+  assert_log_snmp_value(parsed_message, ".snmp.string", "blah");
+
+  log_msg_unref(parsed_message);
+  testcase_end();
+}
+
+static void
+init_and_load_snmp_module()
+{
+  configuration = cfg_new(VERSION_VALUE);
+  plugin_load_module("snmp-format", configuration, NULL);
+  parse_options.format = "snmp";
+
+  msg_format_options_defaults(&parse_options);
+  msg_format_options_init(&parse_options, configuration);
+}
+
+static void
+deinit_snmp_module()
+{
+  if (configuration)
+    cfg_free(configuration);
+
+  configuration = NULL;
+  parse_options.format = NULL;
+  parse_options.format_handler = NULL;
+}
+
+int
+main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+{
+  app_startup();
+  putenv("TZ=UTC");
+  tzset();
+
+  init_and_load_snmp_module();
+
+  test_snmp_format_parses_well_formed_traps_and_puts_result_in_message();
+  test_snmp_format_parses_well_formed_traps_regardless_of_whitespace();
+  test_snmp_format_validate_type_representation();
+  test_snmp_format_fails_for_invalid_trap_message();
+
+  deinit_snmp_module();
+  app_shutdown();
+  return 0;
+}


### PR DESCRIPTION
A new module to parse SNMP trap messages. It does not validate the types, and does not handle escaped quotation marks either, yet. Use it like this:

```
  source { file("/var/log/snmpd.log" format("snmp")); };
```

Fixes #518.

Requested-by: Fabien Wernli
Signed-off-by: Gergely Nagy <algernon@madhouse-project.org>