### PR TITLE
Fix value-pairs tokenizer

### DIFF
--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -617,7 +617,6 @@ vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
   pos = 0;
   do
     {
-      token_start = pos;
       pos += strcspn(&name[pos], "@.");
       if (name[pos] == '@')
         pos = vp_walker_skip_sdata_enterprise_id(name, pos);
@@ -626,6 +625,7 @@ vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
         {
           g_ptr_array_add(array, g_strndup(&name[token_start], pos - token_start));
           pos++;
+          token_start = pos;
         }
     }
   while (pos < name_len);

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -611,10 +611,12 @@ vp_walker_skip_sdata_enterprise_id(const gchar *name, gint pos)
 static GPtrArray *
 vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
 {
-  gint pos, token_start = 0, name_len = strlen(name);
+  gint pos = 0;
+  gint token_start = 0;
+  size_t name_len = strlen(name);
+
   GPtrArray *array = g_ptr_array_sized_new(VP_STACK_INITIAL_SIZE);
 
-  pos = 0;
   do
     {
       pos += strcspn(&name[pos], "@.");

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -49,6 +49,13 @@ test_format_json(void)
                           "{\"_unix\":{\"uid\":\"1000\",\"gid\":\"1000\",\"cmd\":\"command\"},\"_json\":{\"sub\":{\"value2\":\"subvalue2\",\"value1\":\"subvalue1\"},\"foo\":\"bar\"},\"PROGRAM\":\"syslog-ng\",\"PRIORITY\":\"err\",\"PID\":\"23323\",\"MESSAGE\":\"árvíztűrőtükörfúrógép\",\"HOST\":\"bzorp\",\"FACILITY\":\"local3\",\"DATE\":\"Feb 11 10:34:56\",\"APP\":{\"VALUE\":\"value\",\"STRIP4\":\"value\",\"STRIP3\":\"     value     \",\"STRIP2\":\"value     \",\"STRIP1\":\"     value\",\"QVALUE\":\"\\\"value\\\"\"}}");
 
   assert_template_format("$(format-json --scope syslog-proto)", "{\"PROGRAM\":\"syslog-ng\",\"PRIORITY\":\"err\",\"PID\":\"23323\",\"MESSAGE\":\"árvíztűrőtükörfúrógép\",\"HOST\":\"bzorp\",\"FACILITY\":\"local3\",\"DATE\":\"Feb 11 10:34:56\"}");
+
+  assert_template_format("$(format-json @program=${PROGRAM})", "{\"@program\":\"syslog-ng\"}");
+  assert_template_format("$(format-json @program.123=${PROGRAM})", "{\"@program\":{\"123\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json .@program.123=${PROGRAM})", "{\"_@program\":{\"123\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json @.program=${PROGRAM})", "{\"@\":{\"program\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json .program.n@me=${PROGRAM})", "{\"_program\":{\"n@me\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json .program.@name=${PROGRAM})", "{\"_program\":{\"@name\":\"syslog-ng\"}}");
 }
 
 void


### PR DESCRIPTION
Fixes #949.

This revert resolves parsing problems when a token starts with '@'.
In that case, the starting @ symbol disappeared because the `token_start` variable was updated at the beginning of the parser loop.

Also, @dnsjts has a completely rewritten `vp_walker_split_name_to_tokens` function which is much cleaner in my opinion.