### PR TITLE
Improve the performance of utf8-utils by using an optimized implementation of strchr()

### DIFF
--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -14,7 +14,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_runid        	\
 	lib/tests/test_pathutils	\
 	lib/tests/test_utf8utils	\
-	lib/tests/test_userdb
+	lib/tests/test_userdb		\
+	lib/tests/test_str-utils
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
@@ -98,6 +99,11 @@ lib_tests_test_pathutils_LDADD	=	\
 lib_tests_test_utf8utils_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_utf8utils_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_str_utils_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_str_utils_LDADD	=	\
 	$(TEST_LDADD)
 
 CLEANFILES				+= \

--- a/lib/tests/test_str-utils.c
+++ b/lib/tests/test_str-utils.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "testutils.h"
+#include "str-utils.h"
+
+/* this macro defines which strchr() implementation we are testing. It is
+ * extracted as a macro in order to make it easy to switch strchr()
+ * implementation, provided there would be more.
+ */
+
+#define strchr_under_test _strchr_optimized_for_single_char_haystack
+
+static void
+assert_strchr_is_null(const gchar *str, int c)
+{
+  assert_null(strchr_under_test(str, c), "expected a NULL return");
+}
+
+static void
+assert_strchr_finds_character_at(const gchar *str, int c, int ofs)
+{
+  char *result = strchr_under_test(str, c);
+
+  assert_not_null(result, "expected a non-NULL return");
+  assert_true(result - str <= strlen(str), "Expected the strchr() return value to point into the input string or the terminating NUL, it points past the NUL");
+  assert_true(result >= str, "Expected the strchr() return value to point into the input string or the terminating NUL, it points before the start of the string");
+  assert_gint((result - str), ofs, "Expected the strchr() return value to point right to the specified offset");
+}
+
+int
+main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+{
+  assert_strchr_is_null("", 'x');
+  assert_strchr_is_null("a", 'x');
+  assert_strchr_is_null("abc", 'x');
+
+  assert_strchr_finds_character_at("", '\0', 0);
+  assert_strchr_finds_character_at("a", 'a', 0);
+  assert_strchr_finds_character_at("a", '\0', 1);
+  assert_strchr_finds_character_at("abc", 'a', 0);
+  assert_strchr_finds_character_at("abc", 'b', 1);
+  assert_strchr_finds_character_at("abc", 'c', 2);
+  assert_strchr_finds_character_at("abc", '\0', 3);
+  assert_strchr_finds_character_at("0123456789abcdef", '0', 0);
+  assert_strchr_finds_character_at("0123456789abcdef", '7', 7);
+  assert_strchr_finds_character_at("0123456789abcdef", 'f', 15);
+
+  return 0;
+}

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -22,7 +22,7 @@
  *
  */
 #include "utf8utils.h"
-#include <string.h>
+#include "str-utils.h"
 
 static inline gboolean
 _is_character_unsafe(gunichar uchar, const gchar *unsafe_chars)
@@ -33,7 +33,7 @@ _is_character_unsafe(gunichar uchar, const gchar *unsafe_chars)
   if (!unsafe_chars)
     return FALSE;
 
-  return strchr(unsafe_chars, (gchar) uchar) != NULL;
+  return _strchr_optimized_for_single_char_haystack(unsafe_chars, (gchar) uchar) != NULL;
 }
 
 static inline void

--- a/modules/csvparser/csv-scanner.c
+++ b/modules/csvparser/csv-scanner.c
@@ -21,6 +21,7 @@
  *
  */
 #include "csv-scanner.h"
+#include "str-utils.h"
 #include "string-list.h"
 
 #include <string.h>
@@ -170,7 +171,7 @@ _is_at_the_end_of_columns(CSVScanner *self)
 static void
 _parse_opening_quote_character(CSVScanner *self)
 {
-  gchar *quote = strchr(self->options->quotes_start, *self->src);
+  gchar *quote = _strchr_optimized_for_single_char_haystack(self->options->quotes_start, *self->src);
 
   if (quote != NULL)
     {
@@ -260,7 +261,7 @@ _parse_string_delimiters_at_current_position(CSVScanner *self)
 static gboolean
 _parse_character_delimiters_at_current_position(CSVScanner *self)
 {
-  if (strchr(self->options->delimiters, *self->src) != NULL)
+  if (_strchr_optimized_for_single_char_haystack(self->options->delimiters, *self->src) != NULL)
     {
       self->src++;
       return TRUE;

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -29,6 +29,7 @@
 #include "cfg.h"
 #include "str-format.h"
 #include "utf8utils.h"
+#include "str-utils.h"
 
 #include <regex.h>
 #include <ctype.h>
@@ -90,7 +91,7 @@ log_msg_parse_skip_chars(LogMessage *self, const guchar **data, gint *length, co
   gint left = *length;
   gint num_skipped = 0;
 
-  while (max_len && left && strchr(chars, *src))
+  while (max_len && left && _strchr_optimized_for_single_char_haystack(chars, *src))
     {
       src++;
       left--;
@@ -131,7 +132,7 @@ log_msg_parse_skip_chars_until(LogMessage *self, const guchar **data, gint *leng
   gint left = *length;
   gint num_skipped = 0;
 
-  while (left && strchr(delims, *src) == 0)
+  while (left && _strchr_optimized_for_single_char_haystack(delims, *src) == 0)
     {
       src++;
       left--;


### PR DESCRIPTION
…for strchr()

This patch adds an optimized version of strchr() that is often used by
$(format-json) to output escaped strings, which improves $(format-json)
performance by about 3 percent.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>