### PR TITLE
cfg-lex.l: don't report yy_fatal_error() as an unused symbol

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -331,4 +331,4 @@ cfg_lexer_start_block_state(CfgLexer *self, gchar block_boundary[2])
 }
 
 /* avoid warnings of unused symbols */
-gpointer __dummy[] = { yy_top_state };
+gpointer __dummy[] = { yy_top_state, yy_fatal_error };


### PR DESCRIPTION
The code generated by flex contains yy_fatal_error() which is not used in
the generated code. Insert an artificial reference so that it doesn't
get reported.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>