### PR TITLE
Measure unit and functional test coverage

### DIFF
--- a/.lcovrc
+++ b/.lcovrc
@@ -1,0 +1,4 @@
+geninfo_adjust_src_path = /.libs
+geninfo_compat_libtool = 1
+geninfo_auto_base = 1
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - curl http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04/Release.key | sudo apt-key add -
   - echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04 ./" | sudo tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
   - sudo apt-get update -qq
-  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev openjdk-7-jdk gradle-2.2.1 autoconf-archive
+  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev openjdk-7-jdk gradle-2.2.1 autoconf-archive lcov
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 before_script:
   - ./autogen.sh
   - unset PYTHON_CFLAGS # HACK
-  - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
+  - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-gcov --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
   - if [ "$CC" = "clang" ]; then export COPYRIGHTVERBOSITY=1; make check-copyright; fi
   - make -j || make V=1 --keep-going # to make error messages more readable on error
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,35 @@ script:
 compiler:
   - gcc
   - clang
+after_success:
+  - rm libtest/*.gc* # HACK, otherwise lcov/gcov reports Out of memory! error
+  - lcov -c --config-file=.lcovrc --directory . --output-file coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/cfg-lex.l" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/pragma-grammar.y" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/afsocket/afsocket-grammar.y" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/parser-expr-grammar.y" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/compat/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/filter/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/logproto/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/rewrite/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/stats/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/template/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "lib/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "libtest/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/affile/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/afsocket/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/afstomp/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/basicfuncs/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/cryptofuncs/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/csvparser/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/dbparser/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/json/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/kvformat/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/linux-kmsg-format/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/modules/python/pylib/syslogng/debuggercli/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "modules/systemd-journal/tests/*" -o coverage.info
+  - lcov --config-file=.lcovrc --remove coverage.info "tests/*" -o coverage.info
+  - coveralls-lcov coverage.info
 branches:
   except:
     - /wip/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
   - gem install coveralls-lcov
 before_script:
   - ./autogen.sh
-  - unset PYTHON_CFLAGS # HACK
   - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-gcov --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
   - if [ "$CC" = "clang" ]; then export COPYRIGHTVERBOSITY=1; make check-copyright; fi
   - make -j || make V=1 --keep-going # to make error messages more readable on error

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: c
+sudo: required
+dist: trusty
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq curl

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
   - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-gcov --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
   - if [ "$CC" = "clang" ]; then export COPYRIGHTVERBOSITY=1; make check-copyright; fi
   - make -j || make V=1 --keep-going # to make error messages more readable on error
+  - make check
 script:
   - if [ "$CC" = "gcc" ]; then make distcheck V=1; else make func-test V=1; fi
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ install:
   - echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04 ./" | sudo tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
   - sudo apt-get update -qq
   - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev openjdk-7-jdk gradle-2.2.1 autoconf-archive lcov
+  - rvm install 2.0.0
   - sudo pip install -r requirements.txt
+  - gem install coveralls-lcov
 before_script:
   - ./autogen.sh
   - unset PYTHON_CFLAGS # HACK

--- a/configure.ac
+++ b/configure.ac
@@ -362,7 +362,7 @@ if test "x$ac_compiler_gnu" = "xyes"; then
                 CFLAGS="${CFLAGS} -pg"
         fi
         if test "x$enable_gcov" = "xyes"; then
-                CFLAGS="${CFLAGS} -fprofile-arcs -ftest-coverage"
+                CFLAGS="${CFLAGS} --coverage"
         fi
 fi
 CFLAGS="${CFLAGS} -pthread"


### PR DESCRIPTION
This PR implements unit and functional test coverage measurement.

gcc builds measure unit test coverage while clang builds mesure unit and functional test coverage.

Some notes:
- we need a Trusty container as Precise's old lcov/gcov is buggy
- the coveralls-lcov gem uploads the coverage data to coveralls.io (I enabled the service for this repo)
- we need to execute make check again

I sent this PR because I think it's somewhat useful. I'd extract the lcov commands into a shell scipt (like collect-cov.sh) just need to find a good place for it. What if I put all travis related files into a .travis directory?
