### PR TITLE
fix double-free in yydestruct

### DIFF
--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -86,12 +86,11 @@ source_affile
 source_affile_params
 	: string
 	  {
-            last_driver = *instance = affile_sd_new($1, configuration);
-	    free($1);
+      last_driver = *instance = affile_sd_new($1, configuration);
 	    last_reader_options = &((AFFileSourceDriver *) last_driver)->reader_options;
 	    last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_perm_options;
 	  }
-          source_affile_options                 { $$ = last_driver; }
+          source_affile_options                 { $$ = last_driver; free($1); }
         ;
 
 source_affile_options
@@ -112,11 +111,10 @@ source_afpipe_params
 	: string
 	  {
 	    last_driver = *instance = afpipe_sd_new($1, configuration);
-	    free($1);
 	    last_reader_options = &((AFFileSourceDriver *) last_driver)->reader_options;
 	    last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_perm_options;
 	  }
-	  source_afpipe_options				{ $$ = last_driver; }
+	  source_afpipe_options				{ $$ = last_driver; free($1); }
 	;
 
 source_afpipe_options
@@ -160,11 +158,10 @@ dest_affile_params
 	: string
 	  {
 	    last_driver = *instance = affile_dd_new($1, configuration);
-	    free($1);
 	    last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
 	    last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_perm_options;
 	  }
-	  dest_affile_options                           { $$ = last_driver; }
+	  dest_affile_options                           { $$ = last_driver; free($1); }
 	;
 
 dest_affile_options
@@ -186,11 +183,10 @@ dest_afpipe_params
 	: string
 	  {
 	    last_driver = *instance = afpipe_dd_new($1, configuration);
-	    free($1);
 	    last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
 	    last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_perm_options;
 	  }
-	  dest_afpipe_options                   { $$ = last_driver; }
+	  dest_afpipe_options                   { $$ = last_driver; free($1); }
 	;
 
 dest_afpipe_options

--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -76,10 +76,9 @@ source_afprogram_params
 	: string
 	  {
 	    last_driver = *instance = afprogram_sd_new($1, configuration);
-	    free($1);
 	    last_reader_options = &((AFProgramSourceDriver *) last_driver)->reader_options;
 	  }
-	  source_afprogram_options			{ $$ = last_driver; }
+	  source_afprogram_options			{ $$ = last_driver; free($1); }
 	;
 
 source_afprogram_options
@@ -99,10 +98,9 @@ dest_afprogram_params
 	: string
 	  {
 	    last_driver = *instance = afprogram_dd_new($1, configuration);
-	    free($1);
 	    last_writer_options = &((AFProgramDestDriver *) last_driver)->writer_options;
 	  }
-	  dest_afprogram_options			{ $$ = last_driver; }
+	  dest_afprogram_options			{ $$ = last_driver; free($1); }
 	;
 
 dest_afprogram_options

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -236,20 +236,17 @@ source_afunix
 source_afunix_dgram_params
 	: string
 	  {
-        create_and_set_unix_dgram_or_systemd_syslog_source($1, configuration);
-
-	    free($1);
+      create_and_set_unix_dgram_or_systemd_syslog_source($1, configuration);
 	  }
-	  source_afunix_options			{ $$ = last_driver; }
+	  source_afunix_options			{ $$ = last_driver; free($1); }
 	;
 
 source_afunix_stream_params
 	: string
 	  {
       create_and_set_unix_stream_or_systemd_syslog_source($1, configuration);
-	    free($1);
 	  }
-	  source_afunix_options			{ $$ = last_driver; }
+	  source_afunix_options			{ $$ = last_driver; free($1); }
 	;
 
 /* options are common between dgram & stream */
@@ -468,10 +465,9 @@ dest_afunix_dgram_params
 	  {
 	    AFUnixDestDriver *d = afunix_dd_new_dgram($1, configuration);
 
-            afunix_grammar_set_dest_driver(d);
-	    free($1);
+      afunix_grammar_set_dest_driver(d);
 	  }
-	  dest_afunix_options			{ $$ = last_driver; }
+	  dest_afunix_options			{ $$ = last_driver; free($1); }
 	;
 
 dest_afunix_stream_params
@@ -479,10 +475,9 @@ dest_afunix_stream_params
 	  {
 	    AFUnixDestDriver *d = afunix_dd_new_stream($1, configuration);
 
-            afunix_grammar_set_dest_driver(d);
-	    free($1);
+      afunix_grammar_set_dest_driver(d);
 	  }
-	  dest_afunix_options			{ $$ = last_driver; }
+	  dest_afunix_options			{ $$ = last_driver; free($1); }
 	;
 
 dest_afunix_options
@@ -509,10 +504,9 @@ dest_afinet_udp_params
 	  {
 	    AFInetDestDriver *d = afinet_dd_new_udp($1, configuration);
 
-            afinet_grammar_set_dest_driver(d);
-	    free($1);
+      afinet_grammar_set_dest_driver(d);
 	  }
-	  dest_afinet_udp_options		{ $$ = last_driver; }
+	  dest_afinet_udp_options		{ $$ = last_driver; free($1); }
 	;
 
 dest_afinet_udp6_params
@@ -521,9 +515,8 @@ dest_afinet_udp6_params
 	    AFInetDestDriver *d = afinet_dd_new_udp6($1, configuration);
 
 	    afinet_grammar_set_dest_driver(d);
-	    free($1);
 	  }
-	  dest_afinet_udp_options		{ $$ = last_driver; }
+	  dest_afinet_udp_options		{ $$ = last_driver; free($1); }
 	;
 
 
@@ -555,10 +548,9 @@ dest_afinet_tcp_params
 	  {
 	    AFInetDestDriver *d = afinet_dd_new_tcp($1, configuration);
 
-            afinet_grammar_set_dest_driver(d);
-	    free($1);
+      afinet_grammar_set_dest_driver(d);
 	  }
-	  dest_afinet_tcp_options		{ $$ = last_driver; }
+	  dest_afinet_tcp_options		{ $$ = last_driver; free($1); }
 	;
 
 dest_afinet_tcp6_params
@@ -567,9 +559,8 @@ dest_afinet_tcp6_params
 	    AFInetDestDriver *d = afinet_dd_new_tcp6($1, configuration);
 
 	    afinet_grammar_set_dest_driver(d);
-	    free($1);
 	  }
-	  dest_afinet_tcp_options		{ $$ = last_driver; }
+	  dest_afinet_tcp_options		{ $$ = last_driver; free($1); }
 	;
 
 dest_afinet_tcp_options
@@ -603,9 +594,8 @@ dest_afsyslog_params
             AFInetDestDriver *d = afinet_dd_new_syslog($1, configuration);
 
             afinet_grammar_set_dest_driver(d);
-	    free($1);
 	  }
-	  dest_afsyslog_options			{ $$ = last_driver; }
+	  dest_afsyslog_options			{ $$ = last_driver; free($1); }
         ;
 
 
@@ -629,9 +619,8 @@ dest_afnetwork_params
             AFInetDestDriver *d = afinet_dd_new_network($1, configuration);
 
             afinet_grammar_set_dest_driver(d);
-	    free($1);
 	  }
-	  dest_afnetwork_options			{ $$ = last_driver; }
+	  dest_afnetwork_options			{ $$ = last_driver; free($1); }
         ;
 
 dest_afnetwork_options

--- a/modules/afstreams/afstreams-grammar.ym
+++ b/modules/afstreams/afstreams-grammar.ym
@@ -72,9 +72,8 @@ source_afstreams_params
 	: string
 	  {
 	    last_driver = *instance = afstreams_sd_new($1, configuration);
-	    free($1);
 	  }
-	  source_afstreams_options		{ $$ = last_driver; }
+	  source_afstreams_options		{ $$ = last_driver; free($1); }
 	;
 
 source_afstreams_options

--- a/modules/geoip/geoip-parser-grammar.ym
+++ b/modules/geoip/geoip-parser-grammar.ym
@@ -73,10 +73,9 @@ parser_expr_geoip
             template = cfg_tree_check_inline_template(&configuration->tree, $4, &error);
             CHECK_ERROR_GERROR(template != NULL, @4, error, "Error compiling template");
             log_parser_set_template(last_parser, template);
-            free($4);
           }
           parser_geoip_opts
-          ')'					{ $$ = last_parser; }
+          ')'					{ $$ = last_parser; free($4); }
         ;
 
 


### PR DESCRIPTION
Fixes #786

Modules
* [x] afamqp: not needed
* [x] affile
* [x] afmongodb: not needed
* [x] afprog: Bazsi fixed it
* [x] afsmtp: not needed
* [x] afsocket
* [x] afsql: not needed
* [x] afstomp: not needed
* [x] afstreams (depends on #819)
* [x] afuser: not needed
* [x] basicfuncs: (doesn't have grammar)
* [x] confgen: (doesn't have grammar)
* [x] cryptofuncs: (doesn't have grammar)
* [x] csvparser: not needed
* [x] date: not needed
* [x] dbparser: not needed
* [x] geoip
* [x] graphite (doesn't have grammar)
* [x] java: not needed
* [x] java-modules (irrelevant)
* [x] json: not needed
* [x] kvformat: not needed
* [x] linux-kmsg-format: not needed
* [x] pacctformat: not needed
* [x] pseudofile: not needed
* [x] python: not needed
* [x] redis: not needed
* [x] riemann: not needed
* [x] syslogformat: not needed
* [x] systemd-journal: not needed
* [x] system-source (doesn't have grammar)

Legend:
* `not needed` (to change): everyting was ok
* `(doesn't have grammar)`: the module doesn't have a grammar file

This PR depends on PR (I have to rebase this after it's merged) #819.

