### PR TITLE
Fix possible deadlock in patterndb

### DIFF
--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -668,8 +668,10 @@ _pattern_db_process(PatternDB *self, PDBLookupParams *lookup, GArray *dbg_list)
       synthetic_message_apply(&rule->msg, &context->super, msg, buffer);
       if (self->emit)
         {
+          g_static_rw_lock_writer_unlock(&self->lock);
           self->emit(msg, FALSE, self->emit_data);
           pdb_run_rule_actions(rule, self, RAT_MATCH, context, msg, buffer);
+          g_static_rw_lock_writer_lock(&self->lock);
         }
       pdb_rule_unref(rule);
       g_static_rw_lock_writer_unlock(&self->lock);


### PR DESCRIPTION
This is a backport PR, the original pull request can be found here: #844

>patterndb: the set emit function is possible to callback to the mainloop.

>But if the mainloop currently runs the tick_timer of the patterndb,
it causes deadlock, because the timer wait for the patterndb's lock (held by the _pattern_db_process)
and the emit function waits for the mainloop.

>Solution is, that unlock the lock, while the emit functions are run
