### PR TITLE
Fix byteorder handling on bigendian systems in netmask6 filter

### DIFF
--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -51,7 +51,7 @@ static inline uint64_t
 _mask(uint64_t base, uint64_t mask)
 {
   if (G_BYTE_ORDER == G_BIG_ENDIAN)
-    return GUINT64_SWAP_LE_BE(base & mask);
+    return base & mask;
   else
     return GUINT64_SWAP_LE_BE(GUINT64_SWAP_LE_BE(base) & mask);
 }


### PR DESCRIPTION
This is a backport PR, the original pull request can be found here: #838
>Fixes #476 