### PR TITLE
Fix disabling MongoDB destination support in syslog-ng 3.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,7 +159,7 @@ AC_ARG_ENABLE(mongodb,
               ,,enable_mongodb="auto")
 
 AC_ARG_WITH(libmongo-client,
-              [  --with-libmongo-client=[system/internal/auto]
+              [  --with-libmongo-client=[system/internal/auto/no]
                                          Link against the system supplied or the built-in libmongo-client library. (default: auto)]
               ,,with_libmongo_client="auto")
 
@@ -1171,7 +1171,7 @@ fi
 
 if test "x$enable_mongodb" = "xauto"; then
 	AC_MSG_CHECKING(whether to enable mongodb destination support)
-	if test "x$with_mongo_client" != "no"; then
+	if test "x$with_libmongo_client" != "no"; then
 		enable_mongodb="yes"
 	else
 		enable_mongodb="no"


### PR DESCRIPTION
Fixes #958 

There was a minor typo in the configure script which prevented
us from disabling the compilation of the MongoDB destination.

You can use --with-libmongo-client=no configure option to disable
this destination.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>