### PR TITLE
redis: Return error result when redis command is failed

### DIFF
--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -225,6 +225,20 @@ redis_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 
   reply = redisCommandArgv(self->c, argc, argv, argvlen);
 
+  if (!reply)
+    {
+      msg_error("REDIS server error, suspending",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("command", self->command->str),
+                evt_tag_str("key", self->key_str->str),
+                evt_tag_str("param1", self->param1_str->str),
+                evt_tag_str("param2", self->param2_str->str),
+                evt_tag_str("error", self->c->errstr),
+                evt_tag_int("time_reopen", self->super.time_reopen),
+                NULL);
+      return WORKER_INSERT_RESULT_ERROR;
+    }
+
   msg_debug("REDIS command sent",
             evt_tag_str("driver", self->super.super.super.id),
             evt_tag_str("command", self->command->str),


### PR DESCRIPTION
Fix a SIGSEGV when redis result of command return an error.
Fixes #754

Signed-off-by: Fried Zoltan <zoltan.fried@balabit.com>