### PR TITLE
Fix possible double-frees in yydestruct

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -771,27 +771,24 @@ template_block
 	: KW_TEMPLATE string
 	  {
 	    last_template = log_template_new(configuration, $2);
-	    free($2);
 	  }
-	  '{' template_items '}'						{ $$ = last_template; }
+	  '{' template_items '}'						{ $$ = last_template; free($2); }
         ;
 
 template_simple
         : KW_TEMPLATE string
           {
 	    last_template = log_template_new(configuration, $2);
-	    free($2);
           }
-          template_content_inner						{ $$ = last_template; }
+          template_content_inner						{ $$ = last_template; free($2); }
 	;
 
 template_fn
         : KW_TEMPLATE_FUNCTION string
           {
 	    last_template = log_template_new(configuration, $2);
-	    free($2);
           }
-          template_content_inner						{ $$ = last_template; }
+          template_content_inner						{ $$ = last_template; free($2); }
 	;
 	
 template_items


### PR DESCRIPTION
Fixes #865 

The original bugreport is somewhat invalid, because the tested commit was made in nov 30. The mentioned issue cannot be reproduced today with the current master, but it "forced" me to recheck the grammar files.

https://github.com/balabit/syslog-ng/pull/817 eliminated the possible double frees in the modules, but I didn't check the grammar files under lib.

This PR fixes the possible double frees in the grammar files under lib/. AFAIK there is none file left out.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>