### PR TITLE
afsocket: Fix an integer underflow.

### DIFF
--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -86,7 +86,7 @@ _read_text_file_content(const gchar *filename, gchar *buf, gsize buflen)
 static gssize
 _read_text_file_content_without_trailing_newline(const gchar *filename, gchar *buf, gsize buflen)
 {
-  gsize content_len;
+  gssize content_len;
   
   content_len = _read_text_file_content(filename, buf, buflen);
   if (content_len <= 0)


### PR DESCRIPTION
This is a backport PR, the original pull request can be found here: #783

>The reason is that the function return value is a -1 on error, however
>the variable to store that is unsigned, therefore it is unable to store
>the error value and will underflow. The subsequent check will therefore
>not catch the error.
>To fix this change content_len from gsize (unsigned) to gssigned
>(signed).

>This was found with Address Sanitizer.

>Fixes #780