### PR TITLE
scl: add apache-accesslog-parser()

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,4 +1,4 @@
-SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris mbox elasticsearch kafka hdfs
+SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris mbox elasticsearch kafka hdfs apache
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -1,0 +1,54 @@
+#############################################################################
+# Copyright (c) 2015 BalaBit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+block parser apache-accesslog-parser(prefix(".apache.")) {
+
+
+    channel {
+        parser {
+            csv-parser(
+                prefix(`prefix`)
+                dialect(escape-double-char)
+                flags(strip-whitespace)
+                delimiters(" ")
+                quote-pairs('""[]')
+                # field names match of that of Logstash
+                columns("clientip", "ident", "auth",
+                        "timestamp", "rawrequest", "response",
+                        "bytes", "referrer", "agent"));
+
+            csv-parser(
+                prefix(`prefix`)
+                template("${`prefix`rawrequest}")
+                delimiters(" ")
+                dialect(escape-none)
+                flags(strip-whitespace)
+                columns("verb", "request", "httpversion"));
+
+	    date-parser(format("%d/%b/%Y:%H:%M:%S %z")
+                        template("${`prefix`timestamp}"));
+
+	};
+	rewrite {
+	    subst("^HTTP/(.*)$", "$1", value("`prefix`httpversion"));
+	};
+    };
+};


### PR DESCRIPTION
This parser consumes both the "common" and "combined" log formats and
parses them into name value pairs prefixed with ".apache." (but can be specified using the
standard prefix() option). 

The name-value pairs match the one that logstash uses, so it is pretty easy to use syslog-ng to forward apache logs to elasticsearch and display it with kibana.

It also extracts the timestamp of the apache log entry properly, relying on the brand new date-parser().
