### PR TITLE
Fix create-dirs() inheritance in file destinations

### DIFF
--- a/modules/affile/affile-common.h
+++ b/modules/affile/affile-common.h
@@ -28,10 +28,10 @@
 
 typedef struct _FileOpenOptions
 {
-  gboolean create_dirs:1,
-           needs_privileges:1,
+  gboolean needs_privileges:1,
            is_pipe:1;
   gint open_flags;
+  gint create_dirs;
 } FileOpenOptions;
 
 gboolean affile_open_file(gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_opts, gint *fd);

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -464,8 +464,8 @@ affile_dd_init(LogPipe *s)
   if (!log_dest_driver_init_method(s))
     return FALSE;
 
-  if (cfg->create_dirs)
-    self->file_open_options.create_dirs = TRUE;
+  if (self->file_open_options.create_dirs == -1)
+    self->file_open_options.create_dirs = cfg->create_dirs;
   if (self->time_reap == -1)
     self->time_reap = cfg->time_reap;
   
@@ -757,6 +757,7 @@ affile_dd_new_instance(gchar *filename, GlobalConfig *cfg)
       self->filename_is_a_template = TRUE;
     }
   self->time_reap = -1;
+  self->file_open_options.create_dirs = -1;
   self->file_open_options.is_pipe = FALSE;
   self->file_open_options.needs_privileges = FALSE;
   self->file_open_options.open_flags = DEFAULT_DW_REOPEN_FLAGS;


### PR DESCRIPTION
When the global `create-dirs` option was set to `yes`, the local one was ignored.

Signed-off-by: László Várady <laszlo.varady@balabit.com>