### PR TITLE
make sure all path/dir variables are defined in a single location, by configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,9 @@ fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
 toolsdir='${datadir}/syslog-ng/tools'
-scldir='${datadir}/syslog-ng/include/scl'
+
+config_includedir='${datadir}/syslog-ng/include'
+scldir="${config_includedir}/scl"
 
 AC_CONFIG_HEADERS(config.h)
 
@@ -1396,6 +1398,7 @@ AC_DEFINE_UNQUOTED(PATH_LOCALSTATEDIR, "$localstatedir", [local state directory]
 AC_DEFINE_UNQUOTED(PATH_PIDFILEDIR, "$pidfiledir", [local state directory])
 AC_DEFINE_UNQUOTED(PATH_DATAROOTDIR, "$datarootdir", [data root directory])
 AC_DEFINE_UNQUOTED(PATH_DATADIR, "$datadir", [data directory])
+AC_DEFINE_UNQUOTED(PATH_CONFIG_INCLUDEDIR, "$config_includedir", [include directory])
 AC_DEFINE_UNQUOTED(PATH_LIBEXECDIR, "$libexecdir", [libexec directory])
 if test -n "$timezonedir"; then
         AC_DEFINE_UNQUOTED(PATH_TIMEZONEDIR, "$timezonedir", [timezone base directory])
@@ -1451,6 +1454,7 @@ AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)
 AC_SUBST(moduledir)
 AC_SUBST(toolsdir)
+AC_SUBST(config_includedir)
 AC_SUBST(scldir)
 AC_SUBST(systemdsystemunitdir)
 AC_SUBST(SYSLOGNG_LINK)

--- a/configure.ac
+++ b/configure.ac
@@ -1399,6 +1399,7 @@ AC_DEFINE_UNQUOTED(PATH_PIDFILEDIR, "$pidfiledir", [local state directory])
 AC_DEFINE_UNQUOTED(PATH_DATAROOTDIR, "$datarootdir", [data root directory])
 AC_DEFINE_UNQUOTED(PATH_DATADIR, "$datadir", [data directory])
 AC_DEFINE_UNQUOTED(PATH_CONFIG_INCLUDEDIR, "$config_includedir", [include directory])
+AC_DEFINE_UNQUOTED(PATH_SCLDIR, "$scldir", [SCL directory])
 AC_DEFINE_UNQUOTED(PATH_LIBEXECDIR, "$libexecdir", [libexec directory])
 if test -n "$timezonedir"; then
         AC_DEFINE_UNQUOTED(PATH_TIMEZONEDIR, "$timezonedir", [timezone base directory])

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,7 @@ fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
 toolsdir='${datadir}/syslog-ng/tools'
+xsddir='${datadir}/syslog-ng/xsd'
 
 config_includedir='${datadir}/syslog-ng/include'
 scldir="${config_includedir}/scl"
@@ -1400,6 +1401,7 @@ AC_DEFINE_UNQUOTED(PATH_DATAROOTDIR, "$datarootdir", [data root directory])
 AC_DEFINE_UNQUOTED(PATH_DATADIR, "$datadir", [data directory])
 AC_DEFINE_UNQUOTED(PATH_CONFIG_INCLUDEDIR, "$config_includedir", [include directory])
 AC_DEFINE_UNQUOTED(PATH_SCLDIR, "$scldir", [SCL directory])
+AC_DEFINE_UNQUOTED(PATH_XSDDIR, "$xsddir", [XSD directory])
 AC_DEFINE_UNQUOTED(PATH_LIBEXECDIR, "$libexecdir", [libexec directory])
 if test -n "$timezonedir"; then
         AC_DEFINE_UNQUOTED(PATH_TIMEZONEDIR, "$timezonedir", [timezone base directory])
@@ -1457,6 +1459,7 @@ AC_SUBST(moduledir)
 AC_SUBST(toolsdir)
 AC_SUBST(config_includedir)
 AC_SUBST(scldir)
+AC_SUBST(xsddir)
 AC_SUBST(systemdsystemunitdir)
 AC_SUBST(SYSLOGNG_LINK)
 AC_SUBST(SYSLOGNG_DEPS_LIBS)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -11,7 +11,6 @@ EXTRA_DIST	+=  \
 		doc/xsd/patterndb-3.xsd \
 		doc/xsd/patterndb-4.xsd
 
-xsddir		= $(datadir)/xsd
 xsd_DATA	= \
 		doc/xsd/patterndb-1.xsd \
 		doc/xsd/patterndb-2.xsd \

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -396,11 +396,20 @@ cfg_new(gint version)
 void
 cfg_set_global_paths(GlobalConfig *self)
 {
+  gchar *include_path;
+
   cfg_args_set(self->lexer->globals, "syslog-ng-root", get_installation_path_for(SYSLOG_NG_PATH_PREFIX));
   cfg_args_set(self->lexer->globals, "syslog-ng-data", get_installation_path_for(SYSLOG_NG_PATH_DATADIR));
+  cfg_args_set(self->lexer->globals, "syslog-ng-include", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
+  cfg_args_set(self->lexer->globals, "scl-root", get_installation_path_for(SYSLOG_NG_PATH_SCLDIR));
   cfg_args_set(self->lexer->globals, "module-path", module_path);
-  cfg_args_set(self->lexer->globals, "include-path", get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR));
   cfg_args_set(self->lexer->globals, "autoload-compiled-modules", "1");
+
+  include_path = g_strdup_printf("%s:%s",
+                                 get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR),
+                                 get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
+  cfg_args_set(self->lexer->globals, "include-path", include_path);
+  g_free(include_path);
 }
 
 gboolean

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -28,7 +28,7 @@
 #include "patterndb.h"
 
 #define PATH_PATTERNDB_FILE     SYSLOG_NG_PATH_LOCALSTATEDIR "/patterndb.xml"
-#define PATH_XSDDIR             SYSLOG_NG_PATH_DATADIR "/xsd"
+#define PATH_XSDDIR             SYSLOG_NG_PATH_XSDDIR
 
 typedef struct _LogDBParser LogDBParser;
 

--- a/scl/scl.conf
+++ b/scl/scl.conf
@@ -25,7 +25,4 @@
 # `include-path`, then includes all SCL supplied plugins.
 #
 
-@define scl-root "`syslog-ng-data`/include/scl"
-@define include-path "`include-path`:`syslog-ng-data`/include"
-
 @include 'scl/*/*.conf'

--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -7,6 +7,7 @@ libdir=@libdir@
 includedir=@includedir@
 toolsdir=@toolsdir@
 moduledir=@moduledir@
+config_includedir=@config_includedir@
 scldir=@scldir@
 ivykis=@with_ivykis@
 


### PR DESCRIPTION
This one should be a partial fix to #908 as it doesn't yet fix xsddir, but it does for scldir and config_includedir

NOTE: YOU CAN GET SEGFAULTS after merging this in a development environment: I've found a segfault in the lexer if two instances of scl/system/plugin.conf is included into the same config. I'm still diagnosing that issue, but I wanted to get this in.
 