### PR TITLE
configure.ac: link against sasl2 lib only when it is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -950,7 +950,7 @@ if test "x$with_mongoc" = "xinternal" || test "x$with_mongoc" = "xauto-internal"
 		LIBMONGO_LIBS="\
 			-L\$(top_builddir)/modules/afmongodb/mongo-c-driver \
 			-L\$(top_builddir)/modules/afmongodb/mongo-c-driver/src/libbson \
-			-lmongoc-1.0 -lbson -lsasl2 $OPENSSL_LIBS"
+			-lmongoc-1.0 -lbson $OPENSSL_LIBS"
 		LIBMONGO_CFLAGS="\
 			-I\$(top_srcdir)/modules/afmongodb/mongo-c-driver/src/mongoc \
 			-I\$(top_srcdir)/modules/afmongodb/mongo-c-driver/src/libbson/src/bson \
@@ -958,6 +958,7 @@ if test "x$with_mongoc" = "xinternal" || test "x$with_mongoc" = "xauto-internal"
 			-I\$(top_builddir)/modules/afmongodb/mongo-c-driver/src/mongoc \
 		"
 		LIBMONGO_SUBDIRS="modules/afmongodb/mongo-c-driver"
+		AC_CHECK_LIB(sasl2, prop_get, LIBMONGO_LIBS="$LIBMONGO_LIBS -lsasl2")
 	else
 		AC_MSG_WARN([Internal mongo-c-driver sources not found in modules/afmongodb/mongo-c-driver])
 		with_mongoc="no"


### PR DESCRIPTION
In mongo-c-driver sasl support is set to auto by default, but
we forced to link against the sasl2 lib.
As mongo-c-driver is able to work without sasl support, syslog-ng
should also be able to work.

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>