### PR TITLE
F/whitespace fixes

### DIFF
--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -90,7 +90,7 @@ static gint dns_cache_expire_failed = 60;
 static gint dns_cache_persistent_count = 0;
 static gchar *dns_cache_hosts = NULL;
 
-static gboolean 
+static gboolean
 dns_cache_key_equal(DNSCacheKey *e1, DNSCacheKey *e2)
 {
   if (e1->family == e2->family)
@@ -140,7 +140,7 @@ dns_cache_entry_free(DNSCacheEntry *e)
 {
   e->prev->next = e->next;
   e->next->prev = e->prev;
-  
+
   g_free(e->hostname);
   g_free(e);
 }
@@ -184,7 +184,7 @@ dns_cache_check_hosts(glong t)
     return;
 
   cache_hosts_checktime = t;
-  
+
   if (!dns_cache_hosts || stat(dns_cache_hosts, &st) < 0)
     {
       dns_cache_cleanup_persistent_hosts();
@@ -201,27 +201,27 @@ dns_cache_check_hosts(glong t)
         {
           gchar buf[4096];
           char *strtok_saveptr;
-          
+
           while (fgets(buf, sizeof(buf), hosts))
             {
               gchar *p, *ip;
               gint len;
               gint family;
-              union 
+              union
               {
                 struct in_addr ip4;
 #if ENABLE_IPV6
                 struct in6_addr ip6;
 #endif
               } ia;
-              
+
               if (buf[0] == 0 || buf[0] == '\n' || buf[0] == '#')
                 continue;
-                
+
               len = strlen(buf);
               if (buf[len - 1] == '\n')
                 buf[len-1] = 0;
-                
+
               p = strtok_r(buf, " \t", &strtok_saveptr);
               if (!p)
                 continue;
@@ -232,8 +232,8 @@ dns_cache_check_hosts(glong t)
                 family = AF_INET6;
               else
 #endif
-              family = AF_INET;
-                
+                family = AF_INET;
+
               p = strtok_r(NULL, " \t", &strtok_saveptr);
               if (!p)
                 continue;
@@ -244,12 +244,12 @@ dns_cache_check_hosts(glong t)
         }
       else
         {
-          msg_error("Error loading dns cache hosts file", 
-                    evt_tag_str("filename", dns_cache_hosts), 
+          msg_error("Error loading dns cache hosts file",
+                    evt_tag_str("filename", dns_cache_hosts),
                     evt_tag_errno("error", errno),
                     NULL);
         }
-        
+
     }
 }
 
@@ -266,15 +266,15 @@ dns_cache_lookup(gint family, void *addr, const gchar **hostname, gsize *hostnam
   DNSCacheKey key;
   DNSCacheEntry *entry;
   time_t now;
-  
+
   now = cached_g_current_time_sec();
   dns_cache_check_hosts(now);
-  
+
   dns_cache_fill_key(&key, family, addr);
   entry = g_hash_table_lookup(cache, &key);
   if (entry)
     {
-      if (entry->resolved && 
+      if (entry->resolved &&
           ((entry->positive && entry->resolved < now - dns_cache_expire) ||
            (!entry->positive && entry->resolved < now - dns_cache_expire_failed)))
         {
@@ -298,7 +298,7 @@ dns_cache_store(gboolean persistent, gint family, void *addr, const gchar *hostn
 {
   DNSCacheEntry *entry;
   guint hash_size;
-  
+
   entry = g_new(DNSCacheEntry, 1);
 
   dns_cache_fill_key(&entry->key, family, addr);
@@ -320,7 +320,7 @@ dns_cache_store(gboolean persistent, gint family, void *addr, const gchar *hostn
 
   if (persistent && hash_size != g_hash_table_size(cache))
     dns_cache_persistent_count++;
-  
+
   /* persistent elements are not counted */
   if ((gint) (g_hash_table_size(cache) - dns_cache_persistent_count) > dns_cache_size)
     {

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -35,7 +35,7 @@ TLS_BLOCK_START
   /* Thread IDs are low numbered integers that can be used to index
    * per-thread data in an array.  IDs get reused and the smallest possible
    * ID is allocated for newly started threads.  */
-  
+
   /* the thread id is shifted by one, to make 0 the uninitialized state,
    * e.g. everything that sets it adds +1, everything that queries it
    * subtracts 1 */
@@ -199,7 +199,7 @@ main_loop_worker_job_start(void)
 
 /*
  * This function is called in the main thread after a job was finished in
- * one of the worker threads. 
+ * one of the worker threads.
  *
  * If an intrusive operation (reload, termination) is pending and the number
  * of workers has dropped to zero, it commences with the intrusive
@@ -266,7 +266,7 @@ main_loop_worker_invoke_batch_callbacks(void)
   iv_list_for_each_safe(lh, lh2, &batch_callbacks)
     {
       WorkerBatchCallback *cb = iv_list_entry(lh, WorkerBatchCallback, list);
-      
+
       cb->func(cb->user_data);
       iv_list_del_init(&cb->list);
     }
@@ -283,15 +283,15 @@ static gpointer
 _worker_thread_func(gpointer st)
 {
   WorkerThreadParams *p = st;
-  
+
   main_loop_worker_thread_start(p->worker_options);
   p->func(p->data);
   main_loop_call((MainLoopTaskFunc) main_loop_worker_job_complete, NULL, TRUE);
   main_loop_worker_thread_stop();
-  
-  
+
+
   /* NOTE: this assert aims to validate that the worker thread in fact
-   * invokes main_loop_worker_invoke_batch_callbacks() during its operation. 
+   * invokes main_loop_worker_invoke_batch_callbacks() during its operation.
    * Please do so every once a couple of messages, hopefully you have a
    * natural barrier that let's you decide when, the easiest would be
    * log-fetch-limit(), but other limits may also be applicable.
@@ -307,14 +307,14 @@ main_loop_create_worker_thread(WorkerThreadFunc func, WorkerExitNotificationFunc
 {
   GThread *h;
   WorkerThreadParams *p;
-  
+
   main_loop_assert_main_thread();
-  
+
   p = g_new0(WorkerThreadParams, 1);
   p->func = func;
   p->data = data;
   p->worker_options = worker_options;
-  
+
   main_loop_worker_job_start();
   if (terminate_func)
     _register_exit_notification_callback(terminate_func, data);


### PR DESCRIPTION
while browsing the code I've found these and fixed them up. 

done by emacs "whitespace-cleanup" function.

I'd merge this soonish as it really has no real code change, just whitespace, let me know if you have objections.
