### PR TITLE
java: export GRADLE_OPTS environment variable

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -1,5 +1,7 @@
 if ENABLE_JAVA
 
+export GRADLE_OPTS
+
 JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar')
 

--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -1,6 +1,8 @@
 
 if ENABLE_JAVA
 
+export GRADLE_OPTS
+
 JAVA_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 JARS=$(shell find $(abs_top_builddir)/modules/java/syslog-ng-core -name '*.jar')
 GRADLE_WORKDIR=$(abs_top_builddir)/modules/java/.gradle


### PR DESCRIPTION
This is just a dummy PR. I'd like to see the reason behind the compilation failure of the master branch. Travis moved its infrastructure to GCE which may cause this.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>
Reported-by: Peter Czanik <peter.czanik@balabit.com>