### PR TITLE
Keep the program destination open between configuration reloads

### DIFF
--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -53,6 +53,7 @@
 /* INCLUDE_DECLS */
 
 %token KW_PROGRAM
+%token KW_KEEP_ALIVE
 
 %type   <ptr> source_afprogram
 %type   <ptr> source_afprogram_params
@@ -112,6 +113,7 @@ dest_afprogram_options
 dest_afprogram_option
 	: dest_writer_option
 	| dest_driver_option
+	| KW_KEEP_ALIVE '(' yesno ')' { afprogram_dd_set_keep_alive((AFProgramDestDriver *)last_driver, $3); }
 	;
 
 /* INCLUDE_RULES */

--- a/modules/afprog/afprog-parser.c
+++ b/modules/afprog/afprog-parser.c
@@ -31,6 +31,7 @@ int afprog_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 
 static CfgLexerKeyword afprog_keywords[] = {
   { "program",            KW_PROGRAM },
+  { "keep_alive",         KW_KEEP_ALIVE },
   { NULL }
 };
 

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -374,9 +374,7 @@ afprogram_dd_deinit(LogPipe *s)
       self->writer = NULL;
     }
 
-  if (!log_dest_driver_deinit_method(s))
-    return FALSE;
-  return TRUE;
+  return log_dest_driver_deinit_method(s);
 }
 
 static void

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -316,7 +316,6 @@ afprogram_dd_kill_child(AFProgramDestDriver *self)
   if (self->pid != -1)
     {
       pid_t pgid;
-      child_manager_unregister(self->pid);
       msg_verbose("Sending destination program a TERM signal",
                   evt_tag_str("cmdline", self->cmdline->str),
                   evt_tag_int("child_pid", self->pid),
@@ -436,6 +435,8 @@ afprogram_dd_deinit(LogPipe *s)
 
   if (self->writer)
     log_pipe_deinit((LogPipe *) self->writer);
+
+  child_manager_unregister(self->pid);
 
   if (self->keep_alive)
     {

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -300,12 +300,23 @@ afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg)
 static void afprogram_dd_exit(pid_t pid, int status, gpointer s);
 
 static gchar *
-afprogram_dd_format_persist_name(AFProgramDestDriver *self)
+afprogram_dd_format_queue_persist_name(AFProgramDestDriver *self)
 {
   static gchar persist_name[256];
 
   g_snprintf(persist_name, sizeof(persist_name),
              "afprogram_dd_qname(%s,%s)", self->cmdline->str, self->super.super.id);
+
+  return persist_name;
+}
+
+static gchar *
+afprogram_dd_format_persist_name(AFProgramDestDriver *self)
+{
+  static gchar persist_name[256];
+
+  g_snprintf(persist_name, sizeof(persist_name),
+             "afprogram_dd_name(%s,%s)", self->cmdline->str, self->super.super.id);
 
   return persist_name;
 }
@@ -418,7 +429,7 @@ afprogram_dd_init(LogPipe *s)
                          SCS_PROGRAM,
                          self->super.super.id,
                          self->cmdline->str);
-  log_writer_set_queue(self->writer, log_dest_driver_acquire_queue(&self->super, afprogram_dd_format_persist_name(self)));
+  log_writer_set_queue(self->writer, log_dest_driver_acquire_queue(&self->super, afprogram_dd_format_queue_persist_name(self)));
 
   if (!log_pipe_init((LogPipe *) self->writer))
     {

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -366,10 +366,12 @@ afprogram_dd_deinit(LogPipe *s)
 {
   AFProgramDestDriver *self = (AFProgramDestDriver *) s;
 
+  if (self->writer)
+    log_pipe_deinit((LogPipe *) self->writer);
+
   afprogram_dd_kill_child(self);
   if (self->writer)
     {
-      log_pipe_deinit((LogPipe *) self->writer);
       log_pipe_unref((LogPipe *) self->writer);
       self->writer = NULL;
     }

--- a/modules/afprog/afprog.h
+++ b/modules/afprog/afprog.h
@@ -43,10 +43,16 @@ typedef struct _AFProgramDestDriver
   GString *cmdline;
   LogWriter *writer;
   pid_t pid;
+  gboolean keep_alive;
   LogWriterOptions writer_options;
 } AFProgramDestDriver;
 
 LogDriver *afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg);
 LogDriver *afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg);
+
+inline void
+afprogram_dd_set_keep_alive(AFProgramDestDriver *self, gboolean keep_alive) {
+  self->keep_alive = keep_alive;
+}
 
 #endif


### PR DESCRIPTION
This pull request adds the possibility of letting the program destination unclosed and reused between configuration reloads.

New option: `keep_alive(x)`, where `x` is either `yes` or `no`.
The default behaviour has not been changed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/balabit/syslog-ng/722)
<!-- Reviewable:end -->
