### PR TITLE
F/native parser

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1062,6 +1062,10 @@ if test "x$enable_amqp" = "xno"; then
    LIBRABBITMQ_SUBDIRS=""
 fi
 
+if test "x$enable_native" = "xyes" -o "x$enable_native" = "xauto"; then
+    AC_CONFIG_FILES([syslog-ng-native-connector.pc])
+fi
+
 dnl ***************************************************************************
 dnl riemann-client headers/libraries
 dnl ***************************************************************************

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,10 @@ AC_ARG_ENABLE(manpages, AC_HELP_STRING([ --enable-manpages], [ Enable generation
 
 AC_ARG_ENABLE(java, [ --enable-java  Enable java destination (default: auto)],, enable_java="auto")
 
+AC_ARG_ENABLE(native,
+              [  --enable-native        Enable native bindings (default: auto)]
+              ,,enable_native="auto")
+
 AC_ARG_ENABLE(all-modules,
               [  --enable-all-modules    Forcibly enable all modules. (default: auto)]
               ,,enable_all_modules="auto")
@@ -1425,6 +1429,7 @@ AM_CONDITIONAL(ENABLE_JOURNALD, [test "$with_systemd_journal" != "no"])
 AM_CONDITIONAL(ENABLE_PYTHON, [test "$enable_python" != "no"])
 AM_CONDITIONAL(ENABLE_JAVA, [test "$enable_java" = "yes"])
 AM_CONDITIONAL(ENABLE_MANPAGES, [test "$enable_manpages" != "no"])
+AM_CONDITIONAL(ENABLE_NATIVE, [test "$enable_native" != "no"])
 
 # substitution into manual pages
 expanded_sysconfdir=[`patheval $sysconfdir | sed -e 's/-/\\\\-/g'`]
@@ -1531,3 +1536,4 @@ echo "  Redis support (module)      : ${enable_redis:=no}"
 echo "  Riemann destination (module): ${enable_riemann:=no}"
 echo "  python                      : ${enable_python:=no} (pkg-config package: ${with_python:=none})"
 echo "  java                        : ${enable_java:=no}"
+echo "  native bindings             : ${enable_native:=no}"

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -29,6 +29,7 @@ include modules/java/Makefile.am
 include modules/java-modules/Makefile.am
 include modules/kvformat/Makefile.am
 include modules/date/Makefile.am
+include modules/native/Makefile.am
 
 SYSLOG_NG_MODULES	=	\
 	mod-afsocket mod-afstreams mod-affile mod-afprog \
@@ -37,7 +38,8 @@ SYSLOG_NG_MODULES	=	\
 	mod-confgen mod-system-source mod-csvparser mod-dbparser \
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
-	mod-python mod-java mod-java-modules mod-kvformat mod-date
+	mod-python mod-java mod-java-modules mod-kvformat mod-date \
+	mod-native
 
 modules modules/: ${SYSLOG_NG_MODULES}
 

--- a/modules/native/Makefile.am
+++ b/modules/native/Makefile.am
@@ -11,6 +11,8 @@ modules_native_libsyslog_ng_native_connector_a_SOURCES = \
   modules/native/parser.c				\
   modules/native/parser.h
 
+pkgconfig_DATA += syslog-ng-native-connector.pc
+
 modules_native_libsyslog_ng_native_connector_a_CPPFLAGS = \
   $(AM_CPPFLAGS)	-fPIC	\
   -fvisibility=hidden	\

--- a/modules/native/Makefile.am
+++ b/modules/native/Makefile.am
@@ -1,0 +1,35 @@
+if ENABLE_NATIVE
+
+export top_srcdir
+export top_builddir
+
+lib_LIBRARIES = modules/native/libsyslog-ng-native-connector.a
+modules_native_libsyslog_ng_native_connector_a_SOURCES = \
+  modules/native/native-grammar.y       \
+  modules/native/native-parser.c        \
+  modules/native/native-parser.h        \
+  modules/native/parser.c				\
+  modules/native/parser.h
+
+modules_native_libsyslog_ng_native_connector_a_CPPFLAGS = \
+  $(AM_CPPFLAGS)	-fPIC	\
+  -fvisibility=hidden	\
+  -I$(top_srcdir)/modules/native        \
+  -I$(top_builddir)/modules/native
+
+modules_native_libsyslog_ng_native_connector_a_LDFLAGS = $(MODULE_LDFLAGS)
+
+else
+modules/native modules/native/ mod-native: modules/native/libnative.la
+endif
+
+BUILT_SOURCES       +=      \
+  modules/native/native-grammar.y       \
+  modules/native/native-grammar.c       \
+  modules/native/native-grammar.h
+
+EXTRA_DIST        +=      \
+  modules/native/native-grammar.ym
+
+.PHONY: modules/native/ mod-native
+

--- a/modules/native/native-grammar.ym
+++ b/modules/native/native-grammar.ym
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "native-parser.h"
+
+}
+
+
+%code {
+
+#include "cfg-parser.h"
+#include "parser.h"
+#include "native-grammar.h"
+#include "syslog-names.h"
+#include "messages.h"
+#include "plugin.h"
+#include "cfg-grammar.h"
+
+#include <string.h>
+
+void native_parser_set_option(LogParser *s, gchar* key, gchar* value);
+LogParser* native_parser_new(GlobalConfig *cfg);
+
+}
+
+%name-prefix "native_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogParser **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_OPTION
+
+%type <ptr> native
+%type <ptr> native_parser
+%type <ptr> native_parser_params
+%%
+
+start
+  : native
+    {
+      *instance = $1;
+      if (yychar != YYEMPTY)
+        cfg_lexer_unput_token(lexer, &yylval);
+      YYACCEPT;
+    }
+  ;
+
+native
+  : LL_CONTEXT_PARSER native_parser { $$ = $2; }
+  ;
+
+native_parser
+  : LL_IDENTIFIER '(' native_parser_params ')' { $$ = *instance; }
+  ;
+
+native_parser_params
+  : {
+      *instance = native_parser_new(configuration);
+
+      if (!*instance)
+       {
+         msg_error("Cannot create the Native parser, aborting",
+                   NULL);
+         YYERROR;
+       }
+    }
+    native_parser_options
+  ;
+
+native_parser_options
+  : native_parser_option native_parser_options
+  |
+  ;
+
+native_parser_option
+  : KW_OPTION '(' string string ')'
+    {
+      native_parser_set_option(*instance, $3, $4);
+      free($3);
+      free($4);
+    }
+    ;
+
+/* INCLUDE_RULES */
+
+%%
+

--- a/modules/native/native-parser.c
+++ b/modules/native/native-parser.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-parser.h"
+#include "logpipe.h"
+#include "parser.h"
+#include "native-grammar.h"
+
+extern int native_debug;
+
+__attribute__((__visibility__("hidden"))) int native_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
+
+static CfgLexerKeyword native_keywords[] = {
+  { "option",   KW_OPTION },
+  { NULL }
+};
+ 
+__attribute__((__visibility__("hidden"))) CfgParser native_parser =
+{
+#if ENABLE_DEBUG
+  .debug_flag = &native_debug,
+#endif
+  .context = LL_IDENTIFIER,
+  .name = "native-module",
+  .keywords = native_keywords,
+  .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) native_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(native_, LogParser **)
+

--- a/modules/native/native-parser.h
+++ b/modules/native/native-parser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef NATIVE_PARSER_H_INCLUDED
+#define NATIVE_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+#include "parser/parser-expr.h"
+
+CFG_PARSER_DECLARE_LEXER_BINDING(native_, LogParser **)
+
+#endif
+

--- a/modules/native/parser.c
+++ b/modules/native/parser.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "parser.h"
+#include <assert.h>
+
+struct NativeParserProxy;
+
+__attribute__((visibility("hidden"))) void
+native_parser_proxy_free(struct NativeParserProxy* this);
+
+__attribute__((visibility("hidden"))) void
+native_parser_proxy_set_option(struct NativeParserProxy* self, const gchar* key, const gchar* value);
+
+__attribute__((visibility("hidden"))) gboolean
+native_parser_proxy_process(struct NativeParserProxy* this, LogMessage *pmsg, const gchar *input, gsize input_len);
+
+__attribute__((visibility("hidden"))) int
+native_parser_proxy_init(struct NativeParserProxy* s);
+
+__attribute__((visibility("hidden"))) struct NativeParserProxy*
+native_parser_proxy_new(LogParser *super);
+
+__attribute__((visibility("hidden"))) struct NativeParserProxy*
+native_parser_proxy_clone(struct NativeParserProxy *self);
+
+typedef struct _ParserNative {
+  LogParser super;
+  struct NativeParserProxy* native_object;
+} ParserNative;
+
+static LogPipe*
+native_parser_clone(LogPipe *s);
+
+static gboolean
+native_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input, gsize input_len)
+{
+  ParserNative *self = (ParserNative *) s;
+
+  LogMessage *writable_msg = log_msg_make_writable(pmsg, path_options);
+  return native_parser_proxy_process(self->native_object, writable_msg, input, input_len);
+}
+
+void
+native_parser_set_option(LogParser *s, gchar* key, gchar* value)
+{    
+  ParserNative *self = (ParserNative *)s;
+
+  native_parser_proxy_set_option(self->native_object, key, value);
+}
+
+static gboolean
+native_parser_init(LogPipe *s)
+{
+  ParserNative *self = (ParserNative *) s;
+
+  return !!native_parser_proxy_init(self->native_object);
+}
+
+static void
+native_parser_free(LogPipe *s)
+{
+  ParserNative *self = (ParserNative *)s;
+
+  native_parser_proxy_free(self->native_object);
+  log_parser_free_method(s);
+}
+
+static void
+__setup_callback_methods(ParserNative *self)
+{
+  self->super.process = native_parser_process;
+  self->super.super.free_fn = native_parser_free;
+  self->super.super.clone = native_parser_clone;
+  self->super.super.init = native_parser_init;
+}
+
+static LogPipe*
+native_parser_clone(LogPipe *s)
+{
+  ParserNative *self = (ParserNative*) s;
+  ParserNative *cloned;
+  
+  cloned = (ParserNative*) g_new0(ParserNative, 1);
+  log_parser_init_instance(&cloned->super, s->cfg);
+  cloned->native_object = native_parser_proxy_clone(self->native_object);
+  assert(self != cloned);
+
+  if (!cloned->native_object)
+    {
+      g_free(cloned);
+      return NULL;
+    }
+
+  __setup_callback_methods(cloned);
+  
+  return &cloned->super.super; 
+}
+
+__attribute__((visibility("hidden"))) LogParser*
+native_parser_new(GlobalConfig *cfg)
+{
+  ParserNative *self = (ParserNative*) g_new0(ParserNative, 1);
+
+  log_parser_init_instance(&self->super, cfg);
+  self->native_object = native_parser_proxy_new(&self->super);
+
+  if (!self->native_object)
+    {
+      g_free(self);
+      return NULL;
+    }
+
+  __setup_callback_methods(self);
+
+  return &self->super;
+}

--- a/modules/native/parser.h
+++ b/modules/native/parser.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef NATIVE_PARSER_H_INCLUDED
+#define NATIVE_PARSER_H_INCLUDED
+
+#include "parser/parser-expr.h"
+
+void native_parser_set_option(LogParser *s, gchar* key, gchar* value);
+
+#endif

--- a/syslog-ng-native-connector.pc.in
+++ b/syslog-ng-native-connector.pc.in
@@ -1,0 +1,9 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+
+Name: libsyslog-ng-native-connector
+Description: Common connector for a native syslog-ng module
+Required: syslog-ng
+Version: 0.1.0
+Libs: -L${libdir} -lsyslog-ng-native-connector


### PR DESCRIPTION
First I thought that the Rust/native bindings should be landed in incubator first, because of the additional dependencies. As the time went on the interface became simpler and simpler. Now, it doesn't have any additional dependency. Nevertheless, this feature is based on the current master but incubator is based on 3.7.

This is just the C part and doesn't need rustc or other Rust related tools to be installed.

The Rust part is splitted into 3 crates (compilation units) and stored in the following git repo: https://github.com/ihrwein/syslog-ng-rs

That repo also needs a thorough review. 