### PR TITLE
Fix Travis' python related issues in syslog-ng 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 before_script:
   - ./autogen.sh
 script:
+  - unset PYTHON_CFLAGS # HACK
   - ./configure --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
   - make && make distcheck VERBOSE=1 && make func-test VERBOSE=1
 compiler:

--- a/modules/python/pylib/syslogng/debuggercli/completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/completerlang.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, absolute_import
-import ply.yacc as yacc
 import sys
-from .tablexer import TabLexer
 from abc import abstractmethod, ABCMeta
+import ply.yacc as yacc
+from .tablexer import TabLexer
 
 
 class CompleterLang(object):

--- a/modules/python/pylib/syslogng/debuggercli/readline.py
+++ b/modules/python/pylib/syslogng/debuggercli/readline.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
-from .debuggercli import DebuggerCLI
 import readline
 import traceback
+from .debuggercli import DebuggerCLI
 
 
 class ReadlineCompleteHook(object):

--- a/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
+++ b/modules/python/pylib/syslogng/debuggercli/syslognginternals.py
@@ -79,7 +79,7 @@ def get_value_pairs_scopes():
 
 # override implementations from the module supplied by the C implementation.
 try:
-    # pylint: disable=import-error,wildcard-import
+    # pylint: disable=import-error,wildcard-import,wrong-import-position
     from _syslogngdbg import *
 except ImportError:
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 nose==1.3.6
 ply==3.6
 pep8==1.6.2
-pylint==1.4.3
+pylint==1.5.0
+astroid==1.4.0
 logilab-common<=0.63.0


### PR DESCRIPTION
From #837:
> Somehow, nowadays the infrastructure is unhealthy and some flags remain
set that interfere with autoconf include directory detection.

Also from #815:
> This PR updates some python dependencies and fixes the freshly introduced warnings.