### PR TITLE
systemd-journal: fix segmentation fault in g_module_symbol() on startup

### DIFF
--- a/modules/systemd-journal/journald-subsystem.c
+++ b/modules/systemd-journal/journald-subsystem.c
@@ -79,18 +79,18 @@ typedef int
 typedef int
 (*SD_JOURNAL_GET_REALTIME_USEC)(sd_journal *j, guint64 *usec);
 
-SD_JOURNAL_OPEN sd_journal_open;
-SD_JOURNAL_CLOSE sd_journal_close;
-SD_JOURNAL_SEEK_HEAD sd_journal_seek_head;
-SD_JOURNAL_SEEK_TAIL sd_journal_seek_tail;
-SD_JOURNAL_GET_CURSOR sd_journal_get_cursor;
-SD_JOURNAL_NEXT sd_journal_next;
-SD_JOURNAL_RESTART_DATA sd_journal_restart_data;
-SD_JOURNAL_ENUMERATE_DATA sd_journal_enumerate_data;
-SD_JOURNAL_SEEK_CURSOR sd_journal_seek_cursor;
-SD_JOURNAL_GET_FD sd_journal_get_fd;
-SD_JOURNAL_PROCESS sd_journal_process;
-SD_JOURNAL_GET_REALTIME_USEC sd_journal_get_realtime_usec;
+static SD_JOURNAL_OPEN sd_journal_open;
+static SD_JOURNAL_CLOSE sd_journal_close;
+static SD_JOURNAL_SEEK_HEAD sd_journal_seek_head;
+static SD_JOURNAL_SEEK_TAIL sd_journal_seek_tail;
+static SD_JOURNAL_GET_CURSOR sd_journal_get_cursor;
+static SD_JOURNAL_NEXT sd_journal_next;
+static SD_JOURNAL_RESTART_DATA sd_journal_restart_data;
+static SD_JOURNAL_ENUMERATE_DATA sd_journal_enumerate_data;
+static SD_JOURNAL_SEEK_CURSOR sd_journal_seek_cursor;
+static SD_JOURNAL_GET_FD sd_journal_get_fd;
+static SD_JOURNAL_PROCESS sd_journal_process;
+static SD_JOURNAL_GET_REALTIME_USEC sd_journal_get_realtime_usec;
 
 gboolean
 load_journald_subsystem()


### PR DESCRIPTION
syslog-ng was crashing in my development environment at startup
if the systemd-journal() driver was used, in a backtrace like this:

Program received signal SIGSEGV, Segmentation fault.
g_module_symbol (module=0x6771b0, symbol_name=0x7ffff4942a65 "sd_journal_open", symbol=0x7ffff7f838f0 <sd_journal_open>) at /build/glib2.0-ajuDY6/glib2.0-2.46.1/./gmodule/gmodule.c:818
818	/build/glib2.0-ajuDY6/glib2.0-2.46.1/./gmodule/gmodule.c: No such file or directory.
(gdb) bt
#0  g_module_symbol (module=0x6771b0, symbol_name=0x7ffff4942a65 "sd_journal_open", symbol=0x7ffff7f838f0 <sd_journal_open>) at /build/glib2.0-ajuDY6/glib2.0-2.46.1/./gmodule/gmodule.c:818
#1  0x00007ffff493e6cd in load_journald_subsystem () at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/modules/systemd-journal/journald-subsystem.c:105
#2  0x00007ffff493cd0c in systemd_journal_module_init (cfg=0x63a2a0, args=0x0) at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/modules/systemd-journal/systemd-journal-plugin.c:44
#3  0x00007ffff7b4a9d3 in plugin_load_module (module_name=0x6572a0 "sdjournal", cfg=0x63a2a0, args=0x0) at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/plugin.c:385
#4  0x00007ffff7b4a18c in plugin_find (cfg=0x63a2a0, plugin_type=3, plugin_name=0x675c80 "systemd-journal") at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/plugin.c:155
#5  0x00007ffff7b5ee8e in main_parse (lexer=0x63f010, dummy=0x7fffffffd0c8, arg=0x0) at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/cfg-grammar.y:580
#6  0x00007ffff7b2a7a5 in cfg_parser_parse (self=0x7ffff7dd4ee0 <main_parser>, lexer=0x63f010, instance=0x7fffffffd0c8, arg=0x0)
    at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/cfg-parser.h:83
#7  0x00007ffff7b2b7f7 in cfg_run_parser (self=0x63a2a0, lexer=0x63f010, parser=0x7ffff7dd4ee0 <main_parser>, result=0x7fffffffd0c8, arg=0x0)
    at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/cfg.c:430
#8  0x00007ffff7b2ba3a in cfg_read_config (self=0x63a2a0, fname=0x60e940 "etc/syslog-ng.conf", syntax_only=0, preprocess_into=0x0)
    at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/cfg.c:502
#9  0x00007ffff7b45368 in main_loop_read_and_init_config () at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/lib/mainloop.c:447
#10 0x0000000000401b31 in main (argc=1, argv=0x7fffffffd238) at /home/bazsi/zwa/projects/syslog-ng-ose-3.6/source/syslog-ng/syslog-ng/main.c:261

My belief is that the root cause was that the global variables in
journald-subsystem.c are named the same as the symbols in libsystemd.so,
and both are symbols with global visibility. My theory was that due to the name
clash, the actual pointer passed to g_module_symbol() was pointing
to the actual code of the functions, instead of the pointer we wanted
to store the values. I didn't completely confirm this theory, but
adding "static" qualifiers to the variables resolved the issue for me.

Honestly, I don't really like how journal-systemd.c is organized, but this
was only a distraction for me and I was satisfied with resolving the problem
for now.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>