### PR TITLE
Can turn off inheritance of environment variables in program destinations/sources

### DIFF
--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -54,6 +54,7 @@
 
 %token KW_PROGRAM
 %token KW_KEEP_ALIVE
+%token KW_INHERIT_ENVIRONMENT
 
 %type   <ptr> source_afprogram
 %type   <ptr> source_afprogram_params
@@ -88,6 +89,7 @@ source_afprogram_options
 
 source_afprogram_option
 	: source_reader_option
+	| KW_INHERIT_ENVIRONMENT '(' yesno ')' { afprogram_set_inherit_environment(&((AFProgramSourceDriver *)last_driver)->process_info, $3); }
 	;
 
 dest_afprogram
@@ -112,6 +114,7 @@ dest_afprogram_option
 	: dest_writer_option
 	| dest_driver_option
 	| KW_KEEP_ALIVE '(' yesno ')' { afprogram_dd_set_keep_alive((AFProgramDestDriver *)last_driver, $3); }
+	| KW_INHERIT_ENVIRONMENT '(' yesno ')' { afprogram_set_inherit_environment(&((AFProgramDestDriver *)last_driver)->process_info, $3); }
 	;
 
 /* INCLUDE_RULES */

--- a/modules/afprog/afprog-parser.c
+++ b/modules/afprog/afprog-parser.c
@@ -30,8 +30,9 @@ extern int afprog_debug;
 int afprog_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 
 static CfgLexerKeyword afprog_keywords[] = {
-  { "program",            KW_PROGRAM },
-  { "keep_alive",         KW_KEEP_ALIVE },
+  { "program",                 KW_PROGRAM },
+  { "keep_alive",              KW_KEEP_ALIVE },
+  { "inherit_environment",     KW_INHERIT_ENVIRONMENT },
   { NULL }
 };
 

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -79,8 +79,20 @@ afprogram_reload_store_item_destroy_notify(gpointer data)
   afprogram_reload_store_item_free(reload_info);
 }
 
+static inline void
+_exec_program_with_clean_environment(const gchar *cmdline)
+{
+  execle("/bin/sh", "/bin/sh", "-c", cmdline, NULL, NULL);
+}
+
+static inline void
+_exec_program(const gchar *cmdline)
+{
+  execl("/bin/sh", "/bin/sh", "-c", cmdline, NULL);
+}
+
 static gboolean
-afprogram_popen(const gchar *cmdline, GIOCondition cond, pid_t *pid, gint *fd)
+afprogram_popen(const gchar *cmdline, GIOCondition cond, pid_t *pid, gint *fd, gboolean inherit_environment)
 {
   int msg_pipe[2];
   
@@ -134,7 +146,12 @@ afprogram_popen(const gchar *cmdline, GIOCondition cond, pid_t *pid, gint *fd)
       close(devnull);
       close(msg_pipe[0]);
       close(msg_pipe[1]);
-      execl("/bin/sh", "/bin/sh", "-c", cmdline, NULL);
+
+      if (inherit_environment)
+        _exec_program(cmdline);
+      else
+        _exec_program_with_clean_environment(cmdline);
+
       _exit(127);
     }
   if (cond == G_IO_IN)
@@ -202,7 +219,7 @@ afprogram_sd_init(LogPipe *s)
               evt_tag_str("cmdline", self->process_info.cmdline->str),
               NULL);
 
-  if (!afprogram_popen(self->process_info.cmdline->str, G_IO_IN, &self->process_info.pid, &fd))
+  if (!afprogram_popen(self->process_info.cmdline->str, G_IO_IN, &self->process_info.pid, &fd, self->process_info.inherit_environment))
     return FALSE;
 
   /* parent */
@@ -292,6 +309,7 @@ afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg)
   self->super.super.super.free_fn = afprogram_sd_free;
   self->super.super.super.notify = afprogram_sd_notify;
   self->process_info.cmdline = g_string_new(cmdline);
+  afprogram_set_inherit_environment(&self->process_info, TRUE);
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;
   return &self->super.super;
@@ -346,7 +364,7 @@ afprogram_dd_open_program(AFProgramDestDriver *self, int *fd)
                   evt_tag_str("cmdline", self->process_info.cmdline->str),
                   NULL);
 
-      if (!afprogram_popen(self->process_info.cmdline->str, G_IO_OUT, &self->process_info.pid, fd))
+      if (!afprogram_popen(self->process_info.cmdline->str, G_IO_OUT, &self->process_info.pid, fd, self->process_info.inherit_environment))
         return FALSE;
 
       g_fd_set_nonblock(*fd, TRUE);
@@ -521,6 +539,7 @@ afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg)
   self->super.super.super.notify = afprogram_dd_notify;
   self->process_info.cmdline = g_string_new(cmdline);
   self->process_info.pid = -1;
+  afprogram_set_inherit_environment(&self->process_info, TRUE);
   log_writer_options_defaults(&self->writer_options);
   return &self->super.super;
 }
@@ -529,4 +548,10 @@ void
 afprogram_dd_set_keep_alive(AFProgramDestDriver *self, gboolean keep_alive)
 {
   self->keep_alive = keep_alive;
+}
+
+void
+afprogram_set_inherit_environment(AFProgramProcessInfo *self, gboolean inherit_environment)
+{
+  self->inherit_environment = inherit_environment;
 }

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -156,14 +156,14 @@ afprogram_popen(const gchar *cmdline, GIOCondition cond, pid_t *pid, gint *fd)
 static void
 afprogram_sd_kill_child(AFProgramSourceDriver *self)
 {
-  if (self->pid != -1)
+  if (self->process_info.pid != -1)
     {
       msg_verbose("Sending source program a TERM signal",
-                  evt_tag_str("cmdline", self->cmdline->str),
-                  evt_tag_int("child_pid", self->pid),
+                  evt_tag_str("cmdline", self->process_info.cmdline->str),
+                  evt_tag_int("child_pid", self->process_info.pid),
                   NULL);
-      _terminate_process_group_by_pid(self->pid);
-      self->pid = -1;
+      _terminate_process_group_by_pid(self->process_info.pid);
+      self->process_info.pid = -1;
     }
 }
 
@@ -172,16 +172,16 @@ afprogram_sd_exit(pid_t pid, int status, gpointer s)
 {
   AFProgramSourceDriver *self = (AFProgramSourceDriver *) s;
 
-  /* Note: self->pid being -1 means that deinit was called, thus we don't
-   * need to restart the command. self->pid might change due to EPIPE
+  /* Note: self->process_info.pid being -1 means that deinit was called, thus we don't
+   * need to restart the command. self->process_info.pid might change due to EPIPE
    * handling restarting the command before this handler is run. */
-  if (self->pid != -1 && self->pid == pid)
+  if (self->process_info.pid != -1 && self->process_info.pid == pid)
     {
       msg_verbose("Child program exited",
-                  evt_tag_str("cmdline", self->cmdline->str),
+                  evt_tag_str("cmdline", self->process_info.cmdline->str),
                   evt_tag_int("status", status),
                   NULL);
-      self->pid = -1;
+      self->process_info.pid = -1;
     }
 }
 
@@ -199,14 +199,14 @@ afprogram_sd_init(LogPipe *s)
     log_reader_options_init(&self->reader_options, cfg, self->super.super.group);
 
   msg_verbose("Starting source program",
-              evt_tag_str("cmdline", self->cmdline->str),
+              evt_tag_str("cmdline", self->process_info.cmdline->str),
               NULL);
 
-  if (!afprogram_popen(self->cmdline->str, G_IO_IN, &self->pid, &fd))
+  if (!afprogram_popen(self->process_info.cmdline->str, G_IO_IN, &self->process_info.pid, &fd))
     return FALSE;
 
   /* parent */
-  child_manager_register(self->pid, afprogram_sd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify) log_pipe_unref);
+  child_manager_register(self->process_info.pid, afprogram_sd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify) log_pipe_unref);
 
   g_fd_set_nonblock(fd, TRUE);
   g_fd_set_cloexec(fd, TRUE);
@@ -223,7 +223,7 @@ afprogram_sd_init(LogPipe *s)
                              STATS_LEVEL0,
                              SCS_PROGRAM,
                              self->super.super.id,
-                             self->cmdline->str);
+                             self->process_info.cmdline->str);
     }
   log_pipe_append((LogPipe *) self->reader, &self->super.super.super);
   if (!log_pipe_init((LogPipe *) self->reader))
@@ -264,7 +264,7 @@ afprogram_sd_free(LogPipe *s)
   AFProgramSourceDriver *self = (AFProgramSourceDriver *) s;
 
   log_reader_options_destroy(&self->reader_options);
-  g_string_free(self->cmdline, TRUE);
+  g_string_free(self->process_info.cmdline, TRUE);
   log_src_driver_free(s);
 }
 
@@ -291,7 +291,7 @@ afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg)
   self->super.super.super.deinit = afprogram_sd_deinit;
   self->super.super.super.free_fn = afprogram_sd_free;
   self->super.super.super.notify = afprogram_sd_notify;
-  self->cmdline = g_string_new(cmdline);
+  self->process_info.cmdline = g_string_new(cmdline);
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;
   return &self->super.super;
@@ -307,7 +307,7 @@ afprogram_dd_format_queue_persist_name(AFProgramDestDriver *self)
   static gchar persist_name[256];
 
   g_snprintf(persist_name, sizeof(persist_name),
-             "afprogram_dd_qname(%s,%s)", self->cmdline->str, self->super.super.id);
+             "afprogram_dd_qname(%s,%s)", self->process_info.cmdline->str, self->super.super.id);
 
   return persist_name;
 }
@@ -318,7 +318,7 @@ afprogram_dd_format_persist_name(AFProgramDestDriver *self)
   static gchar persist_name[256];
 
   g_snprintf(persist_name, sizeof(persist_name),
-             "afprogram_dd_name(%s,%s)", self->cmdline->str, self->super.super.id);
+             "afprogram_dd_name(%s,%s)", self->process_info.cmdline->str, self->super.super.id);
 
   return persist_name;
 }
@@ -326,33 +326,33 @@ afprogram_dd_format_persist_name(AFProgramDestDriver *self)
 static void
 afprogram_dd_kill_child(AFProgramDestDriver *self)
 {
-  if (self->pid != -1)
+  if (self->process_info.pid != -1)
     {
       msg_verbose("Sending destination program a TERM signal",
-                  evt_tag_str("cmdline", self->cmdline->str),
-                  evt_tag_int("child_pid", self->pid),
+                  evt_tag_str("cmdline", self->process_info.cmdline->str),
+                  evt_tag_int("child_pid", self->process_info.pid),
                   NULL);
-      _terminate_process_group_by_pid(self->pid);
-      self->pid = -1;
+      _terminate_process_group_by_pid(self->process_info.pid);
+      self->process_info.pid = -1;
     }
 }
 
 static inline gboolean
 afprogram_dd_open_program(AFProgramDestDriver *self, int *fd)
 {
-  if (self->pid == -1)
+  if (self->process_info.pid == -1)
     {
       msg_verbose("Starting destination program",
-                  evt_tag_str("cmdline", self->cmdline->str),
+                  evt_tag_str("cmdline", self->process_info.cmdline->str),
                   NULL);
 
-      if (!afprogram_popen(self->cmdline->str, G_IO_OUT, &self->pid, fd))
+      if (!afprogram_popen(self->process_info.cmdline->str, G_IO_OUT, &self->process_info.pid, fd))
         return FALSE;
 
       g_fd_set_nonblock(*fd, TRUE);
     }
 
-  child_manager_register(self->pid, afprogram_dd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify)log_pipe_unref);
+  child_manager_register(self->process_info.pid, afprogram_dd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify)log_pipe_unref);
 
   return TRUE;
 }
@@ -376,16 +376,16 @@ afprogram_dd_exit(pid_t pid, int status, gpointer s)
 {
   AFProgramDestDriver *self = (AFProgramDestDriver *) s;
 
-  /* Note: self->pid being -1 means that deinit was called, thus we don't
-   * need to restart the command. self->pid might change due to EPIPE
+  /* Note: self->process_info.pid being -1 means that deinit was called, thus we don't
+   * need to restart the command. self->process_info.pid might change due to EPIPE
    * handling restarting the command before this handler is run. */
-  if (self->pid != -1 && self->pid == pid)
+  if (self->process_info.pid != -1 && self->process_info.pid == pid)
     {
       msg_verbose("Child program exited, restarting",
-                  evt_tag_str("cmdline", self->cmdline->str),
+                  evt_tag_str("cmdline", self->process_info.cmdline->str),
                   evt_tag_int("status", status),
                   NULL);
-      self->pid = -1;
+      self->process_info.pid = -1;
       afprogram_dd_reopen(self);
     }
 }
@@ -397,10 +397,10 @@ afprogram_dd_restore_reload_store_item(AFProgramDestDriver *self, GlobalConfig *
 
   if (restored_info)
     {
-      self->pid = restored_info->pid;
+      self->process_info.pid = restored_info->pid;
       self->writer = restored_info->writer;
 
-      child_manager_register(self->pid, afprogram_dd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify)log_pipe_unref);
+      child_manager_register(self->process_info.pid, afprogram_dd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify)log_pipe_unref);
       g_free(restored_info);
     }
 
@@ -429,7 +429,7 @@ afprogram_dd_init(LogPipe *s)
                          STATS_LEVEL0,
                          SCS_PROGRAM,
                          self->super.super.id,
-                         self->cmdline->str);
+                         self->process_info.cmdline->str);
   log_writer_set_queue(self->writer, log_dest_driver_acquire_queue(&self->super, afprogram_dd_format_queue_persist_name(self)));
 
   if (!log_pipe_init((LogPipe *) self->writer))
@@ -447,7 +447,7 @@ afprogram_dd_store_reload_store_item(AFProgramDestDriver *self, GlobalConfig *cf
 {
   AFProgramReloadStoreItem *reload_info = g_new0(AFProgramReloadStoreItem, 1);
 
-  reload_info->pid = self->pid;
+  reload_info->pid = self->process_info.pid;
   reload_info->writer = self->writer;
 
   cfg_persist_config_add(cfg, afprogram_dd_format_persist_name(self), reload_info, afprogram_reload_store_item_destroy_notify, FALSE);
@@ -462,7 +462,7 @@ afprogram_dd_deinit(LogPipe *s)
   if (self->writer)
     log_pipe_deinit((LogPipe *) self->writer);
 
-  child_manager_unregister(self->pid);
+  child_manager_unregister(self->process_info.pid);
 
   if (self->keep_alive)
     {
@@ -490,7 +490,7 @@ afprogram_dd_free(LogPipe *s)
   AFProgramDestDriver *self = (AFProgramDestDriver *) s;
 
   log_pipe_unref((LogPipe *) self->writer);
-  g_string_free(self->cmdline, TRUE);
+  g_string_free(self->process_info.cmdline, TRUE);
   log_writer_options_destroy(&self->writer_options);
   log_dest_driver_free(s);
 }
@@ -519,8 +519,8 @@ afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg)
   self->super.super.super.deinit = afprogram_dd_deinit;
   self->super.super.super.free_fn = afprogram_dd_free;
   self->super.super.super.notify = afprogram_dd_notify;
-  self->cmdline = g_string_new(cmdline);
-  self->pid = -1;
+  self->process_info.cmdline = g_string_new(cmdline);
+  self->process_info.pid = -1;
   log_writer_options_defaults(&self->writer_options);
   return &self->super.super;
 }

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -197,17 +197,17 @@ afprogram_sd_init(LogPipe *s)
 
   if (cfg)
     log_reader_options_init(&self->reader_options, cfg, self->super.super.group);
-  
+
   msg_verbose("Starting source program",
               evt_tag_str("cmdline", self->cmdline->str),
-              NULL); 
- 
+              NULL);
+
   if (!afprogram_popen(self->cmdline->str, G_IO_IN, &self->pid, &fd))
     return FALSE;
 
   /* parent */
   child_manager_register(self->pid, afprogram_sd_exit, log_pipe_ref(&self->super.super.super), (GDestroyNotify) log_pipe_unref);
-  
+
   g_fd_set_nonblock(fd, TRUE);
   g_fd_set_cloexec(fd, TRUE);
   if (!self->reader)
@@ -227,7 +227,7 @@ afprogram_sd_init(LogPipe *s)
     }
   log_pipe_append((LogPipe *) self->reader, &self->super.super.super);
   if (!log_pipe_init((LogPipe *) self->reader))
-    { 
+    {
       msg_error("Error initializing program source, closing fd",
                 evt_tag_int("fd", fd),
                 NULL);
@@ -262,7 +262,7 @@ static void
 afprogram_sd_free(LogPipe *s)
 {
   AFProgramSourceDriver *self = (AFProgramSourceDriver *) s;
-  
+
   log_reader_options_destroy(&self->reader_options);
   g_string_free(self->cmdline, TRUE);
   log_src_driver_free(s);
@@ -286,7 +286,7 @@ afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg)
 {
   AFProgramSourceDriver *self = g_new0(AFProgramSourceDriver, 1);
   log_src_driver_init_instance(&self->super, cfg);
-  
+
   self->super.super.super.init = afprogram_sd_init;
   self->super.super.super.deinit = afprogram_sd_deinit;
   self->super.super.super.free_fn = afprogram_sd_free;
@@ -514,7 +514,7 @@ afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg)
 {
   AFProgramDestDriver *self = g_new0(AFProgramDestDriver, 1);
   log_dest_driver_init_instance(&self->super, cfg);
-  
+
   self->super.super.super.init = afprogram_dd_init;
   self->super.super.super.deinit = afprogram_dd_deinit;
   self->super.super.super.free_fn = afprogram_dd_free;

--- a/modules/afprog/afprog.h
+++ b/modules/afprog/afprog.h
@@ -28,21 +28,25 @@
 #include "logwriter.h"
 #include "logreader.h"
 
+typedef struct _AFProgramProcessInfo
+{
+  pid_t pid;
+  GString *cmdline;
+} AFProgramProcessInfo;
+
 typedef struct _AFProgramSourceDriver
 {
   LogSrcDriver super;
-  GString *cmdline;
+  AFProgramProcessInfo process_info;
   LogReader *reader;
-  pid_t pid;
   LogReaderOptions reader_options;
 } AFProgramSourceDriver;
 
 typedef struct _AFProgramDestDriver
 {
   LogDestDriver super;
-  GString *cmdline;
+  AFProgramProcessInfo process_info;
   LogWriter *writer;
-  pid_t pid;
   gboolean keep_alive;
   LogWriterOptions writer_options;
 } AFProgramDestDriver;

--- a/modules/afprog/afprog.h
+++ b/modules/afprog/afprog.h
@@ -32,6 +32,7 @@ typedef struct _AFProgramProcessInfo
 {
   pid_t pid;
   GString *cmdline;
+  gboolean inherit_environment;
 } AFProgramProcessInfo;
 
 typedef struct _AFProgramSourceDriver
@@ -55,5 +56,6 @@ LogDriver *afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg);
 LogDriver *afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg);
 
 void afprogram_dd_set_keep_alive(AFProgramDestDriver *self, gboolean keep_alive);
+void afprogram_set_inherit_environment(AFProgramProcessInfo *self, gboolean inherit_environment);
 
 #endif


### PR DESCRIPTION
Source/destination program used to inherit the entire environment of the parent process.
This pull request introduces a configuration option which can turn off this behavior.