### PR TITLE
linux-audit-scanner: recognize a0-a9* as fields to be decoded

### DIFF
--- a/modules/kvformat/linux-audit-scanner.c
+++ b/modules/kvformat/linux-audit-scanner.c
@@ -104,6 +104,9 @@ _is_field_hex_encoded(const gchar *field)
 {
   gint i;
 
+  if (field[0] == 'a' && isdigit(field[1]))
+    return TRUE;
+
   for (i = 0; hexcoded_fields[i]; i++)
     {
       if (strcmp(hexcoded_fields[i], field) == 0)

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -112,6 +112,10 @@ test_linux_audit_scanner_audit_style_hex_dump_is_decoded(void)
   kv_scanner_input(kv_scanner, "proctitle=2F62696E2F7368002D65002F6574632F696E69742E642F706F737466697800737461747573");
   assert_next_kv_is("proctitle", "/bin/sh\t-e\t/etc/init.d/postfix\tstatus");
   assert_no_more_tokens();
+
+  kv_scanner_input(kv_scanner, "a1=2F62696E2F7368202D6C");
+  assert_next_kv_is("a1", "/bin/sh -l");
+  assert_no_more_tokens();
 }
 
 static void


### PR DESCRIPTION
Argument lists are encoded in a0, a1, ... fields that can potentially be
hex-encoded.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>