### PR TITLE
F/tidy proto const redund void semi

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1213,7 +1213,7 @@ cfg_block_free(CfgBlock *self)
 }
 
 GQuark
-cfg_lexer_error_quark()
+cfg_lexer_error_quark(void)
 {
   return g_quark_from_static_string("cfg-lexer-error-quark");
 }

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -78,11 +78,11 @@ typedef struct YYSTYPE
 /* used to describe a syslog-ng keyword */
 typedef struct _CfgLexerKeyword
 {
-  gchar	*kw_name;
+  const gchar *kw_name;
   gint  kw_token;
   gint  kw_req_version;
   gint  kw_status;
-  gchar *kw_explain;
+  const gchar *kw_explain;
 } CfgLexerKeyword;
 
 #define CFG_KEYWORD_STOP "@!#?"

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -207,7 +207,7 @@ void cfg_block_free(CfgBlock *self);
 
 #define CFG_LEXER_ERROR cfg_lexer_error_quark()
 
-GQuark cfg_lexer_error_quark();
+GQuark cfg_lexer_error_quark(void);
 
 enum CfgLexerError
 {

--- a/lib/logmsg.h
+++ b/lib/logmsg.h
@@ -295,9 +295,9 @@ void log_msg_refcache_start_producer(LogMessage *self);
 void log_msg_refcache_start_consumer(LogMessage *self, const LogPathOptions *path_options);
 void log_msg_refcache_stop(void);
 
-void log_msg_registry_init();
-void log_msg_registry_deinit();
-void log_msg_global_init();
+void log_msg_registry_init(void);
+void log_msg_registry_deinit(void);
+void log_msg_global_init(void);
 void log_msg_global_deinit(void);
 void log_msg_registry_foreach(GHFunc func, gpointer user_data);
 

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -141,7 +141,6 @@ log_proto_server_is_position_tracked(LogProtoServer *s)
   return FALSE;
 }
 
-gboolean log_proto_server_validate_options(LogProtoServer *self);
 void log_proto_server_init(LogProtoServer *s, LogTransport *transport, const LogProtoServerOptions *options);
 void log_proto_server_free_method(LogProtoServer *s);
 void log_proto_server_free(LogProtoServer *s);

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -131,7 +131,7 @@ log_queue_rewind_backlog(LogQueue *self, guint rewind_count)
   if (!self->use_backlog)
     return;
 
-  return self->rewind_backlog(self, rewind_count);
+  self->rewind_backlog(self, rewind_count);
 }
 
 static inline void
@@ -140,7 +140,7 @@ log_queue_rewind_backlog_all(LogQueue *self)
   if (!self->use_backlog)
     return;
 
-  return self->rewind_backlog_all(self);
+  self->rewind_backlog_all(self);
 }
 
 static inline void
@@ -149,7 +149,7 @@ log_queue_ack_backlog(LogQueue *self, guint rewind_count)
   if (!self->use_backlog)
     return;
 
-  return self->ack_backlog(self, rewind_count);
+  self->ack_backlog(self, rewind_count);
 }
 
 static inline LogQueue *

--- a/lib/thread-utils.h
+++ b/lib/thread-utils.h
@@ -32,7 +32,7 @@ typedef pthread_t ThreadId;
 #endif
 
 static inline ThreadId
-get_thread_id()
+get_thread_id(void)
 {
 #ifndef _WIN32
   return pthread_self();

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -274,7 +274,7 @@ get_local_timezone_ofs(time_t when)
 
 
 void
-clean_time_cache()
+clean_time_cache(void)
 {
   memset(&gm_time_cache, 0, sizeof(gm_time_cache));
   memset(&local_time_cache, 0, sizeof(local_time_cache));

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -43,7 +43,6 @@ time_t cached_g_current_time_sec(void);
 gboolean check_nanosleep(void);
 
 int format_zone_info(gchar *buf, size_t buflen, long gmtoff);
-long get_local_timezone_ofs(time_t when);
 glong g_time_val_diff(GTimeVal *t1, GTimeVal *t2);
 void timespec_add_msec(struct timespec *ts, glong msec);
 glong timespec_diff_msec(struct timespec *t1, struct timespec *t2);

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -33,7 +33,7 @@ void cached_localtime(time_t *when, struct tm *tm);
 void cached_gmtime(time_t *when, struct tm *tm);
 
 long get_local_timezone_ofs(time_t when);
-void clean_time_cache();
+void clean_time_cache(void);
 
 
 void invalidate_cached_time(void);

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -577,7 +577,7 @@ afmongodb_dd_init_value_pairs_dot_to_underscore_transformation(MongoDBDestDriver
   vpts = value_pairs_transform_set_new(".*");
   value_pairs_transform_set_add_func(vpts, value_pairs_new_transform_replace_prefix(".", "_"));
   value_pairs_add_transforms(self->vp, vpts);
-};
+}
 
 static gboolean
 afmongodb_dd_init(LogPipe *s)


### PR DESCRIPTION
Small cosmetic improvements uncovered while integrating mongo-c-driver.

Fixed functions declarations which were not full prototypes.
Improved const propagation.
Removed redundant declarations.
Removed ineffective returns from void functions.
Extra semicolon at function definition in afmongodb.c.