### PR TITLE
F/diskq

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -36,6 +36,8 @@
 #include <string.h>
 #include <iv_thread.h>
 
+const QueueType log_queue_fifo_type = "FIFO";
+
 /*
  * LogFifo is a scalable first-in-first-output queue implementation, that:
  *
@@ -520,6 +522,7 @@ log_queue_fifo_new(gint qoverflow_size, const gchar *persist_name)
   self = g_malloc0(sizeof(LogQueueFifo) + log_queue_max_threads * sizeof(self->qoverflow_input[0]));
 
   log_queue_init_instance(&self->super, persist_name);
+  self->super.type = log_queue_fifo_type;
   self->super.use_backlog = FALSE;
   self->super.get_length = log_queue_fifo_get_length;
   self->super.is_empty_racy = log_queue_fifo_is_empty_racy;

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -34,8 +34,11 @@ typedef void (*LogQueuePushNotifyFunc)(gpointer user_data);
 
 typedef struct _LogQueue LogQueue;
 
+typedef char *QueueType;
+
 struct _LogQueue
 {
+  QueueType type;
   /* this object is reference counted, but it is _not_ thread safe to
      acquire/release references in code executing in parallel */
   gint ref_cnt;

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -20,8 +20,10 @@ libtest_libsyslog_ng_test_a_SOURCES =   \
 	libtest/persist_lib.c		\
 	libtest/mock-transport.c	\
 	libtest/mock-transport.h    \
-    libtest/config_parse_lib.c  \
-    libtest/config_parse_lib.h
+  libtest/config_parse_lib.c  \
+  libtest/config_parse_lib.h  \
+  libtest/queue_utils_lib.c \
+  libtest/queue_utils_lib.h
 
 libtestinclude_HEADERS		    =	\
 	libtest/testutils.h		\

--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "queue_utils_lib.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <iv.h>
+#include <iv_thread.h>
+
+int acked_messages = 0;
+int fed_messages = 0;
+
+void
+test_ack(LogMessage *msg, AckType ack_type)
+{
+  acked_messages++;
+}
+
+void
+feed_some_messages(LogQueue *q, int n, MsgFormatOptions *po)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *msg;
+  gint i;
+
+  path_options.ack_needed = q->use_backlog;
+  path_options.flow_control_requested = TRUE;
+  for (i = 0; i < n; i++)
+    {
+      gchar *msg_str = g_strdup_printf("<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép ID :%08d",i);
+      GSockAddr *test_addr = g_sockaddr_inet_new("10.10.10.10", 1010);
+      msg = log_msg_new(msg_str, strlen(msg_str), test_addr, po);
+      g_sockaddr_unref(test_addr);
+      g_free(msg_str);
+
+      log_msg_add_ack(msg, &path_options);
+      msg->ack_func = test_ack;
+      log_queue_push_tail(q, msg, &path_options);
+      fed_messages++;
+    }
+}
+
+void
+send_some_messages(LogQueue *q, gint n)
+{
+  gint i;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  for (i = 0; i < n; i++)
+    {
+      LogMessage *msg = log_queue_pop_head(q, &path_options);
+      if (q->use_backlog)
+        {
+          log_msg_ack(msg, &path_options, AT_PROCESSED);
+        }
+      log_msg_unref(msg);
+    }
+}
+
+void
+app_rewind_some_messages(LogQueue *q, guint n)
+{
+  log_queue_rewind_backlog(q,n);
+}
+
+void
+app_ack_some_messages(LogQueue *q, guint n)
+{
+  log_queue_ack_backlog(q, n);
+}
+
+void
+rewind_messages(LogQueue *q)
+{
+  log_queue_rewind_backlog_all(q);
+}

--- a/libtest/queue_utils_lib.h
+++ b/libtest/queue_utils_lib.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef QUEUE_UTILS_LIB_H
+#define QUEUE_UTILS_LIB_H 1
+
+#include "logqueue.h"
+#include "logpipe.h"
+
+extern int acked_messages;
+extern int fed_messages;
+
+void test_ack(LogMessage *msg, AckType ack_type);
+void feed_some_messages(LogQueue *q, int n, MsgFormatOptions *po);
+
+void send_some_messages(LogQueue *q, gint n);
+
+void app_rewind_some_messages(LogQueue *q, guint n);
+
+void app_ack_some_messages(LogQueue *q, guint n);
+
+void rewind_messages(LogQueue *q);
+
+#endif

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -31,6 +31,7 @@ include modules/kvformat/Makefile.am
 include modules/date/Makefile.am
 include modules/native/Makefile.am
 include modules/cef/Makefile.am
+include modules/diskq/Makefile.am
 
 SYSLOG_NG_MODULES	=	\
 	mod-afsocket mod-afstreams mod-affile mod-afprog \
@@ -40,7 +41,7 @@ SYSLOG_NG_MODULES	=	\
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
 	mod-python mod-java mod-java-modules mod-kvformat mod-date \
-	mod-native mod-cef
+	mod-native mod-cef mod-disk-buffer
 
 modules modules/: ${SYSLOG_NG_MODULES}
 
@@ -54,6 +55,6 @@ modules_test_subdirs	=	\
 	modules_cryptofuncs modules_geoip modules_afstomp \
 	modules_graphite modules_riemann modules_python \
 	modules_systemd_journal modules_kvformat modules_date \
-	modules_cef
+	modules_cef modules_disk_buffer
 
 .PHONY: modules modules/

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -1,0 +1,36 @@
+BUILT_SOURCES += modules/diskq/diskq-grammar.y modules/diskq/diskq-grammar.c modules/diskq/diskq-grammar.h
+EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
+
+module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
+bin_PROGRAMS += modules/diskq/dqtool
+
+modules_diskq_libdisk_buffer_la_SOURCES = \
+  modules/diskq/diskq.c \
+  modules/diskq/diskq.h \
+  modules/diskq/diskq-grammar.y \
+  modules/diskq/diskq-options.h \
+  modules/diskq/diskq-options.c \
+  modules/diskq/diskq-parser.c \
+  modules/diskq/diskq-parser.h \
+  modules/diskq/diskq-plugin.c \
+  modules/diskq/logqueue-disk.c \
+  modules/diskq/logqueue-disk.h \
+  modules/diskq/logqueue-disk-non-reliable.c \
+  modules/diskq/logqueue-disk-non-reliable.h \
+  modules/diskq/logqueue-disk-reliable.c \
+  modules/diskq/logqueue-disk-reliable.h \
+  modules/diskq/qdisk.h \
+  modules/diskq/qdisk.c
+
+modules_diskq_libdisk_buffer_la_CFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq -I$(top_srcdir)/lib -I../../lib
+modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
+
+modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
+modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @BASE_LIBS@ @OPENSSL_LIBS@ @GLIB_LIBS@
+
+modules/diskq modules/diskq/ mod-disk-buffer: modules/diskq/libdisk-buffer.la
+
+include modules/diskq/tests/Makefile.am
+
+.PHONY: modules/diskq/ mod-disk-buffer

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "diskq-parser.h"
+
+}
+
+
+%code {
+
+#include "cfg-parser.h"
+#include "syslog-names.h"
+#include "messages.h"
+#include "diskq.h"
+#include "diskq-options.h"
+#include "diskq-grammar.h"
+
+#include <string.h>
+
+DiskQDestPlugin *last_plugin;
+DiskQueueOptions *last_options;
+
+}
+
+%name-prefix "diskq_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogDriverPlugin **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_DISK_BUFFER
+%token KW_MEM_BUF_LENGTH
+%token KW_DISK_BUF_SIZE
+%token KW_RELIABLE
+%token KW_MEM_BUF_SIZE
+%token KW_QOUT_SIZE
+%token KW_DIR
+
+
+%%
+
+start
+	: LL_CONTEXT_INNER_DEST dest_diskq { YYACCEPT; }
+	;
+
+dest_diskq
+        : KW_DISK_BUFFER
+          {
+            last_plugin = diskq_dest_plugin_new();
+            *instance = &last_plugin->super;
+            last_options = &last_plugin->options;
+          }
+          '(' dest_diskq_options ')' { disk_queue_options_check_plugin_settings(last_options); }
+        ;
+
+dest_diskq_options
+        : dest_diskq_option dest_diskq_options
+        |
+        ;
+
+dest_diskq_option
+        : KW_RELIABLE '(' yesno ')'            { disk_queue_options_reliable_set(last_options, $3); }
+        | KW_MEM_BUF_SIZE '(' LL_NUMBER ')'    { disk_queue_options_mem_buf_size_set(last_options, $3); }
+        | KW_MEM_BUF_LENGTH '(' LL_NUMBER ')'  { disk_queue_options_mem_buf_length_set(last_options, $3); }
+        | KW_DISK_BUF_SIZE '(' LL_NUMBER ')'   { disk_queue_options_disk_buf_size_set(last_options, $3); }
+        | KW_QOUT_SIZE '(' LL_NUMBER ')'       { disk_queue_options_qout_size_set(last_options, $3); }
+        | KW_DIR '(' string ')'                { disk_queue_options_set_dir(last_options, $3); free($3); }
+        ;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "diskq-options.h"
+#include "syslog-ng.h"
+#include "messages.h"
+#include "reloc.h"
+
+void
+disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size)
+{
+  if (qout_size < 64)
+    {
+      msg_warning("WARNING: The configured qout size is smaller than the minimum allowed",
+                  evt_tag_int("configured size", qout_size),
+                  evt_tag_int("minimum allowed size", 64),
+                  evt_tag_int("new size", 64),
+                  NULL);
+      qout_size = 64;
+    }
+  self->qout_size = qout_size;
+}
+
+void
+disk_queue_options_disk_buf_size_set(DiskQueueOptions *self, gint64 disk_buf_size)
+{
+  if (disk_buf_size == 0)
+    {
+      msg_warning("WARNING: The configured disk buffer size is zero. No disk queue file will be created.", NULL);
+    }
+  else if (disk_buf_size < MIN_DISK_BUF_SIZE)
+    {
+      msg_warning("WARNING: The configured disk buffer size is smaller than the minimum allowed",
+                  evt_tag_int("configured size", disk_buf_size),
+                  evt_tag_int("minimum allowed size", MIN_DISK_BUF_SIZE),
+                  evt_tag_int("new size", MIN_DISK_BUF_SIZE),
+                  NULL);
+      disk_buf_size = MIN_DISK_BUF_SIZE;
+    }
+  self->disk_buf_size = disk_buf_size;
+}
+
+void
+disk_queue_options_reliable_set(DiskQueueOptions *self, gboolean reliable)
+{
+  self->reliable = reliable;
+}
+
+void
+disk_queue_options_mem_buf_size_set(DiskQueueOptions *self, gint mem_buf_size)
+{
+  self->mem_buf_size = mem_buf_size;
+}
+
+void
+disk_queue_options_mem_buf_length_set(DiskQueueOptions *self, gint mem_buf_length)
+{
+  self->mem_buf_length = mem_buf_length;
+}
+
+void
+disk_queue_options_check_plugin_settings(DiskQueueOptions *self)
+{
+  if (self->reliable)
+    {
+      if (self->mem_buf_length > 0)
+        {
+          msg_warning("WARNING: Reliable queue: the mem-buf-length parameter is omitted", NULL);
+        }
+    }
+  else
+    {
+      if (self->mem_buf_size > 0)
+        {
+          msg_warning("WARNING: Non-reliable queue: the mem-buf-size parameter is omitted", NULL);
+        }
+    }
+}
+
+void
+disk_queue_options_set_dir(DiskQueueOptions *self, const gchar *dir)
+{
+  if (self->dir)
+    {
+      g_free(self->dir);
+    }
+  self->dir = g_strdup(dir);
+}
+
+void
+disk_queue_options_set_default_options(DiskQueueOptions *self)
+{
+  self->disk_buf_size = -1;
+  self->mem_buf_length = -1;
+  self->reliable = FALSE;
+  self->mem_buf_size = -1;
+  self->qout_size = -1;
+  self->dir = g_strdup(get_installation_path_for(SYSLOG_NG_PATH_LOCALSTATEDIR));
+}
+
+void
+disk_queue_options_destroy(DiskQueueOptions *self)
+{
+  if (self->dir)
+    {
+      g_free(self->dir);
+      self->dir = NULL;
+    }
+}
+
+

--- a/modules/diskq/diskq-options.h
+++ b/modules/diskq/diskq-options.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DISKQ_OPTIONS_H_
+#define DISKQ_OPTIONS_H_
+
+#include "syslog-ng.h"
+#include "logmsg/logmsg-serialize.h"
+
+#define MIN_DISK_BUF_SIZE 1024*1024
+
+typedef struct _DiskQueueOptions
+{
+  gint64 disk_buf_size;
+  gint qout_size;
+  gboolean read_only;
+  gboolean reliable;
+  gint mem_buf_size;
+  gint mem_buf_length;
+  gchar *dir;
+} DiskQueueOptions;
+
+void disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size);
+void disk_queue_options_disk_buf_size_set(DiskQueueOptions *self, gint64 disk_buf_size);
+void disk_queue_options_reliable_set(DiskQueueOptions *self, gboolean reliable);
+void disk_queue_options_mem_buf_size_set(DiskQueueOptions *self, gint mem_buf_size);
+void disk_queue_options_mem_buf_length_set(DiskQueueOptions *self, gint mem_buf_length);
+void disk_queue_options_check_plugin_settings(DiskQueueOptions *self);
+void disk_queue_options_set_dir(DiskQueueOptions *self, const gchar *dir);
+void disk_queue_options_set_default_options(DiskQueueOptions *self);
+void disk_queue_options_destroy(DiskQueueOptions *self);
+
+#endif /* DISKQ_OPTIONS_H_ */

--- a/modules/diskq/diskq-parser.c
+++ b/modules/diskq/diskq-parser.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "diskq.h"
+#include "cfg-parser.h"
+#include "diskq-grammar.h"
+
+extern int diskq_debug;
+int diskq_parse(CfgLexer *lexer, LogDriverPlugin **instance, gpointer arg);
+
+static CfgLexerKeyword diskq_keywords[] = {
+  { "disk_buffer",       KW_DISK_BUFFER },
+  { "mem_buf_length",    KW_MEM_BUF_LENGTH },
+  { "disk_buf_size",     KW_DISK_BUF_SIZE },
+  { "reliable",          KW_RELIABLE },
+  { "mem_buf_size",      KW_MEM_BUF_SIZE },
+  { "qout_size",         KW_QOUT_SIZE },
+  { "dir",               KW_DIR },
+  { NULL }
+};
+
+CfgParser diskq_parser =
+{
+#if ENABLE_DEBUG
+  .debug_flag = &diskq_debug,
+#endif
+  .name = "disk_buffer",
+  .keywords = diskq_keywords,
+  .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer arg)) diskq_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(diskq_, LogDriverPlugin **)

--- a/modules/diskq/diskq-parser.h
+++ b/modules/diskq/diskq-parser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DISKQ_PARSER_H_INCLUDED
+#define DISKQ_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+#include "diskq.h"
+
+extern CfgParser diskq_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(diskq_, LogDriverPlugin **)
+
+#endif

--- a/modules/diskq/diskq-plugin.c
+++ b/modules/diskq/diskq-plugin.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-parser.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser diskq_parser;
+
+static Plugin diskq_plugins[] =
+{
+  {
+    .type = LL_CONTEXT_INNER_DEST,
+    .name = "disk_buffer",
+    .parser = &diskq_parser,
+  },
+};
+
+#ifndef STATIC
+const ModuleInfo module_info =
+{
+  .canonical_name = "disk_buffer",
+  .version = SYSLOG_NG_VERSION,
+  .description = "This module provides disk buffer based queuing mechanism",
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
+  .plugins = diskq_plugins,
+  .plugins_len = G_N_ELEMENTS(diskq_plugins),
+};
+#endif
+
+gboolean
+disk_buffer_module_init(GlobalConfig *cfg, CfgArgs *args)
+{
+  plugin_register(cfg, diskq_plugins, G_N_ELEMENTS(diskq_plugins));
+  return TRUE;
+}

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "driver.h"
+#include "messages.h"
+
+#include "diskq.h"
+#include "logqueue-disk.h"
+#include "logqueue-disk-reliable.h"
+#include "logqueue-disk-non-reliable.h"
+#include "persist-state.h"
+
+static LogQueue *
+_acquire_queue(LogDestDriver *dd, gchar *persist_name, gpointer user_data)
+{
+  DiskQDestPlugin *self = (DiskQDestPlugin *) user_data;
+  GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);
+  LogQueue *queue = NULL;
+  gchar *qfile_name;
+  gboolean success;
+
+  if (persist_name)
+    queue = cfg_persist_config_fetch(cfg, persist_name);
+
+  if (queue)
+    {
+      if (queue->type != log_queue_disk_type || self->options.reliable != log_queue_disk_is_reliable(queue))
+        {
+          log_queue_unref(queue);
+          queue = NULL;
+        }
+    }
+
+  if (!queue)
+    {
+      if (self->options.reliable)
+        queue = log_queue_disk_reliable_new(&self->options);
+      else
+        queue = log_queue_disk_non_reliable_new(&self->options);
+      log_queue_set_throttle(queue, dd->throttle);
+      queue->persist_name = g_strdup(persist_name);
+    }
+
+  qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
+  success = log_queue_disk_load_queue(queue, qfile_name);
+  if (!success)
+    {
+      if (qfile_name && log_queue_disk_load_queue(queue, NULL))
+        {
+          msg_error("Error opening disk-queue file, a new one started",
+                    evt_tag_str("old_filename", qfile_name),
+                    evt_tag_str("new_filename", log_queue_disk_get_filename(queue)),
+                    NULL);
+          g_free(qfile_name);
+        }
+      else
+        {
+          g_free(qfile_name);
+          msg_error("Error initializing log queue", NULL);
+          return NULL;
+        }
+    }
+
+  if (persist_name)
+    {
+      /* save the queue file name to permanent state */
+      qfile_name = (gchar *) log_queue_disk_get_filename(queue);
+      if (qfile_name)
+        {
+          persist_state_alloc_string(cfg->state, persist_name, qfile_name, -1);
+        }
+    }
+
+  return queue;
+}
+
+void
+_release_queue(LogDestDriver *dd, LogQueue *queue, gpointer user_data)
+{
+  GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);
+  gboolean persistent;
+
+  log_queue_disk_save_queue(queue, &persistent);
+  if (queue->persist_name)
+    {
+      cfg_persist_config_add(cfg, queue->persist_name, queue, (GDestroyNotify) log_queue_unref, FALSE);
+    }
+  else
+    {
+      log_queue_unref(queue);
+    }
+}
+
+static gboolean
+_attach(LogDriverPlugin *s, LogDriver *d)
+{
+  DiskQDestPlugin *self = (DiskQDestPlugin *) s;
+  LogDestDriver *dd = (LogDestDriver *) d;
+  GlobalConfig *cfg = log_pipe_get_config(&d->super);
+
+  if (self->options.disk_buf_size == -1)
+    {
+      msg_error("The required 'disk_buf_size()' parameter of diskq module has not been set.", NULL);
+      return FALSE;
+    }
+
+  if (self->options.disk_buf_size < MIN_DISK_BUF_SIZE && self->options.disk_buf_size != 0)
+    {
+      msg_warning("The value of 'disk_buf_size()' is too low, setting to the smallest acceptable value",
+                  evt_tag_int("min_space", MIN_DISK_BUF_SIZE),
+                  NULL);
+      self->options.disk_buf_size = MIN_DISK_BUF_SIZE;
+    }
+
+  if (dd->acquire_queue_data || dd->release_queue_data)
+    if (dd->acquire_queue_data != self)
+      {
+        msg_error("Another queueing plugin is registered in this destination, unable to register diskq again",
+                  evt_tag_str("driver", dd->super.id),
+                  NULL);
+        return FALSE;
+      }
+
+  if (self->options.mem_buf_length < 0)
+    self->options.mem_buf_length = dd->log_fifo_size;
+  if (self->options.mem_buf_length < 0)
+    self->options.mem_buf_length = cfg->log_fifo_size;
+  if (self->options.qout_size < 0)
+    self->options.qout_size = 64;
+
+  dd->acquire_queue_data = self;
+  dd->acquire_queue = _acquire_queue;
+  dd->release_queue_data = self;
+  dd->release_queue = _release_queue;
+  return TRUE;
+}
+
+static void
+_free(LogDriverPlugin *s)
+{
+  DiskQDestPlugin *self = (DiskQDestPlugin *)s;
+  disk_queue_options_destroy(&self->options);
+}
+
+
+DiskQDestPlugin *
+diskq_dest_plugin_new(void)
+{
+  DiskQDestPlugin *self = g_new0(DiskQDestPlugin, 1);
+
+  log_driver_plugin_init_instance(&self->super);
+  disk_queue_options_set_default_options(&self->options);
+  self->super.attach = _attach;
+  self->super.free_fn = _free;
+  return self;
+}

--- a/modules/diskq/diskq.h
+++ b/modules/diskq/diskq.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DISKQ_H
+#define DISKQ_H
+
+#include "config.h"
+#include "logqueue.h"
+#include "driver.h"
+#include "logmsg/logmsg-serialize.h"
+#include "diskq-options.h"
+
+typedef struct _DiskQDestPlugin
+{
+  LogDriverPlugin super;
+  DiskQueueOptions options;
+} DiskQDestPlugin;
+
+DiskQDestPlugin *diskq_dest_plugin_new(void);
+
+#endif

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "logqueue.h"
+#include "template/templates.h"
+#include "logmsg/logmsg.h"
+#include "tags.h"
+#include "messages.h"
+#include "logpipe.h"
+#include "logqueue-disk.h"
+#include "logqueue-disk-reliable.h"
+#include "logqueue-disk-non-reliable.h"
+#include "logmsg/logmsg-serialize.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+gchar *template_string;
+gboolean display_version;
+gboolean debug_flag;
+gboolean verbose_flag;
+
+static GOptionEntry cat_options[] =
+{
+  { "template",  't', 0, G_OPTION_ARG_STRING, &template_string,
+    "Template to format the serialized messages", "<template>" },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+static GOptionEntry info_options[] =
+{
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+static gboolean
+open_queue(char *filename, LogQueue **lq, DiskQueueOptions *options)
+{
+  options->read_only = TRUE;
+  options->reliable = FALSE;
+  FILE *f = fopen(filename, "rb");
+  if (f)
+    {
+      gchar idbuf[5];
+      if (fread(idbuf, 4, 1, f) == 0)
+        fprintf(stderr, "File reading error: %s\n", filename);
+      fclose(f);
+      idbuf[4] = '\0';
+      if (!strcmp(idbuf, "SLRQ"))
+        options->reliable = TRUE;
+    }
+  else
+    {
+      fprintf(stderr, "File not found: %s\n", filename);
+      return FALSE;
+    }
+
+  if (options->reliable)
+    {
+      options->disk_buf_size = 128;
+      options->mem_buf_size = 1024 * 1024;
+      *lq = log_queue_disk_reliable_new(options);
+    }
+  else
+    {
+      options->disk_buf_size = 1;
+      options->mem_buf_size = 128;
+      options->qout_size = 128;
+      *lq = log_queue_disk_non_reliable_new(options);
+    }
+
+  if (!log_queue_disk_load_queue(*lq, filename))
+    {
+      fprintf(stderr, "Error restoring disk buffer file.\n");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gint
+dqtool_cat(int argc, char *argv[])
+{
+  GString *msg;
+  LogMessage *log_msg = NULL;
+  GError *error = NULL;
+  LogTemplate *template = NULL;
+  DiskQueueOptions options = {0};
+  gint i;
+
+  if (template_string)
+    {
+      template_string = g_strcompress(template_string);
+      template = log_template_new(configuration, NULL);
+      if (!log_template_compile(template, template_string, &error))
+        {
+          fprintf(stderr, "Error compiling template: %s, error: %s\n", template->template, error->message);
+          g_clear_error(&error);
+          return 1;
+        }
+      g_free(template_string);
+    }
+
+  if (!template)
+    {
+      template = log_template_new(configuration, NULL);
+      log_template_compile(template, "$DATE $HOST $MSGHDR$MSG\n", NULL);
+    }
+
+  msg = g_string_sized_new(128);
+  for (i = optind; i < argc; i++)
+    {
+      LogPathOptions local_options = LOG_PATH_OPTIONS_INIT;
+      LogQueue *lq;
+
+      if (!open_queue(argv[i], &lq, &options))
+        continue;
+
+      while ((log_msg = log_queue_pop_head(lq, &local_options)) != NULL)
+        {
+          /* format log */
+          log_template_format(template, log_msg, &configuration->template_options, LTZ_LOCAL, 0, NULL, msg);
+          log_msg_unref(log_msg);
+          log_msg = NULL;
+
+          printf("%s", msg->str);
+        }
+
+      log_queue_unref(lq);
+    }
+  g_string_free(msg, TRUE);
+  return 0;
+
+}
+
+static gint
+dqtool_info(int argc, char *argv[])
+{
+  gint i;
+  for (i = optind; i < argc; i++)
+    {
+      LogQueue *lq;
+      DiskQueueOptions options = {0};
+
+      if (!open_queue(argv[i], &lq, &options))
+        continue;
+      log_queue_unref(lq);
+    }
+  return 0;
+}
+
+static GOptionEntry dqtool_options[] =
+{
+  { "debug",     'd', 0, G_OPTION_ARG_NONE, &debug_flag,
+    "Enable debug/diagnostic messages on stderr", NULL },
+  { "verbose",   'v', 0, G_OPTION_ARG_NONE, &verbose_flag,
+    "Enable verbose messages on stderr", NULL },
+  { "version",   'V', 0, G_OPTION_ARG_NONE, &display_version,
+    "Display version number (" SYSLOG_NG_VERSION ")", NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+static struct
+{
+  const gchar *mode;
+  const GOptionEntry *options;
+  const gchar *description;
+  gint (*main)(gint argc, gchar *argv[]);
+} modes[] =
+{
+  { "cat", cat_options, "Print the contents of a disk queue file", dqtool_cat },
+  { "info", info_options, "Print infos about the given disk queue file", dqtool_info },
+  { NULL, NULL },
+};
+
+static const gchar *
+dqtool_mode(int *argc, char **argv[])
+{
+  gint i;
+  const gchar *mode;
+
+  for (i = 1; i < (*argc); i++)
+    {
+      if ((*argv)[i][0] != '-')
+        {
+          mode = (*argv)[i];
+          memmove(&(*argv)[i], &(*argv)[i+1], ((*argc) - i) * sizeof(gchar *));
+          (*argc)--;
+          return mode;
+        }
+    }
+  return NULL;
+}
+
+void
+usage(void)
+{
+  gint mode;
+
+  fprintf(stderr, "Syntax: dqtool <command> [options]\nPossible commands are:\n");
+  for (mode = 0; modes[mode].mode; mode++)
+    {
+      fprintf(stderr, "    %-12s %s\n", modes[mode].mode, modes[mode].description);
+    }
+  exit(1);
+}
+
+void
+version(void)
+{
+  printf(SYSLOG_NG_VERSION "\n");
+}
+
+int
+main(int argc, char *argv[])
+{
+  const gchar *mode_string;
+  GOptionContext *ctx;
+  gint mode;
+  GError *error = NULL;
+
+  mode_string = dqtool_mode(&argc, &argv);
+  if (!mode_string)
+    {
+      usage();
+    }
+
+  ctx = NULL;
+  for (mode = 0; modes[mode].mode; mode++)
+    {
+      if (strcmp(modes[mode].mode, mode_string) == 0)
+        {
+          ctx = g_option_context_new(mode_string);
+#if GLIB_CHECK_VERSION (2, 12, 0)
+          g_option_context_set_summary(ctx, modes[mode].description);
+#endif
+          g_option_context_add_main_entries(ctx, modes[mode].options, NULL);
+          g_option_context_add_main_entries(ctx, dqtool_options, NULL);
+          break;
+        }
+    }
+
+  if (!ctx)
+    {
+      fprintf(stderr, "Unknown command\n");
+      usage();
+    }
+
+  if (!g_option_context_parse(ctx, &argc, &argv, &error))
+    {
+      fprintf(stderr, "Error parsing command line arguments: %s\n", error ? error->message : "Invalid arguments");
+      g_clear_error(&error);
+      g_option_context_free(ctx);
+      return 1;
+    }
+  g_option_context_free(ctx);
+  if (display_version)
+    {
+      version();
+      return 0;
+    }
+
+  configuration = cfg_new(0x0307);
+  configuration->template_options.frac_digits = 3;
+  configuration->template_options.time_zone_info[LTZ_LOCAL] = time_zone_info_new(NULL);
+
+  msg_init(TRUE);
+  log_template_global_init();
+  log_msg_registry_init();
+  log_tags_global_init();
+  modes[mode].main(argc, argv);
+  log_tags_global_deinit();
+  msg_deinit();
+  return 0;
+
+}

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logqueue-disk-non-reliable.h"
+#include "logpipe.h"
+#include "messages.h"
+#include "syslog-ng.h"
+
+#define ITEM_NUMBER_PER_MESSAGE 2
+
+static gboolean
+_start(LogQueueDisk *s, const gchar *filename)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  return qdisk_start(s->qdisk, filename, self->qout, self->qbacklog, self->qoverflow);
+}
+
+static inline guint
+_get_message_number_in_queue(GQueue *queue)
+{
+  return queue->length / ITEM_NUMBER_PER_MESSAGE;
+}
+
+#define HAS_SPACE_IN_QUEUE(queue) _get_message_number_in_queue(queue) < queue ## _size
+
+static gint64
+_get_length (LogQueueDisk *s)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  return _get_message_number_in_queue(self->qout)
+         + qdisk_get_length (s->qdisk)
+         + _get_message_number_in_queue(self->qoverflow);
+}
+
+static LogMessage *
+_get_next_message(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
+{
+  LogMessage *result = NULL;
+  path_options->ack_needed = TRUE;
+  if (qdisk_get_length (self->super.qdisk) > 0)
+    {
+      result = self->super.read_message(&self->super, path_options);
+      path_options->ack_needed = FALSE;
+    }
+  else if (self->qoverflow->length > 0)
+    {
+      result = g_queue_pop_head (self->qoverflow);
+      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qoverflow), path_options);
+    }
+  return result;
+}
+
+static inline gboolean
+_could_move_into_qout(LogQueueDiskNonReliable *self)
+{
+  /* NOTE: we only load half the qout queue at a time */
+  return (_get_message_number_in_queue(self->qout) < (self->qout_size / 2));
+}
+
+static void
+_add_message_to_qout(LogQueueDiskNonReliable *self, LogMessage *msg, LogPathOptions *path_options)
+{
+  /* NOTE: we always generate flow-control disabled entries into
+   * qout, they only get there via backlog rewind */
+
+  g_queue_push_tail (self->qout, msg);
+  g_queue_push_tail (self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
+  log_msg_ack (msg, path_options, AT_PROCESSED);
+}
+
+static inline gboolean
+_has_movable_message(LogQueueDiskNonReliable *self)
+{
+  return self->qoverflow->length > 0
+      && ((HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length (self->super.qdisk) == 0)
+          || qdisk_is_space_avail (self->super.qdisk, 4096));
+}
+
+static void
+_move_messages_from_overflow(LogQueueDiskNonReliable *self)
+{
+  LogMessage *msg;
+  LogPathOptions path_options;
+  /* move away as much entries from the overflow area as possible */
+  while (_has_movable_message(self))
+    {
+      msg = g_queue_pop_head (self->qoverflow);
+      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qoverflow), &path_options);
+
+      if (qdisk_get_length (self->super.qdisk) == 0 && HAS_SPACE_IN_QUEUE(self->qout))
+        {
+          /* we can skip qdisk, go straight to qout */
+          g_queue_push_tail (self->qout, msg);
+          g_queue_push_tail (self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
+          log_msg_ref (msg);
+        }
+      else
+        {
+          if (!self->super.write_message(&self->super, msg))
+            {
+              /* oops, altough there seemed to be some free space available,
+               * we failed saving this message, (it might have needed more
+               * than 4096 bytes than we ensured), push back and break
+               */
+              g_queue_push_head (self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER (&path_options));
+              g_queue_push_head (self->qoverflow, msg);
+              log_msg_ref (msg);
+              break;
+            }
+        }
+      log_msg_ack (msg, &path_options, AT_PROCESSED);
+      log_msg_unref (msg);
+    }
+}
+
+static void
+_move_disk (LogQueueDiskNonReliable *self)
+{
+  LogMessage *msg;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  if (qdisk_is_read_only (self->super.qdisk))
+    return;
+
+  /* stupid message mover between queues */
+
+  if (self->qout->length == 0 && self->qout_size > 0)
+    {
+      do
+        {
+          msg = _get_next_message(self, &path_options);
+
+          if (msg)
+            {
+              _add_message_to_qout(self, msg, &path_options);
+            }
+        }
+      while (msg && _could_move_into_qout(self));
+    }
+  _move_messages_from_overflow(self);
+}
+
+static void
+_ack_backlog (LogQueueDisk *s, guint num_msg_to_ack)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  LogMessage *msg;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  guint i;
+
+  for (i = 0; i < num_msg_to_ack; i++)
+    {
+      if (self->qbacklog->length < ITEM_NUMBER_PER_MESSAGE)
+        return;
+      msg = g_queue_pop_head (self->qbacklog);
+      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qbacklog), &path_options);
+      log_msg_unref (msg);
+      log_msg_ack (msg, &path_options, AT_PROCESSED);
+    }
+}
+
+static void
+_rewind_backlog (LogQueueDisk *s, guint rewind_count)
+{
+  guint i;
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+
+  rewind_count = MIN(rewind_count, _get_message_number_in_queue(self->qbacklog));
+
+  for (i = 0; i < rewind_count; i++)
+    {
+      gpointer ptr_opt = g_queue_pop_tail (self->qbacklog);
+      gpointer ptr_msg = g_queue_pop_tail (self->qbacklog);
+
+      g_queue_push_head (self->qout, ptr_opt);
+      g_queue_push_head (self->qout, ptr_msg);
+
+      stats_counter_inc (self->super.super.stored_messages);
+    }
+}
+
+static LogMessage *
+_pop_head (LogQueueDisk *s, LogPathOptions *path_options)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  LogMessage *msg = NULL;
+
+  if (self->qout->length > 0)
+    {
+      msg = g_queue_pop_head (self->qout);
+      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qout), path_options);
+    }
+  if (msg == NULL)
+    {
+      msg = s->read_message(s, path_options);
+      if (msg)
+        {
+          path_options->ack_needed = FALSE;
+        }
+    }
+  if (msg == NULL)
+    {
+      if (self->qoverflow->length > 0 && qdisk_is_read_only (self->super.qdisk))
+        {
+          msg = g_queue_pop_head (self->qoverflow);
+          POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qoverflow), path_options);
+        }
+    }
+
+  if (msg != NULL)
+    {
+      if (self->super.super.use_backlog)
+        {
+          log_msg_ref (msg);
+          g_queue_push_tail (self->qbacklog, msg);
+          g_queue_push_tail (self->qbacklog, LOG_PATH_OPTIONS_TO_POINTER (path_options));
+        }
+      _move_disk (self);
+    }
+  return msg;
+}
+
+static void
+_push_head (LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+
+  g_static_mutex_lock(&self->super.super.lock);
+  g_queue_push_head (self->qout, LOG_PATH_OPTIONS_TO_POINTER (path_options));
+  g_queue_push_head (self->qout, msg);
+  stats_counter_inc (self->super.super.stored_messages);
+  g_static_mutex_unlock(&self->super.super.lock);
+}
+
+static gboolean
+_push_tail (LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, const LogPathOptions *path_options)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+
+  if (HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length (self->super.qdisk) == 0)
+    {
+      /* simple push never generates flow-control enabled entries to qout, they only get there
+       * when rewinding the backlog */
+
+      g_queue_push_tail (self->qout, msg);
+      g_queue_push_tail (self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
+      log_msg_ref (msg);
+    }
+  else
+    {
+      if (self->qoverflow->length != 0 || !s->write_message(s, msg))
+        {
+          if (HAS_SPACE_IN_QUEUE(self->qoverflow))
+            {
+              g_queue_push_tail (self->qoverflow, msg);
+              g_queue_push_tail (self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER (path_options));
+              log_msg_ref (msg);
+              local_options->ack_needed = FALSE;
+            }
+          else
+            {
+              msg_debug ("Destination queue full, dropping message",
+                         evt_tag_str ("filename", qdisk_get_filename (self->super.qdisk)),
+                         evt_tag_int ("queue_len", _get_length(s)),
+                         evt_tag_int ("mem_buf_length", self->qoverflow_size),
+                         evt_tag_int ("size", qdisk_get_size (self->super.qdisk)),
+                         evt_tag_str ("persist_name", self->super.super.persist_name),
+                         NULL);
+              return FALSE;
+            }
+        }
+    }
+  return TRUE;
+}
+
+static void
+_free_queue (GQueue *q)
+{
+  while (!g_queue_is_empty (q))
+    {
+      LogMessage *lm;
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+      lm = g_queue_pop_head (q);
+      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (q), &path_options);
+      log_msg_ack (lm, &path_options, AT_PROCESSED);
+      log_msg_unref (lm);
+    }
+  g_queue_free (q);
+}
+
+static void
+_freefn (LogQueueDisk *s)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  _free_queue (self->qoverflow);
+  self->qoverflow = NULL;
+  _free_queue (self->qout);
+  self->qout = NULL;
+  _free_queue (self->qbacklog);
+  self->qbacklog = NULL;
+}
+
+static gboolean
+_load_queue (LogQueueDisk *s, const gchar *filename)
+{
+  /* qdisk portion is not yet started when this happens */
+  g_assert(!qdisk_initialized (s->qdisk));
+
+  return _start(s, filename);
+}
+
+static gboolean
+_save_queue (LogQueueDisk *s, gboolean *persistent)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  if (qdisk_save_state (s->qdisk, self->qout, self->qbacklog, self->qoverflow))
+    {
+      *persistent = TRUE;
+      qdisk_deinit (s->qdisk);
+      return TRUE;
+    }
+  return FALSE;
+}
+
+static void
+_set_virtual_functions (LogQueueDisk *self)
+{
+  self->get_length = _get_length;
+  self->ack_backlog = _ack_backlog;
+  self->rewind_backlog = _rewind_backlog;
+  self->pop_head = _pop_head;
+  self->push_head = _push_head;
+  self->push_tail = _push_tail;
+  self->start = _start;
+  self->free_fn = _freefn;
+  self->load_queue = _load_queue;
+  self->save_queue = _save_queue;
+}
+
+LogQueue *
+log_queue_disk_non_reliable_new(DiskQueueOptions *options)
+{
+  g_assert(options->reliable == FALSE);
+  LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
+  log_queue_disk_init_instance (&self->super);
+  qdisk_init (self->super.qdisk, options);
+  self->qbacklog = g_queue_new ();
+  self->qout = g_queue_new ();
+  self->qoverflow = g_queue_new ();
+  self->qout_size = options->qout_size;
+  self->qoverflow_size = options->mem_buf_size;
+  _set_virtual_functions (&self->super);
+  return &self->super.super;
+}
+

--- a/modules/diskq/logqueue-disk-non-reliable.h
+++ b/modules/diskq/logqueue-disk-non-reliable.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LOG_QUEUE_DISK_NON_RELIABLE_H_
+#define LOG_QUEUE_DISK_NON_RELIABLE_H_
+
+#include "logqueue-disk.h"
+
+typedef struct _LogQueueDiskNonReliable
+{
+  LogQueueDisk super;
+  GQueue *qout;
+  GQueue *qoverflow;
+  GQueue *qbacklog;
+  gint qoverflow_size;
+  gint qout_size;
+} LogQueueDiskNonReliable;
+
+LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options);
+
+#endif /* LOG_QUEUE_DISK_NON_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "qdisk.h"
+#include "logpipe.h"
+#include "logqueue-disk-reliable.h"
+#include "messages.h"
+
+static gboolean
+_start(LogQueueDisk *s, const gchar *filename)
+{
+  return qdisk_start(s->qdisk, filename, NULL, NULL, NULL);
+}
+
+static gboolean
+_skip_message(LogQueueDisk *self)
+{
+  GString *serialized;
+  SerializeArchive *sa;
+
+  if (!qdisk_initialized(self->qdisk))
+    return FALSE;
+
+  serialized = g_string_sized_new(64);
+  if (!qdisk_pop_head(self->qdisk, serialized))
+    {
+      g_string_free(serialized, TRUE);
+      return FALSE;
+    }
+
+  sa = serialize_string_archive_new(serialized);
+  serialize_archive_free(sa);
+
+  g_string_free(serialized, TRUE);
+  return TRUE;
+}
+
+static void
+_empty_queue(GQueue *self)
+{
+  while (self && self->length > 0)
+    {
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+      gint64 *temppos = g_queue_pop_head(self);
+      LogMessage *msg = g_queue_pop_head(self);
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self), &path_options);
+
+      g_free(temppos);
+      log_msg_drop(msg, &path_options, AT_PROCESSED);
+    }
+}
+
+static gint64
+_get_length(LogQueueDisk *self)
+{
+  return qdisk_get_length(self->qdisk);
+}
+
+static void
+_ack_backlog(LogQueueDisk *s, guint num_msg_to_ack)
+{
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+  LogMessage *msg;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  guint i;
+
+  for (i = 0; i < num_msg_to_ack; i++)
+    {
+      gint64 pos;
+      if (qdisk_get_backlog_head (self->super.qdisk) == qdisk_get_reader_head (self->super.qdisk))
+        {
+          goto exit_reliable;
+        }
+      if (self->qbacklog->length > 0)
+        {
+          gint64 *temppos = g_queue_pop_head (self->qbacklog);
+          pos = *temppos;
+          if (pos == qdisk_get_backlog_head (self->super.qdisk))
+            {
+              msg = g_queue_pop_head (self->qbacklog);
+              POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qbacklog), &path_options);
+              log_msg_ack (msg, &path_options, AT_PROCESSED);
+              log_msg_unref (msg);
+              g_free (temppos);
+            }
+          else
+            {
+              g_queue_push_head (self->qbacklog, temppos);
+            }
+        }
+      guint64 new_backlog = qdisk_get_backlog_head (self->super.qdisk);
+      new_backlog = qdisk_skip_record(self->super.qdisk, new_backlog);
+      qdisk_set_backlog_head (self->super.qdisk, new_backlog);
+      qdisk_dec_backlog (self->super.qdisk);
+    }
+exit_reliable:
+  qdisk_reset_file_if_possible (self->super.qdisk);
+}
+
+static gint
+_find_pos_in_qbacklog(LogQueueDiskReliable *self, gint64 new_pos)
+{
+  gint result = -1;
+  int i = 0;
+  GList *item = self->qbacklog->tail;
+  while (result == -1 && item != NULL)
+    {
+      GList *pos_i = item->prev->prev;
+      gint64 *pos = pos_i->data;
+      if (*pos == new_pos)
+        {
+          result = i;
+        }
+      item = pos_i->prev;
+      i++;
+    }
+  return result;
+}
+
+static void
+_move_message_from_qbacklog_to_qreliable(LogQueueDiskReliable *self)
+{
+  gpointer ptr_opt = g_queue_pop_tail(self->qbacklog);
+  gpointer ptr_msg = g_queue_pop_tail(self->qbacklog);
+  gpointer ptr_pos = g_queue_pop_tail(self->qbacklog);
+
+  g_queue_push_head(self->qreliable, ptr_opt);
+  g_queue_push_head(self->qreliable, ptr_msg);
+  g_queue_push_head(self->qreliable, ptr_pos);
+}
+
+static void
+_rewind_from_qbacklog(LogQueueDiskReliable *self, gint64 new_pos)
+{
+  gint i;
+  g_assert((self->qbacklog->length % 3) == 0);
+
+  gint rewind_backlog_queue = _find_pos_in_qbacklog(self, new_pos);
+
+  for (i = 0; i <= rewind_backlog_queue; i++)
+    {
+      _move_message_from_qbacklog_to_qreliable(self);
+    }
+}
+
+
+static void
+_rewind_backlog(LogQueueDisk *s, guint rewind_count)
+{
+  guint i;
+
+  guint number_of_messages_stay_in_backlog;
+  gint64 new_read_head;
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+
+  rewind_count = MIN(rewind_count, qdisk_get_backlog_count (self->super.qdisk));
+  number_of_messages_stay_in_backlog = qdisk_get_backlog_count (self->super.qdisk) - rewind_count;
+  new_read_head = qdisk_get_backlog_head (self->super.qdisk);
+  for (i = 0; i < number_of_messages_stay_in_backlog; i++)
+    {
+      new_read_head = qdisk_skip_record(self->super.qdisk, new_read_head);
+    }
+
+  _rewind_from_qbacklog(self, new_read_head);
+
+  qdisk_set_backlog_count (self->super.qdisk, number_of_messages_stay_in_backlog);
+  qdisk_set_reader_head (self->super.qdisk, new_read_head);
+  qdisk_set_length (self->super.qdisk, qdisk_get_length (self->super.qdisk) + rewind_count);
+
+  stats_counter_add (self->super.super.stored_messages, rewind_count);
+}
+
+static LogMessage *
+_pop_head(LogQueueDisk *s, LogPathOptions *path_options)
+{
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+  LogMessage *msg = NULL;
+  if (self->qreliable->length > 0)
+    {
+      gint64 *temppos = g_queue_pop_head (self->qreliable);
+      gint64 pos = *temppos;
+      if (pos == qdisk_get_reader_head (self->super.qdisk))
+        {
+          msg = g_queue_pop_head (self->qreliable);
+          POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qreliable), path_options);
+          _skip_message (s);
+          if (self->super.super.use_backlog)
+            {
+              log_msg_ref (msg);
+              g_queue_push_tail (self->qbacklog, temppos);
+              g_queue_push_tail (self->qbacklog, msg);
+              g_queue_push_tail (self->qbacklog, LOG_PATH_OPTIONS_TO_POINTER (path_options));
+            }
+          else
+            {
+              g_free (temppos);
+            }
+        }
+      else
+        {
+          /* try to write the message to the disk */
+          g_queue_push_head (self->qreliable, temppos);
+        }
+    }
+
+  if (msg == NULL)
+    {
+      msg = s->read_message(s, path_options);
+      if (msg)
+        {
+          path_options->ack_needed = FALSE;
+        }
+    }
+
+  if (msg != NULL)
+    {
+      if (self->super.super.use_backlog)
+        {
+          qdisk_inc_backlog(self->super.qdisk);
+        }
+      else
+        {
+          qdisk_set_backlog_head(self->super.qdisk, qdisk_get_reader_head(self->super.qdisk));
+        }
+    }
+  return msg;
+}
+
+static gboolean
+_push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, const LogPathOptions *path_options)
+{
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+
+  gint64 last_wpos = qdisk_get_writer_head (self->super.qdisk);
+  if (!s->write_message(s, msg))
+    {
+      /* we were not able to store the msg, warn */
+      msg_error("Destination reliable queue full, dropping message",
+                evt_tag_str("filename", qdisk_get_filename (self->super.qdisk)),
+                evt_tag_int("queue_len", _get_length(s)),
+                evt_tag_int("mem_buf_size", qdisk_get_memory_size (self->super.qdisk)),
+                evt_tag_int("disk_buf_size", qdisk_get_size (self->super.qdisk)),
+                evt_tag_str("persist_name", self->super.super.persist_name), NULL);
+
+      return FALSE;
+    }
+
+  /* check the remaining space: if it is less than the mem_buf_size, the message cannot be acked */
+  gint64 wpos = qdisk_get_writer_head (self->super.qdisk);
+  gint64 bpos = qdisk_get_backlog_head (self->super.qdisk);
+  gint64 diff;
+  if (wpos > bpos)
+    diff = qdisk_get_size (self->super.qdisk) - wpos + bpos - QDISK_RESERVED_SPACE;
+  else
+    diff = bpos - wpos;
+  gboolean overflow = diff < qdisk_get_memory_size (self->super.qdisk);
+
+  if (overflow)
+    {
+      /* we have reached the reserved buffer size, keep the msg in memory
+       * the message is written but into the overflow area
+       */
+      gint64 *temppos = g_malloc (sizeof(gint64));
+      *temppos = last_wpos;
+      g_queue_push_tail (self->qreliable, temppos);
+      g_queue_push_tail (self->qreliable, msg);
+      g_queue_push_tail (self->qreliable, LOG_PATH_OPTIONS_TO_POINTER(path_options));
+      log_msg_ref (msg);
+
+      local_options->ack_needed = FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+_free_queue(LogQueueDisk *s)
+{
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+  _empty_queue(self->qreliable);
+  _empty_queue(self->qbacklog);
+  g_queue_free(self->qreliable);
+  self->qreliable = NULL;
+  g_queue_free(self->qbacklog);
+  self->qbacklog = NULL;
+}
+
+static gboolean
+_load_queue(LogQueueDisk *s, const gchar *filename)
+{
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+  _empty_queue(self->qreliable);
+  return qdisk_start(s->qdisk, filename, NULL, NULL, NULL);
+}
+
+static gboolean
+_save_queue (LogQueueDisk *s, gboolean *persistent)
+{
+  *persistent = TRUE;
+  qdisk_deinit (s->qdisk);
+  return TRUE;
+}
+
+
+static void
+_set_virtual_functions(LogQueueDisk *self)
+{
+  self->get_length = _get_length;
+  self->ack_backlog = _ack_backlog;
+  self->rewind_backlog = _rewind_backlog;
+  self->pop_head = _pop_head;
+  self->push_tail = _push_tail;
+  self->free_fn = _free_queue;
+  self->load_queue = _load_queue;
+  self->start = _start;
+  self->save_queue = _save_queue;
+}
+
+LogQueue *
+log_queue_disk_reliable_new(DiskQueueOptions *options)
+{
+  g_assert(options->reliable == TRUE);
+  LogQueueDiskReliable *self = g_new0(LogQueueDiskReliable, 1);
+  log_queue_disk_init_instance(&self->super);
+  qdisk_init(self->super.qdisk, options);
+  self->qreliable = g_queue_new();
+  self->qbacklog = g_queue_new();
+  _set_virtual_functions(&self->super);
+  return &self->super.super;
+}

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LOGQUEUE_DISK_RELIABLE_H_
+#define LOGQUEUE_DISK_RELIABLE_H_
+
+#include "logqueue-disk.h"
+
+typedef struct _LogQueueDiskReliable
+{
+  LogQueueDisk super;
+  GQueue *qreliable;
+  GQueue *qbacklog;
+} LogQueueDiskReliable;
+
+LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options);
+
+#endif /* LOGQUEUE_DISK_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logqueue-disk.h"
+#include "logpipe.h"
+#include "messages.h"
+#include "serialize.h"
+#include "logmsg/logmsg-serialize.h"
+#include "stats/stats-registry.h"
+#include "reloc.h"
+#include "qdisk.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifndef _WIN32
+#include <sys/mman.h>
+#endif
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+const QueueType log_queue_disk_type = "DISK";
+
+static gint64
+_get_length(LogQueue *s)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+  gint64 qdisk_length = 0;
+
+  if (qdisk_initialized(self->qdisk) && self->get_length)
+    {
+      qdisk_length = self->get_length(self);
+    }
+  return qdisk_length;
+}
+
+static void
+_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+  LogPathOptions local_options = *path_options;
+  g_static_mutex_lock(&self->super.lock);
+  if (self->push_tail)
+    {
+      if (self->push_tail(self, msg, &local_options, path_options))
+        {
+          log_queue_push_notify (&self->super);
+          stats_counter_inc(self->super.stored_messages);
+          log_msg_ack(msg, &local_options, AT_PROCESSED);
+          log_msg_unref(msg);
+          g_static_mutex_unlock(&self->super.lock);
+          return;
+        }
+    }
+  stats_counter_inc (self->super.dropped_messages);
+
+  if (path_options->flow_control_requested)
+    log_msg_ack(msg, path_options, AT_SUSPENDED);
+  else
+    log_msg_drop(msg, path_options, AT_PROCESSED);
+
+  g_static_mutex_unlock(&self->super.lock);
+}
+
+static void
+_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  g_static_mutex_lock(&self->super.lock);
+  if (self->push_head)
+    {
+      self->push_head(self, msg, path_options);
+    }
+  g_static_mutex_unlock(&self->super.lock);
+}
+
+static LogMessage *
+_pop_head(LogQueue *s, LogPathOptions *path_options)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+  LogMessage *msg = NULL;
+
+  msg = NULL;
+  g_static_mutex_lock(&self->super.lock);
+  if (self->pop_head)
+    {
+      msg = self->pop_head(self, path_options);
+    }
+  if (msg != NULL)
+    {
+      stats_counter_dec(self->super.stored_messages);
+    }
+  g_static_mutex_unlock(&self->super.lock);
+  return msg;
+}
+
+static void
+_ack_backlog(LogQueue *s, gint num_msg_to_ack)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  g_static_mutex_lock(&self->super.lock);
+
+  if (self->ack_backlog)
+    {
+      self->ack_backlog(self, num_msg_to_ack);
+    }
+
+  g_static_mutex_unlock(&self->super.lock);
+}
+
+static void
+_rewind_backlog(LogQueue *s, guint rewind_count)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  g_static_mutex_lock(&self->super.lock);
+
+  if (self->rewind_backlog)
+    {
+      self->rewind_backlog (self, rewind_count);
+    }
+
+  g_static_mutex_unlock(&self->super.lock);
+}
+
+void
+_backlog_all(LogQueue *s)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  g_static_mutex_lock(&self->super.lock);
+
+  if (self->rewind_backlog)
+    {
+      self->rewind_backlog(self, -1);
+    }
+
+  g_static_mutex_unlock(&self->super.lock);
+}
+
+gboolean
+log_queue_disk_save_queue(LogQueue *s, gboolean *persistent)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  if (!qdisk_initialized(self->qdisk))
+    {
+      *persistent = FALSE;
+      return TRUE;
+    }
+
+  if (self->save_queue)
+    return self->save_queue(self, persistent);
+  return FALSE;
+}
+
+gboolean
+log_queue_disk_load_queue(LogQueue *s, const gchar *filename)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  /* qdisk portion is not yet started when this happens */
+  g_assert(!qdisk_initialized(self->qdisk));
+
+  if (self->load_queue)
+    return self->load_queue(self, filename);
+  return FALSE;
+}
+
+gboolean
+log_queue_disk_is_reliable(LogQueue *s)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+  if (self->is_reliable)
+    return self->is_reliable(self);
+  return FALSE;
+}
+
+const gchar *
+log_queue_disk_get_filename(LogQueue *s)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+  return qdisk_get_filename(self->qdisk);
+}
+
+static void
+_free(LogQueue *s)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+
+  if (self->free_fn)
+    self->free_fn(self);
+
+  qdisk_deinit(self->qdisk);
+  qdisk_free(self->qdisk);
+  g_free(self);
+}
+
+static gboolean
+_pop_disk(LogQueueDisk *self, LogMessage **msg)
+{
+  GString *serialized;
+  SerializeArchive *sa;
+
+  *msg = NULL;
+
+  if (!qdisk_initialized(self->qdisk))
+    return FALSE;
+
+  serialized = g_string_sized_new(64);
+  if (!qdisk_pop_head(self->qdisk, serialized))
+    {
+      g_string_free(serialized, TRUE);
+      return FALSE;
+    }
+
+  sa = serialize_string_archive_new(serialized);
+  *msg = log_msg_new_empty();
+
+  if (!log_msg_deserialize(*msg, sa))
+  {
+      g_string_free(serialized, TRUE);
+      serialize_archive_free(sa);
+      log_msg_unref(*msg);
+      *msg = NULL;
+      msg_error("Can't read correct message from disk-queue file",evt_tag_str("filename",qdisk_get_filename(self->qdisk)),NULL);
+      return TRUE;
+  }
+
+  serialize_archive_free(sa);
+
+  g_string_free(serialized, TRUE);
+  return TRUE;
+}
+
+static LogMessage *
+_read_message(LogQueueDisk *self, LogPathOptions *path_options)
+{
+  LogMessage *msg = NULL;
+  do
+    {
+      if (qdisk_get_length (self->qdisk) == 0)
+        {
+          break;
+        }
+      if (!_pop_disk (self, &msg))
+        {
+          msg_error("Error reading from disk-queue file, dropping disk queue",
+                    evt_tag_str ("filename", qdisk_get_filename (self->qdisk)), NULL);
+          self->restart_corrupted(self);
+          if (msg)
+            log_msg_unref (msg);
+          msg = NULL;
+          return NULL;
+        }
+    }
+  while (msg == NULL);
+  return msg;
+}
+
+static gboolean
+_write_message(LogQueueDisk *self, LogMessage *msg)
+{
+  GString *serialized;
+  SerializeArchive *sa;
+  gboolean consumed = FALSE;
+  if (qdisk_initialized(self->qdisk) && qdisk_is_space_avail(self->qdisk, 64))
+    {
+      serialized = g_string_sized_new(64);
+      sa = serialize_string_archive_new(serialized);
+      log_msg_serialize(msg, sa);
+      consumed = qdisk_push_tail(self->qdisk, serialized);
+      serialize_archive_free(sa);
+      g_string_free(serialized, TRUE);
+    }
+  return consumed;
+}
+
+static void
+_restart_diskq(LogQueueDisk *self, gboolean corrupted)
+{
+  gchar *filename = g_strdup(qdisk_get_filename(self->qdisk));
+  gchar *new_file = NULL;
+  qdisk_deinit(self->qdisk);
+  if (corrupted)
+    {
+      new_file = g_strdup_printf("%s.corrupted",filename);
+      rename(filename,new_file);
+      g_free(new_file);
+    }
+  if (self->start)
+    {
+      self->start(self, filename);
+    }
+  g_free(filename);
+}
+
+static void
+_restart(LogQueueDisk *self)
+{
+  _restart_diskq(self, FALSE);
+}
+
+static void
+_restart_corrupted(LogQueueDisk *self)
+{
+  _restart_diskq(self, TRUE);
+}
+
+
+void
+log_queue_disk_init_instance(LogQueueDisk *self)
+{
+  log_queue_init_instance(&self->super,NULL);
+  self->qdisk = qdisk_new();
+
+  self->super.get_length = _get_length;
+  self->super.push_tail = _push_tail;
+  self->super.push_head = _push_head;
+  self->super.pop_head = _pop_head;
+  self->super.ack_backlog = _ack_backlog;
+  self->super.rewind_backlog = _rewind_backlog;
+  self->super.rewind_backlog_all = _backlog_all;
+  self->super.free_fn = _free;
+
+  self->read_message = _read_message;
+  self->write_message = _write_message;
+  self->restart = _restart;
+  self->restart_corrupted = _restart_corrupted;
+}

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LOGQUEUE_DISK_H_INCLUDED
+#define LOGQUEUE_DISK_H_INCLUDED
+
+#include "logmsg/logmsg.h"
+#include "logqueue.h"
+#include "qdisk.h"
+#include "logmsg/logmsg-serialize.h"
+
+typedef struct _LogQueueDisk LogQueueDisk;
+
+#define LOG_PATH_OPTIONS_FOR_BACKLOG GINT_TO_POINTER(0x80000000)
+
+struct _LogQueueDisk
+{
+  LogQueue super;
+  QDisk *qdisk;         /* disk based queue */
+  gint64 (*get_length)(LogQueueDisk *s);
+  gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, const LogPathOptions *path_options);
+  void (*push_head)(LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options);
+  LogMessage *(*pop_head)(LogQueueDisk *s, LogPathOptions *path_options);
+  void (*ack_backlog)(LogQueueDisk *s, guint num_msg_to_ack);
+  void (*rewind_backlog)(LogQueueDisk *s, guint rewind_count);
+  gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
+  gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
+  gboolean (*start)(LogQueueDisk *s, const gchar *filename);
+  void (*free_fn)(LogQueueDisk *s);
+  gboolean (*is_reliable)(LogQueueDisk *s);
+  LogMessage * (*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
+  gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
+  void (*restart)(LogQueueDisk *self);
+  void (*restart_corrupted)(LogQueueDisk *self);
+};
+
+extern const QueueType log_queue_disk_type;
+
+gboolean log_queue_disk_is_reliable(LogQueue *s);
+const gchar *log_queue_disk_get_filename(LogQueue *self);
+gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
+gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
+void log_queue_disk_init_instance(LogQueueDisk *self);
+
+#endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1,0 +1,1040 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "qdisk.h"
+#include "logpipe.h"
+#include "messages.h"
+#include "serialize.h"
+#include "logmsg/logmsg-serialize.h"
+#include "stats/stats-registry.h"
+#include "reloc.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <errno.h>
+
+/* MADV_RANDOM not defined on legacy Linux systems. Could be removed in the
+ * future, when support for Glibc 2.1.X drops.*/
+#ifndef HAVE_MADV_RANDOM
+#define MADV_RANDOM 1
+#endif
+
+/*pessimistic default for reliable disk queue 10000 x 16 kbyte*/
+#define PESSIMISTIC_MEM_BUF_SIZE 10000 * 16 *1024
+
+#define PATH_QDISK              PATH_LOCALSTATEDIR
+
+typedef union _QDiskFileHeader
+{
+  struct
+  {
+    gchar magic[4];
+    guint8 version;
+    guint8 big_endian;
+    guint8 _pad1;
+
+    gint64 read_head;
+    gint64 write_head;
+    gint64 length;
+
+    gint64 qout_ofs;
+    gint32 qout_len;
+    gint32 qout_count;
+    gint64 qbacklog_ofs;
+    gint32 qbacklog_len;
+    gint32 qbacklog_count;
+    gint64 qoverflow_ofs;
+    gint32 qoverflow_len;
+    gint32 qoverflow_count;
+    gint64 backlog_head;
+    gint64 backlog_len;
+  };
+  gchar _pad2[QDISK_RESERVED_SPACE];
+} QDiskFileHeader;
+
+struct _QDisk
+{
+  gchar *filename;
+  gchar *file_id;
+  gint fd;
+  gint64 read_qout_ofs; /* the size in bytes between read_head and qout_ofs */
+  gint64 prev_read_head;
+  gint64 prev_length;
+  gint64 file_size;
+  QDiskFileHeader *hdr;
+  DiskQueueOptions *options;
+};
+
+static gboolean
+pwrite_strict(gint fd, const void *buf, size_t count, off_t offset)
+{
+  ssize_t written = pwrite(fd, buf, count, offset);
+  gboolean result = TRUE;
+  if (written != count)
+    {
+      if (written != -1)
+        {
+          msg_error("Short written",
+                    evt_tag_int("Number of bytes want to write", count),
+                    evt_tag_int("Number of bytes written", written),
+                    NULL);
+          errno = ENOSPC;
+        }
+      result = FALSE;
+    }
+  return result;
+}
+
+
+static gboolean
+_is_position_eof(QDisk *self, gint64 position)
+{
+  return position >= self->file_size;
+}
+
+static guint64
+_correct_position_if_eof(QDisk *self, gint64 *position)
+{
+  if (_is_position_eof(self, *position))
+    {
+      *position = QDISK_RESERVED_SPACE;
+    }
+  return *position;
+}
+
+static gchar *
+_next_filename(QDisk *self)
+{
+  gint i = 0;
+  gboolean success = FALSE;
+  gchar tmpfname[256];
+  gchar qdir[256];
+
+  g_snprintf(qdir, sizeof(qdir), "%s", self->options->dir);
+
+  /* NOTE: this'd be a security problem if we were not in our private directory. But we are. */
+  while (!success && i < 100000)
+    {
+      struct stat st;
+
+      gchar *format = "%s/syslog-ng-%05d.qf";
+      if (self->options->reliable)
+        format = "%s/syslog-ng-%05d.rqf";
+      g_snprintf(tmpfname, sizeof(tmpfname), format, qdir, i);
+      success = (stat(tmpfname, &st) < 0);
+      i++;
+    }
+  if (!success)
+    {
+      msg_error("Error generating unique queue filename, not using disk queue",
+                 NULL);
+      return NULL;
+    }
+  return g_strdup(tmpfname);
+}
+
+gboolean
+qdisk_initialized(QDisk *self)
+{
+  return self->fd >= 0;
+}
+
+static inline gboolean
+_is_backlog_head_prevent_write_head(QDisk *self)
+{
+  return self->hdr->backlog_head <= self->hdr->write_head;
+}
+
+static inline gboolean
+_is_write_head_less_than_max_size(QDisk *self)
+{
+  return self->hdr->write_head < self->options->disk_buf_size;
+}
+
+static inline gboolean
+_is_able_to_reset_write_head_to_begining_of_qdisk(QDisk *self)
+{
+  return self->hdr->backlog_head != QDISK_RESERVED_SPACE;
+}
+
+static inline gboolean
+_is_free_space_between_write_head_and_backlog_head(QDisk *self, gint msg_len)
+{
+  return self->hdr->write_head + msg_len < self->hdr->backlog_head;
+}
+
+
+gboolean
+qdisk_is_space_avail(QDisk *self, gint at_least)
+{
+  gint64 msg_len = at_least + sizeof(guint32);
+  return (
+      (_is_backlog_head_prevent_write_head(self)) &&
+      (_is_write_head_less_than_max_size(self) || _is_able_to_reset_write_head_to_begining_of_qdisk(self))
+      ) || (_is_free_space_between_write_head_and_backlog_head(self, msg_len));
+
+}
+
+static gboolean
+_truncate_file(QDisk *self, gint64 new_size)
+{
+  gboolean success = TRUE;
+
+  if (ftruncate(self->fd, (glong)new_size) < 0)
+    {
+      success = FALSE;
+      msg_error("Error truncating disk-queue file",
+                evt_tag_errno("error", errno),
+                evt_tag_str("filename", self->filename),
+                evt_tag_int("newsize",self->hdr->write_head),
+                evt_tag_int("fd",self->fd),
+                NULL);
+    }
+
+  return success;
+}
+
+gboolean
+qdisk_push_tail(QDisk *self, GString *record)
+{
+  guint32 n = GUINT32_TO_BE(record->len);
+
+  /* write follows read (e.g. we are appending to the file) OR
+   * there's enough space between write and read.
+   *
+   * If write follows read we need to check two things:
+   *   - either we are below the maximum limit (GINT64_FROM_BE(self->hdr->write_head) < self->options->disk_buf_size)
+   *   - or we can wrap around (GINT64_FROM_BE(self->hdr->read_head) != QDISK_RESERVED_SPACE)
+   * If neither of the above is true, the buffer is full.
+   */
+  if (!qdisk_is_space_avail(self, record->len))
+    return FALSE;
+
+  if (n == 0)
+    {
+      msg_error("Error writing empty message into the disk-queue file",
+          NULL);
+      return FALSE;
+    }
+
+  if (!pwrite_strict(self->fd, (gchar *) &n, sizeof(n), self->hdr->write_head) ||
+      !pwrite_strict(self->fd, record->str, record->len, self->hdr->write_head + sizeof(n)))
+    {
+      msg_error("Error writing disk-queue file",
+          evt_tag_errno("error", errno),
+          NULL);
+      return FALSE;
+    }
+
+  self->hdr->write_head = self->hdr->write_head + record->len + sizeof(n);
+
+
+  /* NOTE: we only wrap around if the read head is before the write,
+   * otherwise we'd truncate the data the read head is still processing, e.g.
+   *
+   * start                limit       file size
+   *   |                     |           |
+   *       ^ read         ^write
+   *
+   * We can truncate in the scenario above, once we surpass the limit,
+   * however if this is the case:
+   *
+   * start                limit       file size
+   *   |                     |           |
+   *                      ^write    ^read
+   *
+   * In this case cannot wrap around, even if the limit is surpassed, as
+   * in that case data still unprocessed by the read head would be lost.
+   * This can happen if the size of the queue file got decreased while
+   * it still had more data.
+   * */
+
+  /* NOTE: if these were equal, that'd mean the queue is empty, so we spoiled something */
+  g_assert(self->hdr->write_head != self->hdr->backlog_head);
+
+  if (self->hdr->write_head > MAX(self->hdr->backlog_head,self->hdr->read_head))
+    {
+      if (self->file_size > self->hdr->write_head)
+        {
+          _truncate_file(self, self->hdr->write_head);
+        }
+      self->file_size = self->hdr->write_head;
+
+      if (self->hdr->write_head > self->options->disk_buf_size && self->hdr->backlog_head  != QDISK_RESERVED_SPACE)
+        {
+          /* we were appending to the file, we are over the limit, and space
+           * is available before the read head. truncate and wrap.
+           *
+           * Otherwise we let the write_head over size limits for a bit and
+           * for the next message, the condition at the beginning of this
+           * function will cause the push to fail */
+          self->hdr->write_head = QDISK_RESERVED_SPACE;
+        }
+    }
+  self->hdr->length++;
+  return TRUE;
+}
+
+gboolean
+qdisk_pop_head(QDisk *self, GString *record)
+{
+  if (self->hdr->read_head != self->hdr->write_head)
+    {
+      guint32 n;
+      gssize res;
+      res = pread(self->fd, (gchar *) &n, sizeof(n), self->hdr->read_head);
+
+      if (res == 0)
+        {
+          /* hmm, we are either at EOF or at hdr->qout_ofs, we need to wrap */
+          self->hdr->read_head = QDISK_RESERVED_SPACE;
+          res = pread(self->fd, (gchar *) &n, sizeof(n), self->hdr->read_head);
+        }
+      if (res != sizeof(n))
+        {
+          msg_error("Error reading disk-queue file",
+                    evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
+                    evt_tag_str("filename", self->filename),
+                    NULL);
+          return FALSE;
+        }
+
+      n = GUINT32_FROM_BE(n);
+      if (n > 10 * 1024 * 1024)
+        {
+          msg_warning("Disk-queue file contains possibly invalid record-length",
+                    evt_tag_int("rec_length", n),
+                    evt_tag_str("filename", self->filename),
+                    NULL);
+          return FALSE;
+        }
+      else if (n == 0)
+        {
+          msg_error("Disk-queue file contains empty record",
+                    evt_tag_int("rec_length", n),
+                    evt_tag_str("filename", self->filename),
+                    NULL);
+          return FALSE;
+        }
+
+      g_string_set_size(record, n);
+      res = pread(self->fd, record->str, n, self->hdr->read_head + sizeof(n));
+      if (res != n)
+        {
+          msg_error("Error reading disk-queue file",
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
+                    evt_tag_int("read_length", n),
+                    NULL);
+          return FALSE;
+        }
+
+      self->hdr->read_head = self->hdr->read_head + record->len + sizeof(n);
+
+      if (self->hdr->read_head > self->hdr->write_head)
+        {
+          self->hdr->read_head = _correct_position_if_eof(self, &self->hdr->read_head);
+        }
+
+      self->hdr->length--;
+      if (!self->options->reliable)
+        {
+          self->hdr->backlog_head = self->hdr->read_head;
+        }
+
+      if (self->hdr->length == 0 && !self->options->reliable)
+        {
+          msg_debug("Queue file became empty, truncating file",
+                    evt_tag_str("filename", self->filename),
+                    NULL);
+          self->hdr->read_head = QDISK_RESERVED_SPACE;
+          self->hdr->write_head = QDISK_RESERVED_SPACE;
+          if (!self->options->reliable)
+            {
+              self->hdr->backlog_head = self->hdr->read_head;
+            }
+          self->hdr->length = 0;
+          _truncate_file(self, self->hdr->write_head);
+        }
+      return TRUE;
+
+    }
+  return FALSE;
+}
+
+static gboolean
+_load_queue(QDisk *self, GQueue *q, gint64 q_ofs, gint32 q_len, gint32 q_count)
+{
+  GString *serialized;
+  SerializeArchive *sa;
+  gint i;
+
+  if (q_ofs)
+    {
+      gssize read_len;
+
+      serialized = g_string_sized_new(q_len);
+      g_string_set_size(serialized, q_len);
+      read_len = pread(self->fd, serialized->str, q_len, q_ofs);
+      if (read_len < 0 || read_len != q_len)
+        {
+          msg_error("Error reading in-memory buffer from disk-queue file",
+                    evt_tag_str("filename", self->filename),
+                    read_len < 0 ? evt_tag_errno("error", errno) : evt_tag_str("error", "short read"),
+                    NULL);
+          g_string_free(serialized, TRUE);
+          return FALSE;
+        }
+      sa = serialize_string_archive_new(serialized);
+      for (i = 0; i < q_count; i++)
+        {
+          LogMessage *msg;
+
+          msg = log_msg_new_empty();
+          if (log_msg_deserialize(msg, sa))
+            {
+              g_queue_push_tail(q, msg);
+              /* we restore the queue without ACKs */
+              g_queue_push_tail(q, GINT_TO_POINTER(0x80000000));
+            }
+          else
+            {
+              msg_error("Error reading message from disk-queue file (maybe currupted file) some messages will be lost",
+                            evt_tag_str("filename", self->filename),
+                            evt_tag_int("lost messages", q_count - i),
+                            NULL);
+              log_msg_unref(msg);
+              break;
+            }
+        }
+      g_string_free(serialized, TRUE);
+      serialize_archive_free(sa);
+    }
+  return TRUE;
+}
+
+static gboolean
+_load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+{
+  gint64 qout_ofs;
+  gint qout_count, qout_len;
+  gint64 qbacklog_ofs;
+  gint qbacklog_count, qbacklog_len;
+  gint64 qoverflow_ofs;
+  gint qoverflow_count, qoverflow_len;
+  gint64 end_ofs;
+
+  if (memcmp(self->hdr->magic, self->file_id, 4) != 0)
+    {
+      msg_error("Error reading disk-queue file header",
+                evt_tag_str("filename", self->filename),
+                NULL);
+      return FALSE;
+    }
+
+  qout_count = self->hdr->qout_count;
+  qout_len = self->hdr->qout_len;
+  qout_ofs = self->hdr->qout_ofs;
+  qbacklog_count = self->hdr->qbacklog_count;
+  qbacklog_len = self->hdr->qbacklog_len;
+  qbacklog_ofs = self->hdr->qbacklog_ofs;
+  qoverflow_count = self->hdr->qoverflow_count;
+  qoverflow_len = self->hdr->qoverflow_len;
+  qoverflow_ofs = self->hdr->qoverflow_ofs;
+  self->read_qout_ofs = qout_ofs;
+
+  if ((self->hdr->read_head < QDISK_RESERVED_SPACE) ||
+      (self->hdr->write_head < QDISK_RESERVED_SPACE) ||
+      (self->hdr->read_head == self->hdr->write_head && self->hdr->length != 0))
+    {
+      msg_error("Inconsistent header data in disk-queue file, ignoring",
+                evt_tag_str("filename", self->filename),
+                evt_tag_int("read_head", self->hdr->read_head),
+                evt_tag_int("write_head", self->hdr->write_head),
+                evt_tag_int("qdisk_length",  self->hdr->length),
+                NULL);
+      return FALSE;
+    }
+
+  if (!self->options->reliable)
+    {
+      if (!(qout_ofs > 0 && qout_ofs < self->hdr->write_head))
+        {
+           if (!_load_queue(self, qout, qout_ofs, qout_len, qout_count))
+             return !self->options->read_only;
+        }
+      else
+        {
+           msg_error("Inconsistent header data in disk-queue file, ignoring qout",
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_int("qout_ofs", qout_ofs),
+                    evt_tag_int("qdisk_length",  self->hdr->length),
+                    NULL);
+        }
+
+      if (!(qbacklog_ofs > 0 && qbacklog_ofs < self->hdr->write_head))
+        {
+          if(!_load_queue(self, qbacklog, qbacklog_ofs, qbacklog_len, qbacklog_count))
+            return !self->options->read_only;
+        }
+      else
+        {
+           msg_error("Inconsistent header data in disk-queue file, ignoring qbacklog",
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_int("qbacklog_ofs", qbacklog_ofs),
+                    evt_tag_int("qdisk_length",  self->hdr->length),
+                    NULL);
+        }
+
+      if (!(qoverflow_ofs > 0 && qoverflow_ofs < self->hdr->write_head))
+        {
+          if(!_load_queue(self, qoverflow, qoverflow_ofs, qoverflow_len, qoverflow_count))
+            return !self->options->read_only;
+        }
+      else
+        {
+           msg_error("Inconsistent header data in disk-queue file, ignoring qoverflow",
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_int("qoverflow_ofs", qoverflow_ofs),
+                    evt_tag_int("qdisk_length",  self->hdr->length),
+                    NULL);
+        }
+    }
+
+  if (!self->options->read_only)
+    {
+      end_ofs = qout_ofs;
+      if (qbacklog_ofs && qbacklog_ofs < end_ofs)
+        end_ofs = qbacklog_ofs;
+      if (qoverflow_ofs && qoverflow_ofs < end_ofs)
+        end_ofs = qoverflow_ofs;
+      if(end_ofs > QDISK_RESERVED_SPACE)
+        _truncate_file(self, end_ofs);
+    }
+
+  if (!self->options->reliable)
+    {
+      self->file_size = qout_ofs;
+
+      msg_info("Disk-buffer state loaded",
+          evt_tag_str("filename", self->filename),
+          evt_tag_int("qout_length", qout_count),
+          evt_tag_int("qbacklog_length", qbacklog_count),
+          evt_tag_int("qoverflow_length", qoverflow_count),
+          evt_tag_int("qdisk_length", self->hdr->length),
+          NULL);
+    }
+  else
+    {
+      struct stat st;
+      fstat(self->fd, &st);
+      self->file_size = st.st_size;
+      msg_info("Reliable disk-buffer state loaded",
+          evt_tag_str("filename", self->filename),
+          evt_tag_int("queue_length", self->hdr->length),
+          evt_tag_int("size", self->hdr->write_head - self->hdr->read_head),
+          NULL);
+    }
+
+  return TRUE;
+}
+
+static gboolean
+_save_queue(QDisk *self, GQueue *q, gint64 *q_ofs, gint32 *q_len)
+{
+  LogMessage *msg;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  SerializeArchive *sa;
+  GString *serialized;
+
+  if (q->length == 0)
+    {
+      *q_ofs = 0;
+      *q_len = 0;
+      return TRUE;
+    }
+
+  serialized = g_string_sized_new(4096);
+  sa = serialize_string_archive_new(serialized);
+  while ((msg = g_queue_pop_head(q)))
+    {
+
+      /* NOTE: we might have some flow-controlled events on qout, when
+       * saving them to disk, we ack them, they are restored as
+       * non-flow-controlled entries later, but then we've saved them to
+       * disk anyway. */
+
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(q), &path_options);
+      log_msg_serialize(msg, sa); 
+      log_msg_ack(msg, &path_options, AT_PROCESSED);
+      log_msg_unref(msg);
+    }
+  serialize_archive_free(sa);
+  *q_ofs = lseek(self->fd, 0, SEEK_END);
+  if (!pwrite_strict(self->fd, serialized->str, serialized->len, *q_ofs))
+    {
+      msg_error("Error writing in-memory buffer of disk-queue to disk",
+                evt_tag_str("filename", self->filename),
+                evt_tag_errno("error", errno),
+                NULL);
+      g_string_free(serialized, TRUE);
+      return FALSE;
+    }
+  *q_len = serialized->len;
+  g_string_free(serialized, TRUE);
+  return TRUE;
+}
+
+gboolean
+qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+{
+  gint64 qout_ofs = 0;
+  gint32 qout_len = 0;
+  gint32 qout_count = 0;
+  gint64 qbacklog_ofs = 0;
+  gint32 qbacklog_len = 0;
+  gint32 qbacklog_count = 0;
+  gint64 qoverflow_ofs = 0;
+  gint32 qoverflow_len = 0;
+  gint32 qoverflow_count = 0;
+
+  if (!self->options->reliable)
+    {
+      qout_count = qout->length / 2;
+      qbacklog_count = qbacklog->length / 2;
+      qoverflow_count = qoverflow->length / 2;
+
+      if (!_save_queue(self, qout, &qout_ofs, &qout_len) ||
+          !_save_queue(self, qbacklog, &qbacklog_ofs, &qbacklog_len) ||
+          !_save_queue(self, qoverflow, &qoverflow_ofs, &qoverflow_len))
+        return FALSE;
+    }
+
+  memcpy(self->hdr->magic, self->file_id, 4);
+
+  self->hdr->qout_ofs = qout_ofs;
+  self->hdr->qout_len = qout_len;
+  self->hdr->qout_count = qout_count;
+
+  self->hdr->qbacklog_ofs = qbacklog_ofs;
+  self->hdr->qbacklog_len = qbacklog_len;
+  self->hdr->qbacklog_count = qbacklog_count;
+
+  self->hdr->qoverflow_ofs = qoverflow_ofs;
+  self->hdr->qoverflow_len = qoverflow_len;
+  self->hdr->qoverflow_count = qoverflow_count;
+
+  if (!self->options->reliable)
+    msg_info("Disk-buffer state saved",
+             evt_tag_str("filename", self->filename),
+             evt_tag_int("qout_length", qout_count),
+             evt_tag_int("qbacklog_length", qbacklog_count),
+             evt_tag_int("qoverflow_length", qoverflow_count),
+             evt_tag_int("qdisk_length", self->hdr->length),
+             NULL);
+  else
+    msg_info("Reliable disk-buffer state saved",
+             evt_tag_str("filename", self->filename),
+             evt_tag_int("qdisk_length", self->hdr->length),
+             NULL);
+
+  return TRUE;
+}
+
+gboolean
+qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+{
+  gboolean new_file = FALSE;
+  gpointer p = NULL;
+  int openflags = 0;
+
+  /*
+   * If qdisk_start is called for already initialized qdisk file
+   * it can cause message loosing.
+   * We need this assert to detect programming error as soon as possible.
+   */
+  g_assert(!qdisk_initialized(self));
+
+  if (self->options->disk_buf_size <= 0)
+    return TRUE;
+
+  if (self->options->read_only && !filename)
+    return FALSE;
+
+  if (!filename)
+    {
+      new_file = TRUE;
+      /* NOTE: this'd be a security problem if we were not in our private directory. But we are. */
+      filename = _next_filename(self);
+    }
+  else
+    {
+      struct stat st;
+      if (stat(filename,&st) == -1)
+        {
+          new_file = TRUE;
+        }
+    }
+
+  self->filename = g_strdup(filename);
+  /* assumes self is zero initialized */
+  openflags = self->options->read_only ? (O_RDONLY | O_LARGEFILE) : (O_RDWR | O_LARGEFILE | (new_file ? O_CREAT : 0));
+
+  self->fd = open(filename, openflags, 0600);
+  if (self->fd < 0)
+    {
+      msg_error("Error opening disk-queue file",
+                evt_tag_str("filename", self->filename),
+                evt_tag_errno("error", errno),
+                NULL);
+      return FALSE;
+    }
+
+  p = mmap(0, sizeof(QDiskFileHeader),  self->options->read_only ? (PROT_READ) : (PROT_READ | PROT_WRITE), MAP_SHARED, self->fd, 0);
+
+  if (p == MAP_FAILED)
+    {
+      msg_error("Error returned by mmap",
+                evt_tag_errno("errno", errno),
+                evt_tag_str("filename", self->filename),
+                NULL);
+       return FALSE;
+     }
+   else
+     {
+       madvise(p, sizeof(QDiskFileHeader), MADV_RANDOM);
+     }
+
+  if (self->options->read_only)
+    {
+      self->hdr = g_malloc(sizeof(QDiskFileHeader));
+      memcpy(self->hdr, p, sizeof(QDiskFileHeader));
+      munmap(p, sizeof(QDiskFileHeader) );
+      p = NULL;
+    }
+  else
+    {
+      self->hdr = p;
+    }
+  /* initialize new file */
+
+  if (new_file)
+    {
+      QDiskFileHeader tmp;
+      memset(&tmp, 0, sizeof(tmp));
+      if (!pwrite_strict(self->fd, &tmp, sizeof(tmp), 0))
+        {
+          msg_error("Error occured while initalizing the new queue file",evt_tag_str("filename",self->filename),evt_tag_errno("error",errno), NULL);
+          munmap((void *)self->hdr, sizeof(QDiskFileHeader));
+          self->hdr = NULL;
+          close(self->fd);
+          self->fd = -1;
+          return FALSE;
+        }
+      self->hdr->version = 1;
+      self->hdr->big_endian = (G_BYTE_ORDER == G_BIG_ENDIAN);
+
+      self->hdr->read_head = QDISK_RESERVED_SPACE;
+      self->hdr->write_head = QDISK_RESERVED_SPACE;
+      self->hdr->backlog_head = self->hdr->read_head;
+      self->hdr->length = 0;
+
+      if (!qdisk_save_state(self, qout, qbacklog, qoverflow))
+        {
+          munmap((void *)self->hdr, sizeof(QDiskFileHeader));
+          self->hdr = NULL;
+          close(self->fd);
+          self->fd = -1;
+          return FALSE;
+        }
+    }
+  else
+    {
+      struct stat st;
+
+      if (fstat(self->fd, &st) != 0 || st.st_size == 0)
+        {
+           msg_error("Error loading disk-queue file",
+                     evt_tag_str("filename", self->filename),
+                     evt_tag_errno("fstat error", errno),
+                     evt_tag_int("size", st.st_size),
+                     NULL);
+           munmap((void *)self->hdr, sizeof(QDiskFileHeader));
+           self->hdr = NULL;
+           close(self->fd);
+           self->fd = -1;
+           return FALSE;
+        }
+      if (self->hdr->version == 0)
+        {
+          self->hdr->big_endian = TRUE;
+          self->hdr->version = 1;
+          self->hdr->backlog_head = self->hdr->read_head;
+          self->hdr->backlog_len = 0;
+        }
+      if ((self->hdr->big_endian && G_BYTE_ORDER == G_LITTLE_ENDIAN) ||
+          (!self->hdr->big_endian && G_BYTE_ORDER == G_BIG_ENDIAN))
+        {
+          self->hdr->read_head = GUINT64_SWAP_LE_BE(self->hdr->read_head);
+          self->hdr->write_head = GUINT64_SWAP_LE_BE(self->hdr->write_head);
+          self->hdr->length = GUINT64_SWAP_LE_BE(self->hdr->length);
+          self->hdr->qout_ofs = GUINT64_SWAP_LE_BE(self->hdr->qout_ofs);
+          self->hdr->qout_len = GUINT32_SWAP_LE_BE(self->hdr->qout_len);
+          self->hdr->qout_count = GUINT32_SWAP_LE_BE(self->hdr->qout_count);
+          self->hdr->qbacklog_ofs = GUINT64_SWAP_LE_BE(self->hdr->qbacklog_ofs);
+          self->hdr->qbacklog_len = GUINT32_SWAP_LE_BE(self->hdr->qbacklog_len);
+          self->hdr->qbacklog_count = GUINT32_SWAP_LE_BE(self->hdr->qbacklog_count);
+          self->hdr->qoverflow_ofs = GUINT64_SWAP_LE_BE(self->hdr->qoverflow_ofs);
+          self->hdr->qoverflow_len = GUINT32_SWAP_LE_BE(self->hdr->qoverflow_len);
+          self->hdr->qoverflow_count = GUINT32_SWAP_LE_BE(self->hdr->qoverflow_count);
+          self->hdr->backlog_head = GUINT64_SWAP_LE_BE(self->hdr->backlog_head);
+          self->hdr->backlog_len = GUINT64_SWAP_LE_BE(self->hdr->backlog_len);
+          self->hdr->big_endian = (G_BYTE_ORDER == G_BIG_ENDIAN);
+        }
+      if (!_load_state(self, qout, qbacklog, qoverflow))
+        {
+          munmap((void *)self->hdr, sizeof(QDiskFileHeader));
+          self->hdr = NULL;
+          close(self->fd);
+          self->fd = -1;
+          return FALSE;
+        }
+
+    }
+  return TRUE;
+}
+
+void
+qdisk_init(QDisk *self, DiskQueueOptions *options)
+{
+  self->fd = -1;
+  self->options = options;
+  if (!self->options->reliable)
+    self->file_id = "SLQF";
+  else
+    {
+      self->file_id = "SLRQ";
+      if (self->options->mem_buf_size < 0)
+        {
+          self->options->mem_buf_size = PESSIMISTIC_MEM_BUF_SIZE;
+        }
+    }
+}
+
+void
+qdisk_deinit(QDisk *self)
+{
+  if (self->filename)
+    {
+      g_free(self->filename);
+      self->filename = NULL;
+    }
+
+  if (self->hdr)
+    {
+      if (self->options->read_only)
+        g_free(self->hdr);
+      else
+        munmap((void *)self->hdr, sizeof(QDiskFileHeader));
+      self->hdr = NULL;
+    }
+
+  if (self->fd != -1)
+    {
+      close(self->fd);
+      self->fd = -1;
+    }
+
+  self->options = NULL;
+}
+
+gssize
+qdisk_read_from_backlog(QDisk *self, gpointer buffer, gsize bytes_to_read)
+{
+  gssize res;
+  res = pread(self->fd, buffer, bytes_to_read, self->hdr->backlog_head);
+  if (res == 0)
+    {
+      self->hdr->backlog_head = QDISK_RESERVED_SPACE;
+      res = pread(self->fd, buffer, bytes_to_read, self->hdr->backlog_head);
+    }
+  if (res != bytes_to_read)
+    {
+      msg_error("Error reading disk-queue file",
+                          evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
+                          evt_tag_str("filename", self->filename),
+                          NULL);
+    }
+  if (self->hdr->backlog_head > self->hdr->write_head)
+    {
+      self->hdr->backlog_head = _correct_position_if_eof(self, &self->hdr->backlog_head);
+    }
+  return res;
+}
+
+gssize
+qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position)
+{
+  gssize res;
+  res = pread(self->fd, buffer, bytes_to_read, position);
+  if (res <= 0)
+    {
+      msg_error("Error reading disk-queue file",
+                evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
+                evt_tag_str("filename", self->filename),
+                NULL);
+    }
+  return res;
+}
+
+guint64
+qdisk_skip_record(QDisk *self, guint64 position)
+{
+  guint64 new_position = position;
+  guint32 s;
+  qdisk_read (self, (gchar *) &s, sizeof(s), position);
+  s = GUINT32_FROM_BE(s);
+  new_position += s + sizeof(s);
+  if (new_position > self->hdr->write_head)
+    {
+      new_position = _correct_position_if_eof(self, (gint64 *)&new_position);
+    }
+  return new_position;
+}
+
+void
+qdisk_set_backlog_count(QDisk *self, gint64 new_value)
+{
+  self->hdr->backlog_len = new_value;
+}
+
+void
+qdisk_reset_file_if_possible(QDisk *self)
+{
+  if (self->hdr->length == 0 && self->hdr->backlog_len == 0)
+    {
+      self->hdr->read_head = QDISK_RESERVED_SPACE;
+      self->hdr->write_head = QDISK_RESERVED_SPACE;
+      self->hdr->backlog_head = QDISK_RESERVED_SPACE;
+      _truncate_file (self, QDISK_RESERVED_SPACE);
+    }
+}
+
+gint64
+qdisk_get_length(QDisk *self)
+{
+  return self->hdr->length;
+}
+
+void
+qdisk_set_length(QDisk *self, gint64 new_value)
+{
+  self->hdr->length = new_value;
+}
+
+gint64
+qdisk_get_size(QDisk *self)
+{
+  return self->options->disk_buf_size;
+}
+
+const gchar *
+qdisk_get_filename(QDisk *self)
+{
+  return self->filename;
+}
+
+gint64
+qdisk_get_writer_head(QDisk *self)
+{
+  return self->hdr->write_head;
+}
+
+gint64
+qdisk_get_reader_head(QDisk *self)
+{
+  return self->hdr->read_head;
+}
+
+void
+qdisk_set_reader_head(QDisk *self, gint64 new_value)
+{
+  self->hdr->read_head = new_value;
+}
+
+gint64
+qdisk_get_backlog_head(QDisk *self)
+{
+  return self->hdr->backlog_head;
+}
+
+void
+qdisk_set_backlog_head(QDisk *self, gint64 new_value)
+{
+  self->hdr->backlog_head = new_value;
+}
+
+void
+qdisk_inc_backlog(QDisk *self)
+{
+  self->hdr->backlog_len++;
+}
+
+void
+qdisk_dec_backlog(QDisk *self)
+{
+  self->hdr->backlog_len--;
+}
+
+gint64
+qdisk_get_backlog_count(QDisk *self)
+{
+  return self->hdr->backlog_len;
+}
+
+gint
+qdisk_get_memory_size(QDisk *self)
+{
+  return self->options->mem_buf_size;
+}
+
+gboolean
+qdisk_is_read_only(QDisk *self)
+{
+  return self->options->read_only;
+}
+
+void
+qdisk_free(QDisk *self)
+{
+  g_free(self);
+}
+
+QDisk *
+qdisk_new()
+{
+  QDisk *self = g_new0(QDisk, 1);
+  return self;
+}
+

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef QDISK_H_
+#define QDISK_H_
+
+#include "syslog-ng.h"
+#include "diskq-options.h"
+
+#define QDISK_RESERVED_SPACE 4096
+#define LOG_PATH_OPTIONS_TO_POINTER(lpo) GUINT_TO_POINTER(0x80000000 | (lpo)->ack_needed)
+
+/* NOTE: this must not evaluate ptr multiple times, otherwise the code that
+ * uses this breaks, as it passes the result of a g_queue_pop_head call,
+ * which has side effects.
+ */
+#define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) (lpo)->ack_needed = (GPOINTER_TO_INT(ptr) & ~0x80000000)
+
+typedef struct _QDisk QDisk;
+
+QDisk *qdisk_new();
+
+gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
+gboolean qdisk_push_tail(QDisk *self, GString *record);
+gboolean qdisk_pop_head(QDisk *self, GString *record);
+gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
+void qdisk_init(QDisk *self, DiskQueueOptions *options);
+void qdisk_deinit(QDisk *self);
+void qdisk_reset_file_if_possible(QDisk *self);
+gboolean qdisk_initialized(QDisk *self);
+void qdisk_free(QDisk *self);
+
+gboolean qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
+
+gint64 qdisk_get_length(QDisk *self);
+void qdisk_set_length(QDisk *self, gint64 new_value);
+gint64 qdisk_get_size(QDisk *self);
+gint64 qdisk_get_writer_head(QDisk *self);
+gint64 qdisk_get_reader_head(QDisk *self);
+void qdisk_set_reader_head(QDisk *self, gint64 new_value);
+gint64 qdisk_get_backlog_head(QDisk *self);
+void qdisk_set_backlog_head(QDisk *self, gint64 new_value);
+void qdisk_inc_backlog(QDisk *self);
+void qdisk_dec_backlog(QDisk *self);
+gint64 qdisk_get_backlog_count(QDisk *self);
+void qdisk_set_backlog_count(QDisk *self, gint64 new_value);
+gint qdisk_get_memory_size(QDisk *self);
+gboolean qdisk_is_read_only(QDisk *self);
+const gchar *qdisk_get_filename(QDisk *self);
+
+gssize qdisk_read_from_backlog(QDisk *self, gpointer buffer, gsize bytes_to_read);
+gssize qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position);
+guint64 qdisk_skip_record(QDisk *self, guint64 position);
+
+#endif /* QDISK_H_ */

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,0 +1,26 @@
+DISKQ_TEST_CFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/libtest -I$(top_srcdir)/modules/diskq @CFLAGS_NOWARN_POINTER_SIGN@
+DISKQ_TEST_LDFLAGS = -dlpreopen $(top_builddir)/modules/syslogformat/libsyslogformat.la -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la
+DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
+
+modules_diskq_tests_TESTS = \
+  modules/diskq/tests/test_diskq \
+  modules/diskq/tests/test_diskq_full \
+  modules/diskq/tests/test_reliable_backlog
+
+check_PROGRAMS += ${modules_diskq_tests_TESTS}
+
+modules_diskq_tests_test_diskq_CFLAGS = $(TEST_CFLAGS) $(DISKQ_TEST_CFLAGS)
+modules_diskq_tests_test_diskq_LDFLAGS = $(TEST_LDFLAGS) $(DISKQ_TEST_LDFLAGS)
+modules_diskq_tests_test_diskq_LDADD = $(TEST_LDADD) $(DISKQ_TEST_LDADD)
+modules_diskq_tests_test_diskq_SOURCE = modules/diskq/tests/test_diskq.c modules/diskq/tests/test_diskq_tools.h
+
+modules_diskq_tests_test_diskq_full_CFLAGS = $(TEST_CFLAGS) $(DISKQ_TEST_CFLAGS)
+modules_diskq_tests_test_diskq_full_LDFLAGS = $(TEST_LDLAGS) $(DISKQ_TEST_LDFLAGS)
+modules_diskq_tests_test_diskq_full_LDADD = $(TEST_LDADD) $(DISKQ_TEST_LDADD)
+modules_diskq_tests_test_diskq_full_SOURCES =  modules/diskq/tests/test_diskq_full.c modules/diskq/tests/test_diskq_tools.h
+
+modules_diskq_tests_test_reliable_backlog_CFLAGS = $(TEST_CFLAGS) $(DISKQ_TEST_CFLAGS)
+modules_diskq_tests_test_reliable_backlog_LDFLAGS = $(TEST_LDLAGS) $(DISKQ_TEST_LDFLAGS)
+modules_diskq_tests_test_reliable_backlog_LDADD = $(TEST_LDADD) $(DISKQ_TEST_LDADD)
+modules_diskq_tests_test_reliable_backlog_SOURCES =  modules/diskq/tests/test_reliable_backlog.c  modules/diskq/tests/test_diskq_tools.h
+

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logqueue.h"
+#include "logqueue-fifo.h"
+#include "logqueue-disk.h"
+#include "logqueue-disk-reliable.h"
+#include "diskq.h"
+#include "logpipe.h"
+#include "apphook.h"
+#include "plugin.h"
+#include "mainloop.h"
+#include "mainloop-call.h"
+#include "mainloop-io-worker.h"
+#include "tls-support.h"
+#include "queue_utils_lib.h"
+#include "test_diskq_tools.h"
+#include "testutils.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <iv.h>
+#include <iv_thread.h>
+
+#define OVERFLOW_SIZE 10000
+#ifdef PATH_QDISK
+  #undef PATH_QDISK
+#endif
+#define PATH_QDISK "./"
+
+MsgFormatOptions parse_options;
+
+static void
+testcase_zero_diskbuf_and_normal_acks()
+{
+  LogQueue *q;
+  gint i;
+  GString *filename;
+  DiskQueueOptions options = {0};
+
+  _construct_options(&options, 10000000, 100000, TRUE);
+
+  q = log_queue_disk_reliable_new(&options);
+  log_queue_set_use_backlog(q, TRUE);
+
+  filename = g_string_sized_new(32);
+  g_string_sprintf(filename,"test-normal_acks.qf");
+  unlink(filename->str);
+  log_queue_disk_load_queue(q,filename->str);
+  fed_messages = 0;
+  acked_messages = 0;
+  for (i = 0; i < 10; i++)
+    feed_some_messages(q, 10, &parse_options);
+
+  send_some_messages(q, fed_messages);
+  app_ack_some_messages(q, fed_messages);
+  assert_gint(fed_messages, acked_messages, "%s: did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d\n", __FUNCTION__, fed_messages, acked_messages);
+
+  log_queue_unref(q);
+  unlink(filename->str);
+  g_string_free(filename,TRUE);
+  disk_queue_options_destroy(&options);
+}
+
+static void
+testcase_zero_diskbuf_alternating_send_acks()
+{
+  LogQueue *q;
+  gint i;
+  GString *filename;
+  DiskQueueOptions options = {0};
+
+  _construct_options(&options, 10000000, 100000, TRUE);
+
+  q = log_queue_disk_reliable_new(&options);
+  log_queue_set_use_backlog(q, TRUE);
+
+  filename = g_string_sized_new(32);
+  g_string_sprintf(filename,"test-send_acks.qf");
+  unlink(filename->str);
+  log_queue_disk_load_queue(q,filename->str);
+  fed_messages = 0;
+  acked_messages = 0;
+  for (i = 0; i < 10; i++)
+    {
+      feed_some_messages(q, 10, &parse_options);
+      send_some_messages(q, 10);
+      app_ack_some_messages(q, 10);
+    }
+
+  assert_gint(fed_messages, acked_messages, "%s: did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d\n", __FUNCTION__, fed_messages, acked_messages);
+  log_queue_unref(q);
+  unlink(filename->str);
+  g_string_free(filename,TRUE);
+  disk_queue_options_destroy(&options);
+}
+
+static void
+testcase_ack_and_rewind_messages()
+{
+  LogQueue *q;
+  gint i;
+  GString *filename;
+  DiskQueueOptions options = {0};
+
+  _construct_options(&options, 10000000, 100000, TRUE);
+
+  q = log_queue_disk_reliable_new(&options);
+  log_queue_set_use_backlog(q, TRUE);
+
+  filename = g_string_sized_new(32);
+  g_string_sprintf(filename,"test-rewind_and_acks.qf");
+  unlink(filename->str);
+  log_queue_disk_load_queue(q,filename->str);
+
+  fed_messages = 0;
+  acked_messages = 0;
+  feed_some_messages(q, 1000, &parse_options);
+  for(i = 0; i < 10; i++)
+    {
+      send_some_messages(q,1);
+      app_rewind_some_messages(q,1);
+    }
+  send_some_messages(q,1000);
+  app_ack_some_messages(q,500);
+  app_rewind_some_messages(q,500);
+  send_some_messages(q,500);
+  app_ack_some_messages(q,500);
+  log_queue_unref(q);
+  unlink(filename->str);
+  g_string_free(filename,TRUE);
+  disk_queue_options_destroy(&options);
+}
+
+#define FEEDERS 1
+#define MESSAGES_PER_FEEDER 10000
+#define MESSAGES_SUM (FEEDERS * MESSAGES_PER_FEEDER)
+#define TEST_RUNS 10
+
+GStaticMutex tlock;
+glong sum_time;
+
+static gpointer
+threaded_feed(gpointer args)
+{
+  LogQueue *q = (LogQueue *)args;
+  char *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép";
+  gint msg_len = strlen(msg_str);
+  gint i;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *msg, *tmpl;
+  GTimeVal start, end;
+  GSockAddr *sa;
+  glong diff;
+
+  iv_init();
+
+  /* emulate main loop for LogQueue */
+  main_loop_worker_thread_start(NULL);
+
+  sa = g_sockaddr_inet_new("10.10.10.10", 1010);
+  tmpl = log_msg_new(msg_str, msg_len, sa, &parse_options);
+  g_get_current_time(&start);
+  for (i = 0; i < MESSAGES_PER_FEEDER; i++)
+    {
+      msg = log_msg_clone_cow(tmpl, &path_options);
+      log_msg_add_ack(msg, &path_options);
+      msg->ack_func = test_ack;
+
+      log_queue_push_tail(q, msg, &path_options);
+
+      if ((i & 0xFF) == 0)
+        main_loop_worker_invoke_batch_callbacks();
+    }
+  main_loop_worker_invoke_batch_callbacks();
+  g_get_current_time(&end);
+  diff = g_time_val_diff(&end, &start);
+  g_static_mutex_lock(&tlock);
+  sum_time += diff;
+  g_static_mutex_unlock(&tlock);
+  main_loop_worker_thread_stop();
+  log_msg_unref(tmpl);
+  g_sockaddr_unref(sa);
+  return NULL;
+}
+
+static gpointer
+threaded_consume(gpointer st)
+{
+  LogQueue *q = (LogQueue *) st;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  gint i;
+
+  /* just to make sure time is properly cached */
+  iv_init();
+
+  for (i = 0; i < MESSAGES_SUM; i++)
+    {
+      LogMessage *msg = NULL;
+      gint slept = 0;
+
+      while(!msg)
+        {
+          msg = log_queue_pop_head(q, &path_options);
+          if (!msg)
+            {
+              struct timespec ns;
+
+              /* sleep 1 msec */
+              ns.tv_sec = 0;
+              ns.tv_nsec = 1000000;
+              nanosleep(&ns, NULL);
+              slept++;
+              if (slept > 10000)
+                {
+                  return GUINT_TO_POINTER(1);
+                }
+            }
+        }
+
+      log_msg_ack(msg, &path_options, AT_PROCESSED);
+      log_msg_unref(msg);
+    }
+
+  return NULL;
+}
+
+
+static void
+testcase_with_threads()
+{
+  LogQueue *q;
+  GThread *thread_feed[FEEDERS], *thread_consume;
+  GString *filename;
+  gint i, j;
+
+  log_queue_set_max_threads(FEEDERS);
+  for (i = 0; i < TEST_RUNS; i++)
+    {
+      DiskQueueOptions options = {0};
+
+      _construct_options(&options, 10000000, 100000, TRUE);
+
+      q = log_queue_disk_reliable_new(&options);
+      filename = g_string_sized_new(32);
+      g_string_sprintf(filename,"test-%04d.qf",i);
+      unlink(filename->str);
+      log_queue_disk_load_queue(q,filename->str);
+
+      for (j = 0; j < FEEDERS; j++)
+        {
+          thread_feed[j] = g_thread_create(threaded_feed, q, TRUE, NULL);
+        }
+
+      thread_consume = g_thread_create(threaded_consume, q, TRUE, NULL);
+
+      for (j = 0; j < FEEDERS; j++)
+      {
+        g_thread_join(thread_feed[j]);
+      }
+      g_thread_join(thread_consume);
+
+      log_queue_unref(q);
+      unlink(filename->str);
+      g_string_free(filename,TRUE);
+      disk_queue_options_destroy(&options);
+      
+    }
+  fprintf(stderr, "Feed speed: %.2lf\n", (double) TEST_RUNS * MESSAGES_SUM * 1000000 / sum_time);
+}
+
+int
+main()
+{
+#if _AIX
+  fprintf(stderr,"On AIX this testcase can't executed, because the overriding of main_loop_io_worker_register_finish_callback does not work\n");
+  return 0;
+#endif
+  app_startup();
+  putenv("TZ=MET-1METDST");
+  tzset();
+
+  configuration = cfg_new(0x308);
+  plugin_load_module("syslogformat", configuration, NULL);
+  plugin_load_module("disk-buffer", configuration, NULL);
+  plugin_load_module("builtin-serializer", configuration, NULL);
+  msg_format_options_defaults(&parse_options);
+  msg_format_options_init(&parse_options, configuration);
+
+  testcase_ack_and_rewind_messages();
+  testcase_with_threads();
+
+  testcase_zero_diskbuf_alternating_send_acks();
+  testcase_zero_diskbuf_and_normal_acks();
+
+  return 0;
+}

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "messages.h"
+#include "logqueue-disk.h"
+#include "logqueue-disk-reliable.h"
+#include "logqueue-disk-non-reliable.h"
+#include "apphook.h"
+#include "plugin.h"
+#include "testutils.h"
+#include "queue_utils_lib.h"
+#include "test_diskq_tools.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define DISKQ_FILENAME "test_become_full.qf"
+
+MsgFormatOptions parse_options;
+
+
+static void msg_post_function(LogMessage *msg)
+{
+  log_msg_unref(msg);
+}
+
+void
+test_diskq_become_full(gboolean reliable)
+{
+  LogQueue *q;
+  acked_messages = 0;
+  fed_messages = 0;
+  DiskQueueOptions options = {0};
+
+  options.reliable = reliable;
+  if (reliable)
+    {
+      _construct_options(&options, 1000, 1000, reliable);
+      q = log_queue_disk_reliable_new(&options);
+    }
+  else
+    {
+      _construct_options(&options, 1000, 0, reliable);
+      q = log_queue_disk_non_reliable_new(&options);
+    }
+
+  log_queue_set_use_backlog(q, TRUE);
+
+  q->persist_name = "test_diskq";
+  stats_lock();
+  stats_register_counter(0, SCS_DESTINATION, q->persist_name, NULL, SC_TYPE_DROPPED, &q->dropped_messages);
+  stats_counter_set(q->dropped_messages, 0);
+  stats_unlock();
+  unlink(DISKQ_FILENAME);
+  log_queue_disk_load_queue(q, DISKQ_FILENAME);
+  feed_some_messages(q, 1000, &parse_options);
+
+  assert_gint(q->dropped_messages->value, 1000, "Bad dropped message number (reliable: %s)", reliable ? "TRUE" : "FALSE");
+
+  log_queue_unref(q);
+  disk_queue_options_destroy(&options);
+  unlink(DISKQ_FILENAME);
+}
+
+int
+main()
+{
+  app_startup();
+  putenv("TZ=MET-1METDST");
+  tzset();
+
+  configuration = cfg_new(0x0308);
+  plugin_load_module("syslogformat", configuration, NULL );
+  plugin_load_module("disk-buffer", configuration, NULL );
+  plugin_load_module("builtin-serializer", configuration, NULL );
+  msg_set_post_func(msg_post_function);
+  msg_format_options_defaults(&parse_options);
+  msg_format_options_init(&parse_options, configuration);
+  test_diskq_become_full(TRUE);
+  test_diskq_become_full(FALSE);
+  return 0;
+}

--- a/modules/diskq/tests/test_diskq_tools.h
+++ b/modules/diskq/tests/test_diskq_tools.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef TEST_DISKQ_TOOLS_H_
+#define TEST_DISKQ_TOOLS_H_
+
+#include "syslog-ng.h"
+#include "logmsg/logmsg-serialize.h"
+#include "diskq-options.h"
+#include "testutils.h"
+
+static inline void
+_construct_options(DiskQueueOptions *options, guint64 size, gint mem_size, gboolean reliable)
+{
+  memset(options, 0, sizeof(DiskQueueOptions));
+  options->disk_buf_size = size;
+  options->mem_buf_length = mem_size;
+  options->mem_buf_size = mem_size;
+  options->qout_size = 0;
+  options->reliable = reliable;
+}
+
+
+#endif /* TEST_DISKQ_TOOLS_H_ */

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "queue_utils_lib.h"
+#include "test_diskq_tools.h"
+#include "testutils.h"
+#include "qdisk.c"
+#include "logqueue-disk-reliable.h"
+#include "apphook.h"
+#include "plugin.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
+MsgFormatOptions parse_options;
+
+#define FILENAME "test_reliable_backlog.qf"
+#define TEST_DISKQ_SIZE QDISK_RESERVED_SPACE + 1000 /* 4096 + 1000 */
+
+static gint num_of_ack;
+
+static gint mark_message_serialized_size;
+
+DiskQueueOptions options;
+
+#define NUMBER_MESSAGES_IN_QUEUE(n) (n * 3)
+
+MsgFormatOptions parse_options;
+
+static void
+_dummy_ack(LogMessage *lm,  AckType ack_type)
+{
+  num_of_ack++;
+}
+
+static LogQueueDiskReliable *
+_init_diskq_for_test(gint64 size, gint64 membuf_size)
+{
+  LogQueueDiskReliable *dq;
+
+  _construct_options(&options, size, membuf_size, TRUE);
+  LogQueue *q = log_queue_disk_reliable_new(&options);
+  struct stat st;
+  num_of_ack = 0;
+  gchar *filename = FILENAME;
+  unlink(filename);
+  log_queue_disk_load_queue(q, filename);
+  dq = (LogQueueDiskReliable *)q;
+  lseek(dq->super.qdisk->fd, size - 1, SEEK_SET);
+  write(dq->super.qdisk->fd, "", 1);
+  fstat(dq->super.qdisk->fd, &st);
+  assert_gint64(st.st_size, size, ASSERTION_ERROR("INITIALIZATION FAILED"));
+  dq->super.super.use_backlog = TRUE;
+  return dq;
+}
+
+static void
+_common_cleanup(LogQueueDiskReliable *dq)
+{
+  log_queue_unref(&dq->super.super);
+  unlink(FILENAME);
+  disk_queue_options_destroy(&options);
+}
+
+static gint
+get_serialized_message_size(LogMessage *msg)
+{
+  GString *serialized;
+  SerializeArchive *sa;
+  gint result;
+
+  serialized = g_string_sized_new(64);
+  sa = serialize_string_archive_new(serialized);
+
+  assert_true(log_msg_serialize(msg, sa), NULL);
+
+  result = serialized->len;
+
+  serialize_archive_free(sa);
+  g_string_free(serialized, TRUE);
+
+  return result + sizeof(guint32);
+}
+
+static void
+set_mark_message_serialized_size()
+{
+  LogMessage *mark_message = log_msg_new_mark();
+  mark_message_serialized_size = get_serialized_message_size(mark_message);
+  log_msg_unref(mark_message);
+}
+
+static void
+_prepare_eof_test(LogQueueDiskReliable *dq, LogMessage **msg1, LogMessage **msg2)
+{
+  LogPathOptions local_options = LOG_PATH_OPTIONS_INIT;
+  gint64 start_pos = TEST_DISKQ_SIZE;
+
+  *msg1 = log_msg_new_mark();
+  *msg2 = log_msg_new_mark();
+
+  (*msg1)->ack_func = _dummy_ack;
+  log_msg_add_ack(*msg1, &local_options);
+
+  (*msg2)->ack_func = _dummy_ack;
+  log_msg_add_ack(*msg2, &local_options);
+
+  dq->super.qdisk->hdr->write_head = start_pos;
+  dq->super.qdisk->hdr->read_head = QDISK_RESERVED_SPACE + mark_message_serialized_size + 1;
+  dq->super.qdisk->hdr->backlog_head = dq->super.qdisk->hdr->read_head;
+
+  log_queue_push_tail(&dq->super.super, *msg1, &local_options);
+  log_queue_push_tail(&dq->super.super, *msg2, &local_options);
+
+  assert_gint(dq->qreliable->length, NUMBER_MESSAGES_IN_QUEUE(2), ASSERTION_ERROR("Messages aren't in qreliable"));
+  assert_gint64(dq->super.qdisk->hdr->write_head, QDISK_RESERVED_SPACE + mark_message_serialized_size, ASSERTION_ERROR("Bad write head"));
+  assert_gint(num_of_ack, 0, ASSERTION_ERROR("Messages are acked"));
+
+  dq->super.qdisk->hdr->read_head = start_pos;
+  dq->super.qdisk->hdr->backlog_head = dq->super.qdisk->hdr->read_head;
+
+}
+
+static void
+test_read_over_eof(LogQueueDiskReliable *dq, LogMessage *msg1, LogMessage *msg2)
+{
+  LogPathOptions read_options;
+  LogMessage *read_message1;
+  LogMessage *read_message2;
+
+  read_message1 = log_queue_pop_head(&dq->super.super, &read_options);
+  assert_true(read_message1 != NULL, ASSERTION_ERROR("Can't read message from queue"));
+  read_message2 = log_queue_pop_head(&dq->super.super, &read_options);
+  assert_true(read_message2 != NULL, ASSERTION_ERROR("Can't read message from queue"));
+  assert_gint(dq->qreliable->length, 0, ASSERTION_ERROR("Queue reliable isn't empty"));
+  assert_gint(dq->qbacklog->length, NUMBER_MESSAGES_IN_QUEUE(2), ASSERTION_ERROR("Messages aren't in the qbacklog"));
+  assert_gint(dq->super.qdisk->hdr->read_head, dq->super.qdisk->hdr->write_head, ASSERTION_ERROR("Read head in bad position"));
+  assert_true(msg1 == read_message1, ASSERTION_ERROR("Message 1 isn't read from qreliable"));
+  assert_true(msg2 == read_message2, ASSERTION_ERROR("Message 2 isn't read from qreliable"));
+}
+
+static void
+test_rewind_over_eof(LogQueueDiskReliable *dq)
+{
+  LogMessage *msg3 = log_msg_new_mark();
+  LogMessage *read_message3;
+
+  LogPathOptions local_options = LOG_PATH_OPTIONS_INIT;
+  msg3->ack_func = _dummy_ack;
+
+  log_queue_push_tail(&dq->super.super, msg3, &local_options);
+  gint64 previous_read_head = dq->super.qdisk->hdr->read_head;
+  read_message3 = log_queue_pop_head(&dq->super.super, &local_options);
+  assert_true(read_message3 != NULL, ASSERTION_ERROR("Can't read message from queue"));
+  assert_gint(dq->super.qdisk->hdr->read_head, dq->super.qdisk->hdr->write_head, ASSERTION_ERROR("Read head in bad position"));
+
+  assert_true(msg3 == read_message3, ASSERTION_ERROR("Message 3 isn't read from qreliable"));
+  log_msg_unref(read_message3);
+
+  log_queue_rewind_backlog(&dq->super.super, 1);
+
+  assert_gint(dq->super.qdisk->hdr->read_head, previous_read_head, ASSERTION_ERROR("Read head is corrupted"));
+
+  read_message3 = log_queue_pop_head(&dq->super.super, &local_options);
+  assert_true(read_message3 != NULL, ASSERTION_ERROR("Can't read message from queue"));
+  assert_gint(dq->super.qdisk->hdr->read_head, dq->super.qdisk->hdr->write_head, ASSERTION_ERROR("Read head in bad position"));
+  assert_true(msg3 == read_message3, ASSERTION_ERROR("Message 3 isn't read from qreliable"));
+
+  log_msg_drop(msg3, &local_options, AT_PROCESSED);
+}
+
+static void
+test_ack_over_eof(LogQueueDiskReliable *dq, LogMessage *msg1, LogMessage *msg2)
+{
+  log_queue_ack_backlog(&dq->super.super, 3);
+  assert_gint(dq->qbacklog->length, 0, ASSERTION_ERROR("Messages are in the qbacklog"));
+  assert_gint(dq->super.qdisk->hdr->backlog_head, dq->super.qdisk->hdr->read_head, ASSERTION_ERROR("Backlog head in bad position"));
+}
+
+/* TestCase:
+   * write two messages into the diskq
+   *  - 1st into the end of the queue,
+   *  - 2nd the beginning of the queue
+   * the read and ack_backlog and rewind_backlog mechanism must detect,
+   * that the read head and backlog head are on the end of the queue,
+   * so they will set to the beginning of the queue
+   */
+/* TODO: add 3 messages and rewind 1 instead of 0 */
+/* TODO: split this test into 3 tests (read ack rewind mechanism  (setup method) */
+static void
+test_over_EOF()
+{
+  LogQueueDiskReliable *dq = _init_diskq_for_test(TEST_DISKQ_SIZE, TEST_DISKQ_SIZE);
+  LogMessage *msg1;
+  LogMessage *msg2;
+
+  LogPathOptions read_options = LOG_PATH_OPTIONS_INIT;
+
+  _prepare_eof_test(dq, &msg1, &msg2);
+
+  test_read_over_eof(dq, msg1, msg2);
+
+  test_rewind_over_eof(dq);
+
+  test_ack_over_eof(dq, msg1, msg2);
+
+  log_msg_drop(msg1, &read_options, AT_PROCESSED);
+  log_msg_drop(msg2, &read_options, AT_PROCESSED);
+  assert_gint(num_of_ack, 2, ASSERTION_ERROR("Messages aren't acked"));
+  _common_cleanup(dq);
+}
+
+/*
+ * The method make the following situation
+ * the backlog contains 6 messages
+ * the qbacklog contains 3 messages,
+ * but messages in qbacklog are the end of the backlog
+ */
+void
+_prepare_rewind_backlog_test(LogQueueDiskReliable *dq, gint64 *start_pos)
+{
+  gint i;
+
+  for (i = 0; i < 8; i++)
+    {
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+      LogMessage *mark_message;
+      mark_message = log_msg_new_mark();
+      mark_message->ack_func = _dummy_ack;
+      log_queue_push_tail(&dq->super.super, mark_message, &path_options);
+    }
+
+  /* Lets read the messages and leave them in the backlog */
+  for (i = 0; i < 8; i++)
+    {
+      LogMessage *msg;
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+      msg = log_queue_pop_head(&dq->super.super, &path_options);
+      log_msg_unref(msg);
+    }
+
+  /* Ack the messages which are not in the qbacklog */
+  log_queue_ack_backlog(&dq->super.super, 5);
+  assert_gint(dq->qbacklog->length, NUMBER_MESSAGES_IN_QUEUE(3), ASSERTION_ERROR("Incorrect number of items in the qbacklog"));
+
+  *start_pos = dq->super.qdisk->hdr->read_head;
+
+  /* Now write 3 more messages and read them from buffer
+   * the number of messages in the qbacklog should not be changed
+   * The backlog should contain 6 messages
+   * from these 6 messages 3 messages are cached in the qbacklog
+   * No readable messages are in the queue
+   */
+  for (i = 0; i < 3; i++)
+    {
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+      LogMessage *mark_message;
+      mark_message = log_msg_new_mark();
+      mark_message->ack_func = _dummy_ack;
+      log_queue_push_tail(&dq->super.super, mark_message, &path_options);
+      mark_message = log_queue_pop_head(&dq->super.super, &path_options);
+      assert_gint(dq->qreliable->length, 0,
+          ASSERTION_ERROR("Incorrect number of items in the qreliable"));
+      assert_gint(dq->qbacklog->length, NUMBER_MESSAGES_IN_QUEUE(3),
+          ASSERTION_ERROR("Incorrect number of items in the qbacklog"));
+      log_msg_unref(mark_message);
+    }
+  assert_gint(dq->super.qdisk->hdr->backlog_len, 6,
+      ASSERTION_ERROR("Incorrect number of messages in the backlog"));
+  assert_gint(dq->super.qdisk->hdr->length, 0,
+      ASSERTION_ERROR("Reliable diskq isn't empty"));
+}
+
+void
+test_rewind_backlog_without_using_qbacklog(LogQueueDiskReliable *dq, gint64 old_read_pos)
+{
+  /*
+     * Rewind the last 2 messages
+     * - the read_head should be moved to the good position
+     * - the qbacklog and qreliable should be untouched
+     */
+    log_queue_rewind_backlog(&dq->super.super, 2);
+    assert_gint64(dq->super.qdisk->hdr->read_head, old_read_pos + mark_message_serialized_size, ASSERTION_ERROR("Bad reader position"));
+    assert_gint(dq->qreliable->length, 0, ASSERTION_ERROR("Incorrect number of items in the qreliable"));
+    assert_gint(dq->qbacklog->length, NUMBER_MESSAGES_IN_QUEUE(3), ASSERTION_ERROR("Incorrect number of items in the qbacklog"));
+}
+
+void
+test_rewind_backlog_partially_used_qbacklog(LogQueueDiskReliable *dq, gint64 old_read_pos)
+{
+  /*
+   * Rewind more 2 messages
+   * - the reader the should be moved to the good position
+   * - the qreliable should contain 1 items
+   * - the qbackbacklog should contain 2 items
+   */
+  log_queue_rewind_backlog(&dq->super.super, 2);
+  assert_gint64(dq->super.qdisk->hdr->read_head, old_read_pos - mark_message_serialized_size, ASSERTION_ERROR("Bad reader position"));
+  assert_gint(dq->qreliable->length, NUMBER_MESSAGES_IN_QUEUE(1), ASSERTION_ERROR("Incorrect number of items in the qreliable"));
+  assert_gint(dq->qbacklog->length, NUMBER_MESSAGES_IN_QUEUE(2), ASSERTION_ERROR("Incorrect number of items in the qbacklog"));
+}
+
+void
+test_rewind_backlog_use_whole_qbacklog(LogQueueDiskReliable *dq)
+{
+  /*
+   * Rewind more 2 messages
+   * - the reader the should be moved to the backlog head
+   * - the qreliable should contain 3 items
+   * - the qbackbacklog should be empty
+   */
+  log_queue_rewind_backlog(&dq->super.super, 2);
+  assert_gint64(dq->super.qdisk->hdr->read_head, dq->super.qdisk->hdr->backlog_head,
+      ASSERTION_ERROR("Bad reader position"));
+  assert_gint(dq->qreliable->length, NUMBER_MESSAGES_IN_QUEUE(3),
+      ASSERTION_ERROR("Incorrect number of items in the qreliable"));
+  assert_gint(dq->qbacklog->length, 0,
+      ASSERTION_ERROR("Incorrect number of items in the qbacklog"));
+
+}
+
+/*
+ * TestCase
+ * backlog contains messages: 1 2 3 4 5 6
+ * qbacklog contains messages: 1 2 3
+ * qbacklog must be always in sync with backlog
+ */
+void
+test_rewind_backlog()
+{
+  LogQueueDiskReliable *dq = _init_diskq_for_test(QDISK_RESERVED_SPACE + mark_message_serialized_size * 10, mark_message_serialized_size * 5);
+  gint64 old_read_pos;
+
+  _prepare_rewind_backlog_test(dq, &old_read_pos);
+
+  test_rewind_backlog_without_using_qbacklog(dq, old_read_pos);
+
+  test_rewind_backlog_partially_used_qbacklog(dq, old_read_pos);
+
+  test_rewind_backlog_use_whole_qbacklog(dq);
+
+  _common_cleanup(dq);
+}
+
+gint
+main(gint argc, gchar **argv)
+{
+  app_startup();
+  putenv("TZ=MET-1METDST");
+  tzset();
+
+  configuration = cfg_new(0x0308);
+  plugin_load_module("syslogformat", configuration, NULL);
+  plugin_load_module("disk-buffer", configuration, NULL);
+  msg_format_options_defaults(&parse_options);
+  msg_format_options_init(&parse_options, configuration);
+  set_mark_message_serialized_size();
+
+  test_over_EOF();
+
+  test_rewind_backlog();
+
+  cfg_free(configuration);
+  app_shutdown();
+
+  return 0;
+}

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -23,5 +23,5 @@ modules/native
 tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|hdfs|http|kafka|[^/]*$)
-modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
+modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
 scl

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -28,6 +28,7 @@
 #include "mainloop.h"
 #include "tls-support.h"
 #include "mainloop-io-worker.h"
+#include "libtest/queue_utils_lib.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -35,68 +36,9 @@
 #include <iv_list.h>
 #include <iv_thread.h>
 
-int acked_messages = 0;
-int fed_messages = 0;
 MsgFormatOptions parse_options;
 
 #define OVERFLOW_SIZE 10000
-
-void
-test_ack(LogMessage *msg, AckType ack_type)
-{
-  acked_messages++;
-}
-
-void
-feed_some_messages(LogQueue **q, int n)
-{
-  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-  LogMessage *msg;
-  gint i;
-
-  path_options.ack_needed = (*q)->use_backlog;
-  for (i = 0; i < n; i++)
-    {
-      char *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép";
-      GSockAddr *sa;
-
-      sa = g_sockaddr_inet_new("10.10.10.10", 1010);
-      msg = log_msg_new(msg_str, strlen(msg_str), sa, &parse_options);
-      g_sockaddr_unref(sa);
-      log_msg_add_ack(msg, &path_options);
-      msg->ack_func = test_ack;
-      log_queue_push_tail((*q), msg, &path_options);
-      fed_messages++;
-    }
-
-}
-
-void
-send_some_messages(LogQueue *q, gint n)
-{
-  gint i;
-  LogMessage *msg;
-  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-
-  for (i = 0; i < n; i++)
-    {
-      msg = log_queue_pop_head(q, &path_options);
-      log_msg_ack(msg, &path_options, AT_PROCESSED);
-      log_msg_unref(msg);
-    }
-}
-
-void
-app_ack_some_messages(LogQueue *q, gint n)
-{
-  log_queue_ack_backlog(q, n);
-}
-
-void
-rewind_messages(LogQueue *q)
-{
-  log_queue_rewind_backlog_all(q);
-}
 
 void
 testcase_zero_diskbuf_and_normal_acks()
@@ -110,7 +52,7 @@ testcase_zero_diskbuf_and_normal_acks()
   fed_messages = 0;
   acked_messages = 0;
   for (i = 0; i < 10; i++)
-    feed_some_messages(&q, 10);
+    feed_some_messages(q, 10, &parse_options);
 
   send_some_messages(q, fed_messages);
   app_ack_some_messages(q, fed_messages);
@@ -136,7 +78,7 @@ testcase_zero_diskbuf_alternating_send_acks()
   acked_messages = 0;
   for (i = 0; i < 10; i++)
     {
-      feed_some_messages(&q, 10);
+      feed_some_messages(q, 10, &parse_options);
       send_some_messages(q, 10);
       app_ack_some_messages(q, 10);
     }


### PR DESCRIPTION
Disk-buffer: this kind of disk buffer is ported from syslog-ng PE.
    
    This is an inner-destination plugin, make it possible to use a disk based queue.
    There are 2 kind of disk-buffer: reliable and non-reliable.
    
    Non-reliable means, that it uses memory buffers,
    therefore this kind of disk-buffer is not crash safe,
    but in some cases it can be faster than the reliable one
    
    The reliable disk-buffer store every message on the queue in serialized format,
    therefore it is crash-safe, but can be slower than the non-reliable disk buffer.

usage examples:
```
destination d_network1("server"
           disk-buffer(
        	reliable(no)
                qout-size(64)
                disk-buf-size(1000000)
                mem-buf-size(10000)
           )
);

destination d_network2("server2"
           disk-buffer(
                  reliable(yes)
                  disk-buf-size(1000000)
                  mem-buf_length(100000)
           )
);
....
```