### PR TITLE
tests/Makefile.am: force remove files generated by copyright check

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,7 @@ check-copyright:
 CLEAN_HOOKS += clean-check-copyright
 
 clean-check-copyright:
-	rm copyright-run.log copyright-err.log
+	rm -f copyright-run.log copyright-err.log
 
 coverage:
 	@$(top_srcdir)/tests/collect-cov.sh


### PR DESCRIPTION
When you call `make clean` without having these files then you
will got an error.

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>