### PR TITLE
Fix defines in diskq

### DIFF
--- a/modules/diskq/diskq-parser.c
+++ b/modules/diskq/diskq-parser.c
@@ -41,7 +41,7 @@ static CfgLexerKeyword diskq_keywords[] = {
 
 CfgParser diskq_parser =
 {
-#if ENABLE_DEBUG
+#if SYSLOG_NG_ENABLE_DEBUG
   .debug_flag = &diskq_debug,
 #endif
   .name = "disk_buffer",

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -39,7 +39,7 @@
 
 /* MADV_RANDOM not defined on legacy Linux systems. Could be removed in the
  * future, when support for Glibc 2.1.X drops.*/
-#ifndef HAVE_MADV_RANDOM
+#ifndef MADV_RANDOM
 #define MADV_RANDOM 1
 #endif
 


### PR DESCRIPTION
I saw a warning on OSX and checked the diskq module for further prefixing issues. These two were the only ones.