### PR TITLE
Clean up configure directory

### DIFF
--- a/Mk/Makefile.am
+++ b/Mk/Makefile.am
@@ -3,7 +3,6 @@ EXTRA_DIST	+= Mk/lex-rules.am \
 		Mk/populate-makefiles.sh \
 		Mk/subdir.mk
 
-toolsdir	= $(datadir)/tools
 tools_DATA	= \
 		Mk/lex-rules.am \
 		lib/cfg-grammar.y

--- a/configure.ac
+++ b/configure.ac
@@ -1439,15 +1439,11 @@ AM_CONDITIONAL(ENABLE_JAVA, [test "$enable_java" = "yes"])
 AM_CONDITIONAL(ENABLE_MANPAGES, [test "$enable_manpages" != "no"])
 AM_CONDITIONAL(ENABLE_NATIVE, [test "$enable_native" != "no"])
 
-# substitution into manual pages
-expanded_sysconfdir=[`patheval $sysconfdir | sed -e 's/-/\\\\-/g'`]
-
 AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)
 AC_SUBST(moduledir)
 AC_SUBST(toolsdir)
 AC_SUBST(scldir)
-AC_SUBST(expanded_sysconfdir)
 AC_SUBST(systemdsystemunitdir)
 AC_SUBST(SYSLOGNG_LINK)
 AC_SUBST(SYSLOGNG_DEPS_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -73,8 +73,8 @@ if test "x$exec_prefix" = "xNONE"; then
 fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
-toolsdir='${datadir}/tools'
-scldir='${datadir}/include/scl'
+toolsdir='${datadir}/syslog-ng/tools'
+scldir='${datadir}/syslog-ng/include/scl'
 
 AC_CONFIG_HEADERS(config.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1441,7 +1441,6 @@ AM_CONDITIONAL(ENABLE_NATIVE, [test "$enable_native" != "no"])
 
 # substitution into manual pages
 expanded_sysconfdir=[`patheval $sysconfdir | sed -e 's/-/\\\\-/g'`]
-expanded_moduledir=[`patheval $moduledir`]
 
 AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)
@@ -1449,7 +1448,6 @@ AC_SUBST(moduledir)
 AC_SUBST(toolsdir)
 AC_SUBST(scldir)
 AC_SUBST(expanded_sysconfdir)
-AC_SUBST(expanded_moduledir)
 AC_SUBST(systemdsystemunitdir)
 AC_SUBST(SYSLOGNG_LINK)
 AC_SUBST(SYSLOGNG_DEPS_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,7 @@ if test "x$exec_prefix" = "xNONE"; then
 fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
+toolsdir='${datadir}/tools'
 
 AC_CONFIG_HEADERS(config.h)
 
@@ -1444,6 +1445,7 @@ expanded_moduledir=[`patheval $moduledir`]
 AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)
 AC_SUBST(moduledir)
+AC_SUBST(toolsdir)
 AC_SUBST(expanded_sysconfdir)
 AC_SUBST(expanded_moduledir)
 AC_SUBST(systemdsystemunitdir)

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,7 @@ fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
 toolsdir='${datadir}/tools'
+scldir='${datadir}/include/scl'
 
 AC_CONFIG_HEADERS(config.h)
 
@@ -1446,6 +1447,7 @@ AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)
 AC_SUBST(moduledir)
 AC_SUBST(toolsdir)
+AC_SUBST(scldir)
 AC_SUBST(expanded_sysconfdir)
 AC_SUBST(expanded_moduledir)
 AC_SUBST(systemdsystemunitdir)

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -18,8 +18,6 @@ SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))
 
-scldir		= $(datadir)/include/scl
-
 scl-install-data-local:
 	for cfg in $(SCL_CONFIGS); do \
 		if [ -f $(DESTDIR)/$(sysconfdir)/$${cfg} ]; then \

--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -7,7 +7,7 @@ libdir=@libdir@
 includedir=@includedir@
 toolsdir=@toolsdir@
 moduledir=@expanded_moduledir@
-scldir=@datadir@/include/scl
+scldir=@scldir@
 ivykis=@with_ivykis@
 
 Name: syslog-ng-dev

--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -2,9 +2,10 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 datarootdir=@datarootdir@
+datadir=@datadir@
 libdir=@libdir@
 includedir=@includedir@
-toolsdir=@datadir@/tools
+toolsdir=@toolsdir@
 moduledir=@expanded_moduledir@
 scldir=@datadir@/include/scl
 ivykis=@with_ivykis@

--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -6,7 +6,7 @@ datadir=@datadir@
 libdir=@libdir@
 includedir=@includedir@
 toolsdir=@toolsdir@
-moduledir=@expanded_moduledir@
+moduledir=@moduledir@
 scldir=@scldir@
 ivykis=@with_ivykis@
 


### PR DESCRIPTION
following up PR #628 that tries to address issue #587.

this PR solves the issue and also cleans up related configure.ac/Makefile.am machinery a bit.

Please note @lbudai, @czanik that once this gets integrated, the --datadir configure option should be removed from debian/rules and rpm specfiles, as it will generate paths like:

/usr/share/syslog-ng/syslog-ng/scl & /usr/share/syslog-ng/syslog-ng/tools

I am not sure where and how we should open tickets about the packaging files to avoid getting lost.
