### PR TITLE
afamqp: support systemwide librabbitmq-c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ GLIB_MIN_VERSION="2.10.1"
 EVTLOG_MIN_VERSION="0.2.12"
 OPENSSL_MIN_VERSION="0.9.8"
 LIBDBI_MIN_VERSION="0.8.0"
+LIBRABBITMQ_MIN_VERSION="0.5.3"
 IVYKIS_MIN_VERSION="0.36.1"
 JSON_C_MIN_VERSION="0.9"
 PCRE_MIN_VERSION="6.1"
@@ -1041,7 +1042,7 @@ if test "x$with_librabbitmq_client" = "xinternal"; then
         with_librabbitmq_client="no"
     fi
 elif test "x$with_librabbitmq_client" = "xsystem"; then
-    AC_MSG_ERROR([Building with system librabbitmq is not supported yet.])
+    PKG_CHECK_MODULES(LIBRABBITMQ, librabbitmq >= $LIBRABBITMQ_MIN_VERSION, , enable_amqp = "no")
 fi
 
 if test "x$with_librabbitmq_client" = "xno"; then

--- a/modules/afamqp/Makefile.am
+++ b/modules/afamqp/Makefile.am
@@ -1,10 +1,19 @@
 DIST_SUBDIRS				+= modules/afamqp/rabbitmq-c
 
+if LIBRABBITMQ_INTERNAL
+
 CLEAN_SUBDIRS 				+= @LIBRABBITMQ_SUBDIRS@
+lr_EXTRA_DEPS = modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
+
+modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la:
+	${MAKE} -C modules/afamqp/rabbitmq-c
+
+endif
 
 if ENABLE_AMQP
 AMQP_DUMMY_C_DEPS			 =	\
-	modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
+	$(lr_EXTRA_DEPS)
+
 module_LTLIBRARIES			+= modules/afamqp/libafamqp.la
 
 modules_afamqp_libafamqp_la_CFLAGS	= 	\
@@ -24,10 +33,8 @@ modules_afamqp_libafamqp_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afamqp_libafamqp_la_DEPENDENCIES=	\
 	$(MODULE_DEPS_LIBS)			\
-	modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
+	$(lr_EXTRA_DEPS)
 
-modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la:
-	${MAKE} -C modules/afamqp/rabbitmq-c
 modules/afamqp modules/afamqp/ mod-afamqp mod-amqp: \
 	modules/afamqp/libafamqp.la
 else


### PR DESCRIPTION
Currently only the internal librabbitmq-c is supported,
if we want to use the preexisting library, the configuration
will fail.
This change is required if we want to get rid of the
internal libraries.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/balabit/syslog-ng/752)
<!-- Reviewable:end -->
