### PR TITLE
F/fix filter numeric ops

### DIFF
--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -61,7 +61,7 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       r = atoi(sb_gstring_string(right_buf)->str);
       if (l == r)
         cmp = 0;
-      else if (l > r)
+      else if (l < r)
         cmp = -1;
       else
         cmp = 1;
@@ -115,38 +115,50 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, gint op)
     case KW_NUM_LT:
       self->cmp_op = FCMP_NUM;
     case KW_LT:
-      self->cmp_op = FCMP_LT;
+      self->cmp_op |= FCMP_LT;
       break;
 
     case KW_NUM_LE:
       self->cmp_op = FCMP_NUM;
     case KW_LE:
-      self->cmp_op = FCMP_LT | FCMP_EQ;
+      self->cmp_op |= FCMP_LT | FCMP_EQ;
       break;
 
     case KW_NUM_EQ:
       self->cmp_op = FCMP_NUM;
     case KW_EQ:
-      self->cmp_op = FCMP_EQ;
+      self->cmp_op |= FCMP_EQ;
       break;
 
     case KW_NUM_NE:
       self->cmp_op = FCMP_NUM;
     case KW_NE:
-      self->cmp_op = 0;
+      self->cmp_op |= 0;
       break;
 
     case KW_NUM_GE:
       self->cmp_op = FCMP_NUM;
     case KW_GE:
-      self->cmp_op = FCMP_GT | FCMP_EQ;
+      self->cmp_op |= FCMP_GT | FCMP_EQ;
       break;
 
     case KW_NUM_GT:
       self->cmp_op = FCMP_NUM;
     case KW_GT:
-      self->cmp_op = FCMP_GT;
+      self->cmp_op |= FCMP_GT;
       break;
+    }
+
+  if (self->cmp_op & FCMP_NUM && cfg_is_config_version_older(left->cfg, 0x0308))
+    {
+      msg_warning("WARNING: due to a bug in " VERSION_3_7 " and earlier, "
+                  "numeric comparison operators like '!=' in filter "
+                  "expressions were evaluated as string operators. This is fixed in " VERSION_3_8 ". "
+                  "As we are operating in compatibility mode, syslog-ng will exhibit the buggy "
+                  "behaviour as previous versions until you bump the @version value in your "
+                  "configuration file",
+                  NULL);
+      self->cmp_op &= ~FCMP_NUM;
     }
   return &self->super;
 }

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -217,7 +217,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   app_startup();
 
-  configuration = cfg_new(0x0302);
+  configuration = cfg_new(VERSION_VALUE);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);
@@ -354,6 +354,18 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_and_new(create_posix_regexp_match("^PTHREAD$", 0), create_posix_regexp_match(" PTHREAD ", 0)), 0);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_and_new(create_posix_regexp_match(" PAD ", 0), create_posix_regexp_match("^PTHREAD$", 0)), 0);
 
+  /* LEVEL_NUM is 7 */
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("7"), KW_NUM_EQ), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("5"), KW_NUM_NE), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("8"), KW_NUM_LT), 1);
+
+  /* 7 < 10 is TRUE */
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("10"), KW_NUM_LT), 1);
+  /* 7 lt 10 is FALSE as 10 orders lower when interpreted as a string */
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("10"), KW_LT), 0);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("5"), KW_NUM_GT), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("7"), KW_NUM_GE), 1);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("$LEVEL_NUM"), create_template("7"), KW_NUM_LE), 1);
 
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("alma"), create_template("korte"), KW_LT), 1);
   testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", fop_cmp_new(create_template("alma"), create_template("korte"), KW_LE), 1);

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -18,10 +18,10 @@ test_cond_funcs(void)
   assert_template_format_with_context("$(grep -m 1 'facility(local3)' $PID)", "23323");
   assert_template_format_with_context("$(grep 'facility(local3)' $PID $PROGRAM)", "23323,syslog-ng,23323,syslog-ng");
   assert_template_format_with_context("$(grep 'facility(local4)' $PID)", "");
-  assert_template_format_with_context("$(grep ('$FACILITY' == 'local4') $PID)", "");
-  assert_template_format_with_context("$(grep ('$FACILITY(' == 'local3(') $PID)", "23323,23323");
-  assert_template_format_with_context("$(grep ('$FACILITY(' == 'local4)') $PID)", "");
-  assert_template_format_with_context("$(grep \\'$FACILITY\\'\\ ==\\ \\'local4\\' $PID)", "");
+  assert_template_format_with_context("$(grep ('$FACILITY' eq 'local4') $PID)", "");
+  assert_template_format_with_context("$(grep ('$FACILITY(' eq 'local3(') $PID)", "23323,23323");
+  assert_template_format_with_context("$(grep ('$FACILITY(' eq 'local4)') $PID)", "");
+  assert_template_format_with_context("$(grep \\'$FACILITY\\'\\ eq\\ \\'local4\\' $PID)", "");
 
   assert_template_format_with_context("$(if 'facility(local4)' alma korte)", "korte");
   assert_template_format_with_context("$(if 'facility(local3)' alma korte)", "alma");
@@ -39,8 +39,8 @@ test_cond_funcs(void)
   assert_template_format_with_context("$(if '\"$FACILITY_NUM\" != \"19\"' alma korte)", "korte");
   assert_template_format_with_context("$(if '\"$FACILITY_NUM\" > \"19\"' alma korte)", "korte");
   assert_template_format_with_context("$(if '\"$FACILITY_NUM\" >= \"19\"' alma korte)", "alma");
-  assert_template_format_with_context("$(if '\"$FACILITY_NUM\" >= \"19\" and \"kicsi\" == \"nagy\"' alma korte)", "korte");
-  assert_template_format_with_context("$(if '\"$FACILITY_NUM\" >= \"19\" or \"kicsi\" == \"nagy\"' alma korte)", "alma");
+  assert_template_format_with_context("$(if '\"$FACILITY_NUM\" >= \"19\" and \"kicsi\" eq \"nagy\"' alma korte)", "korte");
+  assert_template_format_with_context("$(if '\"$FACILITY_NUM\" >= \"19\" or \"kicsi\" eq \"nagy\"' alma korte)", "alma");
 
   assert_template_format_with_context("$(grep 'facility(local3)' $PID)@0", "23323");
   assert_template_format_with_context("$(grep 'facility(local3)' $PID)@1", "23323");

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -337,7 +337,7 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <value name='context-id'>${CONTEXT_ID}</value>\
    </values>\
    <actions>\
-     <action rate='1/60' condition='\"${n11-1}\" == \"v11-1\"' trigger='match'>\
+     <action rate='1/60' condition='\"${n11-1}\" eq \"v11-1\"' trigger='match'>\
        <message>\
          <value name='MESSAGE'>rule11 matched</value>\
          <value name='context-id'>${CONTEXT_ID}</value>\
@@ -346,7 +346,7 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
          </tags>\
        </message>\
      </action>\
-     <action rate='1/60' condition='\"${n11-1}\" == \"v11-1\"' trigger='timeout'>\
+     <action rate='1/60' condition='\"${n11-1}\" eq \"v11-1\"' trigger='timeout'>\
        <message>\
          <value name='MESSAGE'>rule11 timed out</value>\
          <value name='context-id'>${CONTEXT_ID}</value>\
@@ -368,12 +368,12 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <pattern>contextlesstest @STRING:field:@</pattern>\
    </patterns>\
    <actions>\
-     <action condition='\"${field}\" == \"value1\"'>\
+     <action condition='\"${field}\" eq \"value1\"'>\
        <message>\
          <value name='MESSAGE'>message1</value>\
        </message>\
      </action>\
-     <action condition='\"${field}\" == \"value2\"'>\
+     <action condition='\"${field}\" eq \"value2\"'>\
        <message>\
          <value name='MESSAGE'>message2</value>\
        </message>\
@@ -584,7 +584,7 @@ gchar *pdb_msg_count_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <value name='n13-1'>v13-1</value>\
    </values>\
    <actions>\
-    <action condition='\"${n13-1}\" == \"v13-1\"' trigger='match'>\
+    <action condition='\"${n13-1}\" eq \"v13-1\"' trigger='match'>\
      <message inherit-properties='TRUE'>\
       <value name='CONTEXT_LENGTH'>$(context-length)</value>\
      </message>\
@@ -597,7 +597,7 @@ gchar *pdb_msg_count_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <pattern>pattern14</pattern>\
    </patterns>\
    <actions>\
-    <action condition='\"$(context-length)\" == \"1\"' trigger='match'>\
+    <action condition='\"$(context-length)\" eq \"1\"' trigger='match'>\
      <message inherit-properties='TRUE'>\
       <value name='CONTEXT_LENGTH'>$(context-length)</value>\
      </message>\
@@ -610,7 +610,7 @@ gchar *pdb_msg_count_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <pattern>pattern15@ANYSTRING:p15@</pattern>\
    </patterns>\
    <actions>\
-    <action condition='\"$(context-length)\" == \"2\"' trigger='match'>\
+    <action condition='\"$(context-length)\" eq \"2\"' trigger='match'>\
      <message inherit-properties='FALSE'>\
       <value name='fired'>true</value>\
      </message>\


### PR DESCRIPTION
Well, it is embarassing but the numeric side of comparison operators in filter expressions never really worked. The aim of this patch series is to fix them up.

This one should fix #772, thanks for reporting that.

There's a compatibility tradeoff in this series, that is shown by the warning message that I was adding, we might want to discuss that before merging.

Cheers,
Bazsi