### PR TITLE
Fix diskq linking

### DIFF
--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -43,7 +43,7 @@ SYSLOG_NG_MODULES	=	\
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
 	mod-python mod-java mod-java-modules mod-kvformat mod-date \
-	mod-native mod-cef mod-disk-buffer
+	mod-native mod-cef mod-diskq
 
 
 modules modules/: ${SYSLOG_NG_MODULES}
@@ -58,6 +58,6 @@ modules_test_subdirs	=	\
 	modules_cryptofuncs modules_geoip modules_afstomp \
 	modules_graphite modules_riemann modules_python \
 	modules_systemd_journal modules_kvformat modules_date \
-	modules_cef modules_disk_buffer
+	modules_cef modules_diskq
 
 .PHONY: modules modules/

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -32,7 +32,7 @@ modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)
 modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
-modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @BASE_LIBS@ @OPENSSL_LIBS@ @GLIB_LIBS@
+modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(TOOL_DEPS_LIBS) $(top_builddir)/lib/libsyslog-ng.la
 
 modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la \
   modules/diskq/dqtool

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -30,6 +30,7 @@ EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
 modules_diskq_libdisk_buffer_la_CFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq -I$(top_srcdir)/lib -I../../lib
 modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)
 modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
+modules_diskq_libdisk_buffer_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(TOOL_DEPS_LIBS) $(top_builddir)/lib/libsyslog-ng.la

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -1,16 +1,10 @@
 bin_PROGRAMS += modules/diskq/dqtool
-
+noinst_LTLIBRARIES += modules/diskq/libsyslog-ng-disk-buffer.la
 module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
 
-modules_diskq_libdisk_buffer_la_SOURCES = \
-  modules/diskq/diskq.c \
-  modules/diskq/diskq.h \
-  modules/diskq/diskq-grammar.y \
+modules_diskq_libsyslog_ng_disk_buffer_la_SOURCES = \
   modules/diskq/diskq-options.h \
   modules/diskq/diskq-options.c \
-  modules/diskq/diskq-parser.c \
-  modules/diskq/diskq-parser.h \
-  modules/diskq/diskq-plugin.c \
   modules/diskq/logqueue-disk.c \
   modules/diskq/logqueue-disk.h \
   modules/diskq/logqueue-disk-non-reliable.c \
@@ -20,6 +14,22 @@ modules_diskq_libdisk_buffer_la_SOURCES = \
   modules/diskq/qdisk.h \
   modules/diskq/qdisk.c
 
+modules_diskq_libsyslog_ng_disk_buffer_la_CPPFLAGS = \
+  $(AM_CPPFLAGS) \
+  -I$(top_srcdir)/modules/diskq
+modules_diskq_libsyslog_ng_disk_buffer_la_LIBADD	=	\
+  $(MODULE_DEPS_LIBS)
+modules_diskq_libsyslog_ng_disk_buffer_la_DEPENDENCIES	=	\
+  $(MODULE_DEPS_LIBS)
+
+modules_diskq_libdisk_buffer_la_SOURCES = \
+  modules/diskq/diskq.c \
+  modules/diskq/diskq.h \
+  modules/diskq/diskq-grammar.y \
+  modules/diskq/diskq-parser.c \
+  modules/diskq/diskq-parser.h \
+  modules/diskq/diskq-plugin.c
+
 BUILT_SOURCES += \
   modules/diskq/diskq-grammar.y \
   modules/diskq/diskq-grammar.c \
@@ -27,13 +37,16 @@ BUILT_SOURCES += \
 
 EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
 
-modules_diskq_libdisk_buffer_la_CFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq -I$(top_srcdir)/lib -I../../lib
-modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_diskq_libdisk_buffer_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq
+modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
 modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
-modules_diskq_libdisk_buffer_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)
+modules_diskq_libdisk_buffer_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
-modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(TOOL_DEPS_LIBS) $(top_builddir)/lib/libsyslog-ng.la
+modules_diskq_dqtool_LDADD = \
+  $(TOOL_DEPS_LIBS) \
+  $(top_builddir)/lib/libsyslog-ng.la \
+  $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
 
 modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la \
   modules/diskq/dqtool

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -37,16 +37,18 @@ BUILT_SOURCES += \
 
 EXTRA_DIST += modules/diskq/diskq-grammar.ym
 
+LIBSYSLOG_NG_DISK_BUFFER = $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
+
 modules_diskq_libdisk_buffer_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq
-modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
+modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS) $(LIBSYSLOG_NG_DISK_BUFFER)
 modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
-modules_diskq_libdisk_buffer_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
+modules_diskq_libdisk_buffer_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(LIBSYSLOG_NG_DISK_BUFFER)
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = \
   $(TOOL_DEPS_LIBS) \
   $(MODULE_DEPS_LIBS) \
-  $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
+  $(LIBSYSLOG_NG_DISK_BUFFER)
 
 modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la \
   modules/diskq/dqtool

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -35,7 +35,7 @@ BUILT_SOURCES += \
   modules/diskq/diskq-grammar.c \
   modules/diskq/diskq-grammar.h
 
-EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
+EXTRA_DIST += modules/diskq/diskq-grammar.ym
 
 modules_diskq_libdisk_buffer_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq
 modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -1,5 +1,6 @@
-module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
 bin_PROGRAMS += modules/diskq/dqtool
+
+module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
 
 modules_diskq_libdisk_buffer_la_SOURCES = \
   modules/diskq/diskq.c \
@@ -32,8 +33,9 @@ modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @BASE_LIBS@ @OPENSSL_LIBS@ @GLIB_LIBS@
-modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la
 
+modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la \
+  modules/diskq/dqtool
 
 include modules/diskq/tests/Makefile.am
 

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -45,7 +45,7 @@ modules_diskq_libdisk_buffer_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(top_builddi
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = \
   $(TOOL_DEPS_LIBS) \
-  $(top_builddir)/lib/libsyslog-ng.la \
+  $(MODULE_DEPS_LIBS) \
   $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
 
 modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la \

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -1,4 +1,3 @@
-BUILT_SOURCES += modules/diskq/diskq-grammar.y modules/diskq/diskq-grammar.c modules/diskq/diskq-grammar.h
 EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
 
 module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
@@ -21,6 +20,11 @@ modules_diskq_libdisk_buffer_la_SOURCES = \
   modules/diskq/logqueue-disk-reliable.h \
   modules/diskq/qdisk.h \
   modules/diskq/qdisk.c
+
+BUILT_SOURCES += \
+  modules/diskq/diskq-grammar.y \
+  modules/diskq/diskq-grammar.c \
+  modules/diskq/diskq-grammar.h
 
 modules_diskq_libdisk_buffer_la_CFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq -I$(top_srcdir)/lib -I../../lib
 modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -28,9 +28,9 @@ modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @BASE_LIBS@ @OPENSSL_LIBS@ @GLIB_LIBS@
+modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la
 
-modules/diskq modules/diskq/ mod-disk-buffer: modules/diskq/libdisk-buffer.la
 
 include modules/diskq/tests/Makefile.am
 
-.PHONY: modules/diskq/ mod-disk-buffer
+.PHONY: modules/diskq/ mod-diskq

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
-
 module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
 bin_PROGRAMS += modules/diskq/dqtool
 
@@ -25,6 +23,8 @@ BUILT_SOURCES += \
   modules/diskq/diskq-grammar.y \
   modules/diskq/diskq-grammar.c \
   modules/diskq/diskq-grammar.h
+
+EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
 
 modules_diskq_libdisk_buffer_la_CFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq -I$(top_srcdir)/lib -I../../lib
 modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -28,6 +28,7 @@
 #include "logmsg/logmsg-serialize.h"
 #include "stats/stats-registry.h"
 #include "reloc.h"
+#include "compat/lfs.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,6 +1,6 @@
 DISKQ_TEST_CFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/libtest -I$(top_srcdir)/modules/diskq @CFLAGS_NOWARN_POINTER_SIGN@
 DISKQ_TEST_LDFLAGS = ${PREOPEN_SYSLOGFORMAT}
-DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
+DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la $(MODULE_DEPS_LIBS) @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
 
 modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq \

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,5 +1,5 @@
 DISKQ_TEST_CFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/libtest -I$(top_srcdir)/modules/diskq @CFLAGS_NOWARN_POINTER_SIGN@
-DISKQ_TEST_LDFLAGS = -dlpreopen $(top_builddir)/modules/syslogformat/libsyslogformat.la
+DISKQ_TEST_LDFLAGS = ${PREOPEN_SYSLOGFORMAT}
 DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
 
 modules_diskq_tests_TESTS = \

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,6 +1,6 @@
 DISKQ_TEST_CFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/libtest -I$(top_srcdir)/modules/diskq @CFLAGS_NOWARN_POINTER_SIGN@
-DISKQ_TEST_LDFLAGS = -dlpreopen $(top_builddir)/modules/syslogformat/libsyslogformat.la -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la
-DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
+DISKQ_TEST_LDFLAGS = -dlpreopen $(top_builddir)/modules/syslogformat/libsyslogformat.la
+DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
 
 modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq \

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,6 +1,6 @@
 DISKQ_TEST_CFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/libtest -I$(top_srcdir)/modules/diskq @CFLAGS_NOWARN_POINTER_SIGN@
 DISKQ_TEST_LDFLAGS = ${PREOPEN_SYSLOGFORMAT}
-DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la $(MODULE_DEPS_LIBS) @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
+DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(LIBSYSLOG_NG_DISK_BUFFER) $(MODULE_DEPS_LIBS) @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
 
 modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq \


### PR DESCRIPTION
We experienced a warning during diskq building and `make -j` wasn't stable also. This PR intends to fix these two issues.

```
Warning: Linking the executable modules/diskq/dqtool against the loadable module
libdisk-buffer.so is not portable!
```