### PR TITLE
basicfuncs: Add $(pwuid_to_nam) and $(grgid_to_nam) functions

### DIFF
--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -77,7 +77,9 @@ static Plugin basicfuncs_plugins[] =
   /* misc funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_context_length, "context-length"),
   TEMPLATE_FUNCTION_PLUGIN(tf_env, "env"),
-  TEMPLATE_FUNCTION_PLUGIN(tf_template, "template")
+  TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_pwuid_to_nam, "pwuid-to-nam"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_grgid_to_nam, "grgid-to-nam"),
 };
 
 gboolean


### PR DESCRIPTION
For converting UIDs and GIDs to names, add $(pwuid_to_nam) and $(grgid_to_nam) functions that call getpwuid_r() and getgrgid_r().

Implements #979 as thread-safe template functions.