### PR TITLE
F/csvparser refinements

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1035,11 +1035,6 @@ parser_opt
                                                 }
         ;
 
-parser_column_opt
-        : parser_opt
-        | KW_COLUMNS '(' string_list ')'        { log_column_parser_set_columns((LogColumnParser *) last_parser, $3); }
-        ;
-
 /* LogSource related options */
 source_option
         /* NOTE: plugins need to set "last_source_options" in order to incorporate this rule in their grammar */

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -258,6 +258,23 @@ find_cr_or_lf(gchar *s, gsize n)
   return NULL;
 }
 
+/*
+ * NOTE: pointer values below 0x1000 (4096) are taken as special values used
+ * by the application code and are not duplicated, but assumed to be literal
+ * tokens.
+ */
+GList *
+string_list_clone(GList *string_list)
+{
+  GList *cloned = NULL;
+  GList *l;
+
+  for (l = string_list; l; l = l->next)
+    cloned = g_list_append(cloned, GPOINTER_TO_UINT(l->data) > 4096 ? g_strdup(l->data) : l->data);
+
+  return cloned;
+}
+
 GList *
 string_array_to_list(const gchar *strlist[])
 {

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -61,6 +61,7 @@ step_sequence_number(gint32 *seqnum)
     *seqnum = 1;
 }
 
+GList *string_list_clone(GList *string_list);
 GList *string_array_to_list(const gchar *strlist[]);
 void string_list_free(GList *l);
 

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -116,32 +116,3 @@ log_parser_init_instance(LogParser *self, GlobalConfig *cfg)
   self->super.free_fn = log_parser_free_method;
   self->super.queue = log_parser_queue;
 }
-
-/*
- * Abstract class that has a column list to parse fields into.
- */
-
-void
-log_column_parser_set_columns(LogColumnParser *s, GList *columns)
-{
-  LogColumnParser *self = (LogColumnParser *) s;
-
-  string_list_free(self->columns);
-  self->columns = columns;
-}
-
-void
-log_column_parser_free_method(LogPipe *s)
-{
-  LogColumnParser *self = (LogColumnParser *) s;
-
-  string_list_free(self->columns);
-  log_parser_free_method(s);
-}
-
-void
-log_column_parser_init_instance(LogColumnParser *self, GlobalConfig *cfg)
-{
-  log_parser_init_instance(&self->super, cfg);
-  self->super.super.free_fn = log_column_parser_free_method;
-}

--- a/lib/parser/parser-expr.h
+++ b/lib/parser/parser-expr.h
@@ -32,7 +32,6 @@
 #include <string.h>
 
 typedef struct _LogParser LogParser;
-typedef struct _LogColumnParser LogColumnParser;
 
 struct _LogParser
 {
@@ -53,15 +52,5 @@ log_parser_process(LogParser *self, LogMessage **pmsg, const LogPathOptions *pat
     input_len = strlen(input);
   return self->process(self, pmsg, path_options, input, input_len);
 }
-
-struct _LogColumnParser
-{
-  LogParser super;
-  GList *columns;
-};
-
-void log_column_parser_set_columns(LogColumnParser *s, GList *fields);
-void log_column_parser_init_instance(LogColumnParser *self, GlobalConfig *cfg);
-void log_column_parser_free_method(LogPipe *s);
 
 #endif

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -8,9 +8,10 @@ lib_tests_TESTS		= \
 	lib/tests/test_reloc		\
 	lib/tests/test_hostname		\
 	lib/tests/test_rcptid		\
-	lib/tests/test_lexer        \
-	lib/tests/test_str_format   \
-	lib/tests/test_runid        \
+	lib/tests/test_lexer        	\
+	lib/tests/test_str_format   	\
+	lib/tests/test_string_list	\
+	lib/tests/test_runid        	\
 	lib/tests/test_pathutils	\
 	lib/tests/test_utf8utils
 
@@ -81,6 +82,11 @@ lib_tests_test_runid_LDADD	=	\
 lib_tests_test_str_format_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_str_format_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_string_list_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_string_list_LDADD	=	\
 	$(TEST_LDADD)
 
 lib_tests_test_pathutils_CFLAGS	=	\

--- a/lib/tests/test_string_list.c
+++ b/lib/tests/test_string_list.c
@@ -20,8 +20,36 @@ test_string_array_to_list_converts_to_an_equivalent_glist(void)
   string_list_free(l);
 }
 
+static void
+test_clone_string_array_duplicates_elements_while_leaving_token_values_intact(void)
+{
+  const gchar *arr[] = {
+    "foo",
+    "bar",
+    "baz",
+    NULL
+  };
+  GList *l, *l2;
+
+  l = string_array_to_list(arr);
+  l = g_list_append(l, GUINT_TO_POINTER(1));
+  l = g_list_append(l, GUINT_TO_POINTER(2));
+  l2 = string_list_clone(l);
+  string_list_free(l);
+
+  assert_gint(g_list_length(l2), 5, "converted list is not the expected length");
+  assert_string(l2->data, "foo", "first element is expected to be foo");
+  assert_string(l2->next->data, "bar", "second element is expected to be bar");
+  assert_string(l2->next->next->data, "baz", "third element is expected to be baz");
+  assert_gint(GPOINTER_TO_UINT(l2->next->next->next->data), 1, "fourth element is expected to be a token, with a value of 1");
+  assert_gint(GPOINTER_TO_UINT(l2->next->next->next->next->data), 2, "fifth element is expected to be a token, with a value of 2");
+
+  string_list_free(l2);
+}
+
 int
 main(int argc, char *argv[])
 {
   test_string_array_to_list_converts_to_an_equivalent_glist();
+  test_clone_string_array_duplicates_elements_while_leaving_token_values_intact();
 }

--- a/lib/tests/test_string_list.c
+++ b/lib/tests/test_string_list.c
@@ -1,0 +1,27 @@
+#include "misc.h"
+#include "testutils.h"
+
+static void
+test_string_array_to_list_converts_to_an_equivalent_glist(void)
+{
+  const gchar *arr[] = {
+    "foo",
+    "bar",
+    "baz",
+    NULL
+  };
+  GList *l;
+
+  l = string_array_to_list(arr);
+  assert_gint(g_list_length(l), 3, "converted list is not the expected length");
+  assert_string(l->data, "foo", "first element is expected to be foo");
+  assert_string(l->next->data, "bar", "second element is expected to be bar");
+  assert_string(l->next->next->data, "baz", "third element is expected to be baz");
+  string_list_free(l);
+}
+
+int
+main(int argc, char *argv[])
+{
+  test_string_array_to_list_converts_to_an_equivalent_glist();
+}

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -66,7 +66,7 @@ start
 parser_expr_csv
         : KW_CSV_PARSER '('
           {
-            last_parser = *instance = (LogParser *) log_csv_parser_new(configuration);
+            last_parser = *instance = (LogParser *) csv_parser_new(configuration);
           }
           parser_csv_opts
           ')'					{ $$ = last_parser; }
@@ -80,13 +80,13 @@ parser_csv_opts
 
 parser_csv_opt
         : KW_FLAGS '(' parser_csv_flags ')'     {
-                                                  guint32 flags = log_csv_parser_normalize_escape_flags((LogColumnParser *) last_parser, $3);
-                                                  log_csv_parser_set_flags((LogColumnParser *) last_parser, flags);
+                                                  guint32 flags = csv_parser_normalize_escape_flags((LogColumnParser *) last_parser, $3);
+                                                  csv_parser_set_flags((LogColumnParser *) last_parser, flags);
                                                 }
         | KW_DELIMITERS '(' parser_csv_delimiters ')'
-        | KW_QUOTES '(' string ')'              { log_csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
-        | KW_QUOTE_PAIRS '(' string ')'         { log_csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
-        | KW_NULL '(' string ')'                { log_csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_QUOTES '(' string ')'              { csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_QUOTE_PAIRS '(' string ')'         { csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
+        | KW_NULL '(' string ')'                { csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
         | parser_column_opt
         ;
 
@@ -95,8 +95,8 @@ parser_csv_delimiters
   ;
 
 parser_csv_delimiters_chars
-  : KW_CHARS '(' string ')' { log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
-  | string {  log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $1); free($1);  }
+  : KW_CHARS '(' string ')' { csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
+  | string {  csv_parser_set_delimiters((LogColumnParser *) last_parser, $1); free($1);  }
   |
   ;
 
@@ -108,13 +108,13 @@ parser_csv_delimiter_strings
 parser_csv_delimiter_string
         : string parser_csv_delimiter_string
           {
-            log_csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1); free($1);
+            csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1); free($1);
           }
         | 
         ;
 
 parser_csv_flags
-        : string parser_csv_flags               { $$ = log_csv_parser_lookup_flag($1) | $2; free($1); }
+        : string parser_csv_flags               { $$ = csv_parser_lookup_flag($1) | $2; free($1); }
         |					{ $$ = 0; }
         ;
 

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -92,19 +92,19 @@ parser_csv_opt
         ;
 
 parser_csv_delimiters
-  : parser_csv_delimiters_chars parser_csv_delimiter_strings
-  ;
+        : string                                {  csv_parser_set_delimiters(last_parser, $1); free($1);  }
+        | parser_csv_delimiters_opts
+        ;
 
-parser_csv_delimiters_chars
-  : KW_CHARS '(' string ')' { csv_parser_set_delimiters(last_parser, $3); free($3); }
-  | string {  csv_parser_set_delimiters(last_parser, $1); free($1);  }
-  |
-  ;
+parser_csv_delimiters_opts
+        : parser_csv_delimiters_opt parser_csv_delimiters_opts
+        |
+        ;
 
-parser_csv_delimiter_strings
-  : KW_STRINGS '('  string_list  ')'		{ csv_parser_set_string_delimiters(last_parser, $3); }
-  |
-  ;
+parser_csv_delimiters_opt
+        : KW_CHARS '(' string ')'               { csv_parser_set_delimiters(last_parser, $3); free($3); }
+        | KW_STRINGS '('  string_list  ')'	{ csv_parser_set_string_delimiters(last_parser, $3); }
+        ;
 
 parser_csv_flags
         : string parser_csv_flags               { $$ = csv_parser_lookup_flag($1) | $2; free($1); }

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -102,17 +102,9 @@ parser_csv_delimiters_chars
   ;
 
 parser_csv_delimiter_strings
-  : KW_STRINGS '('  parser_csv_delimiter_string  ')'
+  : KW_STRINGS '('  string_list  ')'		{ csv_parser_set_string_delimiters(last_parser, $3); }
   |
   ;
-
-parser_csv_delimiter_string
-        : string parser_csv_delimiter_string
-          {
-            csv_parser_append_string_delimiter(last_parser, $1); free($1);
-          }
-        | 
-        ;
 
 parser_csv_flags
         : string parser_csv_flags               { $$ = csv_parser_lookup_flag($1) | $2; free($1); }

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -66,7 +66,7 @@ start
 parser_expr_csv
         : KW_CSV_PARSER '('
           {
-            last_parser = *instance = (LogParser *) csv_parser_new(configuration);
+            last_parser = *instance = csv_parser_new(configuration);
           }
           parser_csv_opts
           ')'					{ $$ = last_parser; }
@@ -80,14 +80,15 @@ parser_csv_opts
 
 parser_csv_opt
         : KW_FLAGS '(' parser_csv_flags ')'     {
-                                                  guint32 flags = csv_parser_normalize_escape_flags((LogColumnParser *) last_parser, $3);
-                                                  csv_parser_set_flags((LogColumnParser *) last_parser, flags);
+                                                  guint32 flags = csv_parser_normalize_escape_flags(last_parser, $3);
+                                                  csv_parser_set_flags(last_parser, flags);
                                                 }
         | KW_DELIMITERS '(' parser_csv_delimiters ')'
-        | KW_QUOTES '(' string ')'              { csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
-        | KW_QUOTE_PAIRS '(' string ')'         { csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }
-        | KW_NULL '(' string ')'                { csv_parser_set_null_value((LogColumnParser *) last_parser, $3); free($3); }
-        | parser_column_opt
+        | KW_QUOTES '(' string ')'              { csv_parser_set_quotes(last_parser, $3); free($3); }
+        | KW_QUOTE_PAIRS '(' string ')'         { csv_parser_set_quote_pairs(last_parser, $3); free($3); }
+        | KW_NULL '(' string ')'                { csv_parser_set_null_value(last_parser, $3); free($3); }
+        | KW_COLUMNS '(' string_list ')'        { csv_parser_set_columns(last_parser, $3); }
+        | parser_opt
         ;
 
 parser_csv_delimiters
@@ -95,8 +96,8 @@ parser_csv_delimiters
   ;
 
 parser_csv_delimiters_chars
-  : KW_CHARS '(' string ')' { csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
-  | string {  csv_parser_set_delimiters((LogColumnParser *) last_parser, $1); free($1);  }
+  : KW_CHARS '(' string ')' { csv_parser_set_delimiters(last_parser, $3); free($3); }
+  | string {  csv_parser_set_delimiters(last_parser, $1); free($1);  }
   |
   ;
 
@@ -108,7 +109,7 @@ parser_csv_delimiter_strings
 parser_csv_delimiter_string
         : string parser_csv_delimiter_string
           {
-            csv_parser_append_string_delimiter((LogColumnParser *) last_parser, $1); free($1);
+            csv_parser_append_string_delimiter(last_parser, $1); free($1);
           }
         | 
         ;

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -80,20 +80,28 @@ csv_parser_normalize_escape_flags(LogParser *s, guint32 new_flag)
 }
 
 void
+csv_parser_set_flags(LogParser *s, guint32 flags)
+{
+  CSVParser *self = (CSVParser *) s;
+
+  self->flags = flags;
+}
+
+guint32
+csv_parser_get_flags(LogParser *s)
+{
+  CSVParser *self = (CSVParser *) s;
+
+  return self->flags;
+}
+
+void
 csv_parser_set_columns(LogParser *s, GList *columns)
 {
   CSVParser *self = (CSVParser *) s;
 
   string_list_free(self->columns);
   self->columns = columns;
-}
-
-void
-csv_parser_set_flags(LogParser *s, guint32 flags)
-{
-  CSVParser *self = (CSVParser *) s;
-
-  self->flags = flags;
 }
 
 void
@@ -697,12 +705,4 @@ csv_parser_lookup_flag(const gchar *flag)
     return CSV_PARSER_DROP_INVALID;
   msg_error("Unknown CSV parser flag", evt_tag_str("flag", flag), NULL);
   return 0;
-}
-
-guint32
-csv_parser_get_flags(LogParser *s)
-{
-  CSVParser *self = (CSVParser *) s;
-
-  return self->flags;
 }

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -115,6 +115,16 @@ csv_parser_set_delimiters(LogParser *s, const gchar *delimiters)
 }
 
 void
+csv_parser_set_string_delimiters(LogParser *s, GList *string_delimiters)
+{
+  CSVParser *self = (CSVParser *) s;
+
+  if (self->string_delimiters)
+    string_list_free(self->string_delimiters);
+  self->string_delimiters = string_delimiters;
+}
+
+void
 csv_parser_set_quotes(LogParser *s, const gchar *quotes)
 {
   CSVParser *self = (CSVParser *) s;
@@ -158,14 +168,6 @@ csv_parser_set_null_value(LogParser *s, const gchar *null_value)
   if (self->null_value)
     g_free(self->null_value);
   self->null_value = g_strdup(null_value);
-}
-
-void
-csv_parser_append_string_delimiter(LogParser *s, const gchar *string_delimiter)
-{
-  CSVParser *self = (CSVParser *) s;
-
-  self->string_delimiters = g_list_prepend(self->string_delimiters, (gpointer)g_strdup(string_delimiter));
 }
 
 static inline gboolean

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -633,7 +633,7 @@ csv_parser_clone(LogPipe *s)
   g_free(cloned->quotes_start);
   g_free(cloned->quotes_end);
   if (cloned->string_delimiters)
-    g_list_free_full(cloned->string_delimiters, g_free);
+    string_list_free(cloned->string_delimiters);
 
   cloned->delimiters = g_strdup(self->delimiters);
   cloned->quotes_start = g_strdup(self->quotes_start);

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -627,7 +627,6 @@ csv_parser_clone(LogPipe *s)
 {
   CSVParser *self = (CSVParser *) s;
   CSVParser *cloned;
-  GList *l;
 
   cloned = (CSVParser *) csv_parser_new(s->cfg);
   g_free(cloned->delimiters);
@@ -644,10 +643,7 @@ csv_parser_clone(LogPipe *s)
   cloned->string_delimiters = self->string_delimiters;
 
   cloned->super.template = log_template_ref(self->super.template);
-  for (l = self->columns; l; l = l->next)
-    {
-      cloned->columns = g_list_append(cloned->columns, g_strdup(l->data));
-    }
+  cloned->columns = string_list_clone(self->columns);
   return &cloned->super.super;
 }
 

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -640,7 +640,7 @@ csv_parser_clone(LogPipe *s)
   cloned->quotes_end = g_strdup(self->quotes_end);
   cloned->null_value = self->null_value ? g_strdup(self->null_value) : NULL;
   cloned->flags = self->flags;
-  cloned->string_delimiters = self->string_delimiters;
+  cloned->string_delimiters = string_list_clone(self->string_delimiters);
 
   cloned->super.template = log_template_ref(self->super.template);
   cloned->columns = string_list_clone(self->columns);

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -36,16 +36,17 @@
 
 #define CSV_PARSER_FLAGS_DEFAULT  ((CSV_PARSER_STRIP_WHITESPACE) | (CSV_PARSER_ESCAPE_NONE))
 
-void csv_parser_set_flags(LogColumnParser *s, guint32 flags);
-void csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters);
-void csv_parser_set_quotes(LogColumnParser *s, const gchar *quotes);
-void csv_parser_set_quote_pairs(LogColumnParser *s, const gchar *quote_pairs);
-void csv_parser_set_null_value(LogColumnParser *s, const gchar *null_value);
-void csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_delimiter);
-LogColumnParser *csv_parser_new(GlobalConfig *cfg);
+void csv_parser_set_columns(LogParser *s, GList *fields);
+void csv_parser_set_flags(LogParser *s, guint32 flags);
+void csv_parser_set_delimiters(LogParser *s, const gchar *delimiters);
+void csv_parser_set_quotes(LogParser *s, const gchar *quotes);
+void csv_parser_set_quote_pairs(LogParser *s, const gchar *quote_pairs);
+void csv_parser_set_null_value(LogParser *s, const gchar *null_value);
+void csv_parser_append_string_delimiter(LogParser *s, const gchar *string_delimiter);
+LogParser *csv_parser_new(GlobalConfig *cfg);
 guint32 csv_parser_lookup_flag(const gchar *flag);
-guint32 csv_parser_normalize_escape_flags(LogColumnParser *s, guint32 new_flag);
+guint32 csv_parser_normalize_escape_flags(LogParser *s, guint32 new_flag);
 
-guint32 csv_parser_get_flags(LogColumnParser *s);
+guint32 csv_parser_get_flags(LogParser *s);
 
 #endif

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -39,10 +39,10 @@
 void csv_parser_set_columns(LogParser *s, GList *fields);
 void csv_parser_set_flags(LogParser *s, guint32 flags);
 void csv_parser_set_delimiters(LogParser *s, const gchar *delimiters);
+void csv_parser_set_string_delimiters(LogParser *s, GList *string_delimiters);
 void csv_parser_set_quotes(LogParser *s, const gchar *quotes);
 void csv_parser_set_quote_pairs(LogParser *s, const gchar *quote_pairs);
 void csv_parser_set_null_value(LogParser *s, const gchar *null_value);
-void csv_parser_append_string_delimiter(LogParser *s, const gchar *string_delimiter);
 LogParser *csv_parser_new(GlobalConfig *cfg);
 guint32 csv_parser_lookup_flag(const gchar *flag);
 guint32 csv_parser_normalize_escape_flags(LogParser *s, guint32 new_flag);

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -26,26 +26,26 @@
 
 #include "parser/parser-expr.h"
 
-#define LOG_CSV_PARSER_ESCAPE_NONE        0x0001
-#define LOG_CSV_PARSER_ESCAPE_BACKSLASH   0x0002
-#define LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR 0x0004
-#define LOG_CSV_PARSER_ESCAPE_MASK        0x0007
-#define LOG_CSV_PARSER_STRIP_WHITESPACE   0x0008
-#define LOG_CSV_PARSER_GREEDY             0x0010
-#define LOG_CSV_PARSER_DROP_INVALID       0x0020
+#define CSV_PARSER_ESCAPE_NONE        0x0001
+#define CSV_PARSER_ESCAPE_BACKSLASH   0x0002
+#define CSV_PARSER_ESCAPE_DOUBLE_CHAR 0x0004
+#define CSV_PARSER_ESCAPE_MASK        0x0007
+#define CSV_PARSER_STRIP_WHITESPACE   0x0008
+#define CSV_PARSER_GREEDY             0x0010
+#define CSV_PARSER_DROP_INVALID       0x0020
 
-#define LOG_CSV_PARSER_FLAGS_DEFAULT  ((LOG_CSV_PARSER_STRIP_WHITESPACE) | (LOG_CSV_PARSER_ESCAPE_NONE))
+#define CSV_PARSER_FLAGS_DEFAULT  ((CSV_PARSER_STRIP_WHITESPACE) | (CSV_PARSER_ESCAPE_NONE))
 
-void log_csv_parser_set_flags(LogColumnParser *s, guint32 flags);
-void log_csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters);
-void log_csv_parser_set_quotes(LogColumnParser *s, const gchar *quotes);
-void log_csv_parser_set_quote_pairs(LogColumnParser *s, const gchar *quote_pairs);
-void log_csv_parser_set_null_value(LogColumnParser *s, const gchar *null_value);
-void log_csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_delimiter);
-LogColumnParser *log_csv_parser_new(GlobalConfig *cfg);
-guint32 log_csv_parser_lookup_flag(const gchar *flag);
-guint32 log_csv_parser_normalize_escape_flags(LogColumnParser *s, guint32 new_flag);
+void csv_parser_set_flags(LogColumnParser *s, guint32 flags);
+void csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters);
+void csv_parser_set_quotes(LogColumnParser *s, const gchar *quotes);
+void csv_parser_set_quote_pairs(LogColumnParser *s, const gchar *quote_pairs);
+void csv_parser_set_null_value(LogColumnParser *s, const gchar *null_value);
+void csv_parser_append_string_delimiter(LogColumnParser *s, const gchar *string_delimiter);
+LogColumnParser *csv_parser_new(GlobalConfig *cfg);
+guint32 csv_parser_lookup_flag(const gchar *flag);
+guint32 csv_parser_normalize_escape_flags(LogColumnParser *s, guint32 new_flag);
 
-guint32 log_csv_parser_get_flags(LogColumnParser *s);
+guint32 csv_parser_get_flags(LogColumnParser *s);
 
 #endif

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -82,21 +82,21 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
   parse_options.flags = parse_flags;
   logmsg = log_msg_new(msg, strlen(msg), NULL, &parse_options);
 
-  p = log_csv_parser_new(NULL);
-  log_csv_parser_set_flags(p, flags);
+  p = csv_parser_new(NULL);
+  csv_parser_set_flags(p, flags);
   log_column_parser_set_columns(p, string_array_to_list(column_array));
   if (delimiters)
-    log_csv_parser_set_delimiters(p, delimiters);
+    csv_parser_set_delimiters(p, delimiters);
   if (quotes)
-    log_csv_parser_set_quote_pairs(p, quotes);
+    csv_parser_set_quote_pairs(p, quotes);
   if (null_value)
-    log_csv_parser_set_null_value(p, null_value);
+    csv_parser_set_null_value(p, null_value);
 
   if (string_delims)
     {
       for (i = 0; string_delims[i] != NULL; i++)
         {
-          log_csv_parser_append_string_delimiter(p, strdup(string_delims[i]));
+          csv_parser_append_string_delimiter(p, strdup(string_delims[i]));
         }
     }
 
@@ -160,164 +160,164 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   // string delim & single char & a char benne van a stringben is
   const char* string_delims[] = {" :", NULL};
-  testcase("<15> openvpn[2499]: PTHREAD support :initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, string_delims,
+  testcase("<15> openvpn[2499]: PTHREAD support :initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, string_delims,
            "PTHREAD", "support", "initialized", NULL);
 
   // string delim & single char & a char nincs benne a stringben
-  testcase("<15> openvpn[2499]: PTHREAD,support :initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, ",", NULL, NULL, string_delims,
+  testcase("<15> openvpn[2499]: PTHREAD,support :initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, ",", NULL, NULL, string_delims,
            "PTHREAD", "support", "initialized", NULL);
 
   // string delim & multi char & a char benne van a stringben is
-  testcase("<15> openvpn[2499]: PTHREAD support :initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " :", NULL, NULL, string_delims,
+  testcase("<15> openvpn[2499]: PTHREAD support :initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, " :", NULL, NULL, string_delims,
            "PTHREAD", "support", "initialized", NULL);
 
   // string delim & multi char & a char nincs benne a stringben
-  testcase("<15> openvpn[2499]: PTHREAD,support :initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, ";,", NULL, NULL, string_delims,
+  testcase("<15> openvpn[2499]: PTHREAD,support :initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, ";,", NULL, NULL, string_delims,
            "PTHREAD", "support", "initialized", NULL);
 
   // quote + string delim & multi char & a char benne van a stringben is
-  testcase("<15> openvpn[2499]: 'PTHREAD' 'support' :'initialized'", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " :", "''", NULL, string_delims,
+  testcase("<15> openvpn[2499]: 'PTHREAD' 'support' :'initialized'", 0, -1, CSV_PARSER_ESCAPE_NONE, " :", "''", NULL, string_delims,
            "PTHREAD", "support", "initialized", NULL);
 
   // quote + string delim & multi char & a char nincs benne a stringben
-  testcase("<15> openvpn[2499]: 'PTHREAD','support' :'initialized'", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, ";,", "''", NULL, string_delims,
+  testcase("<15> openvpn[2499]: 'PTHREAD','support' :'initialized'", 0, -1, CSV_PARSER_ESCAPE_NONE, ";,", "''", NULL, string_delims,
            "PTHREAD", "support", "initialized", NULL);
 
   // BE + quote + string delim & multi char & a char benne van a stringben is
-  testcase("<15> openvpn[2499]: 'PTHRE\\\'AD' 'support' :'initialized'", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " :", "''", NULL, string_delims,
+  testcase("<15> openvpn[2499]: 'PTHRE\\\'AD' 'support' :'initialized'", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " :", "''", NULL, string_delims,
            "PTHRE'AD", "support", "initialized", NULL);
 
   // DCE + quote + string delim & multi char & a char nincs benne a stringben
-  testcase("<15> openvpn[2499]: 'PTHREAD','sup''port' :'initialized'", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, ";,", "''", NULL, string_delims,
+  testcase("<15> openvpn[2499]: 'PTHREAD','sup''port' :'initialized'", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR, ";,", "''", NULL, string_delims,
            "PTHREAD", "sup'port", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 3, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 3, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 2, LOG_CSV_PARSER_ESCAPE_NONE | LOG_CSV_PARSER_DROP_INVALID, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 2, CSV_PARSER_ESCAPE_NONE | CSV_PARSER_DROP_INVALID, " ", NULL, NULL, NULL,
           NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 2, LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 2, CSV_PARSER_GREEDY | CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD", "support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ,;", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, " ,;", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ,;", NULL, "support", NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, " ,;", NULL, "support", NULL,
            "PTHREAD", "", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD\"+\"support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD\"+\"support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD", "+\"support\"", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"  PTHREAD  \" \" support\" \"initialized \"", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE + LOG_CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"  PTHREAD  \" \" support\" \"initialized \"", 0, -1, CSV_PARSER_ESCAPE_NONE + CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support initialized\"", 0, -1, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_NONE, " ", NULL, NULL, NULL,
            "PTHREAD support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 2, LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, 2, CSV_PARSER_GREEDY | CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD", "support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ;,", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ;,", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, 2, LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, 2, CSV_PARSER_GREEDY | CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD", "\"support\" \"initialized\"", NULL);
 
-  testcase("<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH + LOG_CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH + CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD \\\"support initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD \\\"support initialized\"", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD \"support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ", NULL, NULL, NULL,
            "PTHREAD support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, 2, LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"", 0, 2, CSV_PARSER_GREEDY | CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
            "PTHREAD", "\"support\" \"initialized\"", NULL);
 
-  testcase("<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR + LOG_CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR + CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
            "PTHREAD", "support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"", 0, 2, LOG_CSV_PARSER_GREEDY + LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR + LOG_CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"", 0, 2, CSV_PARSER_GREEDY + CSV_PARSER_ESCAPE_DOUBLE_CHAR + CSV_PARSER_STRIP_WHITESPACE, " ", NULL, NULL, NULL,
            "PTHREAD", "\"  support\" \"initialized  \"", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
            "PTHREAD support", "initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD \"\"support initialized\"", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD \"\"support initialized\"", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
            "PTHREAD \"support initialized", NULL);
 
-  testcase("<15> openvpn[2499]: \"PTHREAD support initialized", 0, -1, LOG_CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
+  testcase("<15> openvpn[2499]: \"PTHREAD support initialized", 0, -1, CSV_PARSER_ESCAPE_DOUBLE_CHAR, " ", NULL, NULL, NULL,
            "PTHREAD support initialized", NULL);
 
-  testcase("postfix/smtpd", LP_NOPARSE, 2, LOG_CSV_PARSER_ESCAPE_NONE | LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_DROP_INVALID, "/", NULL, NULL, NULL,
+  testcase("postfix/smtpd", LP_NOPARSE, 2, CSV_PARSER_ESCAPE_NONE | CSV_PARSER_GREEDY | CSV_PARSER_DROP_INVALID, "/", NULL, NULL, NULL,
            "postfix", "smtpd", NULL);
 
-  testcase("postfix", LP_NOPARSE, 3, LOG_CSV_PARSER_ESCAPE_NONE | LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_DROP_INVALID, "/", NULL, NULL, NULL,
+  testcase("postfix", LP_NOPARSE, 3, CSV_PARSER_ESCAPE_NONE | CSV_PARSER_GREEDY | CSV_PARSER_DROP_INVALID, "/", NULL, NULL, NULL,
            NULL);
 
-  testcase("postfix/smtpd/ququ", LP_NOPARSE, 2, LOG_CSV_PARSER_ESCAPE_NONE | LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_DROP_INVALID, "/", NULL, NULL, NULL,
+  testcase("postfix/smtpd/ququ", LP_NOPARSE, 2, CSV_PARSER_ESCAPE_NONE | CSV_PARSER_GREEDY | CSV_PARSER_DROP_INVALID, "/", NULL, NULL, NULL,
            "postfix", "smtpd/ququ", NULL);
 
-  testcase("Jul 27 19:55:33 myhost zabbix: ZabbixConnector.log : 19:55:32,782 INFO  [Thread-2834]     - [ZabbixEventSyncCommand] Processing   message <?xml version=\"1.0\" encoding=\"UTF-8\"?>", LP_EXPECT_HOSTNAME, 2, LOG_CSV_PARSER_GREEDY, " ", NULL, NULL, NULL,
+  testcase("Jul 27 19:55:33 myhost zabbix: ZabbixConnector.log : 19:55:32,782 INFO  [Thread-2834]     - [ZabbixEventSyncCommand] Processing   message <?xml version=\"1.0\" encoding=\"UTF-8\"?>", LP_EXPECT_HOSTNAME, 2, CSV_PARSER_GREEDY, " ", NULL, NULL, NULL,
            "ZabbixConnector.log", ": 19:55:32,782 INFO  [Thread-2834]     - [ZabbixEventSyncCommand] Processing   message <?xml version=\"1.0\" encoding=\"UTF-8\"?>", NULL);
 
-  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, -1, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
+  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, -1, CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
            "10.100.20.1", "", "", "31/Dec/2007:00:17:10 +0100", "GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1", "200", "2708", "", "curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5", "2", "bugzilla.balabit", NULL);
 
-  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, 11, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
+  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, 11, CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
            "10.100.20.1", "", "", "31/Dec/2007:00:17:10 +0100", "GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1", "200", "2708", "", "curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5", "2", "bugzilla.balabit", NULL);
 
-  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, 10, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
+  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, 10, CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
            "10.100.20.1", "", "", "31/Dec/2007:00:17:10 +0100", "GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1", "200", "2708", "", "curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5", "2", NULL);
 
-  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, 12, LOG_CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
+  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit", LP_NOPARSE, 12, CSV_PARSER_ESCAPE_BACKSLASH, " ", "\"\"[]", "-", NULL,
            "10.100.20.1", "", "", "31/Dec/2007:00:17:10 +0100", "GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1", "200", "2708", "", "curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5", "2", "bugzilla.balabit", "", NULL);
 
-  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit almafa", LP_NOPARSE, 11, LOG_CSV_PARSER_ESCAPE_BACKSLASH | LOG_CSV_PARSER_DROP_INVALID, " ", "\"\"[]", "-", NULL,
+  testcase("10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit almafa", LP_NOPARSE, 11, CSV_PARSER_ESCAPE_BACKSLASH | CSV_PARSER_DROP_INVALID, " ", "\"\"[]", "-", NULL,
            NULL);
 
-  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 5, LOG_CSV_PARSER_ESCAPE_NONE | LOG_CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
+  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 5, CSV_PARSER_ESCAPE_NONE | CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
            "random.vhost", "10.0.0.1", "", "GET /index.html HTTP/1.1", "200", NULL);
 
-  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 5, LOG_CSV_PARSER_ESCAPE_BACKSLASH | LOG_CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
+  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 5, CSV_PARSER_ESCAPE_BACKSLASH | CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
            "random.vhost", "10.0.0.1", "", "GET /index.html HTTP/1.1", "200", NULL);
 
   /* greedy column can be empty */
-  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 6, LOG_CSV_PARSER_ESCAPE_NONE | LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
+  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 6, CSV_PARSER_ESCAPE_NONE | CSV_PARSER_GREEDY | CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
            "random.vhost", "10.0.0.1", "", "GET /index.html HTTP/1.1", "200", "", NULL);
 
-  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 6, LOG_CSV_PARSER_ESCAPE_BACKSLASH | LOG_CSV_PARSER_GREEDY | LOG_CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
+  testcase("random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200", LP_NOPARSE, 6, CSV_PARSER_ESCAPE_BACKSLASH | CSV_PARSER_GREEDY | CSV_PARSER_DROP_INVALID, " ", "\"\"", "-", NULL,
            "random.vhost", "10.0.0.1", "", "GET /index.html HTTP/1.1", "200", "", NULL);
 
-  testcase("random.vhost\t10.0.0.1\t-\t\"GET /index.html HTTP/1.1\"\t200", LP_NOPARSE, 6, LOG_CSV_PARSER_ESCAPE_BACKSLASH, "\t", "\"\"", "-", NULL,
+  testcase("random.vhost\t10.0.0.1\t-\t\"GET /index.html HTTP/1.1\"\t200", LP_NOPARSE, 6, CSV_PARSER_ESCAPE_BACKSLASH, "\t", "\"\"", "-", NULL,
            "random.vhost", "10.0.0.1", "", "GET /index.html HTTP/1.1", "200", "", NULL);
-  testcase("random.vhost\t10.0.0.1\t-\t\"GET /index.html HTTP/1.1\"\t\t200", LP_NOPARSE, 7, LOG_CSV_PARSER_ESCAPE_BACKSLASH, "\t", "\"\"", "-", NULL,
+  testcase("random.vhost\t10.0.0.1\t-\t\"GET /index.html HTTP/1.1\"\t\t200", LP_NOPARSE, 7, CSV_PARSER_ESCAPE_BACKSLASH, "\t", "\"\"", "-", NULL,
            "random.vhost", "10.0.0.1", "", "GET /index.html HTTP/1.1", "", "200", "", NULL);
 
 

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -30,7 +30,7 @@ int
 testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *delimiters, gchar *quotes, gchar *null_value, const gchar *string_delims[], gchar *first_value, ...)
 {
   LogMessage *logmsg;
-  LogParser *p;
+  LogParser *p, *pclone;
   gchar *expected_value;
   gint i;
   va_list va;
@@ -100,8 +100,11 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
         }
     }
 
+  pclone = (LogParser *) log_pipe_clone(&p->super);
+  log_pipe_unref(&p->super);
+
   nvtable = nv_table_ref(logmsg->payload);
-  success = log_parser_process(p, &logmsg, NULL, log_msg_get_value(logmsg, LM_V_MESSAGE, NULL), -1);
+  success = log_parser_process(pclone, &logmsg, NULL, log_msg_get_value(logmsg, LM_V_MESSAGE, NULL), -1);
   nv_table_unref(nvtable);
 
   if (success && !first_value)
@@ -114,7 +117,7 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
       fprintf(stderr, "unexpected non-match; msg=%s\n", msg);
       exit(1);
     }
-  log_pipe_unref(&p->super);
+  log_pipe_unref(&pclone->super);
 
   va_start(va, first_value);
   expected_value = first_value;

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -30,7 +30,7 @@ int
 testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *delimiters, gchar *quotes, gchar *null_value, const gchar *string_delims[], gchar *first_value, ...)
 {
   LogMessage *logmsg;
-  LogColumnParser *p;
+  LogParser *p;
   gchar *expected_value;
   gint i;
   va_list va;
@@ -84,7 +84,7 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
 
   p = csv_parser_new(NULL);
   csv_parser_set_flags(p, flags);
-  log_column_parser_set_columns(p, string_array_to_list(column_array));
+  csv_parser_set_columns(p, string_array_to_list(column_array));
   if (delimiters)
     csv_parser_set_delimiters(p, delimiters);
   if (quotes)
@@ -101,7 +101,7 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
     }
 
   nvtable = nv_table_ref(logmsg->payload);
-  success = log_parser_process(&p->super, &logmsg, NULL, log_msg_get_value(logmsg, LM_V_MESSAGE, NULL), -1);
+  success = log_parser_process(p, &logmsg, NULL, log_msg_get_value(logmsg, LM_V_MESSAGE, NULL), -1);
   nv_table_unref(nvtable);
 
   if (success && !first_value)
@@ -114,7 +114,7 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
       fprintf(stderr, "unexpected non-match; msg=%s\n", msg);
       exit(1);
     }
-  log_pipe_unref(&p->super.super);
+  log_pipe_unref(&p->super);
 
   va_start(va, first_value);
   expected_value = first_value;

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -93,12 +93,7 @@ testcase(gchar *msg, guint parse_flags, gint max_columns, guint32 flags, gchar *
     csv_parser_set_null_value(p, null_value);
 
   if (string_delims)
-    {
-      for (i = 0; string_delims[i] != NULL; i++)
-        {
-          csv_parser_append_string_delimiter(p, strdup(string_delims[i]));
-        }
-    }
+    csv_parser_set_string_delimiters(p, string_array_to_list(string_delims));
 
   pclone = (LogParser *) log_pipe_clone(&p->super);
   log_pipe_unref(&p->super);


### PR DESCRIPTION
This is the first chunk of my work to clean up the code for csv-parser. I only wanted to add a single and simple option, but the code doesn't really help, rather it became rather convoluted.

So instead of adding the new option, I started refactoring what we have there.

There is at least one important bugfix here, one that fixes the clone() method. That should probably be backported to earlier versions as well.

I also have yet another batch of patches, but that still needs some cleanup, so I submit this, hopefully reviewing this in smaller steps is easier.

Cheers,
Bazsi
