### PR TITLE
scl: add logmatic() destination

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,4 +1,19 @@
-SCL_SUBDIRS	= system pacct syslogconf rewrite nodejs graphite cim solaris mbox elasticsearch kafka hdfs apache loggly
+SCL_SUBDIRS	= \
+	system		\
+	pacct		\
+	syslogconf	\
+	rewrite		\
+	nodejs		\
+	graphite	\
+	cim		\
+	solaris		\
+	mbox		\
+	elasticsearch	\
+	kafka		\
+	hdfs		\
+	apache		\
+	loggly		\
+	logmatic
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/logmatic/logmatic.conf
+++ b/scl/logmatic/logmatic.conf
@@ -1,0 +1,69 @@
+#############################################################################
+# Copyright (c) 2015 BalaBit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+#
+#      Just send all syslog to logmatic:
+#         log {
+#             source { system(); };
+#             destination { logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC")); };
+#         };
+#
+# With TLS encryption (make sure you trust the loggly CA cert by putting it
+# to /etc/ssl, or create a separate CA directory):
+#
+#         log {
+#             source { system(); };
+#             destination {
+#                 logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC") port(10515)
+#                       tls(peer-verify(required-trusted) ca-dir('/etc/ssl/certs'))
+#                 );
+#             };
+#         };
+#
+#      Send JSON data:
+#         log {
+#             source { system(); };
+#             destination {
+#                 logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC")
+#                          template("$(format-json --scope all-nv-pairs)"));
+#                 );
+#             };
+#         };
+#
+#      Send already parsed apache logs to logmatic:
+#         log {
+#             source { file("/var/log/apache2/access.log" flags(no-parse)); };
+#             parser { apache-accesslog-parser(); };
+#             destination {
+#                 logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC")
+#                          tag(apache)
+#                          template("$(format-json .apache.*)"));
+#             };
+#         }
+#
+block destination logmatic(token(TOKEN) host('api.logmatic.io') port(10514) template("$MSG")) {
+    tcp("`host`" port(`port`)
+        template("`token` <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} `template`\n")
+	template_escape(no)
+	so-keepalive(yes)
+	`__VARARGS__`
+    );
+};


### PR DESCRIPTION
This patch implements an integration with logmatic.io.

Examples:

  Just send all syslog to logmatic:
     log {
         source { system(); };
         destination { logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC")); };
     };

  Send JSON data:
     log {
         source { system(); };
         destination {
             logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC")
                      template("$(format-json --scope all-nv-pairs)"));
             );
         };
     };


  Send already parsed apache logs to logmatic:
     log {
         source { file("/var/log/apache2/access.log" flags(no-parse)); };
         parser { apache-accesslog-parser(); };
         destination {
             logmatic(token("API-KEY-AS-PROVIDED-BY-LOGMATIC")
                      tag(apache)
                      template("$(format-json .apache.*)"));
         };
     }

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>