### PR TITLE
Fix byteorder handling on bigendian systems in netmask6 filter

### DIFF
--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -52,7 +52,7 @@ static inline uint64_t
 _mask(uint64_t base, uint64_t mask)
 {
   if (G_BYTE_ORDER == G_BIG_ENDIAN)
-    return GUINT64_SWAP_LE_BE(base & mask);
+    return base & mask;
   else
     return GUINT64_SWAP_LE_BE(GUINT64_SWAP_LE_BE(base) & mask);
 }


### PR DESCRIPTION
Fixes #476 

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>