### PR TITLE
F/dbparser code refinements

### DIFF
--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -45,6 +45,8 @@ modules_dbparser_libsyslog_ng_patterndb_la_DEPENDENCIES	=	\
 
 module_LTLIBRARIES					+= modules/dbparser/libdbparser.la
 modules_dbparser_libdbparser_la_SOURCES			=	\
+	modules/dbparser/stateful-parser.c			\
+	modules/dbparser/stateful-parser.h			\
 	modules/dbparser/dbparser.c				\
 	modules/dbparser/dbparser.h				\
 	modules/dbparser/dbparser-grammar.y			\

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -54,7 +54,7 @@ extern LogParser *last_parser;
 %token KW_DB_PARSER
 %token KW_INJECT_MODE
 
-%type <cptr> stateful_parser_inject_mode
+%type <num> stateful_parser_inject_mode
 
 %%
 
@@ -83,13 +83,18 @@ parser_db_opt
         ;
 
 stateful_parser_opt
-	: KW_INJECT_MODE '(' stateful_parser_inject_mode ')'	{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); free($3); }
+	: KW_INJECT_MODE '(' stateful_parser_inject_mode ')'	{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); }
 	| parser_opt
 	;
 
 stateful_parser_inject_mode
-	: string				{ $$ = $1; }
-	| KW_INTERNAL				{ $$ = strdup("internal"); }
+	: string
+	  {
+            $$ = stateful_parser_lookup_inject_mode($1);
+            CHECK_ERROR($$ != -1, @1, "Unknown inject-mode %s", $1);
+            free($1);
+          }
+	| KW_INTERNAL				{ $$ = stateful_parser_lookup_inject_mode("internal"); }
 	;
 
 /* INCLUDE_RULES */

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -79,7 +79,7 @@ parser_db_opts
 /* NOTE: we don't support parser_opt as we don't want the user to specify a template */
 parser_db_opt
         : KW_FILE '(' string ')'                		{ log_db_parser_set_db_file(((LogDBParser *) last_parser), $3); free($3); }
-	| KW_INJECT_MODE '(' parser_db_inject_mode ')'		{ log_db_parser_set_inject_mode(((LogDBParser *) last_parser), $3); free($3); }
+	| KW_INJECT_MODE '(' parser_db_inject_mode ')'		{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); free($3); }
 	| parser_opt
         ;
 

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -54,7 +54,7 @@ extern LogParser *last_parser;
 %token KW_DB_PARSER
 %token KW_INJECT_MODE
 
-%type <cptr> parser_db_inject_mode
+%type <cptr> stateful_parser_inject_mode
 
 %%
 
@@ -79,11 +79,15 @@ parser_db_opts
 /* NOTE: we don't support parser_opt as we don't want the user to specify a template */
 parser_db_opt
         : KW_FILE '(' string ')'                		{ log_db_parser_set_db_file(((LogDBParser *) last_parser), $3); free($3); }
-	| KW_INJECT_MODE '(' parser_db_inject_mode ')'		{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); free($3); }
-	| parser_opt
+	| stateful_parser_opt
         ;
 
-parser_db_inject_mode
+stateful_parser_opt
+	: KW_INJECT_MODE '(' stateful_parser_inject_mode ')'	{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); free($3); }
+	| parser_opt
+	;
+
+stateful_parser_inject_mode
 	: string				{ $$ = $1; }
 	| KW_INTERNAL				{ $$ = strdup("internal"); }
 	;
@@ -91,3 +95,4 @@ parser_db_inject_mode
 /* INCLUDE_RULES */
 
 %%
+

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -26,16 +26,12 @@
 #include "radix.h"
 #include "apphook.h"
 #include "reloc.h"
+#include "stateful-parser.h"
 
 #include <sys/stat.h>
 #include <iv.h>
 #include <string.h>
 
-typedef enum
-{
-  LDBP_IM_PASSTHROUGH = 0,
-  LDBP_IM_INTERNAL = 1,
-} LogDBParserInjectMode;
 
 struct _LogDBParser
 {
@@ -241,15 +237,8 @@ log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file)
 void
 log_db_parser_set_inject_mode(LogDBParser *self, const gchar *inject_mode)
 {
-  if (strcmp(inject_mode, "internal") == 0)
-    {
-      self->inject_mode = LDBP_IM_INTERNAL;
-    }
-  else if (strcmp(inject_mode, "pass-through") == 0 || strcmp(inject_mode, "pass_through") == 0)
-    {
-      self->inject_mode = LDBP_IM_PASSTHROUGH;
-    }
-  else
+  self->inject_mode = stateful_parser_lookup_inject_mode(inject_mode);
+  if (self->inject_mode < 0)
     {
       msg_warning("Unknown inject-mode specified for db-parser",
                   evt_tag_str("inject-mode", inject_mode),

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -35,7 +35,7 @@
 
 struct _LogDBParser
 {
-  LogParser super;
+  StatefulParser super;
   GStaticMutex lock;
   struct iv_timer tick;
   PatternDB *db;
@@ -44,7 +44,6 @@ struct _LogDBParser
   ino_t db_file_inode;
   time_t db_file_mtime;
   gboolean db_file_reloading;
-  LogDBParserInjectMode inject_mode;
 };
 
 static void
@@ -54,17 +53,7 @@ log_db_parser_emit(LogMessage *msg, gboolean synthetic, gpointer user_data)
 
   if (synthetic)
     {
-      if (self->inject_mode == LDBP_IM_PASSTHROUGH)
-        {
-          LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-
-          path_options.ack_needed = FALSE;
-          log_pipe_forward_msg(&self->super.super, log_msg_ref(msg), &path_options);
-        }
-      else
-        {
-          msg_post_message(log_msg_ref(msg));
-        }
+      stateful_parser_emit_synthetic(&self->super, msg);
       msg_debug("db-parser: emitting synthetic message",
                 evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)),
                 NULL);
@@ -75,7 +64,7 @@ static void
 log_db_parser_reload_database(LogDBParser *self)
 {
   struct stat st;
-  GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
+  GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super);
 
   if (stat(self->db_file, &st) < 0)
     {
@@ -218,7 +207,7 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
     {
       log_msg_make_writable(pmsg, path_options);
 
-      if (G_UNLIKELY(self->super.template))
+      if (G_UNLIKELY(self->super.super.template))
         pattern_db_process_with_custom_message(self->db, *pmsg, input, input_len);
       else
         pattern_db_process(self->db, *pmsg);
@@ -234,18 +223,6 @@ log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file)
   self->db_file = g_strdup(db_file);
 }
 
-void
-log_db_parser_set_inject_mode(LogDBParser *self, const gchar *inject_mode)
-{
-  self->inject_mode = stateful_parser_lookup_inject_mode(inject_mode);
-  if (self->inject_mode < 0)
-    {
-      msg_warning("Unknown inject-mode specified for db-parser",
-                  evt_tag_str("inject-mode", inject_mode),
-                  NULL);
-    }
-}
-
 /*
  * NOTE: we could be smarter than this by sharing the radix tree in this case.
  */
@@ -257,7 +234,7 @@ log_db_parser_clone(LogPipe *s)
 
   clone = (LogDBParser *) log_db_parser_new(s->cfg);
   log_db_parser_set_db_file(clone, self->db_file);
-  return &clone->super.super;
+  return &clone->super.super.super;
 }
 
 static void
@@ -272,7 +249,7 @@ log_db_parser_free(LogPipe *s)
 
   if (self->db_file)
     g_free(self->db_file);
-  log_parser_free_method(s);
+  stateful_parser_free_method(s);
 }
 
 LogParser *
@@ -280,21 +257,19 @@ log_db_parser_new(GlobalConfig *cfg)
 {
   LogDBParser *self = g_new0(LogDBParser, 1);
 
-  log_parser_init_instance(&self->super, cfg);
-  self->super.super.free_fn = log_db_parser_free;
-  self->super.super.init = log_db_parser_init;
-  self->super.super.deinit = log_db_parser_deinit;
-  self->super.super.clone = log_db_parser_clone;
-  self->super.process = log_db_parser_process;
+  stateful_parser_init_instance(&self->super, cfg);
+  self->super.super.super.free_fn = log_db_parser_free;
+  self->super.super.super.init = log_db_parser_init;
+  self->super.super.super.deinit = log_db_parser_deinit;
+  self->super.super.super.clone = log_db_parser_clone;
+  self->super.super.process = log_db_parser_process;
   self->db_file = g_strdup(get_installation_path_for(PATH_PATTERNDB_FILE));
   g_static_mutex_init(&self->lock);
   if (cfg_is_config_version_older(cfg, 0x0303))
     {
       msg_warning_once("WARNING: The default behaviour for injecting messages in db-parser() has changed in " VERSION_3_3 " from internal to pass-through, use an explicit inject-mode(internal) option for old behaviour",
                        NULL);
-      self->inject_mode = LDBP_IM_INTERNAL;
+      self->super.inject_mode = LDBP_IM_INTERNAL;
     }
-  else
-    self->inject_mode = LDBP_IM_PASSTHROUGH;
-  return &self->super;
+  return &self->super.super;
 }

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -24,7 +24,7 @@
 #ifndef DBPARSER_H_INCLUDED
 #define DBPARSER_H_INCLUDED
 
-#include "parser/parser-expr.h"
+#include "stateful-parser.h"
 #include "patterndb.h"
 
 #define PATH_PATTERNDB_FILE     PATH_LOCALSTATEDIR "/patterndb.xml"
@@ -33,7 +33,6 @@
 typedef struct _LogDBParser LogDBParser;
 
 void log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file);
-void log_db_parser_set_inject_mode(LogDBParser *self, const gchar *inject_mode);
 LogParser *log_db_parser_new(GlobalConfig *cfg);
 
 void log_pattern_database_init(void);

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -453,7 +453,7 @@ pdb_lookup_ruleset(PDBRuleSet *self, PDBLookupParams *lookup, GArray *dbg_list)
  */
 
 static void
-pattern_db_expire_entry(guint64 now, gpointer user_data)
+pattern_db_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
 {
   PDBContext *context = user_data;
   PatternDB *pdb = context->db;

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -115,8 +115,6 @@ typedef struct _PDBContext
   PatternDB *db;
   /* back reference to the last rule touching this context */
   PDBRule *rule;
-  /* timeout timer */
-  TWEntry *timer;
 } PDBContext;
 
 static void
@@ -670,13 +668,13 @@ _pattern_db_process(PatternDB *self, PDBLookupParams *lookup, GArray *dbg_list)
 
           g_ptr_array_add(context->super.messages, log_msg_ref(msg));
 
-          if (context->timer)
+          if (context->super.timer)
             {
-              timer_wheel_mod_timer(self->timer_wheel, context->timer, rule->context_timeout);
+              timer_wheel_mod_timer(self->timer_wheel, context->super.timer, rule->context_timeout);
             }
           else
             {
-              context->timer = timer_wheel_add_timer(self->timer_wheel, rule->context_timeout, pattern_db_expire_entry,
+              context->super.timer = timer_wheel_add_timer(self->timer_wheel, rule->context_timeout, pattern_db_expire_entry,
                                                      correllation_context_ref(&context->super),
                                                      (GDestroyNotify) correllation_context_unref);
             }

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -53,7 +53,7 @@ typedef struct _PDBAction
   union
   {
     struct {
-      PDBMessage message;
+      SyntheticMessage message;
       PDBActionMessageInheritMode inherit_mode;
     };
   } content;

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -39,7 +39,7 @@ typedef struct _PDBLoader
   PDBRule *current_rule;
   PDBAction *current_action;
   PDBExample *current_example;
-  PDBMessage *current_message;
+  SyntheticMessage *current_message;
   gboolean first_program;
   gboolean in_pattern;
   gboolean in_ruleset;

--- a/modules/dbparser/pdb-rule.h
+++ b/modules/dbparser/pdb-rule.h
@@ -36,7 +36,7 @@ struct _PDBRule
   GAtomicCounter ref_cnt;
   gchar *class;
   gchar *rule_id;
-  PDBMessage msg;
+  SyntheticMessage msg;
   gint context_timeout;
   PDBCorrellationScope context_scope;
   LogTemplate *context_id_template;

--- a/modules/dbparser/stateful-parser.c
+++ b/modules/dbparser/stateful-parser.c
@@ -3,15 +3,9 @@
 
 
 void
-stateful_parser_set_inject_mode(StatefulParser *self, const gchar *inject_mode)
+stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inject_mode)
 {
-  self->inject_mode = stateful_parser_lookup_inject_mode(inject_mode);
-  if (self->inject_mode < 0)
-    {
-      msg_warning("Unknown inject-mode specified",
-                  evt_tag_str("inject-mode", inject_mode),
-                  NULL);
-    }
+  self->inject_mode = inject_mode;
 }
 
 void

--- a/modules/dbparser/stateful-parser.c
+++ b/modules/dbparser/stateful-parser.c
@@ -1,6 +1,48 @@
 #include "stateful-parser.h"
 #include <string.h>
 
+
+void
+stateful_parser_set_inject_mode(StatefulParser *self, const gchar *inject_mode)
+{
+  self->inject_mode = stateful_parser_lookup_inject_mode(inject_mode);
+  if (self->inject_mode < 0)
+    {
+      msg_warning("Unknown inject-mode specified",
+                  evt_tag_str("inject-mode", inject_mode),
+                  NULL);
+    }
+}
+
+void
+stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg)
+{
+  if (self->inject_mode == LDBP_IM_PASSTHROUGH)
+    {
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+      path_options.ack_needed = FALSE;
+      log_pipe_forward_msg(&self->super.super, log_msg_ref(msg), &path_options);
+    }
+  else
+    {
+      msg_post_message(log_msg_ref(msg));
+    }
+}
+
+void
+stateful_parser_init_instance(StatefulParser *self, GlobalConfig *cfg)
+{
+  log_parser_init_instance(&self->super, cfg);
+  self->inject_mode = LDBP_IM_PASSTHROUGH;
+}
+
+void
+stateful_parser_free_method(LogPipe *s)
+{
+  log_parser_free_method(s);
+}
+
 int
 stateful_parser_lookup_inject_mode(const gchar *inject_mode)
 {

--- a/modules/dbparser/stateful-parser.c
+++ b/modules/dbparser/stateful-parser.c
@@ -1,0 +1,12 @@
+#include "stateful-parser.h"
+#include <string.h>
+
+int
+stateful_parser_lookup_inject_mode(const gchar *inject_mode)
+{
+  if (strcasecmp(inject_mode, "internal") == 0)
+    return LDBP_IM_INTERNAL;
+  else if (strcasecmp(inject_mode, "pass-through") == 0 || strcasecmp(inject_mode, "pass_through") == 0)
+    return LDBP_IM_PASSTHROUGH;
+  return -1;
+}

--- a/modules/dbparser/stateful-parser.h
+++ b/modules/dbparser/stateful-parser.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 1998-2013, 2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STATEFUL_PARSER_H_INCLUDED
+#define STATEFUL_PARSER_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+typedef enum
+{
+  LDBP_IM_PASSTHROUGH = 0,
+  LDBP_IM_INTERNAL = 1,
+} LogDBParserInjectMode;
+
+int stateful_parser_lookup_inject_mode(const gchar *inject_mode);
+
+#endif

--- a/modules/dbparser/stateful-parser.h
+++ b/modules/dbparser/stateful-parser.h
@@ -24,13 +24,24 @@
 #ifndef STATEFUL_PARSER_H_INCLUDED
 #define STATEFUL_PARSER_H_INCLUDED 1
 
-#include "syslog-ng.h"
+#include "parser/parser-expr.h"
 
 typedef enum
 {
   LDBP_IM_PASSTHROUGH = 0,
   LDBP_IM_INTERNAL = 1,
 } LogDBParserInjectMode;
+
+typedef struct _StatefulParser
+{
+  LogParser super;
+  LogDBParserInjectMode inject_mode;
+} StatefulParser;
+
+void stateful_parser_set_inject_mode(StatefulParser *self, const gchar *inject_mode);
+void stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg);
+void stateful_parser_init_instance(StatefulParser *self, GlobalConfig *cfg);
+void stateful_parser_free_method(LogPipe *s);
 
 int stateful_parser_lookup_inject_mode(const gchar *inject_mode);
 

--- a/modules/dbparser/stateful-parser.h
+++ b/modules/dbparser/stateful-parser.h
@@ -38,7 +38,7 @@ typedef struct _StatefulParser
   LogDBParserInjectMode inject_mode;
 } StatefulParser;
 
-void stateful_parser_set_inject_mode(StatefulParser *self, const gchar *inject_mode);
+void stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inject_mode);
 void stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg);
 void stateful_parser_init_instance(StatefulParser *self, GlobalConfig *cfg);
 void stateful_parser_free_method(LogPipe *s);

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -190,6 +190,12 @@ synthetic_message_generate_without_context(SyntheticMessage *self, gint inherit_
 }
 
 void
+synthetic_message_init(SyntheticMessage *self)
+{
+  memset(self, 0, sizeof(*self));
+}
+
+void
 synthetic_message_deinit(SyntheticMessage *self)
 {
   gint i;
@@ -204,6 +210,14 @@ synthetic_message_deinit(SyntheticMessage *self)
 
       g_ptr_array_free(self->values, TRUE);
     }
+}
+
+SyntheticMessage *
+synthetic_message_new(void)
+{
+  SyntheticMessage *self = g_new0(SyntheticMessage, 1);
+
+  return self;
 }
 
 void

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -28,7 +28,7 @@
 #include "logpipe.h"
 
 void
-synthetic_message_add_tag(PDBMessage *self, const gchar *text)
+synthetic_message_add_tag(SyntheticMessage *self, const gchar *text)
 {
   LogTagId tag;
 
@@ -39,7 +39,7 @@ synthetic_message_add_tag(PDBMessage *self, const gchar *text)
 }
 
 gboolean
-synthetic_message_add_value_template(PDBMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error)
+synthetic_message_add_value_template(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error)
 {
   LogTemplate *value_template;
 
@@ -58,7 +58,7 @@ synthetic_message_add_value_template(PDBMessage *self, GlobalConfig *cfg, const 
 }
 
 void
-synthetic_message_apply(PDBMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer)
+synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer)
 {
   gint i;
 
@@ -141,7 +141,7 @@ _generate_default_message_from_context(gint inherit_mode, CorrellationContext *c
 }
 
 LogMessage *
-synthetic_message_generate_with_context(PDBMessage *self, gint inherit_mode, CorrellationContext *context, GString *buffer)
+synthetic_message_generate_with_context(SyntheticMessage *self, gint inherit_mode, CorrellationContext *context, GString *buffer)
 {
   LogMessage *genmsg;
 
@@ -167,7 +167,7 @@ synthetic_message_generate_with_context(PDBMessage *self, gint inherit_mode, Cor
 }
 
 LogMessage *
-synthetic_message_generate_without_context(PDBMessage *self, gint inherit_mode, LogMessage *msg, GString *buffer)
+synthetic_message_generate_without_context(SyntheticMessage *self, gint inherit_mode, LogMessage *msg, GString *buffer)
 {
   LogMessage *genmsg;
 
@@ -190,7 +190,7 @@ synthetic_message_generate_without_context(PDBMessage *self, gint inherit_mode, 
 }
 
 void
-synthetic_message_deinit(PDBMessage *self)
+synthetic_message_deinit(SyntheticMessage *self)
 {
   gint i;
 
@@ -207,7 +207,7 @@ synthetic_message_deinit(PDBMessage *self)
 }
 
 void
-synthetic_message_free(PDBMessage *self)
+synthetic_message_free(SyntheticMessage *self)
 {
   synthetic_message_deinit(self);
   g_free(self);

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -46,7 +46,9 @@ LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, gint
 void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
 gboolean synthetic_message_add_value_template(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error);
 void synthetic_message_add_tag(SyntheticMessage *self, const gchar *text);
+void synthetic_message_init(SyntheticMessage *self);
 void synthetic_message_deinit(SyntheticMessage *self);
+SyntheticMessage *synthetic_message_new(void);
 void synthetic_message_free(SyntheticMessage *self);
 
 #endif

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -33,20 +33,20 @@ typedef enum
   RAC_MSG_INHERIT_CONTEXT
 } PDBActionMessageInheritMode;
 
-typedef struct _PDBMessage
+typedef struct _SyntheticMessage
 {
   GArray *tags;
   GPtrArray *values;
-} PDBMessage;
+} SyntheticMessage;
 
-LogMessage *synthetic_message_generate_without_context(PDBMessage *self, gint inherit_mode, LogMessage *msg, GString *buffer);
-LogMessage *synthetic_message_generate_with_context(PDBMessage *self, gint inherit_mode, CorrellationContext *context, GString *buffer);
+LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, gint inherit_mode, LogMessage *msg, GString *buffer);
+LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, gint inherit_mode, CorrellationContext *context, GString *buffer);
 
 
-void synthetic_message_apply(PDBMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
-gboolean synthetic_message_add_value_template(PDBMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error);
-void synthetic_message_add_tag(PDBMessage *self, const gchar *text);
-void synthetic_message_deinit(PDBMessage *self);
-void synthetic_message_free(PDBMessage *self);
+void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
+gboolean synthetic_message_add_value_template(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error);
+void synthetic_message_add_tag(SyntheticMessage *self, const gchar *text);
+void synthetic_message_deinit(SyntheticMessage *self);
+void synthetic_message_free(SyntheticMessage *self);
 
 #endif

--- a/modules/dbparser/tests/test_timer_wheel.c
+++ b/modules/dbparser/tests/test_timer_wheel.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <string.h>
 
 #define NUM_TIMERS 10000
 
@@ -11,7 +12,7 @@ gint num_callbacks;
 guint64 prev_now;
 
 void
-timer_callback(guint64 now, gpointer user_data)
+timer_callback(TimerWheel *self, guint64 now, gpointer user_data)
 {
   guint64 expires = *(guint64 *) user_data;
 
@@ -30,6 +31,19 @@ timer_callback(guint64 now, gpointer user_data)
   num_callbacks++;
 }
 
+#define ASSOC_DATA_STRING "timerwheel associated data, check whether it's freed"
+
+static void
+_test_assoc_data(TimerWheel *wheel)
+{
+  timer_wheel_set_associated_data(wheel, g_strdup(ASSOC_DATA_STRING), (GDestroyNotify) g_free);
+  if (strcmp(timer_wheel_get_associated_data(wheel), ASSOC_DATA_STRING) != 0)
+    {
+      fprintf(stderr, "Associated data mismatch, found=%s, expected=%s", (gchar *) timer_wheel_get_associated_data(wheel), ASSOC_DATA_STRING);
+      exit(1);
+    }
+}
+
 void
 test_wheel(gint seed)
 {
@@ -43,6 +57,7 @@ test_wheel(gint seed)
   expected_callbacks = 0;
   srand(seed);
   wheel = timer_wheel_new();
+  _test_assoc_data(wheel);
   timer_wheel_set_time(wheel, 1);
   for (i = 0; i < NUM_TIMERS; i++)
     {

--- a/modules/dbparser/tests/test_timer_wheel.c
+++ b/modules/dbparser/tests/test_timer_wheel.c
@@ -18,14 +18,16 @@ timer_callback(TimerWheel *self, guint64 now, gpointer user_data)
 
   if (now != expires)
     {
-      fprintf(stderr, "Expected time is not matching current time in callback, now=%" G_GUINT64_FORMAT ", expires=%" G_GUINT64_FORMAT "\n",
-              now, expires);
+      fprintf(stderr, "Expected time is not matching current time in callback, "
+                      "now=%" G_GUINT64_FORMAT ", expires=%" G_GUINT64_FORMAT "\n",
+                      now, expires);
       exit(1);
     }
   if (prev_now > now)
     {
-      fprintf(stderr, "Callback current time is not monotonically increasing, prev_now=%" G_GUINT64_FORMAT ", now=%" G_GUINT64_FORMAT "\n",
-              prev_now, now);
+      fprintf(stderr, "Callback current time is not monotonically increasing, "
+                      "prev_now=%" G_GUINT64_FORMAT ", now=%" G_GUINT64_FORMAT "\n",
+                      prev_now, now);
     }
   prev_now = now;
   num_callbacks++;
@@ -39,7 +41,8 @@ _test_assoc_data(TimerWheel *wheel)
   timer_wheel_set_associated_data(wheel, g_strdup(ASSOC_DATA_STRING), (GDestroyNotify) g_free);
   if (strcmp(timer_wheel_get_associated_data(wheel), ASSOC_DATA_STRING) != 0)
     {
-      fprintf(stderr, "Associated data mismatch, found=%s, expected=%s", (gchar *) timer_wheel_get_associated_data(wheel), ASSOC_DATA_STRING);
+      fprintf(stderr, "Associated data mismatch, found=%s, expected=%s",
+                      (gchar *) timer_wheel_get_associated_data(wheel), ASSOC_DATA_STRING);
       exit(1);
     }
 }
@@ -101,7 +104,9 @@ test_wheel(gint seed)
   timer_wheel_set_time(wheel, latest + 1);
   if (num_callbacks != expected_callbacks)
     {
-      fprintf(stderr, "Error: not enough callbacks received, num_callbacks=%d, expected=%d\n", num_callbacks, expected_callbacks);
+      fprintf(stderr, "Error: not enough callbacks received, "
+                      "num_callbacks=%d, expected=%d\n",
+                      num_callbacks, expected_callbacks);
       exit(1);
     }
   timer_wheel_free(wheel);

--- a/modules/dbparser/timerwheel.h
+++ b/modules/dbparser/timerwheel.h
@@ -27,8 +27,8 @@
 #include "syslog-ng.h"
 
 typedef struct _TWEntry TWEntry;
-typedef void (*TWCallbackFunc)(guint64 now, gpointer user_data);
 typedef struct _TimerWheel TimerWheel;
+typedef void (*TWCallbackFunc)(TimerWheel *tw, guint64 now, gpointer user_data);
 
 TWEntry *timer_wheel_add_timer(TimerWheel *self, gint timeout, TWCallbackFunc cb, gpointer user_data, GDestroyNotify user_data_free);
 void timer_wheel_del_timer(TimerWheel *self, TWEntry *entry);
@@ -38,6 +38,8 @@ guint64 timer_wheel_get_timer_expiration(TimerWheel *self, TWEntry *entry);
 void timer_wheel_set_time(TimerWheel *self, guint64 new_now);
 guint64 timer_wheel_get_time(TimerWheel *self);
 void timer_wheel_expire_all(TimerWheel *self);
+void timer_wheel_set_associated_data(TimerWheel *self, gpointer assoc_data, GDestroyNotify assoc_data_free);
+gpointer timer_wheel_get_associated_data(TimerWheel *self);
 TimerWheel *timer_wheel_new(void);
 void timer_wheel_free(TimerWheel *self);
 


### PR DESCRIPTION
This is a couple of patches against dbparser that help the implementation of the upcoming correllate()
parser, a component that can do correllation with a similar model that we have in db-parser() but without the message parsing/matching logic.
