### PR TITLE
logsource: validate hostname length in log_source_mangle_hostname()

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -177,6 +177,8 @@ log_source_mangle_hostname(LogSource *self, LogMessage *msg)
                   host[255] = 0;
                 }
 	    }
+          if (host_len >= sizeof(host))
+            host_len = sizeof(host) - 1;
           log_msg_set_value(msg, LM_V_HOST, host, host_len);
 	}
       else


### PR DESCRIPTION
When the name of the host is too long, the buffer we use to format the
chained hostname is truncated. However g_snprintf() returns the length the
result would be if no truncation happened, thus we will read uninitialized
bytes off the stack when we use that pointer to set $HOST
with log_msg_set_value().

There can be some security implications, like reading values from the stack
that can help to craft further exploits, especially in the presense of
address space randomization. It can also cause a DoS if the hostname length
is soo large that we would read over the top-of-the-stack, which is probably
not mmapped causing a SIGSEGV.

Reported-by: Badics, Alex <alex.badics@balabit.com>
Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>