### PR TITLE
DNS cache refactor and recycling

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -123,8 +123,8 @@ app_startup(void)
   g_thread_init(NULL);
   crypto_init();
   hostname_global_init();
-  dns_cache_global_init();
-  dns_cache_thread_init();
+  dns_caching_global_init();
+  dns_caching_thread_init();
   afinter_global_init();
   child_manager_init();
   alarm_init();
@@ -170,8 +170,8 @@ app_shutdown(void)
   child_manager_deinit();
   g_list_foreach(application_hooks, (GFunc) g_free, NULL);
   g_list_free(application_hooks);
-  dns_cache_thread_deinit();
-  dns_cache_global_deinit();
+  dns_caching_thread_deinit();
+  dns_caching_global_deinit();
   hostname_global_deinit();
   crypto_deinit();
   msg_deinit();
@@ -194,14 +194,14 @@ void
 app_thread_start(void)
 {
   scratch_buffers_init();
-  dns_cache_thread_init();
+  dns_caching_thread_init();
   main_loop_call_thread_init();
 }
 
 void
 app_thread_stop(void)
 {
-  dns_cache_thread_deinit();
+  dns_caching_thread_deinit();
   scratch_buffers_free();
   main_loop_call_thread_deinit();
 }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -373,6 +373,7 @@ ValuePairsTransformSet *last_vp_transset;
 LogMatcherOptions *last_matcher_options;
 HostResolveOptions *last_host_resolve_options;
 StatsOptions *last_stats_options;
+DNSCacheOptions *last_dns_cache_options;
 
 }
 
@@ -917,17 +918,13 @@ options_item
 	| KW_DIR_PERM '(' LL_NUMBER ')'		{ cfg_dir_perm_set(configuration, $3); }
 	| KW_DIR_PERM '('  ')'		        { cfg_dir_perm_set(configuration, -2); }
         | KW_CUSTOM_DOMAIN '(' string ')'       { configuration->custom_domain = g_strdup($3); free($3); }
-	| KW_DNS_CACHE_SIZE '(' LL_NUMBER ')'	{ configuration->dns_cache_size = $3; }
-	| KW_DNS_CACHE_EXPIRE '(' LL_NUMBER ')'	{ configuration->dns_cache_expire = $3; }
-	| KW_DNS_CACHE_EXPIRE_FAILED '(' LL_NUMBER ')'
-	  			{ configuration->dns_cache_expire_failed = $3; }
-	| KW_DNS_CACHE_HOSTS '(' string ')'     { configuration->dns_cache_hosts = g_strdup($3); free($3); }
 	| KW_FILE_TEMPLATE '(' string ')'	{ configuration->file_template_name = g_strdup($3); free($3); }
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
 	| KW_RECV_TIME_ZONE '(' string ')'      { configuration->recv_time_zone = g_strdup($3); free($3); }
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option
+	| { last_dns_cache_options = &configuration->dns_cache_options; } dns_cache_option
 	;
 
 stat_option
@@ -935,6 +932,15 @@ stat_option
 	| KW_STATS_LEVEL '(' LL_NUMBER ')'         { last_stats_options->level = $3; }
 	| KW_STATS_LIFETIME '(' LL_NUMBER ')'      { last_stats_options->lifetime = $3; }
 	;
+
+dns_cache_option
+	: KW_DNS_CACHE_SIZE '(' LL_NUMBER ')'	{ last_dns_cache_options->cache_size = $3; }
+	| KW_DNS_CACHE_EXPIRE '(' LL_NUMBER ')'	{ last_dns_cache_options->expire = $3; }
+	| KW_DNS_CACHE_EXPIRE_FAILED '(' LL_NUMBER ')'
+	                                        { last_dns_cache_options->expire_failed = $3; }
+	| KW_DNS_CACHE_HOSTS '(' string ')'     { last_dns_cache_options->hosts = g_strdup($3); free($3); }
+        ;
+
 
 /* START_RULES */
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -258,7 +258,7 @@ cfg_init(GlobalConfig *cfg)
   stats_reinit(&cfg->stats_options);
   log_tags_reinit_stats(cfg);
 
-  dns_cache_update_options(&cfg->dns_cache_options);
+  dns_caching_update_options(&cfg->dns_cache_options);
   hostname_reinit(cfg->custom_domain);
   host_resolve_options_init(&cfg->host_resolve_options, cfg);
   log_template_options_init(&cfg->template_options, cfg);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -258,7 +258,7 @@ cfg_init(GlobalConfig *cfg)
   stats_reinit(&cfg->stats_options);
   log_tags_reinit_stats(cfg);
 
-  dns_cache_set_params(cfg->dns_cache_size, cfg->dns_cache_expire, cfg->dns_cache_expire_failed, cfg->dns_cache_hosts);
+  dns_cache_update_options(&cfg->dns_cache_options);
   hostname_reinit(cfg->custom_domain);
   host_resolve_options_init(&cfg->host_resolve_options, cfg);
   log_template_options_init(&cfg->template_options, cfg);
@@ -365,9 +365,7 @@ cfg_new(gint version)
   self->dir_gid = 0;
   self->dir_perm = 0700;
 
-  self->dns_cache_size = 1007;
-  self->dns_cache_expire = 3600;
-  self->dns_cache_expire_failed = 60;
+  dns_cache_options_defaults(&self->dns_cache_options);
   self->threaded = TRUE;
   self->pass_unix_credentials = TRUE;
   
@@ -540,7 +538,7 @@ cfg_free(GlobalConfig *self)
   if (self->bad_hostname_compiled)
     regfree(&self->bad_hostname);
   g_free(self->bad_hostname_re);
-  g_free(self->dns_cache_hosts);
+  dns_cache_options_destroy(&self->dns_cache_options);
   g_free(self->custom_domain);
   plugin_free_plugins(self);
   plugin_free_candidate_modules(self);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -34,6 +34,7 @@
 #include "host-resolve.h"
 #include "type-hinting.h"
 #include "stats/stats.h"
+#include "dnscache.h"
 
 #include <sys/types.h>
 #include <regex.h>
@@ -81,9 +82,8 @@ struct _GlobalConfig
   gboolean bad_hostname_compiled;
   regex_t bad_hostname;
   gchar *bad_hostname_re;
-  gint dns_cache_size, dns_cache_expire, dns_cache_expire_failed;
-  gchar *dns_cache_hosts;
   gchar *custom_domain;
+  DNSCacheOptions dns_cache_options;
   gint time_reopen;
   gint time_reap;
   gint suppress;

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -255,17 +255,17 @@ dns_cache_check_hosts(DNSCache *self, glong t)
  * matching entry at all).
  */
 gboolean
-dns_cache_lookup(gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive)
+_lookup(DNSCache *self, gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive)
 {
   DNSCacheKey key;
   DNSCacheEntry *entry;
   time_t now;
 
   now = cached_g_current_time_sec();
-  dns_cache_check_hosts(dns_cache, now);
+  dns_cache_check_hosts(self, now);
 
   dns_cache_fill_key(&key, family, addr);
-  entry = g_hash_table_lookup(dns_cache->cache, &key);
+  entry = g_hash_table_lookup(self->cache, &key);
   if (entry)
     {
       if (entry->resolved &&
@@ -345,6 +345,12 @@ dns_cache_free(DNSCache *self)
 {
   g_hash_table_destroy(self->cache);
   g_free(self);
+}
+
+gboolean
+dns_cache_lookup(gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive)
+{
+  return _lookup(dns_cache, family, addr, hostname, hostname_len, positive);
 }
 
 void

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -423,38 +423,23 @@ dns_caching_lookup(gint family, void *addr, const gchar **hostname, gsize *hostn
 }
 
 void
-dns_caching_store_persistent(gint family, void *addr, const gchar *hostname)
-{
-  dns_cache_store_persistent(dns_cache, family, addr, hostname);
-}
-
-void
-dns_caching_store_dynamic(gint family, void *addr, const gchar *hostname, gboolean positive)
+dns_caching_store(gint family, void *addr, const gchar *hostname, gboolean positive)
 {
   dns_cache_store_dynamic(dns_cache, family, addr, hostname, positive);
 }
 
 void
-dns_caching_set_params(gint cache_size, gint expire, gint expire_failed, const gchar *hosts)
+dns_caching_update_options(const DNSCacheOptions *new_options)
 {
   DNSCacheOptions *options = &effective_dns_cache_options;
 
   if (options->hosts)
     g_free(options->hosts);
 
-  options->cache_size = cache_size;
-  options->expire = expire;
-  options->expire_failed = expire_failed;
-  options->hosts = g_strdup(hosts);
-}
-
-void
-dns_caching_update_options(const DNSCacheOptions *dns_cache_options)
-{
-  dns_caching_set_params(dns_cache_options->cache_size,
-                       dns_cache_options->expire,
-                       dns_cache_options->expire_failed,
-                       dns_cache_options->hosts);
+  options->cache_size = new_options->cache_size;
+  options->expire = new_options->expire;
+  options->expire_failed = new_options->expire_failed;
+  options->hosts = g_strdup(new_options->hosts);
 }
 
 void

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -65,7 +65,7 @@ struct _DNSCacheEntry
   gboolean positive;
 };
 
-typedef struct _DNSCache
+struct _DNSCache
 {
   GHashTable *cache;
   const DNSCacheOptions *options;
@@ -74,7 +74,7 @@ typedef struct _DNSCache
   gint persistent_count;
   time_t hosts_mtime;
   time_t hosts_checktime;
-} DNSCache;
+};
 
 
 TLS_BLOCK_START
@@ -224,13 +224,13 @@ dns_cache_store(DNSCache *self, gboolean persistent, gint family, void *addr, co
     }
 }
 
-static void
+void
 dns_cache_store_persistent(DNSCache *self, gint family, void *addr, const gchar *hostname)
 {
   dns_cache_store(self, TRUE, family, addr, hostname, TRUE);
 }
 
-static void
+void
 dns_cache_store_dynamic(DNSCache *self, gint family, void *addr, const gchar *hostname, gboolean positive)
 {
   dns_cache_store(self, FALSE, family, addr, hostname, positive);
@@ -369,7 +369,7 @@ dns_cache_lookup(DNSCache *self, gint family, void *addr, const gchar **hostname
   return FALSE;
 }
 
-static DNSCache *
+DNSCache *
 dns_cache_new(const DNSCacheOptions *options)
 {
   DNSCache *self = g_new0(DNSCache, 1);
@@ -384,7 +384,7 @@ dns_cache_new(const DNSCacheOptions *options)
   return self;
 }
 
-static void
+void
 dns_cache_free(DNSCache *self)
 {
   g_hash_table_destroy(self->cache);

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -155,16 +155,16 @@ dns_cache_fill_key(DNSCacheKey *key, gint family, void *addr)
 }
 
 static void
-dns_cache_cleanup_persistent_hosts(void)
+dns_cache_cleanup_persistent_hosts(DNSCache *self)
 {
   struct iv_list_head *ilh, *ilh2;
 
-  iv_list_for_each_safe(ilh, ilh2, &dns_cache->persist_list)
+  iv_list_for_each_safe(ilh, ilh2, &self->persist_list)
     {
       DNSCacheEntry *entry = iv_list_entry(ilh, DNSCacheEntry, list);
 
-      g_hash_table_remove(dns_cache->cache, &entry->key);
-      dns_cache->persistent_count--;
+      g_hash_table_remove(self->cache, &entry->key);
+      self->persistent_count--;
     }
 }
 
@@ -180,7 +180,7 @@ dns_cache_check_hosts(glong t)
 
   if (!dns_cache_hosts || stat(dns_cache_hosts, &st) < 0)
     {
-      dns_cache_cleanup_persistent_hosts();
+      dns_cache_cleanup_persistent_hosts(dns_cache);
       return;
     }
 
@@ -189,7 +189,7 @@ dns_cache_check_hosts(glong t)
       FILE *hosts;
 
       dns_cache->hosts_mtime = st.st_mtime;
-      dns_cache_cleanup_persistent_hosts();
+      dns_cache_cleanup_persistent_hosts(dns_cache);
       hosts = fopen(dns_cache_hosts, "r");
       if (hosts)
         {

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -378,6 +378,15 @@ dns_cache_set_params(gint cache_size, gint expire, gint expire_failed, const gch
 }
 
 void
+dns_cache_update_options(const DNSCacheOptions *dns_cache_options)
+{
+  dns_cache_set_params(dns_cache_options->cache_size,
+                       dns_cache_options->expire,
+                       dns_cache_options->expire_failed,
+                       dns_cache_options->hosts);
+}
+
+void
 dns_cache_thread_init(void)
 {
   g_assert(dns_cache == NULL);
@@ -406,4 +415,20 @@ dns_cache_global_deinit(void)
   if (dns_cache_hosts)
     g_free(dns_cache_hosts);
   dns_cache_hosts = NULL;
+}
+
+void
+dns_cache_options_defaults(DNSCacheOptions *options)
+{
+  options->cache_size = 1007;
+  options->expire = 3600;
+  options->expire_failed = 60;
+  options->hosts = NULL;
+}
+
+void
+dns_cache_options_destroy(DNSCacheOptions *options)
+{
+  g_free(options->hosts);
+  options->hosts = NULL;
 }

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -169,27 +169,27 @@ dns_cache_cleanup_persistent_hosts(DNSCache *self)
 }
 
 static void
-dns_cache_check_hosts(glong t)
+dns_cache_check_hosts(DNSCache *self, glong t)
 {
   struct stat st;
 
-  if (G_LIKELY(dns_cache->hosts_checktime == t))
+  if (G_LIKELY(self->hosts_checktime == t))
     return;
 
-  dns_cache->hosts_checktime = t;
+  self->hosts_checktime = t;
 
   if (!dns_cache_hosts || stat(dns_cache_hosts, &st) < 0)
     {
-      dns_cache_cleanup_persistent_hosts(dns_cache);
+      dns_cache_cleanup_persistent_hosts(self);
       return;
     }
 
-  if (dns_cache->hosts_mtime == -1 || st.st_mtime > dns_cache->hosts_mtime)
+  if (self->hosts_mtime == -1 || st.st_mtime > self->hosts_mtime)
     {
       FILE *hosts;
 
-      dns_cache->hosts_mtime = st.st_mtime;
-      dns_cache_cleanup_persistent_hosts(dns_cache);
+      self->hosts_mtime = st.st_mtime;
+      dns_cache_cleanup_persistent_hosts(self);
       hosts = fopen(dns_cache_hosts, "r");
       if (hosts)
         {
@@ -262,7 +262,7 @@ dns_cache_lookup(gint family, void *addr, const gchar **hostname, gsize *hostnam
   time_t now;
 
   now = cached_g_current_time_sec();
-  dns_cache_check_hosts(now);
+  dns_cache_check_hosts(dns_cache, now);
 
   dns_cache_fill_key(&key, family, addr);
   entry = g_hash_table_lookup(dns_cache->cache, &key);

--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -36,6 +36,14 @@ typedef struct
   gchar *hosts;
 } DNSCacheOptions;
 
+typedef struct _DNSCache DNSCache;
+
+void dns_cache_store_persistent(DNSCache *self, gint family, void *addr, const gchar *hostname);
+void dns_cache_store_dynamic(DNSCache *self, gint family, void *addr, const gchar *hostname, gboolean positive);
+gboolean dns_cache_lookup(DNSCache *self, gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive);
+DNSCache *dns_cache_new(const DNSCacheOptions *options);
+void dns_cache_free(DNSCache *self);
+
 void dns_cache_options_defaults(DNSCacheOptions *options);
 void dns_cache_options_destroy(DNSCacheOptions *options);
 

--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -48,11 +48,7 @@ void dns_cache_options_defaults(DNSCacheOptions *options);
 void dns_cache_options_destroy(DNSCacheOptions *options);
 
 gboolean dns_caching_lookup(gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive);
-
-void dns_caching_store_persistent(gint family, void *addr, const gchar *hostname);
-void dns_caching_store_dynamic(gint family, void *addr, const gchar *hostname, gboolean positive);
-
-void dns_caching_set_params(gint cache_size, gint expire, gint expire_failed, const gchar *hosts);
+void dns_caching_store(gint family, void *addr, const gchar *hostname, gboolean positive);
 void dns_caching_update_options(const DNSCacheOptions *dns_cache_options);
 
 void dns_caching_thread_init(void);

--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -36,20 +36,21 @@ typedef struct
   gchar *hosts;
 } DNSCacheOptions;
 
-gboolean dns_cache_lookup(gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive);
-
-void dns_cache_store_persistent(gint family, void *addr, const gchar *hostname);
-void dns_cache_store_dynamic(gint family, void *addr, const gchar *hostname, gboolean positive);
-
-void dns_cache_set_params(gint cache_size, gint expire, gint expire_failed, const gchar *hosts);
-void dns_cache_update_options(const DNSCacheOptions *dns_cache_options);
-
-void dns_cache_thread_init(void);
-void dns_cache_thread_deinit(void);
-void dns_cache_global_init(void);
-void dns_cache_global_deinit(void);
-
 void dns_cache_options_defaults(DNSCacheOptions *options);
 void dns_cache_options_destroy(DNSCacheOptions *options);
+
+gboolean dns_caching_lookup(gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive);
+
+void dns_caching_store_persistent(gint family, void *addr, const gchar *hostname);
+void dns_caching_store_dynamic(gint family, void *addr, const gchar *hostname, gboolean positive);
+
+void dns_caching_set_params(gint cache_size, gint expire, gint expire_failed, const gchar *hosts);
+void dns_caching_update_options(const DNSCacheOptions *dns_cache_options);
+
+void dns_caching_thread_init(void);
+void dns_caching_thread_deinit(void);
+void dns_caching_global_init(void);
+void dns_caching_global_deinit(void);
+
 
 #endif

--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -28,16 +28,28 @@
 
 #include "syslog-ng.h"
 
+typedef struct
+{
+  gint cache_size;
+  gint expire;
+  gint expire_failed;
+  gchar *hosts;
+} DNSCacheOptions;
+
 gboolean dns_cache_lookup(gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive);
 
 void dns_cache_store_persistent(gint family, void *addr, const gchar *hostname);
 void dns_cache_store_dynamic(gint family, void *addr, const gchar *hostname, gboolean positive);
 
 void dns_cache_set_params(gint cache_size, gint expire, gint expire_failed, const gchar *hosts);
+void dns_cache_update_options(const DNSCacheOptions *dns_cache_options);
 
 void dns_cache_thread_init(void);
 void dns_cache_thread_deinit(void);
 void dns_cache_global_init(void);
 void dns_cache_global_deinit(void);
+
+void dns_cache_options_defaults(DNSCacheOptions *options);
+void dns_cache_options_destroy(DNSCacheOptions *options);
 
 #endif

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -330,7 +330,7 @@ resolve_sockaddr_to_inet_or_inet6_hostname(gsize *result_len, GSockAddr *saddr, 
       positive = FALSE;
     }
   if (host_resolve_options->use_dns_cache)
-    dns_caching_store_dynamic(saddr->sa.sa_family, dnscache_key, hname, positive);
+    dns_caching_store(saddr->sa.sa_family, dnscache_key, hname, positive);
 
   return hostname_apply_options_fqdn(-1, result_len, hname, positive, host_resolve_options);
 }

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -310,7 +310,7 @@ resolve_sockaddr_to_inet_or_inet6_hostname(gsize *result_len, GSockAddr *saddr, 
 
   if (host_resolve_options->use_dns_cache)
     {
-      if (dns_cache_lookup(saddr->sa.sa_family, dnscache_key, (const gchar **) &hname, &hname_len, &positive))
+      if (dns_caching_lookup(saddr->sa.sa_family, dnscache_key, (const gchar **) &hname, &hname_len, &positive))
         return hostname_apply_options_fqdn(hname_len, result_len, hname, positive, host_resolve_options);
     }
 
@@ -330,7 +330,7 @@ resolve_sockaddr_to_inet_or_inet6_hostname(gsize *result_len, GSockAddr *saddr, 
       positive = FALSE;
     }
   if (host_resolve_options->use_dns_cache)
-    dns_cache_store_dynamic(saddr->sa.sa_family, dnscache_key, hname, positive);
+    dns_caching_store_dynamic(saddr->sa.sa_family, dnscache_key, hname, positive);
 
   return hostname_apply_options_fqdn(-1, result_len, hname, positive, host_resolve_options);
 }

--- a/lib/tests/test_host_resolve.c
+++ b/lib/tests/test_host_resolve.c
@@ -42,7 +42,7 @@
   do                                                            	\
     {                                                           	\
       testcase_begin("%s(%s)", func, args);                     	\
-      dns_cache_thread_init();						\
+      dns_caching_thread_init();					\
       host_resolve_options_defaults(&host_resolve_options);		\
       host_resolve_options_init(&host_resolve_options, configuration);	\
       hostname_reinit(NULL);						\
@@ -53,7 +53,7 @@
   do                                                            \
     {                                                           \
       host_resolve_options_destroy(&host_resolve_options);	\
-      dns_cache_thread_deinit();				\
+      dns_caching_thread_deinit();				\
       testcase_end();                                           \
     }                                                           \
   while (0)

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -33,6 +33,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #define DISKQ_FILENAME "test_become_full.qf"
 

--- a/tests/unit/test_dnscache.c
+++ b/tests/unit/test_dnscache.c
@@ -42,13 +42,13 @@ test_expiration(void)
   gsize hn_len;
   gboolean positive;
 
-  dns_cache_set_params(50000, 3, 1, NULL);
+  dns_caching_set_params(50000, 3, 1, NULL);
 
   for (i = 0; i < 10000; i++)
     {
       guint32 ni = htonl(i);
 
-      dns_cache_store_dynamic(AF_INET, (void *) &ni, i < 5000 ? "hostname" : "negative", i < 5000);
+      dns_caching_store_dynamic(AF_INET, (void *) &ni, i < 5000 ? "hostname" : "negative", i < 5000);
     }
 
   for (i = 0; i < 10000; i++)
@@ -57,7 +57,7 @@ test_expiration(void)
 
       hn = NULL;
       positive = FALSE;
-      if (!dns_cache_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
+      if (!dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
         {
           fprintf(stderr, "hmmm cache forgot the cache entry too early, i=%d, hn=%s\n", i, hn);
           exit(1);
@@ -96,7 +96,7 @@ test_expiration(void)
       positive = FALSE;
       if (i < 5000)
         {
-          if (!dns_cache_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive) || !positive)
+          if (!dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive) || !positive)
             {
               fprintf(stderr, "hmmm cache forgot positive entries too early, i=%d\n", i);
               exit(1);
@@ -104,7 +104,7 @@ test_expiration(void)
         }
       else
         {
-          if (dns_cache_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive) || positive)
+          if (dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive) || positive)
             {
               fprintf(stderr, "hmmm cache didn't forget negative entries in time, i=%d\n", i);
               exit(1);
@@ -123,7 +123,7 @@ test_expiration(void)
 
       hn = NULL;
       positive = FALSE;
-      if (dns_cache_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
+      if (dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
         {
           fprintf(stderr, "hmmm cache did not forget an expired entry, i=%d\n", i);
           exit(1);
@@ -140,13 +140,13 @@ test_dns_cache_benchmark(void)
   gboolean positive;
   gint i;
 
-  dns_cache_set_params(50000, 600, 300, NULL);
+  dns_caching_set_params(50000, 600, 300, NULL);
 
   for (i = 0; i < 10000; i++)
     {
       guint32 ni = htonl(i);
 
-      dns_cache_store_dynamic(AF_INET, (void *) &ni, "hostname", TRUE);
+      dns_caching_store_dynamic(AF_INET, (void *) &ni, "hostname", TRUE);
     }
 
   g_get_current_time(&start);
@@ -156,7 +156,7 @@ test_dns_cache_benchmark(void)
       guint32 ni = htonl(i % 10000);
 
       hn = NULL;
-      if (!dns_cache_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
+      if (!dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
         {
           fprintf(stderr, "hmm, dns cache entries expired during benchmarking, this is unexpected\n, i=%d", i);
         }

--- a/tests/unit/test_dnscache.c
+++ b/tests/unit/test_dnscache.c
@@ -41,14 +41,20 @@ test_expiration(void)
   const gchar *hn = NULL;
   gsize hn_len;
   gboolean positive;
-
-  dns_caching_set_params(50000, 3, 1, NULL);
+  DNSCacheOptions options =
+  {
+    .cache_size = 50000,
+    .expire = 3,
+    .expire_failed = 1,
+    .hosts = NULL
+  };
+  DNSCache *cache = dns_cache_new(&options);
 
   for (i = 0; i < 10000; i++)
     {
       guint32 ni = htonl(i);
 
-      dns_caching_store_dynamic(AF_INET, (void *) &ni, i < 5000 ? "hostname" : "negative", i < 5000);
+      dns_cache_store_dynamic(cache, AF_INET, (void *) &ni, i < 5000 ? "hostname" : "negative", i < 5000);
     }
 
   for (i = 0; i < 10000; i++)
@@ -57,7 +63,7 @@ test_expiration(void)
 
       hn = NULL;
       positive = FALSE;
-      if (!dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
+      if (!dns_cache_lookup(cache, AF_INET, (void *) &ni, &hn, &hn_len, &positive))
         {
           fprintf(stderr, "hmmm cache forgot the cache entry too early, i=%d, hn=%s\n", i, hn);
           exit(1);
@@ -96,7 +102,7 @@ test_expiration(void)
       positive = FALSE;
       if (i < 5000)
         {
-          if (!dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive) || !positive)
+          if (!dns_cache_lookup(cache, AF_INET, (void *) &ni, &hn, &hn_len, &positive) || !positive)
             {
               fprintf(stderr, "hmmm cache forgot positive entries too early, i=%d\n", i);
               exit(1);
@@ -104,7 +110,7 @@ test_expiration(void)
         }
       else
         {
-          if (dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive) || positive)
+          if (dns_cache_lookup(cache, AF_INET, (void *) &ni, &hn, &hn_len, &positive) || positive)
             {
               fprintf(stderr, "hmmm cache didn't forget negative entries in time, i=%d\n", i);
               exit(1);
@@ -123,12 +129,14 @@ test_expiration(void)
 
       hn = NULL;
       positive = FALSE;
-      if (dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
+      if (dns_cache_lookup(cache, AF_INET, (void *) &ni, &hn, &hn_len, &positive))
         {
           fprintf(stderr, "hmmm cache did not forget an expired entry, i=%d\n", i);
           exit(1);
         }
     }
+
+  dns_cache_free(cache);
 }
 
 void
@@ -139,14 +147,20 @@ test_dns_cache_benchmark(void)
   gsize hn_len;
   gboolean positive;
   gint i;
-
-  dns_caching_set_params(50000, 600, 300, NULL);
+  DNSCacheOptions options =
+  {
+    .cache_size = 50000,
+    .expire = 600,
+    .expire_failed = 300,
+    .hosts = NULL
+  };
+  DNSCache *cache = dns_cache_new(&options);
 
   for (i = 0; i < 10000; i++)
     {
       guint32 ni = htonl(i);
 
-      dns_caching_store_dynamic(AF_INET, (void *) &ni, "hostname", TRUE);
+      dns_cache_store_dynamic(cache, AF_INET, (void *) &ni, "hostname", TRUE);
     }
 
   g_get_current_time(&start);
@@ -156,13 +170,14 @@ test_dns_cache_benchmark(void)
       guint32 ni = htonl(i % 10000);
 
       hn = NULL;
-      if (!dns_caching_lookup(AF_INET, (void *) &ni, &hn, &hn_len, &positive))
+      if (!dns_cache_lookup(cache, AF_INET, (void *) &ni, &hn, &hn_len, &positive))
         {
           fprintf(stderr, "hmm, dns cache entries expired during benchmarking, this is unexpected\n, i=%d", i);
         }
     }
   g_get_current_time(&end);
   printf("DNS cache speed: %12.3f iters/sec\n", i * 1e6 / g_time_val_diff(&end, &start));
+  dns_cache_free(cache);
 }
 
 int


### PR DESCRIPTION
This is an improved version of #876 by @jbfuzier, which starts with a step-by-step refactor of the dns cache code and adds cache recycling as a trivial last step.

I am not completely satisfied with the end result of dnscache.c, but it is way better than what it was, and I'd like to get this integrated, as I'll have to focus elsewhere.