### PR TITLE
tests: made func tests a bit flexible

### DIFF
--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -480,6 +480,12 @@ plugin_free_candidate_modules(GlobalConfig *cfg)
   cfg->candidate_plugins = NULL;
 }
 
+const gchar*
+plugin_get_module_path()
+{
+    return module_path;
+}
+
 void
 plugin_list_modules(FILE *out, gboolean verbose)
 {

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -77,6 +77,7 @@ gpointer plugin_parse_config(Plugin *plugin, GlobalConfig *cfg, YYLTYPE *yylloc,
 void plugin_register(GlobalConfig *cfg, Plugin *p, gint number);
 gboolean plugin_load_module(const gchar *module_name, GlobalConfig *cfg, CfgArgs *args);
 
+const gchar* plugin_get_module_path();
 void plugin_list_modules(FILE *out, gboolean verbose);
 
 void plugin_load_candidate_modules(GlobalConfig *cfg);

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -129,13 +129,15 @@ version(void)
     }
   printf(SYSLOG_NG_PACKAGE " " SYSLOG_NG_VERSION "\n"
          "Installer-Version: %s\n"
-         "Revision: " SYSLOG_NG_SOURCE_REVISION "\n"
+         "Revision: " SYSLOG_NG_SOURCE_REVISION "\n",
 #if WITH_COMPILE_DATE
-         "Compile-Date: " __DATE__ " " __TIME__ "\n"
+         "Compile-Date: " __DATE__ " " __TIME__ "\n",
 #endif
-         "Available-Modules: ",
          installer_version);
 
+  printf("Module-Path: %s\n", plugin_get_module_path());
+
+  printf("Available-Modules: ");
   plugin_list_modules(stdout, FALSE);
 
   printf("Enable-Debug: %s\n"

--- a/tests/functional/control.py
+++ b/tests/functional/control.py
@@ -31,11 +31,8 @@ def start_syslogng(conf, keep_persist=False, verbose=False):
     syslogng_pid = os.fork()
     if syslogng_pid == 0:
         os.putenv("RANDFILE", "rnd")
-        module_path = ''
-        for (root, dirs, files) in os.walk(os.path.abspath(os.path.join(os.environ['top_builddir'], 'modules'))):
-            module_path = ':'.join(map(lambda x: root + '/' + x + '/.libs', dirs))
-            break
-        rc = os.execl('../../syslog-ng/syslog-ng', '../../syslog-ng/syslog-ng', '-f', 'test.conf', '--fd-limit', '1024', '-F', verbose_opt, '-p', 'syslog-ng.pid', '-R', 'syslog-ng.persist', '--no-caps', '--enable-core', '--seed', '--module-path', module_path)
+        module_path = get_module_path()
+        rc = os.execl(get_syslog_ng_binary(), get_syslog_ng_binary(), '-f', 'test.conf', '--fd-limit', '1024', '-F', verbose_opt, '-p', 'syslog-ng.pid', '-R', 'syslog-ng.persist', '--no-caps', '--enable-core', '--seed', '--module-path', module_path)
         sys.exit(rc)
     time.sleep(5)
     print_user("Syslog-ng started")

--- a/tests/functional/globals.py
+++ b/tests/functional/globals.py
@@ -1,13 +1,38 @@
 import os
 
+def is_running_in_build_tree():
+    return 'SYSLOG_NG_BINARY' not in os.environ
+
+def get_module_path_from_binary():
+    syslog_ng_version_info = os.popen("%s --version" % get_syslog_ng_binary(), 'r').read()
+    for line in syslog_ng_version_info.split("\n"):
+        if 'Module-Path' in line:
+            return line.split(" ")[-1]
+    raise Exception("Failed to determine module paths from syslog-ng version")
+
+def format_module_path_for_intree_modules():
+    module_path = ''
+    for (root, dirs, files) in os.walk(os.path.abspath(os.path.join(os.environ['top_builddir'], 'modules'))):
+        module_path += ':'.join(map(lambda x: root + '/' + x + '/.libs', dirs))
+        break
+    return module_path
+
+def get_module_path():
+    if is_running_in_build_tree():
+        return format_module_path_for_intree_modules()
+    return get_module_path_from_binary()
+
+def get_syslog_ng_binary():
+    return os.getenv('SYSLOG_NG_BINARY', '../../syslog-ng/syslog-ng')
+
 def is_premium():
-    version = os.popen('../../syslog-ng/syslog-ng -V', 'r').read()
+    version = os.popen('%s -V' % get_syslog_ng_binary(), 'r').read()
     if version.find('premium-edition') != -1:
         return True
     return False
 
 def has_module(module):
-    avail_mods = os.popen('../../syslog-ng/syslog-ng -V | grep ^Available-Modules: ', 'r').read()
+    avail_mods = os.popen('%s -V | grep ^Available-Modules: ' % get_syslog_ng_binary(), 'r').read()
     if avail_mods.find(module) != -1:
         return True
     return False


### PR DESCRIPTION
With this minimal fix in tests, syslog-ng can be installed on arbitary place in a host. This place can be passed via SYSLOG_NG_BINARY and functional test can be executed like before.