### PR TITLE
Fix global option inheritance in afunix-source

### DIFF
--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -91,6 +91,10 @@ static gboolean
 afunix_sd_init(LogPipe *s)
 {
   AFUnixSourceDriver *self = (AFUnixSourceDriver *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  if (self->create_dirs == -1)
+    self->create_dirs = cfg->create_dirs;
 
   return afsocket_sd_init_method(s) &&
          afunix_sd_apply_perms_to_socket(self);
@@ -123,8 +127,8 @@ afunix_sd_new_instance(TransportMapper *transport_mapper, gchar *filename, Globa
   file_perm_options_defaults(&self->file_perm_options);
   self->file_perm_options.file_perm = 0666;
   self->pass_unix_credentials = cfg->pass_unix_credentials;
-  self->create_dirs = cfg->create_dirs;
   afunix_sd_set_pass_unix_credentials(self, self->pass_unix_credentials);
+  self->create_dirs = -1;
 
   afunix_sd_adjust_reader_options(self, cfg);
   return self;

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -96,6 +96,11 @@ afunix_sd_init(LogPipe *s)
   if (self->create_dirs == -1)
     self->create_dirs = cfg->create_dirs;
 
+  if (self->pass_unix_credentials == -1)
+    self->pass_unix_credentials = cfg->pass_unix_credentials;
+
+  afunix_sd_set_pass_unix_credentials(self, self->pass_unix_credentials);
+
   return afsocket_sd_init_method(s) &&
          afunix_sd_apply_perms_to_socket(self);
 }
@@ -126,8 +131,7 @@ afunix_sd_new_instance(TransportMapper *transport_mapper, gchar *filename, Globa
   self->filename = g_strdup(filename);
   file_perm_options_defaults(&self->file_perm_options);
   self->file_perm_options.file_perm = 0666;
-  self->pass_unix_credentials = cfg->pass_unix_credentials;
-  afunix_sd_set_pass_unix_credentials(self, self->pass_unix_credentials);
+  self->pass_unix_credentials = -1;
   self->create_dirs = -1;
 
   afunix_sd_adjust_reader_options(self, cfg);

--- a/modules/afsocket/afunix-source.h
+++ b/modules/afsocket/afunix-source.h
@@ -33,7 +33,7 @@ typedef struct _AFUnixSourceDriver
   AFSocketSourceDriver super;
   gchar *filename;
   FilePermOptions file_perm_options;
-  gboolean pass_unix_credentials;
+  gint pass_unix_credentials;
   gint create_dirs;
 } AFUnixSourceDriver;
 

--- a/modules/afsocket/afunix-source.h
+++ b/modules/afsocket/afunix-source.h
@@ -34,7 +34,7 @@ typedef struct _AFUnixSourceDriver
   gchar *filename;
   FilePermOptions file_perm_options;
   gboolean pass_unix_credentials;
-  gboolean create_dirs;
+  gint create_dirs;
 } AFUnixSourceDriver;
 
 AFUnixSourceDriver *afunix_sd_new_stream(gchar *filename, GlobalConfig *cfg);


### PR DESCRIPTION
Fixes: #894 

The global `create-dirs` and `pass-unix-credentials` options were not
inherited in afunix-source if the `options{};` block was positioned lower in the
configuration file than the given module declaration.

This pull request fixes this issue by moving the "inheritance" assignment from
`afunix_sd_new_instance` to `afunix_sd_init`.