### PR TITLE
Fix java version check ('test' has '=', not '==' as operator)

### DIFF
--- a/m4/check_java_support.m4
+++ b/m4/check_java_support.m4
@@ -62,7 +62,7 @@ AC_DEFUN([AX_CHECK_JAVA_VERSION],
       fi
     fi
 
-    if test "$VERSION_OK" == "1";
+    if test "$VERSION_OK" = "1";
     then
       JNI_HOME=`echo $JAVAC_BIN | sed "s/\(.*\)[[/]]bin[[/]]java.*/\1/"`
       JNI_LIBDIR=`find $JNI_HOME -name "libjvm.so" | sed "s/\(.*\)libjvm.so/\1/" | head -n 1`


### PR DESCRIPTION
This is a backport PR, the original pull request can be found here: #897

>configure --enable-java doesn't work for me (syslog-ng 3.7.2):

>    `checking for JAVA_VERSION... ./configure: 16173: test: 1: unexpected operator`