### PR TITLE
Export GRADLE_OPTS environment variable in java-modules so Gradle can use it

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -1,6 +1,6 @@
 if ENABLE_JAVA_MODULES
 
-# GRADLE_OPTS is also needed here but it is exported by the Makefile in modules/java
+export GRADLE_OPTS
 
 JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar')


### PR DESCRIPTION
This environment variable was exported by modules/java but it was removed by #928.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>