### PR TITLE
F/remove fix relative path of syslog ng in func test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1393,6 +1393,7 @@ fi
 if test -n "$env_ld_library_path"; then
         AC_DEFINE_UNQUOTED(ENV_LD_LIBRARY_PATH, "$env_ld_library_path", [set LD_LIBRARY_PATH to this value])
 fi
+AC_DEFINE_UNQUOTED(PATH_MODULEDIR, "$moduledir", [module installation directory])
 AC_DEFINE_UNQUOTED(MODULE_PATH, "$module_path", [module search path])
 AC_DEFINE_UNQUOTED(JAVA_MODULE_PATH, "$java_module_path", [java module search path])
 

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -129,13 +129,13 @@ version(void)
     }
   printf(SYSLOG_NG_PACKAGE " " SYSLOG_NG_VERSION "\n"
          "Installer-Version: %s\n"
-         "Revision: " SYSLOG_NG_SOURCE_REVISION "\n"
-#if WITH_COMPILE_DATE
-         "Compile-Date: " __DATE__ " " __TIME__ "\n"
-#endif
-         "Available-Modules: ",
+         "Revision: " SYSLOG_NG_SOURCE_REVISION "\n",
          installer_version);
 
+#if WITH_COMPILE_DATE
+  printf("Compile-Date: " __DATE__ " " __TIME__ "\n");
+#endif
+  printf("Available-Modules: ");
   plugin_list_modules(stdout, FALSE);
 
   printf("Enable-Debug: %s\n"

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -135,6 +135,9 @@ version(void)
 #if WITH_COMPILE_DATE
   printf("Compile-Date: " __DATE__ " " __TIME__ "\n");
 #endif
+
+  printf("Module-Directory: %s\n", get_installation_path_for(SYSLOG_NG_PATH_MODULEDIR));
+  printf("Module-Path: %s\n", module_path);
   printf("Available-Modules: ");
   plugin_list_modules(stdout, FALSE);
 

--- a/tests/functional/control.py
+++ b/tests/functional/control.py
@@ -31,11 +31,8 @@ def start_syslogng(conf, keep_persist=False, verbose=False):
     syslogng_pid = os.fork()
     if syslogng_pid == 0:
         os.putenv("RANDFILE", "rnd")
-        module_path = ''
-        for (root, dirs, files) in os.walk(os.path.abspath(os.path.join(os.environ['top_builddir'], 'modules'))):
-            module_path = ':'.join(map(lambda x: root + '/' + x + '/.libs', dirs))
-            break
-        rc = os.execl('../../syslog-ng/syslog-ng', '../../syslog-ng/syslog-ng', '-f', 'test.conf', '--fd-limit', '1024', '-F', verbose_opt, '-p', 'syslog-ng.pid', '-R', 'syslog-ng.persist', '--no-caps', '--enable-core', '--seed', '--module-path', module_path)
+        module_path = get_module_path()
+        rc = os.execl(get_syslog_ng_binary(), get_syslog_ng_binary(), '-f', 'test.conf', '--fd-limit', '1024', '-F', verbose_opt, '-p', 'syslog-ng.pid', '-R', 'syslog-ng.persist', '--no-caps', '--enable-core', '--seed', '--module-path', module_path)
         sys.exit(rc)
     time.sleep(5)
     print_user("Syslog-ng started")

--- a/tests/functional/globals.py
+++ b/tests/functional/globals.py
@@ -1,13 +1,37 @@
 import os
 
+def is_running_in_build_tree():
+    return 'SYSLOG_NG_BINARY' not in os.environ
+
+def get_module_path_from_binary():
+    module_path = os.popen("%s --version | grep \"Module-Path:\" | cut -d ' ' -f 2" % get_syslog_ng_binary(), 'r').read().strip()
+    return module_path
+
+def format_module_path_for_intree_modules():
+    module_path = ''
+    for (root, dirs, files) in os.walk(os.path.abspath(os.path.join(os.environ['top_builddir'], 'modules'))):
+        module_path += ':'.join(map(lambda x: root + '/' + x + '/.libs', dirs))
+        break
+    return module_path
+
+def get_module_path():
+    if is_running_in_build_tree():
+        module_path = format_module_path_for_intree_modules()
+    else:
+        module_path = get_module_path_from_binary()
+    return module_path
+
+def get_syslog_ng_binary():
+    return os.getenv('SYSLOG_NG_BINARY', '../../syslog-ng/syslog-ng')
+
 def is_premium():
-    version = os.popen('../../syslog-ng/syslog-ng -V', 'r').read()
+    version = os.popen('%s -V' % get_syslog_ng_binary(), 'r').read()
     if version.find('premium-edition') != -1:
         return True
     return False
 
 def has_module(module):
-    avail_mods = os.popen('../../syslog-ng/syslog-ng -V | grep ^Available-Modules: ', 'r').read()
+    avail_mods = os.popen('%s -V | grep ^Available-Modules: ' % get_syslog_ng_binary(), 'r').read()
     if avail_mods.find(module) != -1:
         return True
     return False


### PR DESCRIPTION
originallly @lmesz submitted this branch as PR #813 which I've reworked a bit. This contains a combination of his and my work and thus superseeds #813, which should be closed without merging.

The aim of this code is to make it possible to run the functest on a binary that is outside of the build tree by specifying a SYSLOG_NG_BINARY environment variable. e.g. functest would be able to run on an installed binary.

I have added @lmesz's signoff to the last patch as it was missing, but please confirm that it is ok this way (see the contributing guide what that means):

https://github.com/balabit/syslog-ng/blob/master/CONTRIBUTING.md

please merge.