### PR TITLE
Removing directives that split up parts of statements.

### DIFF
--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -192,6 +192,15 @@ _result_append_value(GString *result, const LogMessage *lm, NVHandle handle, gbo
   result_append(result, str, len, escape);
 }
 
+gboolean sockaddr_inet_check(const LogMessage *msg)
+{
+#if SYSLOG_NG_ENABLE_IPV6
+    return msg->saddr && (g_sockaddr_inet_check(msg->saddr) || g_sockaddr_inet6_check(msg->saddr));
+#else
+    return msg->saddr && g_sockaddr_inet_check(msg->saddr);
+#endif
+}
+
 gboolean
 log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, const LogMessage *msg)
 {
@@ -339,15 +348,8 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
     case M_SOURCE_IP:
       {
         gchar *ip;
-        int checker;
-
-        checker = msg->saddr;
-#if SYSLOG_NG_ENABLE_IPV6
-        checker = checker && (g_sockaddr_inet_check(msg->saddr) || g_sockaddr_inet6_check(msg->saddr));
-#else
-        checker = checker && g_sockaddr_inet_check(msg->saddr);
-#endif
-        if(checker)
+        
+        if(sockaddr_inet_check(msg))
           {
             gchar buf[MAX_SOCKADDR_STRING];
 

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -192,13 +192,17 @@ _result_append_value(GString *result, const LogMessage *lm, NVHandle handle, gbo
   result_append(result, str, len, escape);
 }
 
-gboolean sockaddr_inet_check(const LogMessage *msg)
+static _is_message_source_an_ip_address(const LogMessage *msg)
 {
+  if (!msg->saddr)
+    return FALSE;
+  if (g_sockaddr_inet_check(msg->saddr))
+    return TRUE;
 #if SYSLOG_NG_ENABLE_IPV6
-    return msg->saddr && (g_sockaddr_inet_check(msg->saddr) || g_sockaddr_inet6_check(msg->saddr));
-#else
-    return msg->saddr && g_sockaddr_inet_check(msg->saddr);
+  if (g_sockaddr_inet6_check(msg->saddr));
+    return TRUE;
 #endif
+  return FALSE;
 }
 
 gboolean
@@ -349,7 +353,7 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
       {
         gchar *ip;
         
-        if(sockaddr_inet_check(msg))
+        if(_is_message_source_an_ip_address(msg))
           {
             gchar buf[MAX_SOCKADDR_STRING];
 

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -339,14 +339,15 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
     case M_SOURCE_IP:
       {
         gchar *ip;
+        int checker;
 
-        if (msg->saddr && (g_sockaddr_inet_check(msg->saddr) ||
+        checker = msg->saddr;
 #if SYSLOG_NG_ENABLE_IPV6
-            g_sockaddr_inet6_check(msg->saddr))
+        checker = checker && (g_sockaddr_inet_check(msg->saddr) || g_sockaddr_inet6_check(msg->saddr));
 #else
-            0)
+        checker = checker && g_sockaddr_inet_check(msg->saddr);
 #endif
-           )
+        if(checker)
           {
             gchar buf[MAX_SOCKADDR_STRING];
 


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.