### PR TITLE
Geoip quiet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: c
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq curl
+  - sudo apt-get install -qq curl python-software-properties
+  - sudo add-apt-repository -y ppa:maxmind/ppa
   - curl http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04/Release.key | sudo apt-key add -
   - echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04 ./" | sudo tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
   - sudo apt-get update -qq
-  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev openjdk-7-jdk gradle-2.2.1 autoconf-archive
+  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev>=1.6.3 libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev openjdk-7-jdk gradle-2.2.1 autoconf-archive
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ PCRE_MIN_VERSION="6.1"
 LMC_MIN_VERSION="0.1.8"
 LRMQ_MIN_VERSION="0.0.1"
 LRC_MIN_VERSION="1.6.0"
+LIBGEOIP_MIN_VERSION="1.6.3"
 JOURNALD_MIN_VERSION="195"
 LIBSYSTEMD_MIN_VERSION="209"
 JAVA_MIN_VERSION="1.7"
@@ -755,7 +756,7 @@ if test "x$enable_geoip" = "xyes" || test "x$enable_geoip" = "xauto"; then
                 AC_MSG_RESULT([yes (GEOIP_LIBS set, will use that.)])
                 with_geoip="yes"
         else
-                PKG_CHECK_MODULES(GEOIP, geoip, with_geoip="yes", with_geoip="no")
+                PKG_CHECK_MODULES(GEOIP, geoip >= $LIBGEOIP_MIN_VERSION, with_geoip="yes", with_geoip="no")
         fi
 
         if test "x$with_geoip" = "xno" && test "x$enable_geoip" = "xyes"; then

--- a/modules/geoip/geoip-parser-grammar.ym
+++ b/modules/geoip/geoip-parser-grammar.ym
@@ -50,6 +50,7 @@
 %token KW_GEOIP
 %token KW_DATABASE
 %token KW_PREFIX
+%token KW_QUIET
 
 %type	<ptr> parser_expr_geoip
 
@@ -89,6 +90,7 @@ parser_geoip_opt
           { geoip_parser_set_prefix(last_parser, $3); free($3); }
         | KW_DATABASE '(' string ')'
           { geoip_parser_set_database(last_parser, $3); free($3); }
+        | KW_QUIET '(' yesno ')' { geoip_parser_set_quiet(last_parser, $3); }
         ;
 
 /* INCLUDE_RULES */

--- a/modules/geoip/geoip-parser-parser.c
+++ b/modules/geoip/geoip-parser-parser.c
@@ -33,6 +33,7 @@ static CfgLexerKeyword geoip_parser_keywords[] =
   { "geoip",          KW_GEOIP },
   { "database",       KW_DATABASE },
   { "prefix",         KW_PREFIX },
+  { "quiet",          KW_QUIET },
   { NULL }
 };
 

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -168,10 +168,9 @@ geoip_parser_free(LogPipe *s)
   log_parser_free_method(s);
 }
 
-static gboolean
-geoip_parser_init(LogPipe *s)
+static void
+__open(GeoIPParser *self)
 {
-  GeoIPParser *self = (GeoIPParser *) s;
   gint open_params = GEOIP_MMAP_CACHE;
 
   geoip_parser_reset_fields(self);
@@ -180,6 +179,14 @@ geoip_parser_init(LogPipe *s)
     open_params |= GEOIP_SILENCE;
 
   self->gi = GeoIP_open(self->database, open_params);
+}
+
+static gboolean
+geoip_parser_init(LogPipe *s)
+{
+  GeoIPParser *self = (GeoIPParser *) s;
+
+  __open(self);
 
   if (!self->gi)
     return FALSE;

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -33,6 +33,7 @@ typedef struct
 
   gchar *database;
   gchar *prefix;
+  gboolean quiet;
 
   struct
   {
@@ -71,6 +72,14 @@ geoip_parser_set_database(LogParser *s, const gchar *database)
 
   g_free(self->database);
   self->database = g_strdup(database);
+}
+
+void
+geoip_parser_set_quiet(LogParser *s, gboolean quiet)
+{
+  GeoIPParser *self = (GeoIPParser *) s;
+
+  self->quiet = quiet;
 }
 
 static gboolean
@@ -163,10 +172,14 @@ static gboolean
 geoip_parser_init(LogPipe *s)
 {
   GeoIPParser *self = (GeoIPParser *) s;
+  gint open_params = GEOIP_MMAP_CACHE;
 
   geoip_parser_reset_fields(self);
+  
+  if (self->quiet)
+    open_params |= GEOIP_SILENCE;
 
-  self->gi = GeoIP_open(self->database, GEOIP_MMAP_CACHE);
+  self->gi = GeoIP_open(self->database, open_params);
 
   if (!self->gi)
     return FALSE;

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -169,7 +169,7 @@ geoip_parser_free(LogPipe *s)
 }
 
 static void
-__open(GeoIPParser *self)
+_open(GeoIPParser *self)
 {
   gint open_params = GEOIP_MMAP_CACHE;
 
@@ -186,7 +186,7 @@ geoip_parser_init(LogPipe *s)
 {
   GeoIPParser *self = (GeoIPParser *) s;
 
-  __open(self);
+  _open(self);
 
   if (!self->gi)
     return FALSE;

--- a/modules/geoip/geoip-parser.h
+++ b/modules/geoip/geoip-parser.h
@@ -28,5 +28,6 @@
 LogParser *geoip_parser_new(GlobalConfig *cfg);
 void geoip_parser_set_database(LogParser *s, const gchar *database);
 void geoip_parser_set_prefix(LogParser *s, const gchar *prefix);
+void geoip_parser_set_quiet(LogParser *s, gboolean quiet);
 
 #endif


### PR DESCRIPTION
Fixes #663 

Note, that this PR sets the minimal supported geoip version to 1.6.3.

You can find fresh geoip debian packages here: https://launchpad.net/~maxmind/+archive/ubuntu/ppa