### PR TITLE
Support native Elasticsearch configuration for transport mode

### DIFF
--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClient.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClient.java
@@ -23,12 +23,20 @@
 
 package org.syslog_ng.elasticsearch.client;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.net.MalformedURLException;
+import java.nio.file.Paths;
+
 import org.apache.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.ImmutableSettings.Builder;
+import org.elasticsearch.common.settings.SettingsException;
 import org.syslog_ng.elasticsearch.ElasticSearchOptions;
 
 public abstract class ESClient {
@@ -103,5 +111,19 @@ public abstract class ESClient {
 
 	protected void resetClient() {
 		this.client = null;
+	}
+
+	protected void loadConfigFile(String cfgFile, Builder settingsBuilder) {
+		if (cfgFile == null || cfgFile.isEmpty()) {
+			return;
+		}
+		try {
+			URL url = new File(cfgFile).toURI().toURL();
+			settingsBuilder.loadFromUrl(url);
+		} catch (MalformedURLException e) {
+			logger.warn("Bad filename format, filename = '" + cfgFile + "'");
+		} catch (SettingsException e) {
+			logger.warn("Can't load settings from file, file = '" + cfgFile + "', reason = '" + e.getMessage() + "'");
+		}
 	}
 }

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESNodeClient.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESNodeClient.java
@@ -59,26 +59,11 @@ public class ESNodeClient extends ESClient {
 		return result;
 	}
 
-	private void loadConfigFile(String cfgFile, NodeBuilder nodeBuilder) {
-		if (cfgFile == null || cfgFile.isEmpty()) {
-			return;
-		}
-		try {
-			URL url = new File(cfgFile).toURI().toURL();
-			Builder builder = nodeBuilder().settings().loadFromUrl(url);
-			nodeBuilder = nodeBuilder.settings(builder);
-		} catch (MalformedURLException e) {
-			logger.warn("Bad filename format, filename = '" + cfgFile + "'");
-		} catch (SettingsException e) {
-			logger.warn("Can't load settings from file, file = '" + cfgFile + "', reason = '" + e.getMessage() + "'");
-		}
-	}
-
 	@Override
 	public Client createClient() {
 		NodeBuilder nodeBuilder = createNodeBuilder(options.getCluster());
 		nodeBuilder.settings().put("discovery.initial_state_timeout", "5s");
-		loadConfigFile(options.getConfigFile(), nodeBuilder);
+		loadConfigFile(options.getConfigFile(), nodeBuilder.settings());
 		node = nodeBuilder.node();
 	    return node.client();
 	}

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESTransportClient.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESTransportClient.java
@@ -38,17 +38,23 @@ public class ESTransportClient extends ESClient {
 	public ESTransportClient(ElasticSearchOptions options) {
 		super(options);
 	}
-
-	public Client createClient() {
-		String clusterName = options.getCluster();
+	
+	private Settings buildSettings() {
 		Builder settingsBuilder = ImmutableSettings.settingsBuilder();
+		String clusterName = options.getCluster();
+
+		loadConfigFile(options.getConfigFile(), settingsBuilder);
 		settingsBuilder = settingsBuilder.put("client.transport.sniff", true).classLoader(Settings.class.getClassLoader());
 
 		if (clusterName != null) {
-			settingsBuilder = settingsBuilder.put("cluster.name", clusterName);
+		        settingsBuilder = settingsBuilder.put("cluster.name", clusterName);
 		}
 
-		settings = settingsBuilder.build();
+		return settingsBuilder.build();
+	}
+
+	public Client createClient() {
+		settings = buildSettings();
 
 		String[] servers =  options.getServerList();
 


### PR DESCRIPTION
Previously, this feature was available only for node mode.
By supporting loading native elasticsearch config, it is possible now
to use Shield with syslog-ng.

When you want to use Shield, you have to add elasticsearch-shield-1.3.3.jar
to your classpath.

```
shield.ssl.keystore.path: /home/test/es/shield/client.jks
shield.ssl.keystore.password: qqq123
shield.transport.ssl: true
shield.user: es_admin:qqq123
```

```
@version: 3.8

destination d_elastic {
    elasticsearch(
        client_lib_dir(/usr/share/elasticsearch/lib)
        client_mode("transport")
        cluster("es-syslog-ng")
        index("es-syslog-ng")
        port("9300")
        server("vagrant-es-server")
        type("slng_test_type")
        resource("/opt/syslog-ng/etc/elasticsearch.yml")
    );
};

```

Fixes: #826

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>