### PR TITLE
syslog-ng.pc: add eventlog as a required package

### DIFF
--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -12,6 +12,6 @@ ivykis=@with_ivykis@
 Name: syslog-ng-dev
 Description: Dev package for syslog-ng module
 Version: @VERSION@
-Requires: glib-2.0
+Requires: glib-2.0 eventlog
 Libs: -L${libdir} @GLIB_LIBS@ -lsyslog-ng
 Cflags: -I${includedir}/syslog-ng @INTERNAL_IVYKIS_CFLAGS@


### PR DESCRIPTION
If a program wants to compile something which includes headers from syslog-ng then it needs to know that eventlog is also needed.

Signed-off-by: Tibor Benke <ihrwein@gmail.com>