### PR TITLE
logmsg: Fix a logmsg_cached_abort assignment

### DIFF
--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -1413,7 +1413,7 @@ log_msg_ack(LogMessage *self, const LogPathOptions *path_options, AckType ack_ty
            * delayed until log_msg_refcache_stop() is called */
 
           logmsg_cached_acks--;
-          logmsg_cached_abort |= (ACKTYPE_TO_ABORTFLAG(ack_type) == AT_ABORTED ? TRUE : FALSE);
+          logmsg_cached_abort |= ACKTYPE_TO_ABORTFLAG(ack_type);
           return;
         }
 


### PR DESCRIPTION
Explanation for the diff:
 * `#define ACKTYPE_TO_ABORTFLAG(x) (x == AT_ABORTED ? 1 : 0)`
 * AT_ABORTED is equal to 2

Therefore the second check will fail always.

This issue has been found by Coverity Scan.
CID: 41449
Related Common Weakness Enumeration: CWE-569.

The report can be found here:
https://scan4.coverity.com/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/balabit/syslog-ng/751)
<!-- Reviewable:end -->
