### PR TITLE
Fix program driver keep-alive() option linkage

### DIFF
--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -523,3 +523,9 @@ afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg)
   log_writer_options_defaults(&self->writer_options);
   return &self->super.super;
 }
+
+void
+afprogram_dd_set_keep_alive(AFProgramDestDriver *self, gboolean keep_alive)
+{
+  self->keep_alive = keep_alive;
+}

--- a/modules/afprog/afprog.h
+++ b/modules/afprog/afprog.h
@@ -50,9 +50,6 @@ typedef struct _AFProgramDestDriver
 LogDriver *afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg);
 LogDriver *afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg);
 
-inline void
-afprogram_dd_set_keep_alive(AFProgramDestDriver *self, gboolean keep_alive) {
-  self->keep_alive = keep_alive;
-}
+void afprogram_dd_set_keep_alive(AFProgramDestDriver *self, gboolean keep_alive);
 
 #endif


### PR DESCRIPTION
This is a backport PR, the original pull request can be found here: #864
> Fixes: #863