### PR TITLE
travis.yml: add --keep-going to make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - unset PYTHON_CFLAGS # HACK
   - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
   - if [ "$CC" = "clang" ]; then export COPYRIGHTVERBOSITY=1; make check-copyright; fi
-  - make -j || make V=1 # to make error messages more readable on error
+  - make -j || make V=1 --keep-going # to make error messages more readable on error
 script:
   - if [ "$CC" = "gcc" ]; then make distcheck V=1; else make func-test V=1; fi
 compiler:


### PR DESCRIPTION
This switch is added in order to show as many compilation error
as possible, therefore the output of a failed Travis CI build might be
more valuable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/balabit/syslog-ng/895)
<!-- Reviewable:end -->
