### PR TITLE
Minor linker/include fixes related to OS X build

### DIFF
--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -30,6 +30,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <netinet/in.h>
 
 /* sockaddr public interface */

--- a/modules/date/Makefile.am
+++ b/modules/date/Makefile.am
@@ -15,6 +15,9 @@ modules_date_libdate_la_SOURCES	 = \
 	modules/date/strptime-tz.c	           \
 	modules/date/strptime-tz.h
 
+modules_date_libdate_la_LIBADD = \
+	$(MODULE_DEPS_LIBS)
+
 modules_date_libdate_la_LDFLAGS	 = \
 	$(MODULE_LDFLAGS)
 modules_date_libdate_la_DEPENDENCIES	=  \

--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -93,10 +93,10 @@ modules_java_libmod_java_la_SOURCES = \
     modules/java/proxies/java-template-proxy.h \
     modules/java/proxies/internal-message-sender-proxy.c
 
-modules_java_libmod_java_la_LIBADD =  $(JNI_LIBS)
+modules_java_libmod_java_la_LIBADD =  $(JNI_LIBS) $(MODULE_DEPS_LIBS)
 
 modules_java_libmod_java_la_LDFLAGS = \
-    -avoid-version -module -no-undefined
+    -avoid-version -module -no-undefined $(MODULE_LDFLAGS)
 
 modules_java_libmod_java_la_DEPENDENCIES  = \
         $(MODULE_DEPS_LIBS)

--- a/modules/kvformat/Makefile.am
+++ b/modules/kvformat/Makefile.am
@@ -19,6 +19,9 @@ modules_kvformat_libkvformat_la_CPPFLAGS	=	\
 	-I$(top_srcdir)/modules/kvformat			\
 	-I$(top_builddir)/modules/kvformat
 
+modules_kvformat_libkvformat_la_LIBADD = \
+	$(MODULE_DEPS_LIBS)
+
 modules_kvformat_libkvformat_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_kvformat_libkvformat_la_DEPENDENCIES	=	\


### PR DESCRIPTION
This PR fixes some linking and header issues in `date`, `kvformat`, `java` modules and in `gsockaddr.h` on OS X (Apple LLVM version 7.0.2).

Partial fix for #821.