### PR TITLE
Fix Java's internal logger

### DIFF
--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -37,6 +37,7 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
 	public static void register(Logger logger) {
 		if (logger.getAppender(SyslogNgInternalLogger.NAME) == null) {
 			logger.addAppender(new SyslogNgInternalLogger());
+			logger.setLevel(Level.DEBUG);
 		}
 	}
 

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -78,6 +78,9 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
         case Level.ERROR_INT:
             InternalMessageSender.error(message);
             break;
+        case Level.FATAL_INT:
+            InternalMessageSender.fatal(message);
+            break;
         case Level.WARN_INT:
             InternalMessageSender.warning(message);
             break;

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -36,6 +36,7 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
 
     public static void register(Logger logger) {
         if (logger.getAppender(SyslogNgInternalLogger.NAME) == null) {
+            logger.removeAllAppenders();
             logger.addAppender(new SyslogNgInternalLogger());
             logger.setLevel(Level.DEBUG);
         }

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -57,20 +57,15 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
 
 	@Override
 	protected void append(LoggingEvent event) {
-		 String message = null;
-         if(event.locationInformationExists()){
-	            StringBuilder formatedMessage = new StringBuilder();
-	            formatedMessage.append(event.getLocationInformation().getClassName());
-	            formatedMessage.append(".");
-	            formatedMessage.append(event.getLocationInformation().getMethodName());
-	            formatedMessage.append(":");
-	            formatedMessage.append(event.getLocationInformation().getLineNumber());
-	            formatedMessage.append(" - ");
-	            formatedMessage.append(event.getMessage().toString());
-	            message = formatedMessage.toString();
-	        }else{
-	            message = event.getMessage().toString();
-	        }
+        StringBuilder formatedMessage = new StringBuilder();
+        formatedMessage.append(event.getLocationInformation().getClassName());
+        formatedMessage.append(".");
+        formatedMessage.append(event.getLocationInformation().getMethodName());
+        formatedMessage.append(":");
+        formatedMessage.append(event.getLocationInformation().getLineNumber());
+        formatedMessage.append(" - ");
+        formatedMessage.append(event.getMessage().toString());
+        String message = formatedMessage.toString();
 
 	        switch(event.getLevel().toInt()){
 	        case Level.INFO_INT:

--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -32,31 +32,31 @@ import org.syslog_ng.InternalMessageSender;
 
 public class SyslogNgInternalLogger extends AppenderSkeleton {
 
-	public static final String NAME = "syslog-ng-internal";
+    public static final String NAME = "syslog-ng-internal";
 
-	public static void register(Logger logger) {
-		if (logger.getAppender(SyslogNgInternalLogger.NAME) == null) {
-			logger.addAppender(new SyslogNgInternalLogger());
-			logger.setLevel(Level.DEBUG);
-		}
-	}
+    public static void register(Logger logger) {
+        if (logger.getAppender(SyslogNgInternalLogger.NAME) == null) {
+            logger.addAppender(new SyslogNgInternalLogger());
+            logger.setLevel(Level.DEBUG);
+        }
+    }
 
-	public SyslogNgInternalLogger() {
-		super();
-		this.name = NAME;
-	}
+    public SyslogNgInternalLogger() {
+        super();
+        this.name = NAME;
+    }
 
-	@Override
-	public void close() {
-	}
+    @Override
+    public void close() {
+    }
 
-	@Override
-	public boolean requiresLayout() {
-		return false;
-	}
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
 
-	@Override
-	protected void append(LoggingEvent event) {
+    @Override
+    protected void append(LoggingEvent event) {
         StringBuilder formatedMessage = new StringBuilder();
         formatedMessage.append(event.getLocationInformation().getClassName());
         formatedMessage.append(".");
@@ -67,25 +67,25 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
         formatedMessage.append(event.getMessage().toString());
         String message = formatedMessage.toString();
 
-	        switch(event.getLevel().toInt()){
-	        case Level.INFO_INT:
-	            InternalMessageSender.info(message);
-	            break;
-	        case Level.DEBUG_INT:
-	            InternalMessageSender.debug(message);
-	            break;
-	        case Level.ERROR_INT:
-	            InternalMessageSender.error(message);
-	            break;
-	        case Level.WARN_INT:
-	        	InternalMessageSender.warning(message);
-	            break;
-	        case Level.TRACE_INT:
-	            InternalMessageSender.debug(message);
-	            break;
-	        default:
-	            break;
-	        }
-	}
+        switch(event.getLevel().toInt()) {
+        case Level.INFO_INT:
+            InternalMessageSender.info(message);
+            break;
+        case Level.DEBUG_INT:
+            InternalMessageSender.debug(message);
+            break;
+        case Level.ERROR_INT:
+            InternalMessageSender.error(message);
+            break;
+        case Level.WARN_INT:
+            InternalMessageSender.warning(message);
+            break;
+        case Level.TRACE_INT:
+            InternalMessageSender.debug(message);
+            break;
+        default:
+            break;
+        }
+    }
 
 }


### PR DESCRIPTION
This PR resolves multiple issues with the `SyslogNgInternalLogger`:

- `FATAL` loglevel was missing
- only the default log appender worked, `SyslogNgInternalLogger` hasn't produced any output (with kafka destination, where the kafka lib also manipulates on log4j's root logger)
- `locationInformationExists()` wasn't used properly