### PR TITLE
Check copyright headers during the execution of make check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_script:
   - ./autogen.sh
   - unset PYTHON_CFLAGS # HACK
   - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl 
-  - if [ "$CC" = "clang" ]; then export COPYRIGHTVERBOSITY=1; make check-copyright; fi
   - make -j || make V=1 --keep-going # to make error messages more readable on error
 script:
   - if [ "$CC" = "gcc" ]; then make distcheck V=1; else make func-test V=1; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,8 @@ local-check:
 	${AM_v_at}${MAKE} check check_PROGRAMS="${current_tests} ${subdir_tests}" \
 				TESTS="${current_tests} ${subdir_tests}"
 
+check-local: check-copyright
+
 ${check_PROGRAMS}: LDFLAGS+="${test_ldflags}"
 
 noinst_LIBRARIES	=

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,19 @@
-EXTRA_DIST += tests/collect-cov.sh
+EXTRA_DIST += \
+	tests/collect-cov.sh \
+	tests/copyright/check.sh \
+	tests/copyright/policy \
+	tests/copyright/license.text.GPLv2+.txt \
+	tests/copyright/license.text.GPLv2+_SSL.txt \
+	tests/copyright/license.text.LGPLv2.1+.txt \
+	tests/copyright/license.text.LGPLv2.1+_SSL.txt
 
 check-copyright:
 	@$(top_srcdir)/tests/copyright/check.sh $(top_srcdir) $(top_builddir) policy
+
+CLEAN_HOOKS += clean-check-copyright
+
+clean-check-copyright:
+	rm copyright-run.log copyright-err.log
 
 coverage:
 	@$(top_srcdir)/tests/collect-cov.sh

--- a/tests/copyright/check.sh
+++ b/tests/copyright/check.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-COPYRIGHTVERBOSITY="${COPYRIGHTVERBOSITY-3}" # 0..4, 0=least amount of output
+COPYRIGHTVERBOSITY="${COPYRIGHTVERBOSITY-1}" # 0..4, 0=least amount of output
 COLUMNS="118" # hack when running in a pipe
 PREVIEW="" # non-null to preview files in error
 
 main() {
  if [ $# -ne 3 -a $# -ne 2 ]; then
   echo "usage: $0 <repo dir> <result dir> [<license policy>]" >&2
+  echo "export COPYRIGHTVERBOSITY=2 # 0..4, where 0=shorter output" >&2
   return 1
  fi
 
@@ -29,7 +30,7 @@ main() {
  local LOG="$BUILDDIR/copyright-run.log"
  local ERR="$BUILDDIR/copyright-err.log"
 
- echo "debug: verbose log in $LOG" >&2
+ echo "debug: more verbose copyright log in $LOG" >&2
 
  local SIGS="2 3 6 7 8 9 11 15"
  trap -- "rm --recursive \"$WORKDIR\" ; exit 1;" $SIGS
@@ -258,7 +259,7 @@ compare_expected_detected() {
      if
       is_license_compatible "$PATHMATCH" "$LICTEXTMATCHB"
      then
-      if [ 0$COPYRIGHTVERBOSITY -ge 2 ]; then
+      if [ 0$COPYRIGHTVERBOSITY -ge 1 ]; then
        printf "%s\n" "warning: compatible $FILE expected:$PATHMATCH detected:$LICTEXTMATCHB" >&2
       fi
      else

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -2,8 +2,12 @@
 .*\.(md|am)$
 .*/[^/]+-grammar\.[ch]$
 lib/cfg-lex\.[ch]$
+lib/ivykis
+lib/jsonc
 modules/java/org_syslog_ng_[^./_-]+\.h$
 modules/(afmongodb|afamqp)/dummy\.c$
+modules/afamqp/rabbitmq-c
+modules/afmongodb/mongo-c-driver
 (syslog-ng-)?config\.h$
 (contrib|debian|lib|modules)/.*\.conf
 dist\.conf


### PR DESCRIPTION
* tests/copyright/policy:
  * Ignore our git submodules
* tests/copyright/check.sh:
  * Reduce default verbosity
* Makefile.am,.travis.yml:
  * Invoke check-copyright on `make check`