### PR TITLE
Add Elasticsearch 2 destination with Shield support

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -37,6 +37,7 @@ endif
 EXTRA_DIST += \
 	modules/java-modules/common/build.gradle  \
 	modules/java-modules/elastic/build.gradle \
+	modules/java-modules/elastic-v2/build.gradle \
 	modules/java-modules/kafka/build.gradle \
 	modules/java-modules/hdfs/build.gradle    \
 	modules/java-modules/dummy/build.gradle   \
@@ -84,5 +85,16 @@ EXTRA_DIST += \
 	modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java \
 	modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java \
 	modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java \
-	modules/java-modules/dummy/src/main/java/org/syslog_ng/DummyTextDestination.java 
-
+	modules/java-modules/dummy/src/main/java/org/syslog_ng/DummyTextDestination.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessor.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/DummyProcessor.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESBulkMessageProcessor.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessorFactory.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESSingleMessageProcessor.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESTransportClient.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESNodeClient.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/UnknownESClientModeException.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java

--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -97,4 +97,6 @@ EXTRA_DIST += \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESNodeClient.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/UnknownESClientModeException.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java \
-	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESTransportShieldClient.java
+

--- a/modules/java-modules/build.gradle
+++ b/modules/java-modules/build.gradle
@@ -11,6 +11,9 @@ allprojects {
             dirs '/usr/lib/syslog-ng-java-module-dependency-jars/jars'
         }
       mavenCentral()
+      maven {
+        url "http://maven.elasticsearch.org/releases"
+      }
     }
 
     compileJava {
@@ -18,4 +21,3 @@ allprojects {
         targetCompatibility "1.7"
     }
 }
-

--- a/modules/java-modules/elastic-v2/build.gradle
+++ b/modules/java-modules/elastic-v2/build.gradle
@@ -1,0 +1,12 @@
+project.buildDir = syslogBuildDir+'/elastic-v2/gradle'
+
+dependencies {
+    compile 'org.elasticsearch:elasticsearch:2.1.1'
+    compile name: 'syslog-ng-common'
+    compile name: 'syslog-ng-core'
+    compile 'junit:junit:4.12'
+    compile 'org.hamcrest:hamcrest-core:1.3'
+    compile 'log4j:log4j:1.2.17'
+    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
+}
+

--- a/modules/java-modules/elastic-v2/build.gradle
+++ b/modules/java-modules/elastic-v2/build.gradle
@@ -2,6 +2,7 @@ project.buildDir = syslogBuildDir+'/elastic-v2/gradle'
 
 dependencies {
     compile 'org.elasticsearch:elasticsearch:2.1.1'
+    compile 'org.elasticsearch.plugin:shield:2.1.1'
     compile name: 'syslog-ng-common'
     compile name: 'syslog-ng-core'
     compile 'junit:junit:4.12'

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2;
+
+import org.syslog_ng.LogMessage;
+import org.syslog_ng.LogTemplate;
+import org.syslog_ng.StructuredLogDestination;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.ESClient;
+import org.syslog_ng.elasticsearch_v2.client.ESClientFactory;
+import org.syslog_ng.elasticsearch_v2.client.UnknownESClientModeException;
+import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessor;
+import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessorFactory;
+import org.syslog_ng.options.InvalidOptionException;
+import org.syslog_ng.logging.SyslogNgInternalLogger;
+import org.apache.log4j.Logger;
+import org.elasticsearch.action.index.IndexRequest;
+
+public class ElasticSearchDestination extends StructuredLogDestination {
+
+	ESClient client;
+	ESMessageProcessor msgProcessor;
+	ElasticSearchOptions options;
+	Logger logger;
+
+	boolean opened;
+
+	public ElasticSearchDestination(long handle) {
+		super(handle);
+		logger = Logger.getRootLogger();
+		SyslogNgInternalLogger.register(logger);
+		options = new ElasticSearchOptions(this);
+	}
+
+	@Override
+	protected boolean init() {
+		boolean result = false;
+		try {
+			options.init();
+			client = ESClientFactory.getESClient(options);
+			msgProcessor = ESMessageProcessorFactory.getMessageProcessor(options, client);
+			client.init();
+			if (options.getClientMode().equals(ElasticSearchOptions.CLIENT_MODE_TRANSPORT) && options.getFlushLimit() > 1) {
+				logger.warn("Using transport client mode with bulk message processing (flush_limit > 1) can cause high message dropping rate in case of connection broken, using node client mode is suggested");
+			}
+			result = true;
+		}
+		catch (InvalidOptionException | UnknownESClientModeException e){
+			logger.error(e.getMessage());
+			return false;
+		}
+		return result;
+	}
+
+	@Override
+	protected boolean isOpened() {
+		return opened;
+	}
+
+	@Override
+	protected boolean open() {
+		opened = client.open();
+		if (opened){
+			msgProcessor.init();
+		}
+		return opened;
+	}
+
+    private IndexRequest createIndexRequest(LogMessage msg) {
+    	String formattedMessage = options.getMessageTemplate().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+    	String customId = options.getCustomId().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+    	String index = options.getIndex().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+    	String type = options.getType().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+    	logger.debug("Outgoing log entry, json='" + formattedMessage + "'");
+    	return new IndexRequest(index, type, customId).source(formattedMessage);
+    }
+
+	@Override
+	protected boolean send(LogMessage msg) {
+		if (!client.isOpened()) {
+			close();
+			return false;
+		}
+		return msgProcessor.send(createIndexRequest(msg));
+	}
+
+	@Override
+	protected void close() {
+		if (opened) {
+			msgProcessor.flush();
+			msgProcessor.deinit();
+			client.close();
+			opened = false;
+		}
+	}
+
+	@Override
+	protected String getNameByUniqOptions() {
+		return String.format("ElasticSearch_v2,%s,%s", client.getClusterName(), options.getIndex().getValue());
+	}
+
+	@Override
+	protected void deinit() {
+		client.deinit();
+		options.deinit();
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -49,7 +49,8 @@ public class ElasticSearchOptions {
 	public static String FLUSH_LIMIT_DEFAULT = "5000";
 	public static String CLIENT_MODE_TRANSPORT = "transport";
 	public static String CLIENT_MODE_NODE = "node";
-	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE));
+	public static String CLIENT_MODE_SHIELD = "shield";
+	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE, CLIENT_MODE_SHIELD));
 
 	public static String CLIENT_MODE_DEFAULT = CLIENT_MODE_TRANSPORT;
 	public static String CONCURRENT_REQUESTS_DEFAULT = "1";

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.syslog_ng.LogDestination;
+import org.syslog_ng.options.*;
+
+public class ElasticSearchOptions {
+
+	public static String SERVER = "server";
+	public static String PORT = "port";
+	public static String CLUSTER = "cluster";
+	public static String INDEX = "index";
+	public static String TYPE = "type";
+	public static String MESSAGE_TEMPLATE = "message_template";
+	public static String CUSTOM_ID = "custom_id";
+	public static String FLUSH_LIMIT = "flush_limit";
+	public static String CLIENT_MODE = "client_mode";
+	public static String CONFIG_FILE = "resource";
+	public static String CONCURRENT_REQUESTS = "concurrent_requests";
+
+	public static String SERVER_DEFAULT = "localhost";
+	public static String PORT_DEFAULT = "9300";
+	public static String MESSAGE_TEMPLATE_DEFAULT = "$(format-json --scope rfc5424 --exclude DATE --key ISODATE)";
+	public static String FLUSH_LIMIT_DEFAULT = "5000";
+	public static String CLIENT_MODE_TRANSPORT = "transport";
+	public static String CLIENT_MODE_NODE = "node";
+	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE));
+
+	public static String CLIENT_MODE_DEFAULT = CLIENT_MODE_TRANSPORT;
+	public static String CONCURRENT_REQUESTS_DEFAULT = "1";
+
+	private LogDestination owner;
+	private Options options;
+
+	public ElasticSearchOptions(LogDestination owner) {
+		this.owner = owner;
+		options = new Options();
+		fillOptions();
+	}
+
+	public void init() throws InvalidOptionException {
+		options.validate();
+	}
+
+	public void deinit() {
+		options.deinit();
+	}
+
+	public Option getOption(String optionName) {
+		return options.get(optionName);
+	}
+
+	public TemplateOption getMessageTemplate() {
+		return options.getTemplateOption(MESSAGE_TEMPLATE);
+	}
+
+	public TemplateOption getCustomId() {
+		return options.getTemplateOption(CUSTOM_ID);
+	}
+
+	public TemplateOption getIndex() {
+		return options.getTemplateOption(INDEX);
+	}
+
+	public TemplateOption getType() {
+		return options.getTemplateOption(TYPE);
+	}
+
+	public String[] getServerList() {
+		return options.get(SERVER).getValueAsStringList(" ");
+	}
+
+	public int getPort() {
+		return options.get(PORT).getValueAsInteger();
+	}
+
+	public String getCluster() {
+		return options.get(CLUSTER).getValue();
+	}
+
+	public int getFlushLimit() {
+		return options.get(FLUSH_LIMIT).getValueAsInteger();
+	}
+
+	public String getClientMode() {
+		return options.get(CLIENT_MODE).getValue();
+	}
+
+	public String getConfigFile() {
+		return options.get(CONFIG_FILE).getValue();
+	}
+
+        public int getConcurrentRequests() {
+        	return options.get(CONCURRENT_REQUESTS).getValueAsInteger();
+        }	
+
+	private void fillOptions() {
+		fillStringOptions();
+		fillTemplateOptions();
+	}
+
+	private void fillTemplateOptions() {
+		options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, INDEX))));
+		options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, TYPE))));
+		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, MESSAGE_TEMPLATE, MESSAGE_TEMPLATE_DEFAULT)));
+		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, CUSTOM_ID)));
+	}
+
+	private void fillStringOptions() {
+		options.put(new StringOption(owner, SERVER, SERVER_DEFAULT));
+		options.put(new PortCheckDecorator(new StringOption(owner, PORT, PORT_DEFAULT)));
+		options.put(new StringOption(owner, CLUSTER));
+		options.put(new IntegerRangeCheckOptionDecorator(new StringOption(owner, FLUSH_LIMIT, FLUSH_LIMIT_DEFAULT), -1, Integer.MAX_VALUE));
+		options.put(new EnumOptionDecorator(new StringOption(owner, CLIENT_MODE, CLIENT_MODE_DEFAULT), CLIENT_MODES));
+		options.put(new StringOption(owner, CONFIG_FILE));
+		options.put(new IntegerRangeCheckOptionDecorator(new StringOption(owner, CONCURRENT_REQUESTS, CONCURRENT_REQUESTS_DEFAULT), 0, Integer.MAX_VALUE));
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -23,12 +23,17 @@
 
 package org.syslog_ng.elasticsearch_v2.client;
 
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
 import org.apache.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.common.settings.Settings.Builder;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 
 public abstract class ESClient {
@@ -104,4 +109,16 @@ public abstract class ESClient {
 	protected void resetClient() {
 		this.client = null;
 	}
+	
+    protected void loadConfigFile(String cfgFile, Builder settingsBuilder) {
+        if (cfgFile == null || cfgFile.isEmpty()) {
+            return;
+        }
+        try {
+            URI url = new File(cfgFile).toURI();
+            settingsBuilder.loadFromPath(Paths.get(url));
+        } catch (SettingsException e) {
+            logger.warn("Can't load settings from file, file = '" + cfgFile + "', reason = '" + e.getMessage() + "'");
+        }
+    }
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.client;
+
+import org.apache.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.client.Client;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+
+public abstract class ESClient {
+	private Client client;
+	private static final String TIMEOUT = "5s";
+	protected Logger logger;
+
+	protected ElasticSearchOptions options;
+
+	public ESClient(ElasticSearchOptions options) {
+		this.options = options;
+		logger = Logger.getRootLogger();
+	}
+
+	private boolean waitForStatus(ClusterHealthStatus status) {
+		ClusterHealthRequestBuilder healthRequest = client.admin().cluster().prepareHealth();
+		healthRequest.setTimeout(TIMEOUT);
+		healthRequest.setWaitForStatus(status);
+		ClusterHealthResponse response = (ClusterHealthResponse) healthRequest.execute().actionGet();
+		return !response.isTimedOut();
+	}
+
+	public void connect() throws ElasticsearchException {
+		String clusterName = getClusterName();
+		logger.info("connecting to cluster, cluster_name='" + clusterName + "'");
+		if (!waitForStatus(ClusterHealthStatus.GREEN)) {
+			logger.debug("Failed to wait for green");
+			logger.debug("Wait for read yellow status...");
+
+			if (!waitForStatus(ClusterHealthStatus.YELLOW)) {
+				logger.debug("Timedout");
+				throw new ElasticsearchException("Can't connect to cluster: " + clusterName);
+			}
+		}
+		logger.info("conneted to cluster, cluster_name='" + clusterName + "'");
+	}
+
+	public final boolean open() {
+		if (client == null) {
+			client = createClient();
+		}
+		try {
+			connect();
+		}
+		catch (ElasticsearchException e) {
+			logger.error("Failed to connect to " + getClusterName() + ", reason='" + e.getMessage() + "'");
+			close();
+			return false;
+		}
+		return true;
+	}
+
+	public String getClusterName() {
+		return client.settings().get("cluster.name");
+	}
+
+	public abstract void close();
+
+	public abstract boolean isOpened();
+
+	public abstract void deinit();
+
+	public final void init() {
+		client = createClient();
+	}
+
+	public abstract Client createClient();
+
+	public Client getClient() {
+		return client;
+	}
+
+	protected void resetClient() {
+		this.client = null;
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.client;
+
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+
+public class ESClientFactory {
+	public static ESClient getESClient(ElasticSearchOptions options) throws UnknownESClientModeException {
+		String client_type = options.getClientMode();
+		if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_TRANSPORT)) {
+			return new ESTransportClient(options);
+		}
+		else if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_NODE)) {
+			return new ESNodeClient(options);
+		}
+		throw new UnknownESClientModeException(client_type);
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESNodeClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESNodeClient.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.client;
+
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings.Builder;
+import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+
+public class ESNodeClient extends ESClient {
+	private Node node;
+
+	public ESNodeClient(ElasticSearchOptions options) {
+		super(options);
+	}
+
+	@Override
+	public void close() {
+		getClient().close();
+	}
+
+	private NodeBuilder createNodeBuilder(String cluster) {
+		NodeBuilder result = nodeBuilder().data(false)
+				  .client(true);
+
+		if (cluster != null) {
+			result = result.clusterName(cluster);
+		}
+		return result;
+	}
+
+	private void loadConfigFile(String cfgFile, NodeBuilder nodeBuilder) {
+		if (cfgFile == null || cfgFile.isEmpty()) {
+			return;
+		}
+		try {
+			URI url = new File(cfgFile).toURI();			
+			Builder builder = nodeBuilder().settings().loadFromPath(Paths.get(url));			
+			nodeBuilder = nodeBuilder.settings(builder);
+		} catch (SettingsException e) {
+			logger.warn("Can't load settings from file, file = '" + cfgFile + "', reason = '" + e.getMessage() + "'");
+		}
+	}
+
+	@Override
+	public Client createClient() {
+		NodeBuilder nodeBuilder = createNodeBuilder(options.getCluster());
+		nodeBuilder.settings().put("discovery.initial_state_timeout", "5s");
+		loadConfigFile(options.getConfigFile(), nodeBuilder);
+		node = nodeBuilder.node();
+	    return node.client();
+	}
+
+	@Override
+	public boolean isOpened() {
+		return true;
+	}
+
+	@Override
+	public void deinit() {
+		node.close();
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESNodeClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESNodeClient.java
@@ -28,7 +28,6 @@ import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
-
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.settings.SettingsException;

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESTransportClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESTransportClient.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.client;
+
+import java.net.InetSocketAddress;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+
+public class ESTransportClient extends ESClient {
+	private Settings settings;
+	private TransportClient transportClient;
+
+	public ESTransportClient(ElasticSearchOptions options) {
+		super(options);
+	}
+
+	public Client createClient() {
+		String clusterName = options.getCluster();
+		Builder settingsBuilder = Settings.builder();
+		settingsBuilder = settingsBuilder.put("client.transport.sniff", true);
+		        
+		if (clusterName != null) {
+			settingsBuilder = settingsBuilder.put("cluster.name", clusterName);
+		}
+
+		settings = settingsBuilder.build();
+
+		String[] servers =  options.getServerList();
+
+		transportClient = TransportClient.builder().settings(settings).build();
+
+        for (String server : servers) {
+            InetSocketAddress inetSocketAddress = new InetSocketAddress(server, options.getPort());
+            if (inetSocketAddress.isUnresolved()) {
+                logger.warn("Cannot resolve server, address = " + server + ", skipping from server list");
+            } else {
+                transportClient.addTransportAddress(new InetSocketTransportAddress(inetSocketAddress));
+            }
+        }
+		return transportClient;
+	}
+
+	public void close() {
+		getClient().close();
+		resetClient();
+	}
+
+	@Override
+	public boolean isOpened() {
+		return !transportClient.connectedNodes().isEmpty();
+	}
+
+	@Override
+	public void deinit() {
+
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESTransportShieldClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESTransportShieldClient.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2016 Zoltan Pallagi <zoltan.pallagi@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -23,20 +24,24 @@
 
 package org.syslog_ng.elasticsearch_v2.client;
 
+import java.util.ArrayList;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.shield.ShieldPlugin;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 
-public class ESClientFactory {
-	public static ESClient getESClient(ElasticSearchOptions options) throws UnknownESClientModeException {
-		String client_type = options.getClientMode();
-		if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_TRANSPORT)) {		    
-			return new ESTransportClient(options);
-		}
-		else if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_NODE)) {
-			return new ESNodeClient(options);
-		}
-		else if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_SHIELD)) {
-            return new ESTransportShieldClient(options);
-        }
-		throw new UnknownESClientModeException(client_type);
-	}	
+public class ESTransportShieldClient extends ESTransportClient {
+
+	public ESTransportShieldClient(ElasticSearchOptions options) {
+		super(options);
+	}
+	
+	@Override
+    public Client createClient() {
+	    ArrayList<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();    
+        plugins.add(ShieldPlugin.class);
+        
+        super.createClient(plugins);
+        return transportClient;
+    }
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/UnknownESClientModeException.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/UnknownESClientModeException.java
@@ -1,0 +1,8 @@
+package org.syslog_ng.elasticsearch_v2.client;
+
+@SuppressWarnings("serial")
+public class UnknownESClientModeException extends Exception {
+	public UnknownESClientModeException(String client_mode) {
+		super("Unkown client_mode: " + client_mode);
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/DummyProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/DummyProcessor.java
@@ -1,0 +1,24 @@
+package org.syslog_ng.elasticsearch_v2.messageprocessor;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.ESClient;
+
+public class DummyProcessor extends ESMessageProcessor {
+
+	public DummyProcessor(ElasticSearchOptions options, ESClient client) {
+		super(options, client);
+		
+	}
+
+	@Override
+	public void init() {
+		logger.warn("Using option(\"flush_limit\", \"0\"), means only testing the Elasticsearch client site without sending logs to the ES");
+	}
+
+	@Override
+	public boolean send(IndexRequest req) {
+		return true;
+	}
+
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESBulkMessageProcessor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.messageprocessor;
+
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.unit.TimeValue;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.ESClient;
+
+public class ESBulkMessageProcessor extends ESMessageProcessor {
+	private BulkProcessor bulkProcessor;
+
+	private class BulkProcessorListener implements BulkProcessor.Listener {
+		@Override
+		public void beforeBulk(long executionId, BulkRequest request) {
+			logger.debug("Start bulk processing, id='" + executionId + "'");
+		}
+
+		@Override
+		public void afterBulk(long executionId, BulkRequest request,
+				BulkResponse response) {
+			logger.debug("Bulk processing finished successfully, id='" + executionId + "'"
+					+ ", numberOfMessages='" + request.numberOfActions() + "'");
+		}
+
+		@Override
+		public void afterBulk(long executionId, BulkRequest request,
+				Throwable failure) {
+			String errorMessage = "Bulk processing failed,";
+			errorMessage += " id='" + executionId + "'";
+			errorMessage += ", numberOfMessages='" + request.numberOfActions() + "'";
+			errorMessage += ", error='" + failure.getMessage() + "'";
+			logger.error(errorMessage);
+		}
+	}
+
+	public ESBulkMessageProcessor(ElasticSearchOptions options, ESClient client) {
+		super(options, client);
+	}
+
+	@Override
+	public boolean send(IndexRequest req) {
+		bulkProcessor.add(req);
+		return true;
+	}
+
+	@Override
+	public void flush() {
+		bulkProcessor.flush();
+	}
+
+	@Override
+	public void init() {
+		bulkProcessor = BulkProcessor.builder(
+				client.getClient(),
+				new BulkProcessorListener()
+			)
+			.setBulkActions(options.getFlushLimit())
+			.setFlushInterval(new TimeValue(1000))
+			.setConcurrentRequests(options.getConcurrentRequests())
+			.build();
+	}
+
+	@Override
+	public void deinit() {
+		try {
+			bulkProcessor.awaitClose(1, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.messageprocessor;
+
+import org.apache.log4j.Logger;
+import org.elasticsearch.action.index.IndexRequest;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.ESClient;
+
+public abstract class ESMessageProcessor {
+	protected ElasticSearchOptions options;
+	protected ESClient client;
+	protected Logger logger;
+
+
+	public ESMessageProcessor(ElasticSearchOptions options, ESClient client) {
+		this.options = options;
+		this.client = client;
+		logger = Logger.getRootLogger();
+	}
+
+	public void init() {
+
+	}
+
+	public void flush() {
+
+	}
+
+	public void deinit() {
+
+	}
+
+	public abstract boolean send(IndexRequest req);
+
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessorFactory.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.messageprocessor;
+
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.ESClient;
+
+public class ESMessageProcessorFactory {
+	public static ESMessageProcessor getMessageProcessor(ElasticSearchOptions options, ESClient client) {
+		int flush_limit = options.getFlushLimit();
+		if (flush_limit > 1) {
+			return new ESBulkMessageProcessor(options, client);
+		}
+		if (flush_limit == -1) {
+			return new DummyProcessor(options, client);
+		}
+		else {
+			return new ESSingleMessageProcessor(options, client);
+		}
+	}
+}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESSingleMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESSingleMessageProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.messageprocessor;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.ESClient;
+
+public class ESSingleMessageProcessor extends ESMessageProcessor {
+
+	public ESSingleMessageProcessor(ElasticSearchOptions options, ESClient client) {
+		super(options, client);
+	}
+
+	@Override
+	public boolean send(IndexRequest req) {
+		try {
+			IndexResponse response = client.getClient().index(req).actionGet();
+			logger.debug("Message inserted with id: " + response.getId());
+			return true;
+		}
+		catch (ElasticsearchException e) {
+			logger.error("Failed to send message: " + e.getMessage());
+			return false;
+		}
+	}
+
+}

--- a/modules/java-modules/settings.gradle
+++ b/modules/java-modules/settings.gradle
@@ -1,1 +1,1 @@
-include 'dummy', 'common', 'hdfs', 'kafka', 'elastic', 'http'
+include 'dummy', 'common', 'hdfs', 'kafka', 'elastic', 'http', 'elastic-v2'

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -52,3 +52,36 @@ block destination elasticsearch(
     `__VARARGS__`
   );
 };
+
+block destination elasticsearch2(
+  index("")
+  type("")
+  template("$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})")
+  port("9300")
+  server("localhost")
+  flush_limit("5000")
+  client_mode("node")
+  cluster("")
+  custom_id("")
+  resource("")
+  client_lib_dir("")
+  concurrent_requests("1")
+)
+{
+  java(
+    class_path("`module-path`/java-modules/*.jar:`client_lib_dir`/*.jar")
+    class_name("org.syslog_ng.elasticsearch_v2.ElasticSearchDestination")
+    option("index", `index`)
+    option("type", `type`)
+    option("server", `server`)
+    option("port", `port`)
+    option("message-template", `template`)
+    option("cluster", `cluster`)
+    option("flush_limit", `flush_limit`)
+    option("client_mode", `client_mode`)
+    option("resource", `resource`)
+    option("custom_id", `custom_id`)
+    option("concurrent_requests", `concurrent_requests`)
+    `__VARARGS__`
+  );
+};


### PR DESCRIPTION
Support ElasticSearch 2 with Shield.

Example config:
```
destination d_elastic {
    elasticsearch2(
        client_lib_dir(/usr/share/elasticsearch/lib)
        client_mode("shield")
        cluster("es-syslog-ng")
        index("es-syslog-ng")
        port("9300")
        server("vagrant-es-server")
        type("slng_test_type")
        resource("/opt/syslog-ng-ose-3.8/etc/elasticsearch.yml")
    );
};
```