### PR TITLE
F/value pairs cleanups

### DIFF
--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -55,6 +55,7 @@ append_unsafe_utf8_as_escaped_binary(GString *escaped_string, const gchar *str, 
       switch (uchar)
         {
           case (gunichar) -1:
+          case (gunichar) -2:
             g_string_append_printf(escaped_string, "\\x%02x", *(guint8 *) char_ptr);
             char_ptr++;
             continue;

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -603,13 +603,13 @@ vp_walker_stack_push (vp_stack_t *stack,
 }
 
 static void
-_extract_name_token(GPtrArray *array, const gchar *name, gsize len)
+vp_walker_extract_name_token(GPtrArray *array, const gchar *name, gsize len)
 {
   g_ptr_array_add(array, g_strndup(name, len));
 }
 
 static GPtrArray *
-vp_walker_name_value_split(const gchar *name)
+vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
 {
   gint pos, token_start = 0, name_len = strlen(name);
   GPtrArray *array = g_ptr_array_sized_new(VP_STACK_INITIAL_SIZE);
@@ -633,7 +633,7 @@ vp_walker_name_value_split(const gchar *name)
         }
       if (name[pos] == '.' || pos == name_len)
         {
-          _extract_name_token(array, &name[token_start], pos - token_start);
+          vp_walker_extract_name_token(array, &name[token_start], pos - token_start);
           pos++;
           token_start = pos;
         }
@@ -678,7 +678,7 @@ vp_walker_name_split(vp_walk_state_t *state,
   gchar *key = NULL;
   guint i, start;
 
-  tokens = vp_walker_name_value_split(name);
+  tokens = vp_walker_split_name_to_tokens(state, name);
 
   start = vp_stack_height(&state->stack);
   for (i = start; i < tokens->len - 1; i++)

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -683,9 +683,12 @@ vp_walker_name_split(vp_walk_state_t *state,
   start = vp_stack_height(&state->stack);
   for (i = start; i < tokens->len - 1; i++)
     {
-      vp_walk_stack_data_t *p = vp_stack_peek(&state->stack);
-      vp_walk_stack_data_t *nt = vp_walker_stack_push(&state->stack, g_strdup(g_ptr_array_index(tokens, i)),
-                                 vp_walker_name_combine_prefix(tokens, i));
+      vp_walk_stack_data_t *p, *nt;
+
+      p = vp_stack_peek(&state->stack);
+      nt = vp_walker_stack_push(&state->stack,
+                                g_strdup(g_ptr_array_index(tokens, i)),
+                                vp_walker_name_combine_prefix(tokens, i));
 
       if (p)
         state->obj_start(nt->key, nt->prefix, &nt->data,

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -695,7 +695,8 @@ vp_walker_name_split(vp_stack_t *stack, vp_walk_state_t *state,
 
   /* The last token is the key (well, second to last, last being
      NULL), so treat that normally. */
-  key = g_strdup(g_ptr_array_index(tokens, tokens->len - 1));
+  key = g_ptr_array_index(tokens, tokens->len - 1);
+  g_ptr_array_index(tokens, tokens->len - 1) = NULL;
 
   g_ptr_array_foreach(tokens, (GFunc)g_free, NULL);
   g_ptr_array_free(tokens, TRUE);

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -443,6 +443,11 @@ evt_tag_value_pairs(const char* key, ValuePairs *vp, LogMessage *msg, gint32 seq
    return result;
 };
 
+/*******************************************************************************
+ * vp_stack (represented by vp_stack_t)
+ *
+ * A not very generic stack implementation used by vp_walker.
+ *******************************************************************************/
 typedef struct
 {
   gchar *key;
@@ -530,6 +535,12 @@ vp_stack_height(vp_stack_t *stack)
   return stack->count;
 }
 
+/*******************************************************************************
+ * vp_walker (represented by vp_walk_state_t),
+ *
+ * The stuff that translates name-value pairs to a tree with SAX like
+ * callbacks. (start/value/end)
+ *******************************************************************************/
 static void
 vp_walker_stack_unwind_until (vp_walk_state_t *state,
                               const gchar *name)
@@ -745,6 +756,10 @@ vp_walk_cmp(const gchar *s1, const gchar *s2)
   return strcmp(s2, s1);
 }
 
+/*******************************************************************************
+ * Public API
+ *******************************************************************************/
+
 gboolean
 value_pairs_walk(ValuePairs *vp,
                  VPWalkCallbackFunc obj_start_func,
@@ -906,6 +921,10 @@ value_pairs_add_transforms(ValuePairs *vp, gpointer vpts)
 {
   vp->transforms = g_list_append(vp->transforms, vpts);
 }
+
+/*******************************************************************************
+ * Command line parser
+ *******************************************************************************/
 
 static void
 vp_cmdline_parse_rekey_finish (gpointer data)

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -887,6 +887,17 @@ value_pairs_new(void)
   return vp;
 }
 
+ValuePairs *
+value_pairs_new_default(GlobalConfig *cfg)
+{
+  ValuePairs *vp = value_pairs_new();
+
+  value_pairs_add_scope(vp, "selected-macros");
+  value_pairs_add_scope(vp, "nv-pairs");
+  value_pairs_add_scope(vp, "sdata");
+  return vp;
+}
+
 void
 value_pairs_free (ValuePairs *vp)
 {
@@ -1260,16 +1271,5 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
       vp = NULL;
     }
 
-  return vp;
-}
-
-ValuePairs *
-value_pairs_new_default(GlobalConfig *cfg)
-{
-  ValuePairs *vp = value_pairs_new();
-
-  value_pairs_add_scope(vp, "selected-macros");
-  value_pairs_add_scope(vp, "nv-pairs");
-  value_pairs_add_scope(vp, "sdata");
   return vp;
 }

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -617,7 +617,7 @@ static GPtrArray *
 vp_walker_name_value_split(const gchar *name)
 {
   int i, current_name_start_idx = 0, name_len = strlen(name);
-  GPtrArray *array = g_ptr_array_new();
+  GPtrArray *array = g_ptr_array_sized_new(VP_STACK_INITIAL_SIZE);
 
   for (i = 0; i < name_len; i++)
     {

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -634,7 +634,10 @@ vp_walker_name_value_split(const gchar *name)
     vp_walker_name_value_split_add_name_token(array, name, &current_name_start_idx, &i);
 
   if (array->len == 0)
-    return NULL;
+    {
+      g_ptr_array_free(array, TRUE);
+      return NULL;
+    }
 
   return array;
 }

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -566,8 +566,8 @@ vp_walker_free_stack_data(vp_walk_stack_data_t *t)
 }
 
 static void
-vp_walker_stack_unwind_until (vp_walk_state_t *state,
-                              const gchar *name)
+vp_walker_stack_unwind_containers_until(vp_walk_state_t *state,
+                                        const gchar *name)
 {
   vp_walk_stack_data_t *t;
 
@@ -597,9 +597,9 @@ vp_walker_stack_unwind_until (vp_walk_state_t *state,
 }
 
 static void
-vp_walker_stack_unwind_all(vp_walk_state_t *state)
+vp_walker_stack_unwind_all_containers(vp_walk_state_t *state)
 {
-  vp_walker_stack_unwind_until(state, NULL);
+  vp_walker_stack_unwind_containers_until(state, NULL);
 }
 
 static void
@@ -671,8 +671,8 @@ vp_walker_name_combine_prefix(GPtrArray *tokens, gint until)
 }
 
 static gchar *
-vp_walker_name_split(vp_walk_state_t *state,
-                     const gchar *name)
+vp_walker_start_containers_for_name(vp_walk_state_t *state,
+                                    const gchar *name)
 {
   GPtrArray *tokens;
   gchar *key = NULL;
@@ -719,9 +719,9 @@ value_pairs_walker(const gchar *name, TypeHint type, const gchar *value,
   gchar *key;
   gboolean result;
 
-  vp_walker_stack_unwind_until (state, name);
-  key = vp_walker_name_split (state, name);
-  data = vp_stack_peek (&state->stack);
+  vp_walker_stack_unwind_containers_until(state, name);
+  key = vp_walker_start_containers_for_name(state, name);
+  data = vp_stack_peek(&state->stack);
 
   if (data != NULL)
     result = state->process_value(key, data->prefix,
@@ -771,7 +771,7 @@ value_pairs_walk(ValuePairs *vp,
   result = value_pairs_foreach_sorted(vp, value_pairs_walker,
                                       (GCompareDataFunc)vp_walk_cmp, msg,
                                       seq_num, time_zone_mode, template_options, &state);
-  vp_walker_stack_unwind_all(&state);
+  vp_walker_stack_unwind_all_containers(&state);
   state.obj_end(NULL, NULL, NULL, NULL, NULL, user_data);
   vp_stack_destroy(&state.stack);
 

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -615,12 +615,6 @@ vp_walker_stack_unwind_all_containers(vp_walk_state_t *state)
   vp_walker_stack_unwind_containers_until(state, NULL);
 }
 
-static void
-vp_walker_extract_name_token(GPtrArray *array, const gchar *name, gsize len)
-{
-  g_ptr_array_add(array, g_strndup(name, len));
-}
-
 static GPtrArray *
 vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
 {
@@ -646,7 +640,7 @@ vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
         }
       if (name[pos] == '.' || pos == name_len)
         {
-          vp_walker_extract_name_token(array, &name[token_start], pos - token_start);
+          g_ptr_array_add(array, g_strndup(&name[token_start], pos - token_start));
           pos++;
           token_start = pos;
         }

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -466,16 +466,6 @@ typedef struct
   guint count;
 } vp_stack_t;
 
-typedef struct
-{
-  VPWalkCallbackFunc obj_start;
-  VPWalkCallbackFunc obj_end;
-  VPWalkValueCallbackFunc process_value;
-
-  gpointer user_data;
-  vp_stack_t stack;
-} vp_walk_state_t;
-
 static void
 vp_stack_init(vp_stack_t *stack)
 {
@@ -541,6 +531,16 @@ vp_stack_height(vp_stack_t *stack)
  * The stuff that translates name-value pairs to a tree with SAX like
  * callbacks. (start/value/end)
  *******************************************************************************/
+
+typedef struct
+{
+  VPWalkCallbackFunc obj_start;
+  VPWalkCallbackFunc obj_end;
+  VPWalkValueCallbackFunc process_value;
+
+  gpointer user_data;
+  vp_stack_t stack;
+} vp_walk_state_t;
 static void
 vp_walker_stack_unwind_until (vp_walk_state_t *state,
                               const gchar *name)

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -640,6 +640,7 @@ vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
   pos = 0;
   do
     {
+      token_start = pos;
       pos += strcspn(&name[pos], "@.");
       if (name[pos] == '@')
         pos = vp_walker_skip_sdata_enterprise_id(name, pos);
@@ -648,7 +649,6 @@ vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
         {
           g_ptr_array_add(array, g_strndup(&name[token_start], pos - token_start));
           pos++;
-          token_start = pos;
         }
     }
   while (pos < name_len);

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -575,7 +575,7 @@ vp_walker_stack_unwind_until (vp_walk_state_t *state,
     {
       vp_walk_stack_data_t *p;
 
-      if (strncmp(name, t->prefix, t->prefix_len) == 0)
+      if (name && strncmp(name, t->prefix, t->prefix_len) == 0)
         {
           /* This one matched, put it back, PUT IT BACK! */
           vp_stack_push(&state->stack, t);
@@ -599,25 +599,7 @@ vp_walker_stack_unwind_until (vp_walk_state_t *state,
 static void
 vp_walker_stack_unwind_all(vp_walk_state_t *state)
 {
-  vp_walk_stack_data_t *t;
-
-  while ((t = vp_stack_pop(&state->stack)) != NULL)
-    {
-      vp_walk_stack_data_t *p = vp_stack_peek(&state->stack);
-
-      if (p)
-        state->obj_end(t->key, t->prefix, &t->data,
-                       p->prefix, &p->data,
-                       state->user_data);
-      else
-        state->obj_end(t->key, t->prefix, &t->data,
-                       NULL, NULL,
-                       state->user_data);
-
-      g_free(t->key);
-      g_free(t->prefix);
-      g_free(t);
-    }
+  vp_walker_stack_unwind_until(state, NULL);
 }
 
 static void

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -541,6 +541,22 @@ typedef struct
   gpointer user_data;
   vp_stack_t stack;
 } vp_walk_state_t;
+
+static vp_walk_stack_data_t *
+vp_walker_stack_push (vp_stack_t *stack,
+                      gchar *key, gchar *prefix)
+{
+  vp_walk_stack_data_t *nt = g_new(vp_walk_stack_data_t, 1);
+
+  nt->key = key;
+  nt->prefix = prefix;
+  nt->prefix_len = strlen(nt->prefix);
+  nt->data = NULL;
+
+  vp_stack_push(stack, nt);
+  return nt;
+}
+
 static void
 vp_walker_stack_unwind_until (vp_walk_state_t *state,
                               const gchar *name)
@@ -596,21 +612,6 @@ vp_walker_stack_unwind_all(vp_walk_state_t *state)
       g_free(t->prefix);
       g_free(t);
     }
-}
-
-static vp_walk_stack_data_t *
-vp_walker_stack_push (vp_stack_t *stack,
-                      gchar *key, gchar *prefix)
-{
-  vp_walk_stack_data_t *nt = g_new(vp_walk_stack_data_t, 1);
-
-  nt->key = key;
-  nt->prefix = prefix;
-  nt->prefix_len = strlen(nt->prefix);
-  nt->data = NULL;
-
-  vp_stack_push(stack, nt);
-  return nt;
 }
 
 static void

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -558,6 +558,14 @@ vp_walker_stack_push (vp_stack_t *stack,
 }
 
 static void
+vp_walker_free_stack_data(vp_walk_stack_data_t *t)
+{
+  g_free(t->key);
+  g_free(t->prefix);
+  g_free(t);
+}
+
+static void
 vp_walker_stack_unwind_until (vp_walk_state_t *state,
                               const gchar *name)
 {
@@ -584,9 +592,7 @@ vp_walker_stack_unwind_until (vp_walk_state_t *state,
         state->obj_end(t->key, t->prefix, &t->data,
                        NULL, NULL,
                        state->user_data);
-      g_free(t->key);
-      g_free(t->prefix);
-      g_free(t);
+      vp_walker_free_stack_data(t);
     }
 }
 


### PR DESCRIPTION
I originally wanted to speed up value-pairs, but the biggest effect was a patch that wasn't thread safe, which I have dropped at the end.

So this series of patches does not really touch value-pairs performance (well at least for my naive testcase, YMMV), but reorganizes the code a bit, extracts a few functions, generally makes the code easier to read and maintain.

I have a few thoughts now how to improve value-pairs performance drastically, but I would do as a separate iteration, after this is integrated, and probably I would start by splitting up this huge file with intermingled internal layers.

Please merge, thanks.
