### PR TITLE
.travis.yml: unset PYTHON_CFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 before_script:
   - ./autogen.sh
 script:
+  - unset PYTHON_CFLAGS # HACK
   - ./configure --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
   - make && make distcheck VERBOSE=1 && make func-test VERBOSE=1
 compiler:


### PR DESCRIPTION
Somehow, nowadays the infrastructure is unhealthy and some flags remain
set that interfere with autoconf include directory detection.