### PR TITLE
F/copyright review 2015 extended

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ install:
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh
-script:
   - unset PYTHON_CFLAGS # HACK
   - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
-  - make && make distcheck VERBOSE=1 && make func-test VERBOSE=1
+  - if [ "$CC" = "clang" ]; then export COPYRIGHTVERBOSITY=1; make check-copyright; fi
+  - make -j || make V=1 # to make error messages more readable on error
+script:
+  - if [ "$CC" = "gcc" ]; then make distcheck V=1; else make func-test V=1; fi
 compiler:
   - gcc
   - clang

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Corinna Vinschen - cygwin packaging files and portability fixes
 Charles G. Waldman - file source driver fixes
 Philip Bellino - IPv6 bugfixes
 Vijay Ramasubramanian - extending time related macros
+The Regents of the University of California & Chris Torek - strcasestr()
 
 Suggestions, good bugreports, helping newbies on the mailing list:
 ------------------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,29 @@ the [Incubator](https://github.com/balabit/syslog-ng-incubator) first,
 because it is easier to have your code accepted there. The Incubator
 is the repository of new and experimental modules.
 
+## Licensing
+
+Please ensure that your contribution is clean in respect to licensing and
+copyright.
+
+If your contribution is eligible for copyright, you should also extend the list
+of copyright holders at the top of the relevant files which carry your
+modifications.
+
+The absolute minimum to specify is the identity of the author entity, which is
+usually one or more of an e-mail address and your full name or the name of the
+legal entity who holds the intellectual rights if it is not you.
+Please make it clear which is the case, because this may depend on your
+contract if you are employed or are a subcontractor.
+
+Note that from time to time, we may rephrase the exact text surrounding
+attributions, however the specified identities and the license binding a given
+contribution will not be changed in a legally incompatibly manner.
+
+Every new file must carry a standard copyright notice and be compatible with
+our licensing scheme described in COPYING.
+You should observe some of the existing files for reference.
+
 ## Additional resources
 
 For additional information, have a look at the

--- a/COPYING
+++ b/COPYING
@@ -1,14 +1,26 @@
-Copyright (c) 2002-2012 BalaBit IT Security Ltd.
-Copyright (c) 1996-2012 Balázs Scheidler
+Copyright (c) 2002-2015 Balabit
+Copyright (c) 1996-2015 Balázs Scheidler
 
 syslog-ng is licensed under the combination of the GPL and LGPL licenses.
 
-The syslog-ng core (lib/, libtest/ and syslog-ng/ subdirectories) is
-licensed under the Lesser General Public License as described in the
-file LGPL.txt
+The syslog-ng core contained in the following subdirectories
+is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version
+(please refer to the file LGPL.txt for more details):
 
-The syslog-ng modules (modules/ subdirectory) are licensed under the
-General Public License as described in the file GPL.txt
+lib/
+libtest/
+syslog-ng/
+modules/java-common/
+modules/java/(native|proxies|src)/
+
+The syslog-ng modules (modules/ subdirectory except the ones mentioned above)
+is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 as published
+by the Free Software Foundation, or (at your option) any later version
+(please refer to the file LGPL.txt for more details).
 
 FAQ:
 ====

--- a/COPYING
+++ b/COPYING
@@ -41,3 +41,43 @@ Q: Who is permitted to create non-free plugins for syslog-ng? Is it just
 BalaBit (the current copyright holder as of the initial 3.2 release)?
 
 A: No, everyone including BalaBit.
+
+PORTIONS WERE CONTRIBUTED UNDER THE FOLLOWING LICENSES:
+======================================================
+
+lib/compat:
+/*-
+ * Copyright (c) 1990, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the University of
+ *      California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */

--- a/COPYING
+++ b/COPYING
@@ -15,6 +15,7 @@ libtest/
 syslog-ng/
 modules/java-common/
 modules/java/(native|proxies|src)/
+modules/native/
 
 The syslog-ng modules (modules/ subdirectory except the ones mentioned above)
 is free software; you can redistribute it and/or modify it

--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/alarms.c
+++ b/lib/alarms.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/alarms.h
+++ b/lib/alarms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/block-ref-grammar.ym
+++ b/lib/block-ref-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/block-ref-parser.c
+++ b/lib/block-ref-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/block-ref-parser.h
+++ b/lib/block-ref-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/bookmark.h
+++ b/lib/bookmark.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/cache.h
+++ b/lib/cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/cfg-args.c
+++ b/lib/cfg-args.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-args.h
+++ b/lib/cfg-args.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-lexer-subst.c
+++ b/lib/cfg-lexer-subst.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2010-2013 Balabit
+ * Copyright (c) 2010-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "cfg-lexer-subst.h"
 #include "cfg-args.h"
 #include "cfg-lexer.h"

--- a/lib/cfg-lexer-subst.h
+++ b/lib/cfg-lexer-subst.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-lexer-subst.h
+++ b/lib/cfg-lexer-subst.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2012 Balabit
- * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2010-2013 Balabit
+ * Copyright (c) 2010-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/children.c
+++ b/lib/children.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/children.h
+++ b/lib/children.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/compat.h
+++ b/lib/compat/compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/getutent.c
+++ b/lib/compat/getutent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/getutent.h
+++ b/lib/compat/getutent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/inet_aton.c
+++ b/lib/compat/inet_aton.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/lfs.h
+++ b/lib/compat/lfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/memrchr.c
+++ b/lib/compat/memrchr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/pio.c
+++ b/lib/compat/pio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/pio.h
+++ b/lib/compat/pio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/socket.h
+++ b/lib/compat/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/strcasestr.c
+++ b/lib/compat/strcasestr.c
@@ -22,6 +22,42 @@
  *
  */
 
+/*-
+ * Copyright (c) 1990, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the University of
+ *      California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
 #include "compat/string.h"
 
 #ifndef SYSLOG_NG_HAVE_STRCASESTR

--- a/lib/compat/strcasestr.c
+++ b/lib/compat/strcasestr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/compat/string.h
+++ b/lib/compat/string.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/strtok_r.c
+++ b/lib/compat/strtok_r.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/tests/test_strtok_r.c
+++ b/lib/compat/tests/test_strtok_r.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2002-2013 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "syslog-ng.h"
 #include "testutils.h"
 

--- a/lib/compat/time.h
+++ b/lib/compat/time.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@madhouse-project.org>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/control/control-server-unix.c
+++ b/lib/control/control-server-unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/control/control.h
+++ b/lib/control/control.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013-2015 Balabit
+ * Copyright (c) 2013 Juhász Viktor <jviktor@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "control/control-server.h"
 #include "control/control.c"

--- a/lib/control/tests/test_control_connection.c
+++ b/lib/control/tests/test_control_connection.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013-2014 Balabit
+ * Copyright (c) 2013 Juhász Viktor <jviktor@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "control/control-server.h"
 #include "apphook.h"

--- a/lib/crypto.c
+++ b/lib/crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/crypto.c
+++ b/lib/crypto.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2012 Balabit
- * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2011-2015 Balabit
+ * Copyright (c) 2011-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/crypto.h
+++ b/lib/crypto.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2011-2015 Balabit
+ * Copyright (c) 2011-2015 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
 #ifndef CRYPTO_H_INCLUDED
 #define CRYPTO_H_INCLUDED
 

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "debugger/debugger.h"
 #include "logpipe.h"
 

--- a/lib/debugger/debugger-main.h
+++ b/lib/debugger/debugger-main.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2015 Balabit
- * Copyright (c) 2014-2015 Balázs Scheidler
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,7 @@
  * COPYING for details.
  *
  */
+
 #ifndef DEBUGGER_DEBUGGER_MAIN_H_INCLUDED
 #define DEBUGGER_DEBUGGER_MAIN_H_INCLUDED 1
 

--- a/lib/debugger/debugger-main.h
+++ b/lib/debugger/debugger-main.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2015 Balabit
- * Copyright (c) 2014-2015 Balázs Scheidler
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2015 Balabit
- * Copyright (c) 2014-2015 Balázs Scheidler
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler <bazsi@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "debugger/debugger.h"
 #include "apphook.h"
 

--- a/lib/debugger/tracer.c
+++ b/lib/debugger/tracer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/debugger/tracer.c
+++ b/lib/debugger/tracer.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2015 Balabit
- * Copyright (c) 2014-2015 Balázs Scheidler
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2015 Balabit
- * Copyright (c) 2014-2015 Balázs Scheidler
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/fdhelpers.c
+++ b/lib/fdhelpers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/fdhelpers.h
+++ b/lib/fdhelpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2012 Balazs Scheidler <bazsilgernon@balabit.hu>
+ * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2012 Balazs Scheidler <bazsilgernon@balabit.hu>
+ * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-call.h
+++ b/lib/filter/filter-call.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-cmp.h
+++ b/lib/filter/filter-cmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-expr-parser.c
+++ b/lib/filter/filter-expr-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-expr-parser.h
+++ b/lib/filter/filter-expr-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014 Balabit
  * Copyright (c) 2013, 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-in-list.h
+++ b/lib/filter/filter-in-list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-netmask.h
+++ b/lib/filter/filter-netmask.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Zoltan Fried
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Zoltan Fried
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/filter/filter-netmask6.h
+++ b/lib/filter/filter-netmask6.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Zoltan Fried
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/filter/filter-netmask6.h
+++ b/lib/filter/filter-netmask6.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Zoltan Fried
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/filter/filter-op.c
+++ b/lib/filter/filter-op.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-op.h
+++ b/lib/filter/filter-op.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-pipe.h
+++ b/lib/filter/filter-pipe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-pri.c
+++ b/lib/filter/filter-pri.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-pri.h
+++ b/lib/filter/filter-pri.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-re.h
+++ b/lib/filter/filter-re.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler
+ * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "filter-tags.h"
 #include "logmsg.h"
 

--- a/lib/filter/filter-tags.h
+++ b/lib/filter/filter-tags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2005-2015 Balabit
+ * Copyright (c) 2005-2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "filter/filter-expr.h"
 #include "filter/filter-expr-grammar.h"
 #include "filter/filter-netmask.h"

--- a/lib/filter/tests/test_filters_in_list.c
+++ b/lib/filter/tests/test_filters_in_list.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013, 2014 Balabit
+ * Copyright (c) 2013, 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include <stdlib.h>
 #include <glib.h>
 

--- a/lib/filter/tests/test_filters_netmask6.c
+++ b/lib/filter/tests/test_filters_netmask6.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Zoltan Fried
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "gsocket.h"
 #include "logmsg.h"
 

--- a/lib/find-crlf.c
+++ b/lib/find-crlf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/find-crlf.h
+++ b/lib/find-crlf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/globals.c
+++ b/lib/globals.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/gsocket.c
+++ b/lib/gsocket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/gsocket.h
+++ b/lib/gsocket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/host-id.c
+++ b/lib/host-id.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/host-id.c
+++ b/lib/host-id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/host-id.h
+++ b/lib/host-id.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/host-id.h
+++ b/lib/host-id.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/host-resolve.h
+++ b/lib/host-resolve.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/hostname-unix.c
+++ b/lib/hostname-unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/hostname.c
+++ b/lib/hostname.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/hostname.h
+++ b/lib/hostname.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logmatcher.h
+++ b/lib/logmatcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logmpx.h
+++ b/lib/logmpx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logmsg.h
+++ b/lib/logmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-builtins.h
+++ b/lib/logproto/logproto-builtins.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-dgram-server.c
+++ b/lib/logproto/logproto-dgram-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-dgram-server.h
+++ b/lib/logproto/logproto-dgram-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-framed-client.c
+++ b/lib/logproto/logproto-framed-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-framed-client.h
+++ b/lib/logproto/logproto-framed-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-framed-server.h
+++ b/lib/logproto/logproto-framed-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-indented-multiline-server.c
+++ b/lib/logproto/logproto-indented-multiline-server.c
@@ -15,6 +15,10 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
  */
 
 #include "logproto-indented-multiline-server.h"

--- a/lib/logproto/logproto-indented-multiline-server.c
+++ b/lib/logproto/logproto-indented-multiline-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-indented-multiline-server.h
+++ b/lib/logproto/logproto-indented-multiline-server.h
@@ -16,6 +16,10 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 #ifndef LOGPROTO_INDENTED_MULTILINE_SERVER_INCLUDED
 #define LOGPROTO_INDENTED_MULTILINE_SERVER_INCLUDED

--- a/lib/logproto/logproto-indented-multiline-server.h
+++ b/lib/logproto/logproto-indented-multiline-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-record-server.c
+++ b/lib/logproto/logproto-record-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-record-server.h
+++ b/lib/logproto/logproto-record-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -15,6 +15,10 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
  */
 
 #include "logproto-regexp-multiline-server.h"

--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-regexp-multiline-server.h
+++ b/lib/logproto/logproto-regexp-multiline-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-regexp-multiline-server.h
+++ b/lib/logproto/logproto-regexp-multiline-server.h
@@ -16,6 +16,10 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 #ifndef LOGPROTO_REGEXP_MULTILINE_SERVER_INCLUDED
 #define LOGPROTO_REGEXP_MULTILINE_SERVER_INCLUDED

--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto-text-server.h
+++ b/lib/logproto/logproto-text-server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/logproto.h
+++ b/lib/logproto/logproto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logproto/tests/test-dgram-server.c
+++ b/lib/logproto/tests/test-dgram-server.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test-framed-server.c
+++ b/lib/logproto/tests/test-framed-server.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test-indented-multiline-server.c
+++ b/lib/logproto/tests/test-indented-multiline-server.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test-record-server.c
+++ b/lib/logproto/tests/test-record-server.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test-regexp-multiline-server.c
+++ b/lib/logproto/tests/test-regexp-multiline-server.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2013-2014 Balabit
+ * Copyright (c) 2013-2014 Balázs Scheidler <balazs.scheidler@balabit.com>
+ * Copyright (c) 2014 Viktor Tusa <viktor.tusa@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test-server-options.c
+++ b/lib/logproto/tests/test-server-options.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test-text-server.c
+++ b/lib/logproto/tests/test-text-server.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "mock-transport.h"
 #include "proto_lib.h"
 #include "msg_parse_lib.h"

--- a/lib/logproto/tests/test_findeom.c
+++ b/lib/logproto/tests/test_findeom.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2008-2013 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "logproto/logproto-server.h"
 #include "logmsg.h"
 #include <stdlib.h>

--- a/lib/logproto/tests/test_logproto.c
+++ b/lib/logproto/tests/test_logproto.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "test_logproto.h"
 #include "mock-transport.h"
 #include "proto_lib.h"

--- a/lib/logproto/tests/test_logproto.h
+++ b/lib/logproto/tests/test_logproto.h
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef TEST_LOGPROTO_H_INCLUDED
 #define TEST_LOGPROTO_H_INCLUDED
 

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logqueue-fifo.h
+++ b/lib/logqueue-fifo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logstamp.c
+++ b/lib/logstamp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logstamp.h
+++ b/lib/logstamp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014 Balabit
  * Copyright (c) 2013, 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014 Balabit
  * Copyright (c) 2013, 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop-call.c
+++ b/lib/mainloop-call.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop-call.h
+++ b/lib/mainloop-call.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop-io-worker.h
+++ b/lib/mainloop-io-worker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/memtrace.c
+++ b/lib/memtrace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/memtrace.h
+++ b/lib/memtrace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/messages.c
+++ b/lib/messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/ml-batched-timer.c
+++ b/lib/ml-batched-timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/ml-batched-timer.h
+++ b/lib/ml-batched-timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/module-config.c
+++ b/lib/module-config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/module-config.h
+++ b/lib/module-config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/nvtable.c
+++ b/lib/nvtable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/nvtable.h
+++ b/lib/nvtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013-2014 Balabit
+ * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "parse-number.h"
 
 #include <string.h>

--- a/lib/parse-number.h
+++ b/lib/parse-number.h
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013-2014 Balabit
+ * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef PARSE_NUMBER_H_INCLUDED
 #define PARSE_NUMBER_H_INCLUDED
 

--- a/lib/parser/parser-expr-grammar.ym
+++ b/lib/parser/parser-expr-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/parser/parser-expr-parser.c
+++ b/lib/parser/parser-expr-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/parser/parser-expr-parser.h
+++ b/lib/parser/parser-expr-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/parser/parser-expr.h
+++ b/lib/parser/parser-expr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/pathutils.c
+++ b/lib/pathutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/pathutils.h
+++ b/lib/pathutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/persist-state.h
+++ b/lib/persist-state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/persistable-state-header.h
+++ b/lib/persistable-state-header.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  * Copyright (c) 2012-2013 Viktor Juhasz
  * Copyright (c) 2012-2013 Viktor Tusa

--- a/lib/persistable-state-presenter.c
+++ b/lib/persistable-state-presenter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/persistable-state-presenter.h
+++ b/lib/persistable-state-presenter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/plugin-types.h
+++ b/lib/plugin-types.h
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler <bazsi@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef PLUGIN_TYPES_H_INCLUDED
 #define PLUGIN_TYPES_H_INCLUDED
 

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/poll-events.c
+++ b/lib/poll-events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/poll-events.h
+++ b/lib/poll-events.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/poll-fd-events.c
+++ b/lib/poll-fd-events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/poll-fd-events.h
+++ b/lib/poll-fd-events.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/pragma-parser.c
+++ b/lib/pragma-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/pragma-parser.h
+++ b/lib/pragma-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/presented-persistable-state.h
+++ b/lib/presented-persistable-state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/rcptid.c
+++ b/lib/rcptid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/rcptid.h
+++ b/lib/rcptid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/reloc.c
+++ b/lib/reloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/reloc.h
+++ b/lib/reloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-expr-parser.c
+++ b/lib/rewrite/rewrite-expr-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-expr-parser.h
+++ b/lib/rewrite/rewrite-expr-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-expr.h
+++ b/lib/rewrite/rewrite-expr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-groupset.c
+++ b/lib/rewrite/rewrite-groupset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhász <viktor.juhasz@balabit.com>
  * Copyright (c) 2014 Viktor Tusa <viktor.tusa@balabit.com>
  *

--- a/lib/rewrite/rewrite-groupset.h
+++ b/lib/rewrite/rewrite-groupset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Tusa <viktor.tusa@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-set-tag.c
+++ b/lib/rewrite/rewrite-set-tag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-set-tag.h
+++ b/lib/rewrite/rewrite-set-tag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-set.c
+++ b/lib/rewrite/rewrite-set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-set.h
+++ b/lib/rewrite/rewrite-set.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-subst.c
+++ b/lib/rewrite/rewrite-subst.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/rewrite-subst.h
+++ b/lib/rewrite/rewrite-subst.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Viktor Tusa <viktor.tusa@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "apphook.h"
 #include "plugin.h"
 #include "testutils.h"

--- a/lib/ringbuffer.c
+++ b/lib/ringbuffer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/ringbuffer.h
+++ b/lib/ringbuffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/run-id.h
+++ b/lib/run-id.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/scratch-buffers.c
+++ b/lib/scratch-buffers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Balabit
  * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/scratch-buffers.h
+++ b/lib/scratch-buffers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Balabit
  * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/seqnum.h
+++ b/lib/seqnum.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/serialize.c
+++ b/lib/serialize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/serialize.h
+++ b/lib/serialize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/service-management.c
+++ b/lib/service-management.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/service-management.h
+++ b/lib/service-management.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -1,17 +1,18 @@
 /*
  * Copyright (c) 2015 Balabit
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-csv.h
+++ b/lib/stats/stats-csv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-log.c
+++ b/lib/stats/stats-log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-log.h
+++ b/lib/stats/stats-log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-syslog.c
+++ b/lib/stats/stats-syslog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats-syslog.h
+++ b/lib/stats/stats-syslog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/stats.h
+++ b/lib/stats/stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler <bazsi@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "stats/stats-cluster.h"
 

--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/str-format.h
+++ b/lib/str-format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/str-utils.c
+++ b/lib/str-utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/string-list.c
+++ b/lib/string-list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/string-list.h
+++ b/lib/string-list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/syslog-names.c
+++ b/lib/syslog-names.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/syslog-names.h
+++ b/lib/syslog-names.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tags.c
+++ b/lib/tags.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tags.c
+++ b/lib/tags.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2002-2012 Balabit
- * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2009-2013 Balabit
+ * Copyright (c) 2009 Marton Illes
+ * Copyright (c) 2009-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tags.h
+++ b/lib/tags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tags.h
+++ b/lib/tags.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2002-2011 Balabit
- * Copyright (c) 1998-2011 Balázs Scheidler
+ * Copyright (c) 2009-2013 Balabit
+ * Copyright (c) 2009 Marton Illes
+ * Copyright (c) 2009-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/template/common-template-typedefs.h
+++ b/lib/template/common-template-typedefs.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/template/common-template-typedefs.h
+++ b/lib/template/common-template-typedefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Laszlo Budai
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/compiler.h
+++ b/lib/template/compiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/escaping.c
+++ b/lib/template/escaping.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/escaping.h
+++ b/lib/template/escaping.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/function.h
+++ b/lib/template/function.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/repr.c
+++ b/lib/template/repr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/repr.h
+++ b/lib/template/repr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/simple-function.c
+++ b/lib/template/simple-function.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/simple-function.h
+++ b/lib/template/simple-function.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2007-2014 Balabit
+ * Copyright (c) 2007-2014 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "syslog-ng.h"
 #include "template_lib.h"
 

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013-2014 Balabit
+ * Copyright (c) 2013-2014 Balázs Scheidler <balazs.scheidler@balabit.com>
+ * Copyright (c) 2013 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/template/tests/test_template_on_error.c
+++ b/lib/template/tests/test_template_on_error.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include <libgen.h>
 
 #include "template/templates.h"

--- a/lib/template/tests/test_template_speed.c
+++ b/lib/template/tests/test_template_speed.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2009-2014 Balabit
+ * Copyright (c) 2009-2014 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "syslog-ng.h"
 #include "logmsg.h"
 #include "template/templates.h"

--- a/lib/template/user-function.c
+++ b/lib/template/user-function.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/template/user-function.h
+++ b/lib/template/user-function.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tests/test_cache.c
+++ b/lib/tests/test_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_cfg_lexer_subst.c
+++ b/lib/tests/test_cfg_lexer_subst.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_cfg_tree.c
+++ b/lib/tests/test_cfg_tree.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tests/test_host_resolve.c
+++ b/lib/tests/test_host_resolve.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_hostname.c
+++ b/lib/tests/test_hostname.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "cfg-lexer.h"
 #include "cfg-grammar.h"

--- a/lib/tests/test_log_message.c
+++ b/lib/tests/test_log_message.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2013-2014 Balabit
+ * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_pathutils.c
+++ b/lib/tests/test_pathutils.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Viktor Tusa <tusa@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "pathutils.h"
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/lib/tests/test_rcptid.c
+++ b/lib/tests/test_rcptid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/tests/test_reloc.c
+++ b/lib/tests/test_reloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_runid.c
+++ b/lib/tests/test_runid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
  * Copyright (c) 2013 Viktor Tusa
  *

--- a/lib/tests/test_str_format.c
+++ b/lib/tests/test_str_format.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Balázs Scheidler <bazsi@balabit.hu>
+ * Copyright (c) 2014 Viktor Tusa <tusa@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "str-format.h"
 #include "testutils.h"
 

--- a/lib/tests/test_string_list.c
+++ b/lib/tests/test_string_list.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 #include "string-list.h"
 #include "testutils.h"
 

--- a/lib/tests/test_type_hints.c
+++ b/lib/tests/test_type_hints.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/tests/test_userdb.c
+++ b/lib/tests/test_userdb.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2010 Balabit
  * Copyright (c) 2010 Balázs Scheidler
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/lib/tests/test_userdb.c
+++ b/lib/tests/test_userdb.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010 Balabit
+ * Copyright (c) 2010 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "userdb.h"
 
 int main(void)

--- a/lib/tests/test_utf8utils.c
+++ b/lib/tests/test_utf8utils.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "utf8utils.h"
 

--- a/lib/thread-utils.h
+++ b/lib/thread-utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tls-support.h
+++ b/lib/tls-support.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/logtransport.c
+++ b/lib/transport/logtransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/tests/test_aux_data.c
+++ b/lib/transport/tests/test_aux_data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-aux-data.c
+++ b/lib/transport/transport-aux-data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-aux-data.h
+++ b/lib/transport/transport-aux-data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-device.c
+++ b/lib/transport/transport-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-device.h
+++ b/lib/transport/transport-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-file.c
+++ b/lib/transport/transport-file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-file.h
+++ b/lib/transport/transport-file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-pipe.c
+++ b/lib/transport/transport-pipe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-pipe.h
+++ b/lib/transport/transport-pipe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-socket.c
+++ b/lib/transport/transport-socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-socket.h
+++ b/lib/transport/transport-socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/transport/transport-tls.h
+++ b/lib/transport/transport-tls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/type-hinting.c
+++ b/lib/type-hinting.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2014 Balabit
  * Copyright (c) 2012-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/type-hinting.h
+++ b/lib/type-hinting.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2014 Balabit
  * Copyright (c) 2012-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/userdb.c
+++ b/lib/userdb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/userdb.h
+++ b/lib/userdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/utf8utils.h
+++ b/lib/utf8utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/utf8utils.h
+++ b/lib/utf8utils.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2012 Balabit
  * Copyright (c) 2010-2012 Balázs Scheidler
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *

--- a/lib/uuid.h
+++ b/lib/uuid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2012 Balabit
  * Copyright (c) 2010-2012 Balázs Scheidler
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *

--- a/lib/value-pairs.h
+++ b/lib/value-pairs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Balabit
  * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -1,9 +1,10 @@
 /*
  * Copyright (c) 2002-2012 Balabit
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/lib/vptransform.c
+++ b/lib/vptransform.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Balabit
  * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/lib/vptransform.h
+++ b/lib/vptransform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Balabit
  * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/config_parse_lib.c
+++ b/libtest/config_parse_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhász <viktor.juhasz@balabit.com>
  * Copyright (c) 2014 Viktor Tusa <viktor.tusa@balabit.com>
  *

--- a/libtest/config_parse_lib.h
+++ b/libtest/config_parse_lib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhász <viktor.juhasz@balabit.com>
  * Copyright (c) 2014 Viktor Tusa <viktor.tusa@balabit.com>
  *

--- a/libtest/libtest.c
+++ b/libtest/libtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/persist_lib.c
+++ b/libtest/persist_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Tusa
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/persist_lib.h
+++ b/libtest/persist_lib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Tusa
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/proto_lib.h
+++ b/libtest/proto_lib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012 Balabit
+ * Copyright (c) 2012 Peter Gyorko
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012 Balabit
+ * Copyright (c) 2012 Peter Gyorko
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2014 Balabit
  * Copyright (c) 2012-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2012, 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012, 2014 Balabit
  * Copyright (c) 2012, 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afamqp/afamqp-parser.h
+++ b/modules/afamqp/afamqp-parser.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2014 Balabit
  * Copyright (c) 2012-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afamqp/afamqp.h
+++ b/modules/afamqp/afamqp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-common.h
+++ b/modules/affile/affile-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-parser.h
+++ b/modules/affile/affile-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-plugin.c
+++ b/modules/affile/affile-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/logproto-file-writer.h
+++ b/modules/affile/logproto-file-writer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/logproto-linux-proc-kmsg-reader.h
+++ b/modules/affile/logproto-linux-proc-kmsg-reader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/poll-file-changes.h
+++ b/modules/affile/poll-file-changes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/affile/tests/test_affile_open_file.c
+++ b/modules/affile/tests/test_affile_open_file.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Laszlo Budai
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "affile/affile-common.h"
 #include "lib/messages.h"

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afmongodb/afmongodb-parser.c
+++ b/modules/afmongodb/afmongodb-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afmongodb/afmongodb-parser.h
+++ b/modules/afmongodb/afmongodb-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2012 Balabit
  * Copyright (c) 2010-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afmongodb/afmongodb.h
+++ b/modules/afmongodb/afmongodb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2013 Balabit
  * Copyright (c) 2010-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afprog/afprog-parser.c
+++ b/modules/afprog/afprog-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afprog/afprog-parser.h
+++ b/modules/afprog/afprog-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afprog/afprog-plugin.c
+++ b/modules/afprog/afprog-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afprog/afprog.h
+++ b/modules/afprog/afprog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsmtp/afsmtp-parser.c
+++ b/modules/afsmtp/afsmtp-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Balabit
  * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsmtp/afsmtp-parser.h
+++ b/modules/afsmtp/afsmtp-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Balabit
  * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsmtp/afsmtp.h
+++ b/modules/afsmtp/afsmtp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Balabit
  * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afinet-dest.h
+++ b/modules/afsocket/afinet-dest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afinet-source.c
+++ b/modules/afsocket/afinet-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afinet-source.h
+++ b/modules/afsocket/afinet-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afinet.c
+++ b/modules/afsocket/afinet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afinet.h
+++ b/modules/afsocket/afinet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-parser.h
+++ b/modules/afsocket/afsocket-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-plugin.c
+++ b/modules/afsocket/afsocket-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket-systemd-override.h
+++ b/modules/afsocket/afsocket-systemd-override.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Tibor Benke
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef AFSOCKET_GRAMMAR_EXTRA_H_INCLUDED
 #define AFSOCKET_GRAMMAR_EXTRA_H_INCLUDED
 

--- a/modules/afsocket/afsocket.c
+++ b/modules/afsocket/afsocket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afsocket.h
+++ b/modules/afsocket/afsocket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afunix-dest.c
+++ b/modules/afsocket/afunix-dest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afunix-dest.h
+++ b/modules/afsocket/afunix-dest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/afunix-source.h
+++ b/modules/afsocket/afunix-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/socket-options-inet.c
+++ b/modules/afsocket/socket-options-inet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/socket-options-inet.h
+++ b/modules/afsocket/socket-options-inet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/socket-options.c
+++ b/modules/afsocket/socket-options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/socket-options.h
+++ b/modules/afsocket/socket-options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/systemd-syslog-source.c
+++ b/modules/afsocket/systemd-syslog-source.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2013-2014 Benke Tibor
+ * Copyright (c) 2013-2014 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/afsocket/systemd-syslog-source.c
+++ b/modules/afsocket/systemd-syslog-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 2013-2014 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/systemd-syslog-source.c
+++ b/modules/afsocket/systemd-syslog-source.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2013-2014 Tibor Benke
  *

--- a/modules/afsocket/systemd-syslog-source.h
+++ b/modules/afsocket/systemd-syslog-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  * Copyright (c) 2013-2014 Tibor Benke
  *

--- a/modules/afsocket/systemd-syslog-source.h
+++ b/modules/afsocket/systemd-syslog-source.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2014 Balázs Scheidler
- * Copyright (c) 2013-2014 Benke Tibor
+ * Copyright (c) 2013-2014 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "afinet.h"
 #include "afsocket.h"
 #include "stats/stats-registry.h"

--- a/modules/afsocket/tests/test-transport-mapper-unix.c
+++ b/modules/afsocket/tests/test-transport-mapper-unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/tests/test-transport-mapper.c
+++ b/modules/afsocket/tests/test-transport-mapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/tests/transport-mapper-lib.c
+++ b/modules/afsocket/tests/transport-mapper-lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/tests/transport-mapper-lib.c
+++ b/modules/afsocket/tests/transport-mapper-lib.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2013 Balabit
- * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/afsocket/tests/transport-mapper-lib.h
+++ b/modules/afsocket/tests/transport-mapper-lib.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef AFSOCKET_OPTIONS_LIB_H_INCLUDED
 #define AFSOCKET_OPTIONS_LIB_H_INCLUDED
 

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/transport-mapper-unix.h
+++ b/modules/afsocket/transport-mapper-unix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/transport-mapper.c
+++ b/modules/afsocket/transport-mapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  * Copyright (c) 2014 Gergely Nagy
  *

--- a/modules/afsocket/transport-unix-socket.h
+++ b/modules/afsocket/transport-unix-socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/unix-credentials.c
+++ b/modules/afsocket/unix-credentials.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsocket/unix-credentials.h
+++ b/modules/afsocket/unix-credentials.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit S.a.r.l., Luxembourg, Luxembourg
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsql/afsql-parser.c
+++ b/modules/afsql/afsql-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsql/afsql-parser.h
+++ b/modules/afsql/afsql-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsql/afsql-plugin.c
+++ b/modules/afsql/afsql-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -7,13 +7,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/afstomp-parser.c
+++ b/modules/afstomp/afstomp-parser.c
@@ -7,13 +7,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/afstomp-parser.c
+++ b/modules/afstomp/afstomp-parser.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/afstomp-parser.h
+++ b/modules/afstomp/afstomp-parser.h
@@ -7,13 +7,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/afstomp-parser.h
+++ b/modules/afstomp/afstomp-parser.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -8,13 +8,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *

--- a/modules/afstomp/afstomp.h
+++ b/modules/afstomp/afstomp.h
@@ -7,13 +7,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/afstomp.h
+++ b/modules/afstomp/afstomp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Nagy, Attila <bra@fsn.hu>
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/stomp.c
+++ b/modules/afstomp/stomp.c
@@ -6,13 +6,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/stomp.c
+++ b/modules/afstomp/stomp.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/stomp.h
+++ b/modules/afstomp/stomp.h
@@ -6,13 +6,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/afstomp/stomp.h
+++ b/modules/afstomp/stomp.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstomp/tests/test_stomp_proto.c
+++ b/modules/afstomp/tests/test_stomp_proto.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Viktor Tusa <tusa@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "stomp.h"
 #include "testutils.h"
 

--- a/modules/afstreams/afstreams-grammar.ym
+++ b/modules/afstreams/afstreams-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstreams/afstreams-parser.c
+++ b/modules/afstreams/afstreams-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstreams/afstreams-parser.h
+++ b/modules/afstreams/afstreams-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstreams/afstreams-plugin.c
+++ b/modules/afstreams/afstreams-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afstreams/afstreams.h
+++ b/modules/afstreams/afstreams.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afuser/afuser-grammar.ym
+++ b/modules/afuser/afuser-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afuser/afuser-parser.c
+++ b/modules/afuser/afuser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afuser/afuser-parser.h
+++ b/modules/afuser/afuser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afuser/afuser-plugin.c
+++ b/modules/afuser/afuser-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/afuser/afuser.h
+++ b/modules/afuser/afuser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2014 Balabit
- * Copyright (c) 1998-2014 Balázs Scheidler
+ * Copyright (c) 2010-2015 Balabit
+ * Copyright (c) 2010-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/basicfuncs/cond-funcs.c
+++ b/modules/basicfuncs/cond-funcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  * Copyright (c) 2013-2014 Gergely Nagy
  *

--- a/modules/basicfuncs/ip-funcs.c
+++ b/modules/basicfuncs/ip-funcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/basicfuncs/misc-funcs.c
+++ b/modules/basicfuncs/misc-funcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  * Copyright (c) 2014 Viktor Tusa <tusavik@gmail.com>
  *

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010-2015 Balabit
+ * Copyright (c) 2010-2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "template_lib.h"
 #include "apphook.h"
 #include "plugin.h"

--- a/modules/basicfuncs/tf-template.c
+++ b/modules/basicfuncs/tf-template.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2014 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/confgen/confgen-plugin.c
+++ b/modules/confgen/confgen-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/confgen/confgen.h
+++ b/modules/confgen/confgen.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2012 Peter Gyongyosi <gyp@balabit.hu>
  *

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>,
- *                    Peter Gyongyosi <gyp@balabit.hu>
+ * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2012 Peter Gyongyosi <gyp@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2012-2015 Balabit
+ * Copyright (c) 2012-2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "template_lib.h"
 #include "apphook.h"
 #include "plugin.h"

--- a/modules/csvparser/csv-scanner.c
+++ b/modules/csvparser/csv-scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csv-scanner.h
+++ b/modules/csvparser/csv-scanner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csvparser-parser.c
+++ b/modules/csvparser/csvparser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csvparser-parser.h
+++ b/modules/csvparser/csvparser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csvparser-plugin.c
+++ b/modules/csvparser/csvparser-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 BalaBit
+ * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2008-2015 Balabit
+ * Copyright (c) 2008-2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "csvparser.h"
 
 #include "syslog-ng.h"

--- a/modules/csvparser/tests/test_csvparser_perf.c
+++ b/modules/csvparser/tests/test_csvparser_perf.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "csvparser.h"
 #include "logmsg.h"
 #include "string-list.h"

--- a/modules/date/date-grammar.ym
+++ b/modules/date/date-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/date-parser-parser.c
+++ b/modules/date/date-parser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/date-parser-parser.h
+++ b/modules/date/date-parser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/date-parser.h
+++ b/modules/date/date-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/date-plugin.c
+++ b/modules/date/date-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/strptime-tz.c
+++ b/modules/date/strptime-tz.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/strptime-tz.h
+++ b/modules/date/strptime-tz.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/date/tests/test_date.c
+++ b/modules/date/tests/test_date.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ * Copyright (c) 2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "date-parser.h"
 #include "apphook.h"
 #include "testutils.h"

--- a/modules/dbparser/correllation-context.c
+++ b/modules/dbparser/correllation-context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/correllation-context.h
+++ b/modules/dbparser/correllation-context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/correllation-key.c
+++ b/modules/dbparser/correllation-key.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/correllation-key.h
+++ b/modules/dbparser/correllation-key.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/correllation.c
+++ b/modules/dbparser/correllation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/correllation.h
+++ b/modules/dbparser/correllation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/dbparser-parser.h
+++ b/modules/dbparser/dbparser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/dbparser-plugin.c
+++ b/modules/dbparser/dbparser-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/patterndb.h
+++ b/modules/dbparser/patterndb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/patternize.c
+++ b/modules/dbparser/patternize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2012 Balabit
  * Copyright (c) 2009-2011 Péter Gyöngyösi
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/patternize.h
+++ b/modules/dbparser/patternize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2012 Balabit
  * Copyright (c) 2009-2011 Péter Gyöngyösi
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-example.c
+++ b/modules/dbparser/pdb-example.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-example.h
+++ b/modules/dbparser/pdb-example.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-load.h
+++ b/modules/dbparser/pdb-load.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-program.c
+++ b/modules/dbparser/pdb-program.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-program.h
+++ b/modules/dbparser/pdb-program.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-rule.c
+++ b/modules/dbparser/pdb-rule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-rule.h
+++ b/modules/dbparser/pdb-rule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-ruleset.c
+++ b/modules/dbparser/pdb-ruleset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdb-ruleset.h
+++ b/modules/dbparser/pdb-ruleset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/radix.c
+++ b/modules/dbparser/radix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/radix.h
+++ b/modules/dbparser/radix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/stateful-parser.c
+++ b/modules/dbparser/stateful-parser.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2002-2013, 2015 Balabit
+ * Copyright (c) 1998-2013, 2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "stateful-parser.h"
 #include <string.h>
 

--- a/modules/dbparser/stateful-parser.h
+++ b/modules/dbparser/stateful-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013, 2015 BalaBit
+ * Copyright (c) 2002-2013, 2015 Balabit
  * Copyright (c) 1998-2013, 2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/tests/test_parsers.c
+++ b/modules/dbparser/tests/test_parsers.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2013 Balabit
+ * Copyright (c) 2013 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include <string.h>
 

--- a/modules/dbparser/tests/test_parsers_e2e.c
+++ b/modules/dbparser/tests/test_parsers_e2e.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010-2014 Balabit
+ * Copyright (c) 2010-2014 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 gboolean fail = FALSE;
 gboolean verbose = FALSE;
 

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010-2015 Balabit
+ * Copyright (c) 2010-2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "apphook.h"
 #include "tags.h"
 #include "logmsg.h"

--- a/modules/dbparser/tests/test_patternize.c
+++ b/modules/dbparser/tests/test_patternize.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010-2013 Balabit
+ * Copyright (c) 2010-2013 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "patternize.h"
 #include "logmsg.h"
 #include "cfg.h"

--- a/modules/dbparser/tests/test_radix.c
+++ b/modules/dbparser/tests/test_radix.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2008-2015 Balabit
+ * Copyright (c) 2008-2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ * Copyright (c) 2009 Marton Illes
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 
 #include "apphook.h"
 #include "radix.h"

--- a/modules/dbparser/tests/test_timer_wheel.c
+++ b/modules/dbparser/tests/test_timer_wheel.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010, 2015 Balabit
+ * Copyright (c) 2010, 2015 Balázs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "timerwheel.h"
 
 

--- a/modules/dbparser/timerwheel.c
+++ b/modules/dbparser/timerwheel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/dbparser/timerwheel.h
+++ b/modules/dbparser/timerwheel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/geoip-parser-grammar.ym
+++ b/modules/geoip/geoip-parser-grammar.ym
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/geoip-parser-parser.c
+++ b/modules/geoip/geoip-parser-parser.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/geoip-parser-parser.h
+++ b/modules/geoip/geoip-parser-parser.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/geoip-parser.h
+++ b/modules/geoip/geoip-parser.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/geoip-plugin.c
+++ b/modules/geoip/geoip-plugin.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/geoip/tfgeoip.c
+++ b/modules/geoip/tfgeoip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2013 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/graphite/graphite-output.h
+++ b/modules/graphite/graphite-output.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/graphite/graphite-plugin.c
+++ b/modules/graphite/graphite-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Tusa <tusa@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.logging;
 
 import org.apache.log4j.AppenderSkeleton;

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/BooleanOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/BooleanOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 import java.util.Arrays;

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/BooleanOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/BooleanOptionDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/EnumOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/EnumOptionDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/EnumOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/EnumOptionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 public class IntegerOptionDecorator extends OptionDecorator {

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerOptionDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerRangeCheckOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerRangeCheckOptionDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerRangeCheckOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/IntegerRangeCheckOptionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/InvalidOptionException.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/InvalidOptionException.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/InvalidOptionException.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/InvalidOptionException.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 public class InvalidOptionException extends Exception {

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/Option.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/Option.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/Option.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/OptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/OptionDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/OptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/OptionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/Options.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/Options.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 import java.util.HashMap;

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/Options.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/Options.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/PortCheckDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/PortCheckDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/PortCheckDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/PortCheckDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/RequiredOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/RequiredOptionDecorator.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/RequiredOptionDecorator.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/RequiredOptionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/StringOption.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/StringOption.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/StringOption.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/StringOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options;
 
 import org.syslog_ng.LogMessage;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestBooleanOptionDecorator.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestBooleanOptionDecorator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import org.junit.After;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestEnumOptionDecorator.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestEnumOptionDecorator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import static org.junit.Assert.*;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestIntegerOptionDecorator.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestIntegerOptionDecorator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import org.junit.Before;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestIntegerRangeCheckOptionDecorator.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestIntegerRangeCheckOptionDecorator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import org.junit.Before;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestOption.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestOption.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import static org.junit.Assert.*;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestPortCheckDecorator.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestPortCheckDecorator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import org.junit.Before;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestRequiredOptionDecorator.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestRequiredOptionDecorator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import org.junit.Before;

--- a/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestStringOption.java
+++ b/modules/java-modules/common/src/test/java/org/syslog_ng/options/test/TestStringOption.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.options.test;
 
 import org.junit.Before;

--- a/modules/java-modules/dummy/src/main/java/org/syslog_ng/DummyTextDestination.java
+++ b/modules/java-modules/dummy/src/main/java/org/syslog_ng/DummyTextDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClient.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClientFactory.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESNodeClient.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESNodeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESTransportClient.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESTransportClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESBulkMessageProcessor.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESBulkMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESMessageProcessor.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESMessageProcessorFactory.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESMessageProcessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESSingleMessageProcessor.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/messageprocessor/ESSingleMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -1,7 +1,24 @@
 /*
- * Copyright (c) 2015 BalaBit
- * All Rights Reserved.
- * Authors: Zoltan Pallagi <zoltan.pallagi@balabit.com>
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Zoltan Pallagi <zoltan.pallagi@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 package org.syslog_ng.hdfs;

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Adam Arsenault <adam.arsenault@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.http;
 
 import org.syslog_ng.*;

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Adam Arsenault <adam.arsenault@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2015 BalaBit
- * All Rights Reserved.
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 package org.syslog_ng.kafka;

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationOptions.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationOptions.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationOptions.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationOptions.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.kafka;
 
 import org.syslog_ng.LogDestination;

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationProperties.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationProperties.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationProperties.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestinationProperties.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.kafka;
 
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/MockLogDestination.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/MockLogDestination.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/MockLogDestination.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/MockLogDestination.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import java.util.Hashtable;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestBooleanOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestBooleanOptionDecorator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestBooleanOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestBooleanOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.After;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestEnumOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestEnumOptionDecorator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestEnumOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestEnumOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import static org.junit.Assert.*;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerOptionDecorator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerRangeCheckOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerRangeCheckOptionDecorator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerRangeCheckOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestIntegerRangeCheckOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestOption.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestOption.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestOption.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestOption.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import static org.junit.Assert.*;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestPortCheckDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestPortCheckDecorator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestPortCheckDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestPortCheckDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestRequiredOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestRequiredOptionDecorator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestRequiredOptionDecorator.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestRequiredOptionDecorator.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestStringOption.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestStringOption.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Balabit
- * Copyright (c) 2015 Benke Tibor
+ * Copyright (c) 2015 Tibor Benke
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestStringOption.java
+++ b/modules/java-modules/kafka/src/test/java/org/syslog_ng/test/TestStringOption.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Benke Tibor
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.test;
 
 import org.junit.Before;

--- a/modules/java/native/java-class-loader.c
+++ b/modules/java/native/java-class-loader.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java-class-loader.c
+++ b/modules/java/native/java-class-loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-class-loader.h
+++ b/modules/java/native/java-class-loader.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java-class-loader.h
+++ b/modules/java/native/java-class-loader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java-destination.h
+++ b/modules/java/native/java-destination.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-destination.h
+++ b/modules/java/native/java-destination.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -2,9 +2,10 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-parser.c
+++ b/modules/java/native/java-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-parser.c
+++ b/modules/java/native/java-parser.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java-parser.h
+++ b/modules/java/native/java-parser.h
@@ -2,9 +2,10 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/modules/java/native/java-parser.h
+++ b/modules/java/native/java-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-plugin.c
+++ b/modules/java/native/java-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java-plugin.c
+++ b/modules/java/native/java-plugin.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java_machine.h
+++ b/modules/java/native/java_machine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/native/java_machine.h
+++ b/modules/java/native/java_machine.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/internal-message-sender-proxy.c
+++ b/modules/java/proxies/internal-message-sender-proxy.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/internal-message-sender-proxy.c
+++ b/modules/java/proxies/internal-message-sender-proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/proxies/java-destination-proxy.c
+++ b/modules/java/proxies/java-destination-proxy.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/java-destination-proxy.c
+++ b/modules/java/proxies/java-destination-proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/proxies/java-destination-proxy.h
+++ b/modules/java/proxies/java-destination-proxy.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/java-destination-proxy.h
+++ b/modules/java/proxies/java-destination-proxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/proxies/java-logmsg-proxy.c
+++ b/modules/java/proxies/java-logmsg-proxy.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/java-logmsg-proxy.c
+++ b/modules/java/proxies/java-logmsg-proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/proxies/java-logmsg-proxy.h
+++ b/modules/java/proxies/java-logmsg-proxy.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/java-logmsg-proxy.h
+++ b/modules/java/proxies/java-logmsg-proxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/proxies/java-template-proxy.c
+++ b/modules/java/proxies/java-template-proxy.c
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/java-template-proxy.c
+++ b/modules/java/proxies/java-template-proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/proxies/java-template-proxy.h
+++ b/modules/java/proxies/java-template-proxy.h
@@ -2,17 +2,18 @@
  * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/proxies/java-template-proxy.h
+++ b/modules/java/proxies/java-template-proxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2015 Balabit
  * Copyright (c) 2010-2015 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/DummyStructuredDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/DummyStructuredDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/DummyStructuredDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/DummyStructuredDestination.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/DummyTextDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/DummyTextDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/DummyTextDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/DummyTextDestination.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
+++ b/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
+++ b/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/LogMessage.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogMessage.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng;
 
 public class LogMessage {

--- a/modules/java/src/main/java/org/syslog_ng/LogPipe.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/LogPipe.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogPipe.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/LogTemplate.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogTemplate.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng;
 
 public class LogTemplate {

--- a/modules/java/src/main/java/org/syslog_ng/StructuredLogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/StructuredLogDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/StructuredLogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/StructuredLogDestination.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
+++ b/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
+++ b/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/src/main/java/org/syslog_ng/TextLogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/TextLogDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/java/src/main/java/org/syslog_ng/TextLogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/TextLogDestination.java
@@ -2,17 +2,18 @@
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/json/dot-notation.c
+++ b/modules/json/dot-notation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/dot-notation.h
+++ b/modules/json/dot-notation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Balabit
  * Copyright (c) 2011 Balint Kovacs <blint@balabit.hu>
  * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *

--- a/modules/json/format-json.h
+++ b/modules/json/format-json.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/json-parser-grammar.ym
+++ b/modules/json/json-parser-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/json-parser-parser.c
+++ b/modules/json/json-parser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/json-parser-parser.h
+++ b/modules/json/json-parser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Balabit
  * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/json-parser.h
+++ b/modules/json/json-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/json-plugin.c
+++ b/modules/json/json-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2012 Balabit
  * Copyright (c) 2011-2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/tests/test_dot_notation.c
+++ b/modules/json/tests/test_dot_notation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Balabit
  * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Balazs Scheidler <bazsi@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/kvformat/format-welf.c
+++ b/modules/kvformat/format-welf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/format-welf.h
+++ b/modules/kvformat/format-welf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-parser-grammar.ym
+++ b/modules/kvformat/kv-parser-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-parser-parser.c
+++ b/modules/kvformat/kv-parser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-parser-parser.h
+++ b/modules/kvformat/kv-parser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-parser.h
+++ b/modules/kvformat/kv-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-scanner.c
+++ b/modules/kvformat/kv-scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/kvformat-plugin.c
+++ b/modules/kvformat/kvformat-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/linux-audit-scanner.c
+++ b/modules/kvformat/linux-audit-scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/linux-audit-scanner.h
+++ b/modules/kvformat/linux-audit-scanner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/tests/test_format_welf.c
+++ b/modules/kvformat/tests/test_format_welf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2013 Balabit
  * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/linux-kmsg-format/linux-kmsg-format-plugin.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/linux-kmsg-format/linux-kmsg-format-plugin.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format-plugin.c
@@ -6,13 +6,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 

--- a/modules/linux-kmsg-format/linux-kmsg-format-plugin.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format-plugin.c
@@ -14,6 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 #include "linux-kmsg-format.h"

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2013 Balabit
  * Copyright (c) 2012-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -6,13 +6,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -14,6 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 #include "linux-kmsg-format.h"

--- a/modules/linux-kmsg-format/linux-kmsg-format.h
+++ b/modules/linux-kmsg-format/linux-kmsg-format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/linux-kmsg-format/linux-kmsg-format.h
+++ b/modules/linux-kmsg-format/linux-kmsg-format.h
@@ -14,6 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 #ifndef LINUX_KMSG_FORMAT_H_INCLUDED

--- a/modules/linux-kmsg-format/linux-kmsg-format.h
+++ b/modules/linux-kmsg-format/linux-kmsg-format.h
@@ -6,13 +6,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -14,6 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
  */
 
 #include "syslog-ng.h"

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2012-2013 Balabit
+ * Copyright (c) 2012-2013 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #include "syslog-ng.h"
 
 #include "testutils.h"

--- a/modules/native/native-grammar.ym
+++ b/modules/native/native-grammar.ym
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Tibor Benke
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/native/native-parser.c
+++ b/modules/native/native-parser.c
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Tibor Benke
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/native/native-parser.h
+++ b/modules/native/native-parser.h
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Tibor Benke
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/native/parser.c
+++ b/modules/native/parser.c
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Tibor Benke
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/native/parser.h
+++ b/modules/native/parser.h
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Tibor Benke
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/pacctformat/pacct-format-plugin.c
+++ b/modules/pacctformat/pacct-format-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pacctformat/pacct-format.c
+++ b/modules/pacctformat/pacct-format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pacctformat/pacct-format.h
+++ b/modules/pacctformat/pacct-format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2011 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pseudofile/pseudofile-grammar.ym
+++ b/modules/pseudofile/pseudofile-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pseudofile/pseudofile-parser.c
+++ b/modules/pseudofile/pseudofile-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pseudofile/pseudofile-parser.h
+++ b/modules/pseudofile/pseudofile-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pseudofile/pseudofile-plugin.c
+++ b/modules/pseudofile/pseudofile-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pseudofile/pseudofile.c
+++ b/modules/pseudofile/pseudofile.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/pseudofile/pseudofile.h
+++ b/modules/pseudofile/pseudofile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/python/python-config.c
+++ b/modules/python/python-config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-config.h
+++ b/modules/python/python-config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-debugger.h
+++ b/modules/python/python-debugger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2014-2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-main.h
+++ b/modules/python/python-main.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/python/python-module.h
+++ b/modules/python/python-module.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/python/python-parser.h
+++ b/modules/python/python-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/modules/python/python-tf.h
+++ b/modules/python/python-tf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/python/python-value-pairs.h
+++ b/modules/python/python-value-pairs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 BalaBit
+ * Copyright (c) 2014-2015 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
  *

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -8,12 +8,12 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the
  * OpenSSL libraries as published by the OpenSSL project. See the file

--- a/modules/redis/redis-parser.c
+++ b/modules/redis/redis-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/redis/redis-parser.h
+++ b/modules/redis/redis-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *

--- a/modules/redis/redis.h
+++ b/modules/redis/redis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014, 2015 Balabit
  * Copyright (c) 2013, 2014, 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/riemann/riemann-parser.c
+++ b/modules/riemann/riemann-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013, 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/riemann/riemann-parser.h
+++ b/modules/riemann/riemann-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Balabit
  * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/riemann/riemann-plugin.c
+++ b/modules/riemann/riemann-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014 Balabit
  * Copyright (c) 2013, 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014, 2015 Balabit
  * Copyright (c) 2013, 2014, 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/riemann/riemann.h
+++ b/modules/riemann/riemann.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013, 2014 Balabit
  * Copyright (c) 2013, 2014, 2015 Gergely Nagy
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-format-plugin.c
+++ b/modules/syslogformat/syslog-format-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-format.h
+++ b/modules/syslogformat/syslog-format.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-parser-grammar.ym
+++ b/modules/syslogformat/syslog-parser-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-parser-parser.c
+++ b/modules/syslogformat/syslog-parser-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-parser-parser.h
+++ b/modules/syslogformat/syslog-parser-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/syslogformat/syslog-parser.h
+++ b/modules/syslogformat/syslog-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2014 Balabit
  * Copyright (c) 2012-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2012-2014 Gergely Nagy <algernon@balabit.hu>
  *

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/journald-helper.c
+++ b/modules/systemd-journal/journald-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/journald-helper.c
+++ b/modules/systemd-journal/journald-helper.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/journald-subsystem.c
+++ b/modules/systemd-journal/journald-subsystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/journald-subsystem.c
+++ b/modules/systemd-journal/journald-subsystem.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/journald-subsystem.h
+++ b/modules/systemd-journal/journald-subsystem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/journald-subsystem.h
+++ b/modules/systemd-journal/journald-subsystem.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -6,13 +6,13 @@
  * under the terms of the GNU General Public License version 2 as published
  * by the Free Software Foundation, or (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/systemd-journal-parser.c
+++ b/modules/systemd-journal/systemd-journal-parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/systemd-journal-parser.c
+++ b/modules/systemd-journal/systemd-journal-parser.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/systemd-journal-parser.h
+++ b/modules/systemd-journal/systemd-journal-parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/systemd-journal-parser.h
+++ b/modules/systemd-journal/systemd-journal-parser.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/systemd-journal-plugin.c
+++ b/modules/systemd-journal/systemd-journal-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/systemd-journal-plugin.c
+++ b/modules/systemd-journal/systemd-journal-plugin.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/systemd-journal.c
+++ b/modules/systemd-journal/systemd-journal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2012-2014 Balabit
  * Copyright (c) 2012-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/systemd-journal.c
+++ b/modules/systemd-journal/systemd-journal.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2012-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2012-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/systemd-journal.h
+++ b/modules/systemd-journal/systemd-journal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/systemd-journal.h
+++ b/modules/systemd-journal/systemd-journal.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/tests/journald-mock.c
+++ b/modules/systemd-journal/tests/journald-mock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/tests/journald-mock.c
+++ b/modules/systemd-journal/tests/journald-mock.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/tests/journald-mock.h
+++ b/modules/systemd-journal/tests/journald-mock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/tests/journald-mock.h
+++ b/modules/systemd-journal/tests/journald-mock.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/tests/test-source.c
+++ b/modules/systemd-journal/tests/test-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/tests/test-source.c
+++ b/modules/systemd-journal/tests/test-source.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/tests/test-source.h
+++ b/modules/systemd-journal/tests/test-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/tests/test-source.h
+++ b/modules/systemd-journal/tests/test-source.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2010-2014 Balabit
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2014      BalaBit S.a.r.l., Luxembourg, Luxembourg
  * Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2010-2014 Viktor Juhasz <viktor.juhasz@balabit.com>
  *

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2015 BalaBit
+# Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/cim/template.conf
+++ b/scl/cim/template.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2014 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -1,4 +1,4 @@
-#
+#############################################################################
 # Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -18,7 +18,7 @@
 # OpenSSL libraries as published by the OpenSSL project. See the file
 # COPYING for details.
 #
-#
+#############################################################################
 
 block destination elasticsearch(
   index("")

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 BalaBit
+# Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/graphite/plugin.conf
+++ b/scl/graphite/plugin.conf
@@ -1,24 +1,27 @@
-## scl/graphite/plugin.conf -- Graphite destination for syslog-ng
-##
-## Copyright (c) 2014 Balabit
-## Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
-##
-## This program is free software; you can redistribute it and/or modify it
-## under the terms of the GNU General Public License version 2 as published
-## by the Free Software Foundation, or (at your option) any later version.
-##
-## This program is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-## GNU General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with this program; if not, write to the Free Software
-## Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-##
-## As an additional exemption you are allowed to compile & link against the
-## OpenSSL libraries as published by the OpenSSL project. See the file
-## COPYING for details.
+#############################################################################
+# Copyright (c) 2014 Balabit
+# Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+#
+# scl/graphite/plugin.conf -- Graphite destination for syslog-ng
 
 block destination graphite(
       host("localhost") port(2003)

--- a/scl/graphite/plugin.conf
+++ b/scl/graphite/plugin.conf
@@ -1,6 +1,6 @@
 ## scl/graphite/plugin.conf -- Graphite destination for syslog-ng
 ##
-## Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+## Copyright (c) 2014 Balabit
 ## Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
 ##
 ## This program is free software; you can redistribute it and/or modify it

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 BalaBit
+# Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -1,4 +1,4 @@
-#
+#############################################################################
 # Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -18,6 +18,7 @@
 # OpenSSL libraries as published by the OpenSSL project. See the file
 # COPYING for details.
 #
+#############################################################################
 
 
 block destination hdfs(

--- a/scl/kafka/plugin.conf
+++ b/scl/kafka/plugin.conf
@@ -1,4 +1,4 @@
-#
+#############################################################################
 # Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -18,7 +18,7 @@
 # OpenSSL libraries as published by the OpenSSL project. See the file
 # COPYING for details.
 #
-#
+#############################################################################
 
 block destination kafka(
   topic("")

--- a/scl/kafka/plugin.conf
+++ b/scl/kafka/plugin.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 BalaBit
+# Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/loggly/loggly.conf
+++ b/scl/loggly/loggly.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2015 BalaBit
+# Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/logmatic/logmatic.conf
+++ b/scl/logmatic/logmatic.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2015 BalaBit
+# Copyright (c) 2015 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/mbox/mbox.conf
+++ b/scl/mbox/mbox.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2015 Balabit
 # Copyright (c) 2015 Fabien Wernli
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/scl/nodejs/plugin.conf
+++ b/scl/nodejs/plugin.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2014 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/pacct/plugin.conf
+++ b/scl/pacct/plugin.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2010 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2010 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/rewrite/cc-mask.conf
+++ b/scl/rewrite/cc-mask.conf
@@ -1,4 +1,5 @@
 #############################################################################
+# Copyright (c) 2013 Balabit
 # Copyright (c) 2013 Márton Illés <marci@balabit.com>
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -18,7 +19,7 @@
 # OpenSSL libraries as published by the OpenSSL project. See the file
 # COPYING for details.
 #
-##########################################################################
+#############################################################################
 #
 # The rewrite rules below can be used to mask out or hash credit card
 # numbers in log messages.

--- a/scl/scl.conf
+++ b/scl/scl.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2010-2014 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2010-2014 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/solaris/plugin.conf
+++ b/scl/solaris/plugin.conf
@@ -1,3 +1,25 @@
+#############################################################################
+# Copyright (c) 2014 Balabit
+# Copyright (c) 2014 Balazs Scheidler <balazs.scheidler@balabit.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
 
 block parser extract-solaris-msgid() {
 

--- a/scl/syslogconf/plugin.conf
+++ b/scl/syslogconf/plugin.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2010 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2010 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/scl/system/plugin.conf
+++ b/scl/system/plugin.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2010-2012 BalaBit IT Ltd, Budapest, Hungary
+# Copyright (c) 2010-2012 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published

--- a/syslog-ng-ctl/control-client-unix.c
+++ b/syslog-ng-ctl/control-client-unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/syslog-ng-ctl/control-client.c
+++ b/syslog-ng-ctl/control-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/syslog-ng-ctl/control-client.h
+++ b/syslog-ng-ctl/control-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/syslog-ng/wrapper.c
+++ b/syslog-ng/wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,8 @@
 EXTRA_DIST += tests/collect-cov.sh
 
+check-copyright:
+	@$(top_srcdir)/tests/copyright/check.sh $(top_srcdir) $(top_builddir) policy
+
 coverage:
 	@$(top_srcdir)/tests/collect-cov.sh
 

--- a/tests/copyright/check.sh
+++ b/tests/copyright/check.sh
@@ -1,0 +1,540 @@
+#!/bin/bash
+COPYRIGHTVERBOSITY="${COPYRIGHTVERBOSITY-3}" # 0..4, 0=least amount of output
+COLUMNS="118" # hack when running in a pipe
+PREVIEW="" # non-null to preview files in error
+
+main() {
+ if [ $# -ne 3 -a $# -ne 2 ]; then
+  echo "usage: $0 <repo dir> <result dir> [<license policy>]" >&2
+  return 1
+ fi
+
+ REPO="$1"
+ BUILDDIR="$2"
+ DATADIR="`dirname "$0"`"
+ POLICY="$DATADIR/${3-policy}"
+ local WORKDIR="`tempfile -p "cpy-" -s ".check_copyright.tmp"`"
+ rm "$WORKDIR" &&
+ mkdir "$WORKDIR" ||
+  { echo "error: can't create $WORKDIR"; return 1 ; }
+
+ [ -d "$REPO" ] ||
+  { echo "error: not a dir $REPO"; return 1 ; }
+ [ -d "$BUILDDIR" ] ||
+  { echo "error: not a dir $BUILDDIR"; return 1 ; }
+ [ -d "$DATADIR" ] ||
+  { echo "error: not a dir $DATADIR"; return 1 ; }
+ [ -f "$POLICY" ] ||
+  { echo "error: not a file $POLICY"; return 1 ; }
+ local LOG="$BUILDDIR/copyright-run.log"
+ local ERR="$BUILDDIR/copyright-err.log"
+
+ echo "debug: verbose log in $LOG" >&2
+
+ local SIGS="2 3 6 7 8 9 11 15"
+ trap -- "rm --recursive \"$WORKDIR\" ; exit 1;" $SIGS
+
+ main_logged 2>&1 |
+ if [ 0$COPYRIGHTVERBOSITY -ge 2 ]; then
+  tee "$LOG"
+
+  grep "^error: " "$LOG" > "$ERR"
+ else
+  tee "$LOG" |
+  grep "^error: " |
+  tee "$ERR"
+ fi
+
+ local ERRORCNT="`grep --count --extended-regexp "^error: " "$ERR"`"
+
+ {
+  if [ 0$COPYRIGHTVERBOSITY -ge 2 ]; then
+   if [ 0$ERRORCNT -eq 0 ]; then
+    echo "no problem, we're as clean as the ocean" >&2
+   else
+    echo "$ERRORCNT errors in our philosophy - bummer" >&2
+   fi
+  elif [ 0$COPYRIGHTVERBOSITY -ge 1 ]; then
+   echo "$ERRORCNT"
+  fi
+ } 2>&1 |
+ tee -a "$LOG"
+
+ rm --recursive "$WORKDIR" 2>/dev/null
+ trap -- "" $SIGS
+ [ 0$ERRORCNT -eq 0 ]
+}
+
+main_logged() {
+ rm --recursive "$WORKDIR" 2>/dev/null
+ mkdir --parents "$WORKDIR" || return 1
+
+ if ! parse_expected_licenses; then
+  echo "error: can't parse licenses" >&2
+  return 1
+ fi
+
+ LICENSES="$WORKDIR/licenses.txt"
+ HOLDERS="$WORKDIR/holders.txt"
+ MISSING="$BUILDDIR/missing.txt"
+
+ find \
+  . \
+  -iname '.git' -prune \
+  -o \
+ -type f -print |
+ sed "s~^\./~~" |
+ grep --extended-regexp "\.(c|h|am|md|ym|conf)$" |
+ prune_ignored_paths |
+ sort |
+ while read FILE; do
+  local PATHMATCH="`try_match_path "$FILE"`"
+
+  if [ "$PATHMATCH" = "ignore" ]; then
+   if [ 0$COPYRIGHTVERBOSITY -ge 2 ]; then
+    echo "debug: ignoring $FILE" >&2
+   fi
+  else
+   cat "$FILE" |
+   escape |
+   join_lines |
+   extract_holder_license "$FILE" |
+   try_process_holder_license "$PATHMATCH"
+  fi
+ done
+
+ sort_holders_licenses
+}
+
+try_match_path() {
+ local FILE="$1"
+ local PATFILE
+
+ local PATHMATCH=""
+ for PATFILE in "$WORKDIR"/license.path.*.txt
+ do
+  if
+   echo "$FILE" |
+   grep --quiet --extended-regexp --file "$PATFILE"
+  then
+   local KIND="`\
+    echo "$PATFILE" |
+    sed --regexp-extended "s~^.*/license\.path\.([^/]+)\.txt$~\1~"`"
+   if [ "$KIND" = "ignore" ]; then
+    local PATHMATCH="$KIND"
+    break
+   fi
+   if [ -z "$PATHMATCH" ]; then
+    local PATHMATCH="$KIND"
+   else
+    local PATHMATCH="$PATHMATCH,$KIND"
+   fi
+  fi
+ done
+ echo "$PATHMATCH"
+}
+
+try_process_holder_license() {
+ local PATHMATCH="$1"
+
+ read
+ HOLDER="$REPLY"
+ read
+ LICENSE="$REPLY"
+
+ if [ -z "$HOLDER" -a -z "$LICENSE" ]; then
+  {
+   if
+    grep --quiet --ignore-case "copyright" "$FILE"
+   then
+    printf "error: can't parse $FILE (nonstandard license declaration?)"
+   else
+    printf "error: missing license $FILE (nonstandard license declaration?)"
+   fi
+   if [ -n "$PREVIEW" ]; then
+    printf " "
+    cat "$FILE"
+   fi
+  } |
+  escaped_preview >&2
+  if [ -z "$PATHMATCH" ]; then
+   echo "error: unmatched path $FILE (add to $POLICY)" >&2
+  else
+   if [ "0$COPYRIGHTVERBOSITY" -ge 1 ]; then
+    echo "info: $FILE path expects $PATHMATCH" >&2
+   fi
+  fi
+ else
+  if [ "0$COPYRIGHTVERBOSITY" -ge 4 ]; then
+   {
+    printf "$FILE\n" >&2
+    printf "%s" "$HOLDER" | unescape >&2
+    printf "%s" "$LICENSE" | unescape >&2
+   } |
+   sed "s~^~debug: ~"
+  fi
+
+  if [ -z "$HOLDER" ]; then
+   echo "error: missing copyright holders in $FILE" >&2
+   if [ -n "$PREVIEW" ]; then
+    {
+     printf "debug: "
+     cat "$FILE"
+    } |
+    escaped_preview >&2
+   fi
+  else
+   printf "%s" "$HOLDER" |
+   unescape >> $HOLDERS
+  fi
+
+  if [ -z "$LICENSE" ]; then
+   echo "error: missing license in $FILE" >&2
+   if [ -n "$PREVIEW" ]; then
+    {
+     printf "debug: "
+     cat "$FILE"
+    } |
+    escaped_preview >&2
+   fi
+  else
+   got_both_holder_and_license
+  fi
+ fi
+
+ if [ -z "$HOLDER" -o -z "$LICENSE" ]; then
+  printf "%s\n" "$FILE" >> $MISSING
+ fi
+}
+
+got_both_holder_and_license() {
+   printf "%s\n" "$LICENSE" >> $LICENSES
+
+   local LICTEXTMATCH="`\
+    grep --line-regexp --fixed-strings --with-filename \
+     "$LICENSE" "$WORKDIR"/license.text.*.txt |
+    head --lines 1 |
+    sed --regexp-extended "s~^.*/license\.text\.([^/]+)\.txt:.*$~\1~"`"
+
+   if [ -n "$PATHMATCH" -a -n "$LICTEXTMATCH" ]; then
+    compare_expected_detected
+   else
+    if [ -z "$PATHMATCH" ]; then
+     echo "error: unmatched path $FILE (add to $POLICY)" >&2
+
+     if [ -n "$LICTEXTMATCH" -a "0$COPYRIGHTVERBOSITY" -ge 1 ]; then
+      echo "info: $FILE detected $LICTEXTMATCH" >&2
+     fi
+    fi
+
+    if [ -z "$LICTEXTMATCH" ]; then
+     {
+      printf "error: unknown license $FILE (typo in declaration?)"
+      if [ -n "$PREVIEW" ]; then
+       echo " $LICENSE"
+      fi
+     } |
+     escaped_preview >&2
+
+     if [ -n "$PATHMATCH" -a "0$COPYRIGHTVERBOSITY" -ge 1 ]; then
+      echo "info: $FILE path expects $PATHMATCH" >&2
+     fi
+    fi
+   fi
+}
+
+compare_expected_detected() {
+    if is_balabit_copyright "$HOLDER"
+    then
+     local LICTEXTMATCHB="$LICTEXTMATCH"
+    else
+     local LICTEXTMATCHB="$LICTEXTMATCH,non-balabit"
+    fi
+    if [ "$PATHMATCH" = "$LICTEXTMATCHB" ]; then
+     if [ "0$COPYRIGHTVERBOSITY" -ge 3 ]; then
+      echo "debug: match $FILE expected $PATHMATCH = detected $LICTEXTMATCHB" >&2
+     fi
+    else
+     if
+      is_license_compatible "$PATHMATCH" "$LICTEXTMATCHB"
+     then
+      if [ 0$COPYRIGHTVERBOSITY -ge 2 ]; then
+       printf "%s\n" "warning: compatible $FILE expected:$PATHMATCH detected:$LICTEXTMATCHB" >&2
+      fi
+     else
+      printf "%s" "error: mismatch $FILE" >&2
+      if [ 0$COPYRIGHTVERBOSITY -ge 1 ]; then
+       printf " expected:$PATHMATCH detected:$LICTEXTMATCHB" >&2
+      fi
+      printf "\n" >&2
+     fi
+    fi
+}
+
+extract_holder_license() {
+ local FILE="$1"
+ local EXT="`echo "$FILE" | sed -r "s~^.*\.([^.]+)$~\1~"`"
+ case "$EXT" in
+  c|h|ym)
+    extract_holder_license_c
+    ;;
+  conf)
+    extract_holder_license_sh
+    ;;
+  *)
+    echo "info: unknown file extension $FILE" >&2
+ esac
+}
+
+extract_holder_license_sh() {
+sed --regexp-extended "
+ s~^\
+#############################################################################<br>\
+(\
+(# Copyright \(c\) ([0-9, -]+) [^ <][^<]*<br>)+\
+)\
+#<br>\
+(\
+#( [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>\
+(#(| [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>)*\
+#( [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>\
+|\
+(#(| [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>)*\
+#( [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>\
+)\
+#<br>\
+#############################################################################<br>\
+.*$\
+~\1\n\4~
+t success
+ s~^.*$~~
+:success
+" |
+ sed --regexp-extended "
+  s~(^|<br>)# ?~\1~g
+"
+}
+
+extract_holder_license_c() {
+# note that holders must be present in the present implementation
+sed --regexp-extended "
+ s~^\
+ */\*<br>\
+(\
+( \* Copyright \(c\) ([0-9, -]+) [^ <][^<]*<br>)+\
+)\
+( \*<br>)+\
+(\
+ \*( [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>\
+( \*(| [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>)*\
+ \*( [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>\
+|\
+( \*(| [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>)*\
+ \*( [^ <]([^<]|<[^b][^>]*>|<b[^r>][^>]*>|<br[^>]+>)*)<br>\
+)\
+( \*<br>)*\
+ \*/<br>\
+.*$\
+~\1\n\5~
+t success
+ s~^.*$~~
+:success
+" |
+ sed --regexp-extended "
+  s~(^|<br>) \* ?~\1~g
+"
+}
+
+is_balabit_copyright() {
+ echo "$@" |
+ grep --quiet --extended-regexp "\
+^\
+(Copyright \(c\) ([0-9, -]+) [^ <][^<]*<br>)*\
+Copyright \(c\) ([0-9, -]+) Bala[bB]it<br>\
+(Copyright \(c\) ([0-9, -]+) [^ <][^<]*<br>)*\
+$"
+ return $?
+}
+
+parse_expected_licenses() {
+ generate_known_licenses || return 1
+
+ cat "$POLICY" |
+ grep --invert-match --extended-regexp "^\s*$" |
+ sed "
+  s~^ ~L ~
+  t e
+  s~^~P ~
+  :e
+ " |
+ {
+ local ERR=0
+ while read KIND LINE
+ do
+  case "$KIND" in
+   L)
+    local LICENSE="`
+     echo "$LINE" |
+     sed -rn "
+      s~^(ignore|((GPLv2\+|LGPLv2\.1\+)(_SSL)?|4-BSD)(,non-balabit)?)$~&~
+      T e
+      p
+      :e
+     "
+    `"
+    if [ -z "$LICENSE" ]; then
+     echo "error: can't parse license: '${LINE}'" >&2
+     local ERR=1
+    fi
+    ;;
+   P)
+    if [ -n "$LICENSE" ]; then
+     echo "$LINE" |
+     sed --regexp-extended "
+      s~^~^~
+      s~$~(/.*)?$~
+     " >> "$WORKDIR/license.path.$LICENSE.txt"
+    else
+     echo "error: ignored unknowned licensed path '${LINE}' in $POLICY" >&2
+     local ERR=1
+    fi
+    ;;
+   *)
+    echo "error: assertion failed in parse_expected_licenses: unknown key '$KIND $LINE'" >&2
+    local ERR=1
+  esac
+ done
+
+ return $ERR
+ }
+}
+
+is_license_compatible() {
+ local EXPECTED="$1"
+ local SUBMITTED="$2"
+
+ if [ "$EXPECTED" = "$SUBMITTED" ]; then
+  return 0
+ fi
+
+ case "$EXPECTED" in
+  GPLv2+_SSL)
+   [ "$SUBMITTED" = "LGPLv2.1+_SSL" ]
+   ;;
+  *)
+   false
+ esac
+}
+
+generate_known_licenses() {
+ for FILE in "$DATADIR"/license.text.*.txt; do
+  local NAME="`basename "$FILE"`"
+  cat "$FILE" |
+  escape |
+  join_lines > "$WORKDIR/$NAME"
+ done
+}
+
+prune_ignored_paths() {
+ local IGNORE="$WORKDIR/ignore.paths.txt"
+ if [ ! -f "$IGNORE" ]; then
+  git submodule status |
+  cut -d " " -f 3 |
+  sed --regexp-extended "
+   s~^~^~
+   s~$~(/.*)?$~
+  " |
+  cat > "$IGNORE"
+ fi
+
+ grep --invert-match --extended-regexp --file "$IGNORE"
+}
+
+sort_holders_licenses() {
+ {
+  for FILE in $LICENSES $HOLDERS; do
+   local DEST="$BUILDDIR/`basename $FILE`"
+   if [ -f "$FILE" ]; then
+    cat "$FILE" |
+    sort |
+    uniq -c |
+    sort -n > "$DEST"
+
+    if [ "0$COPYRIGHTVERBOSITY" -ge 2 ]; then
+     echo "$DEST"
+     cat "$DEST"
+    fi
+   fi
+  done
+
+  if [ -f "$HOLDERS" ]; then
+   local DEST="$BUILDDIR/holders.name.txt"
+   cat "$HOLDERS" |
+   sed --regexp-extended "s~^ \* Copyright \(c\) [0-9, -]*~~" |
+   sort |
+   uniq -c |
+   sort -n > "$DEST"
+
+    if [ "0$COPYRIGHTVERBOSITY" -ge 2 ]; then
+     echo "$DEST"
+     cat "$DEST"
+    fi
+  fi
+ } |
+ sed "s~^~debug: ~" >&2
+}
+
+# note: needs escaped data as input
+join_lines() {
+ sed "
+:join_lines
+N
+s~\n~<br>~
+t join_lines" "$@" |
+sed "s~$~<br>~"
+}
+
+escape() {
+ sed "
+s~&~\&amp;~g
+s~<~\&lt;~g
+s~>~\&gt;~g
+" "$@"
+}
+
+unescape() {
+ sed "
+s~<br>~\n~g
+s~&gt;~>~g
+s~&lt;~<~g
+s~&amp;~\&~g
+" "$@"
+}
+
+escaped_preview() {
+ escape "$@" |
+ join_lines |
+ preview |
+ sed "s~<br>$~~" # TODO
+}
+
+preview() {
+ if [ -n "$COLUMNS" ]; then
+  local COLS="$COLUMNS"
+ elif which tput >/dev/null; then
+  local COLS="`tput cols`"
+ fi
+ [ -z "$COLS" ] &&
+  local COLS=80
+
+ cat "$@" |
+ if [ -n "$PREVIEW" ]; then
+  dd bs=1 count=$COLS status=noxfer 2>/dev/null
+ else
+  cat
+ fi
+ echo
+}
+
+main "$@"
+

--- a/tests/copyright/license.text.GPLv2+.txt
+++ b/tests/copyright/license.text.GPLv2+.txt
@@ -1,0 +1,12 @@
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 as published
+by the Free Software Foundation, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA

--- a/tests/copyright/license.text.GPLv2+_SSL.txt
+++ b/tests/copyright/license.text.GPLv2+_SSL.txt
@@ -1,0 +1,16 @@
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 as published
+by the Free Software Foundation, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+As an additional exemption you are allowed to compile & link against the
+OpenSSL libraries as published by the OpenSSL project. See the file
+COPYING for details.

--- a/tests/copyright/license.text.LGPLv2.1+.txt
+++ b/tests/copyright/license.text.LGPLv2.1+.txt
@@ -1,0 +1,13 @@
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA

--- a/tests/copyright/license.text.LGPLv2.1+_SSL.txt
+++ b/tests/copyright/license.text.LGPLv2.1+_SSL.txt
@@ -1,0 +1,17 @@
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+As an additional exemption you are allowed to compile & link against the
+OpenSSL libraries as published by the OpenSSL project. See the file
+COPYING for details.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -1,0 +1,23 @@
+ ignore
+.*\.(md|am)$
+.*/[^/]+-grammar\.[ch]$
+lib/cfg-lex\.[ch]$
+modules/java/org_syslog_ng_[^./_-]+\.h$
+modules/(afmongodb|afamqp)/dummy\.c$
+(syslog-ng-)?config\.h$
+(contrib|debian|lib|modules)/.*\.conf
+dist\.conf
+scl/syslog-ng\.conf
+ LGPLv2.1+_SSL
+lib/(compat|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|[^/]*$)
+libtest
+syslog-ng(-ctl)?
+modules/java-modules/common
+modules/java/(native|proxies|src)
+ GPLv2+_SSL
+tests
+modules/java/(tools|[^/]*$)
+modules/java-modules/(dummy|elastic|hdfs|http|kafka|[^/]*$)
+modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|native|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
+scl
+

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -14,10 +14,10 @@ libtest
 syslog-ng(-ctl)?
 modules/java-modules/common
 modules/java/(native|proxies|src)
+modules/native
  GPLv2+_SSL
 tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|hdfs|http|kafka|[^/]*$)
-modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|native|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
+modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
 scl
-

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2007-2015 Balabit
+ * Copyright (c) 2007-2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "syslog-ng.h"
 
 #include <syslog-ng-config.h>

--- a/tests/unit/test_clone_logmsg.c
+++ b/tests/unit/test_clone_logmsg.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2014 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "msg_parse_lib.h"
 #include "syslog-ng.h"

--- a/tests/unit/test_dnscache.c
+++ b/tests/unit/test_dnscache.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2007-2013 Balabit
+ * Copyright (c) 2007-2013 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "dnscache.h"
 #include "apphook.h"
 #include "timeutils.h"

--- a/tests/unit/test_findcrlf.c
+++ b/tests/unit/test_findcrlf.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2008 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "find-crlf.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/unit/test_hostid.c
+++ b/tests/unit/test_hostid.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Laszlo Budai
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "syslog-ng.h"
 #include "host-id.h"

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2008-2014 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "logqueue.h"
 #include "logqueue-fifo.h"
 #include "logpipe.h"

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2009-2014 Balabit
+ * Copyright (c) 2009-2014 Viktor Juhasz
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "syslog-ng.h"
 #include "logwriter.h"
 #include "logmsg.h"

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2008-2014 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "logmatcher.h"
 #include "apphook.h"
 #include "plugin.h"

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2007-2015 Balabit
+ * Copyright (c) 2007-2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "testutils.h"
 #include "msg_parse_lib.h"
 

--- a/tests/unit/test_msgsdata.c
+++ b/tests/unit/test_msgsdata.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2008-2014 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "logmsg.h"
 #include "apphook.h"
 #include "cfg.h"

--- a/tests/unit/test_nvtable.c
+++ b/tests/unit/test_nvtable.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2009-2014 Balabit
+ * Copyright (c) 2009-2014 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "nvtable.h"
 #include "apphook.h"
 #include "logmsg.h"

--- a/tests/unit/test_persist_state.c
+++ b/tests/unit/test_persist_state.c
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2010-2014 Balabit
+ * Copyright (c) 2010-2014 Balázs Scheidler
+ * Copyright (c) 2014 Viktor Tusa
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "persist-state.h"
 #include "apphook.h"
 

--- a/tests/unit/test_ringbuffer.c
+++ b/tests/unit/test_ringbuffer.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Laszlo Budai
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include <string.h>
 
 #include "testutils.h"

--- a/tests/unit/test_serialize.c
+++ b/tests/unit/test_serialize.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2007-2009 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "serialize.h"
 #include "apphook.h"
 #include <string.h>

--- a/tests/unit/test_skeleton.c
+++ b/tests/unit/test_skeleton.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2012 Balabit
+ * Copyright (c) 2012 Peter Gyorko
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include <stdlib.h>
 
 #include "testutils.h"

--- a/tests/unit/test_tags.c
+++ b/tests/unit/test_tags.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2009-2013 Balabit
+ * Copyright (c) 2009 Marton Illes
+ * Copyright (c) 2009-2013 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
 
 #include "apphook.h"
 #include "tags.h"

--- a/tests/unit/test_thread_wakeup.c
+++ b/tests/unit/test_thread_wakeup.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2010-2011 Balabit
+ * Copyright (c) 2010-2011 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/tests/unit/test_value_pairs.c
+++ b/tests/unit/test_value_pairs.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Laszlo Budai
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "value-pairs.h"
 #include "vptransform.h"
 #include "logmsg.h"

--- a/tests/unit/test_value_pairs_walk.c
+++ b/tests/unit/test_value_pairs_walk.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2014 Viktor Tusa
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include <libtest/testutils.h>
 #include <value-pairs.h>
 #include <apphook.h>

--- a/tests/unit/test_zone.c
+++ b/tests/unit/test_zone.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2005-2015 Balabit
+ * Copyright (c) 2005-2011 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "apphook.h"
 #include "timeutils.h"
 #include "timeutils.h"


### PR DESCRIPTION
This is the extended version of the copyright cleanup PR #822. Theoretically all previous occurrences have been replaced with the new convention of Copyright (c) 2015 Balabit, but do comment if you this it has an error. It is enough to merge f/copyright-review-2015-extended, because it also contains f/copyright-review-2015.

Fixes #824 