### PR TITLE
README: fix release download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,9 @@ Performance:
 Installation from Source
 ========================
 
-Releases are tagged in the [github repository][github-repo] and
-tarballs ready to compile are made available at [BalaBit][balabit]'s
-syslog-ng [tarball repository][balabit-download].
+Releases and tarballs ready to compile are are made available at [GitHub][github-repo].
 
  [github-repo]: https://github.com/balabit/syslog-ng/releases
- [balabit]: http://www.balabit.com/
- [balabit-download]: http://www.balabit.com/network-security/syslog-ng/opensource-logging-system/downloads/download/syslog-ng-ose/3.5
 
 To compile from source, the usual drill applies (assuming you have
 the required dependencies):


### PR DESCRIPTION
I've just noticed that the informations under https://github.com/balabit/syslog-ng#installation-from-source are no longer correct.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>