### PR TITLE
F/java modpath cleanups

### DIFF
--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -96,7 +96,6 @@ static const gchar *cfgfilename;
 static const gchar *persist_file;
 static const gchar *ctlfilename;
 const gchar *module_path;
-const gchar *java_module_path;
 static gchar *preprocess_into = NULL;
 gboolean syntax_only = FALSE;
 gboolean interactive_mode = FALSE;
@@ -532,6 +531,5 @@ main_loop_global_init(void)
   persist_file = get_installation_path_for(PATH_PERSIST_CONFIG);
   ctlfilename = get_installation_path_for(PATH_CONTROL_SOCKET);
   module_path = get_installation_path_for(SYSLOG_NG_MODULE_PATH);
-  java_module_path = get_installation_path_for(SYSLOG_NG_JAVA_MODULE_PATH);
 }
 

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -54,6 +54,5 @@ typedef struct _AckRecord AckRecord;
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;
 extern const gchar *module_path;
-extern const gchar *java_module_path;
 
 #endif

--- a/modules/java/native/java-class-loader.c
+++ b/modules/java/native/java-class-loader.c
@@ -32,7 +32,7 @@
 jstring
 __create_class_path(ClassLoader *self, JNIEnv *java_env, const gchar *class_path)
 {
-  GString *g_class_path = g_string_new(java_module_path);
+  GString *g_class_path = g_string_new(get_installation_path_for(SYSLOG_NG_JAVA_MODULE_PATH));
   jstring str_class_path = NULL;
   g_string_append(g_class_path, "/" SYSLOG_NG_JAR);
   if (class_path && (strlen(class_path) > 0))

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -41,7 +41,7 @@ struct _JavaVMSingleton
 static JavaVMSingleton *g_jvm_s;
 
 JavaVMSingleton *
-java_machine_ref()
+java_machine_ref(void)
 {
   if (g_jvm_s)
     {
@@ -138,7 +138,7 @@ java_machine_attach_thread(JavaVMSingleton* self, JNIEnv **penv)
 }
 
 void
-java_machine_detach_thread()
+java_machine_detach_thread(void)
 {
   (*(g_jvm_s->jvm))->DetachCurrentThread(g_jvm_s->jvm);
 }

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -52,7 +52,7 @@ java_machine_ref()
       g_jvm_s = g_new0(JavaVMSingleton, 1);
       g_atomic_counter_set(&g_jvm_s->ref_cnt, 1);
 
-      g_jvm_s->class_path = g_string_new(java_module_path);
+      g_jvm_s->class_path = g_string_new(get_installation_path_for(SYSLOG_NG_JAVA_MODULE_PATH));
       g_string_append(g_jvm_s->class_path, "/syslog-ng-core.jar");
     }
   return g_jvm_s;

--- a/modules/java/native/java_machine.h
+++ b/modules/java/native/java_machine.h
@@ -32,11 +32,11 @@
 
 typedef struct _JavaVMSingleton JavaVMSingleton;
 
-JavaVMSingleton *java_machine_ref();
+JavaVMSingleton *java_machine_ref(void);
 void java_machine_unref(JavaVMSingleton *self);
 gboolean java_machine_start(JavaVMSingleton* self);
 
-void java_machine_detach_thread();
+void java_machine_detach_thread(void);
 
 JNIEnv *java_machine_get_env(JavaVMSingleton *self, JNIEnv **penv);
 


### PR DESCRIPTION
While reviewing pr #813 by @lmesz I found some mess related to java_module_path (and module_path for that matter, but that'll come in a separate PR).

The problem is that java_module_path variable was made global whereas it doesn't have to be one, so it's better if we don't make it one.

This branch aims to fix that up.
