### PR TITLE
F/copyright review 2015

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Corinna Vinschen - cygwin packaging files and portability fixes
 Charles G. Waldman - file source driver fixes
 Philip Bellino - IPv6 bugfixes
 Vijay Ramasubramanian - extending time related macros
+The Regents of the University of California & Chris Torek - strcasestr()
 
 Suggestions, good bugreports, helping newbies on the mailing list:
 ------------------------------------------------------------------

--- a/COPYING
+++ b/COPYING
@@ -41,3 +41,43 @@ Q: Who is permitted to create non-free plugins for syslog-ng? Is it just
 BalaBit (the current copyright holder as of the initial 3.2 release)?
 
 A: No, everyone including BalaBit.
+
+PORTIONS WERE CONTRIBUTED UNDER THE FOLLOWING LICENSES:
+======================================================
+
+lib/compat:
+/*-
+ * Copyright (c) 1990, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the University of
+ *      California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */

--- a/lib/compat/strcasestr.c
+++ b/lib/compat/strcasestr.c
@@ -22,6 +22,42 @@
  *
  */
 
+/*-
+ * Copyright (c) 1990, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the University of
+ *      California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
 #include "compat/string.h"
 
 #ifndef SYSLOG_NG_HAVE_STRCASESTR

--- a/lib/compat/tests/test_strtok_r.c
+++ b/lib/compat/tests/test_strtok_r.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2002-2013 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "syslog-ng.h"
 #include "testutils.h"
 

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2012 Balazs Scheidler <bazsilgernon@balabit.hu>
+ * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2012 Balazs Scheidler <bazsilgernon@balabit.hu>
+ * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>,
- *                    Peter Gyongyosi <gyp@balabit.hu>
+ * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2012 Peter Gyongyosi <gyp@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/BooleanOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/BooleanOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 import java.util.Arrays;

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 public class IntegerOptionDecorator extends OptionDecorator {

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/InvalidOptionException.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/InvalidOptionException.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 public class InvalidOptionException extends Exception {

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/Options.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/Options.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 import java.util.HashMap;

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 import org.syslog_ng.LogMessage;

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -1,7 +1,24 @@
 /*
- * Copyright (c) 2015 BalaBit
- * All Rights Reserved.
- * Authors: Zoltan Pallagi <zoltan.pallagi@balabit.com>
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Zoltan Pallagi <zoltan.pallagi@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 package org.syslog_ng.hdfs;

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Adam Arsenault <adam.arsenault@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.http;
 
 import org.syslog_ng.*;

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2015 BalaBit
- * All Rights Reserved.
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 package org.syslog_ng.kafka;

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationOptions.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationOptions.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.kafka;
 
 import org.syslog_ng.LogDestination;

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationProperties.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationProperties.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.kafka;
 
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/MockLogDestination.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/MockLogDestination.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import java.util.Hashtable;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestBooleanOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestBooleanOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.After;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestEnumOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestEnumOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import static org.junit.Assert.*;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerRangeCheckOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerRangeCheckOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestOption.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestOption.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import static org.junit.Assert.*;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestPortCheckDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestPortCheckDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestRequiredOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestRequiredOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestStringOption.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestStringOption.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;


### PR DESCRIPTION
EDIT: If you agree to retrospectively adjust the old copyright headers as well, you can close PR #822 and merge the extended version instead: https://github.com/balabit/syslog-ng/pull/823

PR #822 does not contain the following proposed automatic modifications.
(I would also do merging around s.a.r.l lines manually,
because the legal entity did not change and lived in continuity.)

```bash
find . -type f |
while read FILE; do
sed --silent --regexp-extended "
 s~\<Portions created by ~&~
 t skip
 s~^ \* Copyright \(c\) 1990, 1993$~&~
 t skip

s~^((.*)\<[cC]opyright \([cC]\) ([0-9,. -]+[0-9])\
( Bala[bB]it( IT Ltd(, Budapest, Hungary)?\
| S\.a\.r\.l\., Luxembourg, Luxembourg)?)?)$~\
-\1\n\
+\2Copyright (c) \3~

 T skip
 s~2015$~&~
 t ok
 s~-2014 *$~-2015~
 t ok
 s~(2014) *$~\1-2015~
 t ok
 s~$~, 2015~
 :ok
 s~$~ Balabit~
 p
 :skip
" \
"$FILE" || break
done |
grep --line-buffered --extended-regexp --color=always "(Balabit)?$" |
less --RAW-CONTROL-CHARS
```