### PR TITLE
F/cap refactor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1393,7 +1393,7 @@ AC_DEFINE_UNQUOTED(ENABLE_MEMTRACE, `enable_value $enable_memtrace`, [Enable mem
 AC_DEFINE_UNQUOTED(ENABLE_SPOOF_SOURCE, `enable_value $enable_spoof_source`, [Enable spoof source support])
 AC_DEFINE_UNQUOTED(ENABLE_IPV6, `enable_value $enable_ipv6`, [Enable IPv6 support])
 AC_DEFINE_UNQUOTED(ENABLE_TCP_WRAPPER, `enable_value $enable_tcp_wrapper`, [Enable TCP wrapper support])
-AC_DEFINE_UNQUOTED(ENABLE_LINUX_CAPS, `enable_value $enable_linux_caps`, [Enable Linux capability management support])
+AC_DEFINE_UNQUOTED(ENABLE_LINUX_CAPS, `enable_value $has_linux_caps`, [Enable Linux capability management support])
 AC_DEFINE_UNQUOTED(ENABLE_ENV_WRAPPER, `enable_value $enable_env_wrapper`, [Enable environment wrapper support])
 AC_DEFINE_UNQUOTED(ENABLE_SYSTEMD, `enable_value $enable_systemd`, [Enable systemd support])
 AC_DEFINE_UNQUOTED(SYSTEMD_JOURNAL_MODE, `journald_mode`, [Systemd-journal support mode])
@@ -1421,6 +1421,7 @@ AM_CONDITIONAL(ENABLE_JOURNALD, [test "$with_systemd_journal" != "no"])
 AM_CONDITIONAL(ENABLE_PYTHON, [test "$enable_python" != "no"])
 AM_CONDITIONAL(ENABLE_JAVA, [test "$enable_java" = "yes"])
 AM_CONDITIONAL(ENABLE_MANPAGES, [test "$enable_manpages" != "no"])
+AM_CONDITIONAL(ENABLE_LINUX_CAPS, [test "$has_linux_caps" = "yes"])
 
 # substitution into manual pages
 expanded_sysconfdir=[`patheval $sysconfdir | sed -e 's/-/\\\\-/g'`]

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -128,6 +128,7 @@ pkginclude_HEADERS			+= \
 	lib/poll-fd-events.h		\
 	lib/pragma-parser.h		\
 	lib/presented-persistable-state.h			\
+	lib/privileged-linux.h \
 	lib/reloc.h			\
 	lib/rcptid.h			\
 	lib/run-id.h			\
@@ -207,6 +208,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/poll-fd-events.c		\
 	lib/pragma-parser.c		\
 	lib/persistable-state-presenter.c		\
+	lib/privileged-linux.c \
 	lib/rcptid.c			\
 	lib/reloc.c			\
 	lib/run-id.c			\

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -208,7 +208,6 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/poll-fd-events.c		\
 	lib/pragma-parser.c		\
 	lib/persistable-state-presenter.c		\
-	lib/privileged-linux.c \
 	lib/rcptid.c			\
 	lib/reloc.c			\
 	lib/run-id.c			\
@@ -247,6 +246,10 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(control_sources)		\
 	$(debugger_sources)		\
 	$(compat_sources)
+
+if ENABLE_LINUX_CAPS
+lib_libsyslog_ng_la_SOURCES += lib/privileged-linux.c
+endif
 
 lib_libsyslog_ng_la_CFLAGS		= @UUID_CFLAGS@ $(libsystemd_CFLAGS)
 lib_libsyslog_ng_la_LIBADD		+= @OPENSSL_LIBS@ @UUID_LIBS@ $(LIBNET_LIBS)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -249,7 +249,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(compat_sources)
 
 lib_libsyslog_ng_la_CFLAGS		= @UUID_CFLAGS@ $(libsystemd_CFLAGS)
-lib_libsyslog_ng_la_LIBADD		+= @OPENSSL_LIBS@ @UUID_LIBS@
+lib_libsyslog_ng_la_LIBADD		+= @OPENSSL_LIBS@ @UUID_LIBS@ $(LIBNET_LIBS)
 
 # each line with closely related files (e.g. the ones generated from the same source)
 BUILT_SOURCES += lib/cfg-lex.c lib/cfg-lex.h						\

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -181,7 +181,6 @@ file_perm_options_create_containing_directory(const FilePermOptions *self, gchar
   struct stat st;
   gint rc;
   gchar *p;
-  cap_t saved_caps;
 
   /* check that the directory exists */
   dirname = g_path_get_dirname(name);
@@ -215,11 +214,7 @@ file_perm_options_create_containing_directory(const FilePermOptions *self, gchar
         {
           if (mkdir(name, self->dir_perm < 0 ? 0700 : (mode_t) self->dir_perm) == -1)
             return FALSE;
-          saved_caps = g_process_cap_save();
-          g_process_cap_modify(CAP_CHOWN, TRUE);
-          g_process_cap_modify(CAP_FOWNER, TRUE);
           file_perm_options_apply_dir(self, name);
-          g_process_cap_restore(saved_caps);
         }
       *p = '/';
       p = strchr(p + 1, '/');

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -167,39 +167,11 @@ file_perm_options_apply_fd(const FilePermOptions *self, gint fd)
 #endif
 }
 
-/**
- *
- * This function receives a complete path (directory + filename) and creates
- * the directory portion if it does not exist. The point is that the caller
- * wants to ensure that the given filename can be opened after this function
- * returns. (at least it won't fail because of missing directories).
- **/
 gboolean
 file_perm_options_create_containing_directory(const FilePermOptions *self, gchar *name)
 {
-  gchar *dirname;
   struct stat st;
-  gint rc;
-  gchar *p;
-
-  /* check that the directory exists */
-  dirname = g_path_get_dirname(name);
-  rc = stat(dirname, &st);
-  g_free(dirname);
-
-  if (rc == 0)
-    {
-      /* directory already exists */
-      return TRUE;
-    }
-  else if (rc < 0 && errno != ENOENT)
-    {
-      /* some real error occurred */
-      return FALSE;
-    }
-
-  /* directory does not exist */
-  p = name + 1;
+  gchar *p = name + 1;
 
   p = strchr(p, '/');
   while (p)
@@ -219,5 +191,6 @@ file_perm_options_create_containing_directory(const FilePermOptions *self, gchar
       *p = '/';
       p = strchr(p + 1, '/');
     }
+
   return TRUE;
 }

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -448,6 +448,17 @@ g_process_set_caps(const gchar *caps)
 }
 
 /**
+ * g_process_get_caps:
+ * Return the all permitted capbilities
+ **/
+
+const gchar *
+g_process_get_caps()
+{
+  return process_opts.caps;
+}
+
+/**
  * g_process_set_argv_space:
  * @argc: Original argc, as received by the main function in it's first parameter
  * @argv: Original argv, as received by the main function in it's second parameter

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -441,11 +441,10 @@ g_process_set_working_dir(const gchar *cwd)
  * capability set. The process will change its capabilities to this value
  * during startup, provided it has enough permissions to do so.
  **/
-void 
+void
 g_process_set_caps(const gchar *caps)
 {
-  if (!process_opts.caps)
-    process_opts.caps = caps;
+  process_opts.caps = caps;
 }
 
 /**

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -305,41 +305,6 @@ g_process_cap_restore(cap_t r)
   return;
 }
 
-#ifndef PR_CAPBSET_READ
-
-/* old glibc versions don't have PR_CAPBSET_READ, we define it to the
- * value as defined in newer versions. */
-
-#define PR_CAPBSET_READ 23
-#endif
-
-gboolean
-g_process_check_cap_syslog(void)
-{
-  int ret;
-
-  if (have_capsyslog)
-    return TRUE;
-
-  if (CAP_SYSLOG == -1)
-    return FALSE;
-
-  ret = prctl(PR_CAPBSET_READ, CAP_SYSLOG);
-  if (ret == -1)
-    return FALSE;
-
-  ret = cap_from_name("cap_syslog", NULL);
-  if (ret == -1)
-    {
-      fprintf (stderr, "CAP_SYSLOG seems to be supported by the system, but "
-	       "libcap can't parse it. Falling back to CAP_SYS_ADMIN!\n");
-      return FALSE;
-    }
-
-  have_capsyslog = TRUE;
-  return TRUE;
-}
-
 #endif
 
 /**

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -26,6 +26,7 @@
 #include "misc.h"
 #include "messages.h"
 #include "reloc.h"
+#include "privileged-linux.h"
  
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -678,18 +679,7 @@ g_process_enable_core(void)
 
   if (process_opts.core)
     {
-#if ENABLE_LINUX_CAPS
-      if (!prctl(PR_GET_DUMPABLE, 0, 0, 0, 0))
-        {
-          gint rc;
-
-          rc = prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
-
-          if (rc < 0)
-            g_process_message("Cannot set process to be dumpable; error='%s'", g_strerror(errno));
-        }
-#endif
-
+      set_process_dumpable();
       limit.rlim_cur = limit.rlim_max = RLIM_INFINITY;
       if (setrlimit(RLIMIT_CORE, &limit) < 0)
         g_process_message("Error setting core limit to infinity; error='%s'", g_strerror(errno));

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -801,10 +801,7 @@ g_process_change_root(void)
 static gboolean
 g_process_change_user(void)
 {
-#if ENABLE_LINUX_CAPS
-  if (process_opts.caps)
-    prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0);
-#endif
+  set_keep_caps_flag(process_opts.caps);
 
   if (process_opts.gid >= 0)
     {

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -72,6 +72,7 @@ void g_process_set_pidfile(const gchar *pidfile);
 void g_process_set_pidfile_dir(const gchar *pidfile_dir);
 void g_process_set_working_dir(const gchar *cwd);
 void g_process_set_caps(const gchar *caps);
+const gchar* g_process_get_caps();
 void g_process_set_argv_space(gint argc, gchar **argv);
 void g_process_set_use_fdlimit(gboolean use);
 void g_process_set_check(gint check_period, gboolean (*check_fn)(void));

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -46,10 +46,6 @@ gboolean g_process_cap_modify(int capability, int onoff);
 cap_t g_process_cap_save(void);
 void g_process_cap_restore(cap_t r);
 
-#ifndef CAP_SYSLOG
-#define CAP_SYSLOG -1
-#endif
-
 #else
 
 typedef gpointer cap_t;

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -40,22 +40,6 @@ typedef enum
   G_PM_SAFE_BACKGROUND,
 } GProcessMode;
 
-#if ENABLE_LINUX_CAPS
-
-gboolean g_process_cap_modify(int capability, int onoff);
-cap_t g_process_cap_save(void);
-void g_process_cap_restore(cap_t r);
-
-#else
-
-typedef gpointer cap_t;
-
-#define g_process_cap_modify(cap, onoff)
-#define g_process_cap_save() NULL
-#define g_process_cap_restore(cap) cap = cap
-
-#endif
-
 void g_process_message(const gchar *fmt, ...);
 
 void g_process_set_mode(GProcessMode mode);

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -24,11 +24,21 @@
 #include "privileged-linux.h"
 #include "gprocess.h"
 #include "messages.h"
+#include "file-perms.h"
+#include "affile/affile-common.h"
 
 #include <errno.h>
 #include <sys/capability.h>
 #include <sys/prctl.h>
 #include <glib.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "gsockaddr.h"
+#include "gsocket.h"
+
+#if ENABLE_SPOOF_SOURCE
+#include <libnet.h>
+#endif
 
 #ifndef PR_CAPBSET_READ
 

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -41,3 +41,10 @@ set_process_dumpable()
         g_process_message("Cannot set process to be dumpable; error='%s'", g_strerror(errno));
     }
 }
+
+void
+set_keep_caps_flag(const gchar *caps)
+{
+  if (caps)
+    prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0);
+}

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -87,6 +87,15 @@ check_syslog_cap()
   return TRUE;
 }
 
+void
+setup_caps()
+{
+  if (check_syslog_cap())
+    g_process_set_caps(BASE_CAPS_WITH_SYSLOG_CAP);
+  else
+    g_process_set_caps(BASE_CAPS_WITH_SYS_ADMIN_CAP);
+}
+
 static gint
 __set_caps(cap_t caps, gchar *error_message)
 {

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -23,6 +23,7 @@
 
 #include "privileged-linux.h"
 #include "gprocess.h"
+#include "messages.h"
 
 #include <errno.h>
 #include <sys/capability.h>
@@ -84,4 +85,21 @@ check_syslog_cap()
 
   have_capsyslog = TRUE;
   return TRUE;
+}
+
+static gint
+__set_caps(cap_t caps, gchar *error_message)
+{
+  gchar *cap_text;
+  gint rc;
+
+  rc = cap_set_proc(caps);
+  if (rc == -1)
+    {
+      cap_text = cap_to_text(caps, NULL);
+      g_process_message(error_message, "caps", cap_text, "errno", errno);
+      cap_free(cap_text);
+    }
+
+  return rc;
 }

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -136,3 +136,25 @@ setup_permitted_caps(const gchar *caps)
     }
   return TRUE;
 }
+
+gint
+restore_caps(cap_t caps)
+{
+  if (!g_process_get_caps())
+    return 0;
+
+  return __set_caps(caps, "Error managing capability set, restore original capabilities returned an error");
+}
+
+gint
+raise_caps(const gchar* new_caps, cap_t *old_caps)
+{
+  if (!g_process_get_caps())
+    return 0;
+
+  gchar str[1024];
+  g_snprintf(str, sizeof(str), "%s%s", g_process_get_caps(), new_caps);
+
+  *old_caps = cap_get_proc();
+  return __set_caps(cap_from_text(str), "Error managing capability set, raise a new capability sets returned an error");
+}

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 BalaBit IT Ltd, Budapest, Hungary
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "privileged-linux.h"
+#include "gprocess.h"
+
+#include <errno.h>
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#include <glib.h>
+
+void
+set_process_dumpable()
+{
+  gint rc;
+
+  if (!prctl(PR_GET_DUMPABLE, 0, 0, 0, 0))
+    {
+      rc = prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+      if (rc < 0)
+        g_process_message("Cannot set process to be dumpable; error='%s'", g_strerror(errno));
+    }
+}

--- a/lib/privileged-linux.c
+++ b/lib/privileged-linux.c
@@ -103,3 +103,36 @@ __set_caps(cap_t caps, gchar *error_message)
 
   return rc;
 }
+
+/**
+ * Change the current capset to the value specified by the user.  causes the
+ * startup process to fail if this function returns FALSE, but we only do
+ * this if the capset cannot be parsed, otherwise a failure changing the
+ * capabilities will not result in failure
+ *
+ * Returns: TRUE to indicate success
+ **/
+gboolean
+setup_permitted_caps(const gchar *caps)
+{
+  cap_t cap;
+
+  if (caps)
+    {
+      cap = cap_from_text(caps);
+      if (!cap)
+        {
+          g_process_message("Error parsing capabilities: %s", caps);
+          return FALSE;
+        }
+
+      if (cap_set_proc(cap) == -1)
+        {
+          g_process_message("Error setting permitted capabilities, capability management is disabled");
+          g_process_set_caps(NULL);
+        }
+
+      cap_free(cap);
+    }
+  return TRUE;
+}

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 BalaBit IT Ltd, Budapest, Hungary
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PRIVILEGED_H_INCLUDED
+#define PRIVILEGED_H_INCLUDED
+
+#include <glib.h>
+
+void set_process_dumpable();
+
+#endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -36,6 +36,7 @@
 #include <libnet.h>
 #endif
 
+#if ENABLE_LINUX_CAPS
 #define BASE_CAPS "cap_net_bind_service,cap_net_broadcast,cap_net_raw," \
   "cap_dac_read_search,cap_dac_override,cap_chown,cap_fowner,"
 
@@ -77,5 +78,22 @@ do {                                                  \
   if (raised_caps_result != -1)                       \
     restore_caps(saved_caps);                         \
 } while(0)
+
+#else
+
+#define setup_caps()
+#define set_process_dumpable()
+#define set_keep_caps_flag(caps)
+#define check_syslog_cap() FALSE
+#define setup_permitted_caps(caps) TRUE
+#define restore_caps(caps) 0
+#define raise_caps(new_caps, old_caps) 0
+#define get_open_file_caps(open_opts) NULL
+#define PRIVILEGED_CALL(caps, function, result, ...)  \
+do {                                                  \
+  result = function(__VA_ARGS__);                     \
+} while(0)
+
+#endif
 
 #endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -27,5 +27,6 @@
 #include <glib.h>
 
 void set_process_dumpable();
+void set_keep_caps_flag(const gchar *caps);
 
 #endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -33,6 +33,18 @@
 #define BASE_CAPS_WITH_SYSLOG_CAP BASE_CAPS"cap_syslog=p "
 #define BASE_CAPS_WITH_SYS_ADMIN_CAP BASE_CAPS"cap_sys_admin=p "
 
+#define STAT_CAPS "cap_dac_read_search+e"
+#define MKFIFO_CAPS "cap_dac_override+e"
+#define CHANGE_FILE_RIGHTS_CAPS "cap_chown,cap_fowner+e"
+#define INIT_RAW_NET_CAPS "cap_net_raw+e"
+#define BIND_SERVICE_CAPS "cap_net_bind_service+e"
+#define MKDIR_AND_PERM_RIGHTS_CAPS "cap_chown,cap_fowner,cap_dac_override+e"
+#define SYSLOG_CAPS "cap_syslog+e"
+#define SYSADMIN_CAPS "cap_sys_admin+e"
+#define OPEN_AS_READ_CAPS "cap_dac_read_search+e"
+#define OPEN_AS_READ_AND_WRITE_CAPS "cap_dac_override+e"
+#define OPEN_CAPS(x) get_open_file_caps(x)
+
 void setup_caps();
 void set_process_dumpable();
 void set_keep_caps_flag(const gchar *caps);

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -25,10 +25,14 @@
 #define PRIVILEGED_H_INCLUDED
 
 #include <glib.h>
+#include <sys/capability.h>
 
 void set_process_dumpable();
 void set_keep_caps_flag(const gchar *caps);
 gboolean check_syslog_cap();
 gboolean setup_permitted_caps(const gchar *caps);
+
+gint restore_caps(cap_t caps);
+gint raise_caps(const gchar* new_caps, cap_t *old_caps);
 
 #endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -28,5 +28,6 @@
 
 void set_process_dumpable();
 void set_keep_caps_flag(const gchar *caps);
+gboolean check_syslog_cap();
 
 #endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -27,6 +27,13 @@
 #include <glib.h>
 #include <sys/capability.h>
 
+#define BASE_CAPS "cap_net_bind_service,cap_net_broadcast,cap_net_raw," \
+  "cap_dac_read_search,cap_dac_override,cap_chown,cap_fowner,"
+
+#define BASE_CAPS_WITH_SYSLOG_CAP BASE_CAPS"cap_syslog=p "
+#define BASE_CAPS_WITH_SYS_ADMIN_CAP BASE_CAPS"cap_sys_admin=p "
+
+void setup_caps();
 void set_process_dumpable();
 void set_keep_caps_flag(const gchar *caps);
 gboolean check_syslog_cap();

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -29,5 +29,6 @@
 void set_process_dumpable();
 void set_keep_caps_flag(const gchar *caps);
 gboolean check_syslog_cap();
+gboolean setup_permitted_caps(const gchar *caps);
 
 #endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -53,5 +53,6 @@ gboolean setup_permitted_caps(const gchar *caps);
 
 gint restore_caps(cap_t caps);
 gint raise_caps(const gchar* new_caps, cap_t *old_caps);
+const gchar* get_open_file_caps(const FileOpenOptions *open_opts);
 
 #endif

--- a/lib/privileged-linux.h
+++ b/lib/privileged-linux.h
@@ -54,6 +54,10 @@
 #define OPEN_AS_READ_AND_WRITE_CAPS "cap_dac_override+e"
 #define OPEN_CAPS(x) get_open_file_caps(x)
 
+#ifndef CAP_SYSLOG
+#define CAP_SYSLOG -1
+#endif
+
 void setup_caps();
 void set_process_dumpable();
 void set_keep_caps_flag(const gchar *caps);

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -12,8 +12,11 @@ lib_tests_TESTS		= \
 	lib/tests/test_str_format   \
 	lib/tests/test_runid        \
 	lib/tests/test_pathutils	\
-	lib/tests/test_cap      	\
 	lib/tests/test_utf8utils
+
+if ENABLE_LINUX_CAPS
+lib_tests_TESTS += lib/tests/test_cap
+endif
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -12,6 +12,7 @@ lib_tests_TESTS		= \
 	lib/tests/test_str_format   \
 	lib/tests/test_runid        \
 	lib/tests/test_pathutils	\
+	lib/tests/test_cap      	\
 	lib/tests/test_utf8utils
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
@@ -86,6 +87,11 @@ lib_tests_test_str_format_LDADD	=	\
 lib_tests_test_pathutils_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_pathutils_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_cap_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_cap_LDADD	=	\
 	$(TEST_LDADD)
 
 lib_tests_test_utf8utils_CFLAGS	=	\

--- a/lib/tests/test_cap.c
+++ b/lib/tests/test_cap.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2002-2015 BalaBit IT Ltd, Budapest, Hungary
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "gprocess.h"
+#include "testutils.h"
+#include "privileged-linux.h"
+
+#include <sys/capability.h>
+
+#define CAP_TESTCASE(testfunc, ...) { testcase_begin("%s(%s)", #testfunc, #__VA_ARGS__); testfunc(__VA_ARGS__); testcase_end(); }
+
+#define PERMITTED_CAPS "cap_chown,cap_fowner,cap_dac_override=p "
+
+#define OPEN_RO_FLAGS (O_RDONLY | O_NOCTTY | O_NONBLOCK | O_LARGEFILE)
+#define OPEN_WO_FLAGS (O_WRONLY | O_NOCTTY | O_NONBLOCK | O_LARGEFILE)
+#define OPEN_RW_FLAGS (O_RDWR | O_NOCTTY | O_NONBLOCK | O_LARGEFILE)
+
+static gint
+privileged_function()
+{
+  return 1;
+}
+
+static void
+setup_defaults()
+{
+  cap_t caps;
+
+  caps = cap_from_text(PERMITTED_CAPS);
+  cap_set_proc(caps);
+  g_process_set_caps(PERMITTED_CAPS);
+}
+
+static gboolean
+check_string_or(const gchar *actual, const gchar *expected, const gchar *or_expected)
+{
+  gint actual_len;
+  gint expected_len;
+  gint or_expected_len;
+
+  if (expected == NULL || or_expected == NULL || actual == NULL)
+    return FALSE;
+
+  actual_len = strlen(actual);
+  expected_len = strlen(expected);
+  or_expected_len = strlen(or_expected);
+
+  if ((actual_len == expected_len &&
+       memcmp(actual, expected, actual_len) == 0) ||
+     (actual_len == or_expected_len &&
+      memcmp(actual, or_expected, actual_len) == 0))
+    return TRUE;
+
+  return FALSE;
+}
+
+static gboolean
+__check_root_rights()
+{
+  setup_permitted_caps(PERMITTED_CAPS);
+  if (cap_compare(cap_get_proc(), cap_from_text(PERMITTED_CAPS)) != 0)
+    {
+      g_process_message("Please run this test with root user!");
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static void
+__test_privileged_call_with_a_permitted_cap()
+{
+  gint result = 0;
+
+  setup_defaults();
+  PRIVILEGED_CALL("cap_fowner+e", privileged_function, result);
+  assert_gint(result, 1, "Error: privileged_function() function is not called");
+  assert_gint(result, 1, "Error raise 'cap_chown,cap_fowner,cap_dac_override=p,cap_fowner+e' caps");
+}
+
+static void
+__test_privileged_call_with_a_not_permitted_cap()
+{
+  gint result = 0;
+  cap_t caps;
+
+  setup_defaults();
+  PRIVILEGED_CALL("cap_sys_admin+e", privileged_function, result);
+  assert_gint(result, 1, "Error: privileged_function() function is not called");
+  caps = cap_from_text(PERMITTED_CAPS"cap_sys_admin+e");
+  assert_gint(cap_compare(cap_get_proc(), caps), 1, "Error raised 'cap_chown,cap_fowner,cap_dac_override=p,cap_sys_admin+e' caps");
+}
+
+static void
+__test_raise_and_restore_a_permitted_cap()
+{
+  cap_t caps;
+  cap_t saved_caps;
+  gint raised_caps_result;
+  gint restored_caps_result;
+
+  setup_defaults();
+  caps = cap_from_text(PERMITTED_CAPS);
+  raised_caps_result = raise_caps("cap_chown+e", &saved_caps);
+  assert_gint(cap_compare(saved_caps, caps), 0, "Error: saved caps are wrong");
+  assert_gint(raised_caps_result, 0, "Error: not raised 'cap_chown' cap");
+  restored_caps_result = restore_caps(saved_caps);
+  assert_gint(cap_compare(cap_get_proc(), caps), 0, "Error: restored caps are wrong");
+  assert_gint(restored_caps_result, 0, "Error: not restored ''cap_chown,cap_fowner,cap_dac_override=p' caps");
+}
+
+static void
+__test_get_open_file_caps()
+{
+  FileOpenOptions open_opts;
+
+  open_opts.needs_privileges = FALSE;
+  open_opts.open_flags = OPEN_RO_FLAGS;
+  assert_string(get_open_file_caps(&open_opts), OPEN_AS_READ_CAPS, "");
+
+  open_opts.needs_privileges = TRUE;
+  open_opts.open_flags = OPEN_RO_FLAGS;
+  assert_true(check_string_or(get_open_file_caps(&open_opts), SYSADMIN_CAPS, SYSLOG_CAPS), "");
+
+  open_opts.needs_privileges = FALSE;
+  open_opts.open_flags = OPEN_WO_FLAGS;
+  assert_string(get_open_file_caps(&open_opts), OPEN_AS_READ_AND_WRITE_CAPS, "");
+}
+
+int
+main()
+{
+  g_process_set_name("capability test");
+  if (!__check_root_rights())
+    return 0;
+
+  CAP_TESTCASE(__test_privileged_call_with_a_permitted_cap);
+  CAP_TESTCASE(__test_privileged_call_with_a_not_permitted_cap);
+  CAP_TESTCASE(__test_raise_and_restore_a_permitted_cap);
+  CAP_TESTCASE(__test_get_open_file_caps);
+
+  return 0;
+}

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -117,8 +117,10 @@ static inline void
 _validate_file_type(const gchar *name, FileOpenOptions *open_opts)
 {
   struct stat st;
+  gint stat_result;
 
-  if (stat(name, &st) >= 0)
+  PRIVILEGED_CALL(STAT_CAPS, stat, stat_result, name, &st);
+  if (stat_result >= 0)
     {
       if (open_opts->is_pipe && !S_ISFIFO(st.st_mode))
         {

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -161,6 +161,11 @@ affile_open_file(gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_
 
   _validate_file_type(name, open_opts);
 
+  if (open_opts->create_dirs &&
+      perm_opts &&
+      !__create_containing_directory_and_set_perm_options(perm_opts, name))
+    return FALSE;
+
   *fd = _open_fd(name, open_opts, perm_opts);
 
   _set_fd_permission(perm_opts, *fd);

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -24,6 +24,7 @@
 #include "messages.h"
 #include "gprocess.h"
 #include "misc.h"
+#include "privileged-linux.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -81,15 +82,16 @@ _obtain_capabilities(gchar *name, FileOpenOptions *open_opts, FilePermOptions *p
 static inline void
 _set_fd_permission(FilePermOptions *perm_opts, int fd)
 {
+  gboolean result G_GNUC_UNUSED;
+
   if (fd != -1)
     {
       g_fd_set_cloexec(fd, TRUE);
 
-      g_process_cap_modify(CAP_CHOWN, TRUE);
-      g_process_cap_modify(CAP_FOWNER, TRUE);
-
       if (perm_opts)
-        file_perm_options_apply_fd(perm_opts, fd);
+        {
+          PRIVILEGED_CALL(CHANGE_FILE_RIGHTS_CAPS, file_perm_options_apply_fd, result, perm_opts, fd);
+        }
     }
 }
 

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -26,6 +26,7 @@
 #include "messages.h"
 #include "gprocess.h"
 #include "transport-mapper-unix.h"
+#include "privileged-linux.h"
 
 #include <string.h>
 #include <sys/types.h>
@@ -76,14 +77,8 @@ afunix_sd_adjust_reader_options(AFUnixSourceDriver *self, GlobalConfig *cfg)
 static gboolean
 afunix_sd_apply_perms_to_socket(AFUnixSourceDriver *self)
 {
-  cap_t saved_caps;
-
-  saved_caps = g_process_cap_save();
-  g_process_cap_modify(CAP_CHOWN, TRUE);
-  g_process_cap_modify(CAP_FOWNER, TRUE);
-  g_process_cap_modify(CAP_DAC_OVERRIDE, TRUE);
-  file_perm_options_apply_file(&self->file_perm_options, self->filename);
-  g_process_cap_restore(saved_caps);
+  gboolean result G_GNUC_UNUSED;
+  PRIVILEGED_CALL(CHANGE_FILE_RIGHTS_CAPS, file_perm_options_apply_file, result, &self->file_perm_options, self->filename);
   return TRUE;
 }
 

--- a/modules/afsocket/transport-mapper.c
+++ b/modules/afsocket/transport-mapper.c
@@ -28,21 +28,14 @@
 #include "messages.h"
 #include "misc.h"
 #include "transport/transport-socket.h"
+#include "privileged-linux.h"
 
 static gboolean
 transport_mapper_privileged_bind(gint sock, GSockAddr *bind_addr)
 {
-  cap_t saved_caps;
-  GIOStatus status;
-
-  saved_caps = g_process_cap_save();
-  g_process_cap_modify(CAP_NET_BIND_SERVICE, TRUE);
-  g_process_cap_modify(CAP_DAC_OVERRIDE, TRUE);
-
-  status = g_bind(sock, bind_addr);
-
-  g_process_cap_restore(saved_caps);
-  return status == G_IO_STATUS_NORMAL;
+  GIOStatus result;
+  PRIVILEGED_CALL(STAT_CAPS, g_bind, result, sock, bind_addr);
+  return result == G_IO_STATUS_NORMAL;
 }
 
 gboolean

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -39,6 +39,7 @@
 #include "mainloop.h"
 #include "plugin.h"
 #include "reloc.h"
+#include "privileged-linux.h"
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -171,7 +172,7 @@ setup_caps (void)
    * indicate readability. Enabling/disabling cap_sys_admin on every poll
    * invocation seems to be too expensive. So I enable it for now.
    */
-  if (g_process_check_cap_syslog())
+  if (check_syslog_cap())
     g_process_set_caps(capsstr_syslog);
   else
     g_process_set_caps(capsstr_sys_admin);

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -156,33 +156,6 @@ version(void)
 
 }
 
-#if ENABLE_LINUX_CAPS
-#define BASE_CAPS "cap_net_bind_service,cap_net_broadcast,cap_net_raw," \
-  "cap_dac_read_search,cap_dac_override,cap_chown,cap_fowner=p "
-
-static void
-setup_caps (void)
-{
-  static gchar *capsstr_syslog = BASE_CAPS "cap_syslog=ep";
-  static gchar *capsstr_sys_admin = BASE_CAPS "cap_sys_admin=ep";
-
-  /* Set up the minimal privilege we'll need
-   *
-   * NOTE: polling /proc/kmsg requires cap_sys_admin, otherwise it'll always
-   * indicate readability. Enabling/disabling cap_sys_admin on every poll
-   * invocation seems to be too expensive. So I enable it for now.
-   */
-  if (check_syslog_cap())
-    g_process_set_caps(capsstr_syslog);
-  else
-    g_process_set_caps(capsstr_sys_admin);
-}
-#else
-
-#define setup_caps()
-
-#endif
-
 int 
 main(int argc, char *argv[])
 {


### PR DESCRIPTION
This patches are refactoring capability related functionality of syslog-ng and some functions of syslog-ng will be stricted than before:
- open a file source or destination
- open a socket (ip or unix)
- initialize spoof source
