### PR TITLE
Don't fail during cleanup if there are no copyright-* logs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,7 @@ check-copyright:
 CLEAN_HOOKS += clean-check-copyright
 
 clean-check-copyright:
-	rm copyright-run.log copyright-err.log
+	rm -f copyright-run.log copyright-err.log
 
 coverage:
 	@$(top_srcdir)/tests/collect-cov.sh


### PR DESCRIPTION
Just check the diff.