### PR TITLE
scl: add loggly() destination

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,4 +1,4 @@
-SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris mbox elasticsearch kafka hdfs apache
+SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris mbox elasticsearch kafka hdfs apache loggly
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/loggly/loggly.conf
+++ b/scl/loggly/loggly.conf
@@ -1,0 +1,75 @@
+#############################################################################
+# Copyright (c) 2015 BalaBit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# EXAMPLES:
+#
+# Just send all syslog to loggly:
+#    log {
+#        source { system(); };
+#        destination { loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY")); };
+#    };
+#
+# With TLS encryption (make sure you trust the loggly CA cert by putting it
+# to /etc/ssl, or create a separate CA directory):
+#
+#    log {
+#       destination {
+#                loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY") port(6514)
+#                       tls(peer-verify(required-trusted) ca-dir('/etc/ssl/certs'))
+#                );
+#       };
+#    };
+#
+#
+# Send JSON data:
+#    log {
+#        source { system(); };
+#        destination {
+#            loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY")
+#                   template("$(format-json --scope all-nv-pairs)"));
+#            );
+#        };
+#    };
+#
+#
+# Send already parsed apache logs to loggly:
+#    log {
+#        source { file("/var/log/apache2/access.log" flags(no-parse)); };
+#        parser { apache-accesslog-parser(); };
+#        destination {
+#            loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY")
+#                   tag(apache)
+#                   template("$(format-json .apache.* timestamp=${ISODATE})"));
+#        };
+#    }
+#
+block destination loggly(token(TOKEN)
+                         tag("tag")
+                         host('logs-01.loggly.com')
+                         port(514)
+                         template("$MSG")) {
+    tcp("`host`" port(`port`)
+        template("<${PRI}>1 ${ISODATE} ${HOST} ${PROGRAM} ${PID} ${MSGID} [`token`@41058 tag=\"`tag`\"] `template`\n")
+	template_escape(no)
+	`__VARARGS__`
+    );
+};


### PR DESCRIPTION
Examples:
```
 Just send all syslog to loggly:
    log {
        source { system(); };
        destination { loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY")); };
    };

 Send JSON data:
    log {
        source { system(); };
        destination {
            loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY")
                   template("$(format-json --scope all-nv-pairs)"));
            );
        };
    };


 Send already parsed apache logs to loggly:
    log {
        source { file("/var/log/apache2/access.log" flags(no-parse)); };
        parser { apache-accesslog-parser(); };
        destination {
            loggly(token("USER-TOKEN-AS-PROVIDED-BY-LOGGLY")
                   tag(apache)
                   template("$(format-json .apache.* timestamp=${ISODATE})"));
        };
    }
```
Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>

as requested by @fekete-robert  and fixes #798 