### PR TITLE
F/libmongo client compatibility over mongo c driver

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,6 +192,11 @@ AC_ARG_WITH(mongoc,
                                          Link against the system supplied or the built-in mongo-c-driver library. (default: auto)]
               ,,with_mongoc="auto")
 
+AC_ARG_ENABLE(legacy-mongodb-options,
+              [  --enable-legacy-mongodb-options=[yes/no]
+                                         Support libmongo-client non-URI MongoDB options. (default: yes)]
+              ,,enable_legacy_mongodb_options="yes")
+
 AC_ARG_WITH(jsonc,
               [  --with-jsonc=[system/internal/auto/no]
                                          Link against the system supplied or the built-in jsonc library or explicitly disable it. (default:auto)]
@@ -979,6 +984,13 @@ dnl ***************************************************************************
 dnl mongo-c-driver headers/libraries
 dnl ***************************************************************************
 
+if test x"$enable_legacy_mongodb_options" = x"no"; then
+	enable_legacy_mongodb_options_bit=0
+else
+	enable_legacy_mongodb_options_bit=1
+fi
+AC_DEFINE_UNQUOTED(ENABLE_LEGACY_MONGODB_OPTIONS, [$enable_legacy_mongodb_options_bit], [Support libmongo-client non-URI MongoDB options])
+
 if test "x$with_mongoc" = "xauto"; then
   with_mongoc="system"
   PKG_CHECK_MODULES(LIBMONGO, libmongoc >= $LMC_MIN_VERSION,,with_mongoc="auto-internal")
@@ -1549,6 +1561,7 @@ AM_CONDITIONAL(ENABLE_JAVA_MODULES, [test "$enable_java_modules" = "yes"])
 AM_CONDITIONAL(ENABLE_MANPAGES, [test "$enable_manpages" != "no"])
 AM_CONDITIONAL(ENABLE_NATIVE, [test "$enable_native" != "no"])
 AM_CONDITIONAL(ENABLE_EXTRA_WARNINGS, [test "$enable_extra_warnings" = "yes"])
+AM_CONDITIONAL(ENABLE_LEGACY_MONGODB_OPTIONS, [test x"$enable_legacy_mongodb_options" != x"no"])
 
 AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)
@@ -1641,6 +1654,7 @@ echo "  Linux capability support    : ${has_linux_caps:=no}"
 echo "  Env wrapper support         : ${enable_env_wrapper:=no}"
 echo "  systemd support             : ${enable_systemd:=no} (unit dir: ${systemdsystemunitdir:=none})"
 echo "  systemd-journal support     : ${with_systemd_journal:=no}"
+echo "  libmongo-client options     : ${enable_legacy_mongodb_options}"
 echo " Modules:"
 echo "  Module search path          : ${module_path}"
 echo "  Sun STREAMS support (module): ${enable_sun_streams:=no}"

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -138,13 +138,18 @@ assert_grabbed_messages_contain_non_fatal(const gchar *pattern, const gchar *err
   print_failure(error_message, args, "no grabbed message contains the pattern=%s", pattern);
   va_end(args);
 
-  fprintf(stderr, "  # Grabbed internal messages follow:\n");
-  for (l = internal_messages; l; l = l->next)
+  if (internal_messages)
     {
-      LogMessage *msg = (LogMessage *) l->data;
-      const gchar *msg_text = log_msg_get_value(msg, LM_V_MESSAGE, NULL);
+      fprintf(stderr, "  # Grabbed internal messages follow:\n");
+      for (l = internal_messages; l; l = l->next)
+        {
+          LogMessage *msg = (LogMessage *) l->data;
+          const gchar *msg_text = log_msg_get_value(msg, LM_V_MESSAGE, NULL);
 
-      fprintf(stderr, "  #\t%s\n", msg_text);
+          fprintf(stderr, "  #\t%s\n", msg_text);
+        }
+    } else {
+        fprintf(stderr, "  # No internal messeges grabbed!\n");
     }
 
   return FALSE;

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -112,6 +112,26 @@ start_grabbing_messages(void)
 }
 
 void
+display_grabbed_messages(void)
+{
+  GList *l;
+
+  if (internal_messages)
+    {
+      fprintf(stderr, "  # Grabbed internal messages follow:\n");
+      for (l = internal_messages; l; l = l->next)
+        {
+          LogMessage *msg = (LogMessage *) l->data;
+          const gchar *msg_text = log_msg_get_value(msg, LM_V_MESSAGE, NULL);
+
+          fprintf(stderr, "  #\t%s\n", msg_text);
+        }
+    } else {
+        fprintf(stderr, "  # No internal messeges grabbed!\n");
+    }
+}
+
+void
 stop_grabbing_messages(void)
 {
   msg_set_post_func(NULL);
@@ -138,19 +158,7 @@ assert_grabbed_messages_contain_non_fatal(const gchar *pattern, const gchar *err
   print_failure(error_message, args, "no grabbed message contains the pattern=%s", pattern);
   va_end(args);
 
-  if (internal_messages)
-    {
-      fprintf(stderr, "  # Grabbed internal messages follow:\n");
-      for (l = internal_messages; l; l = l->next)
-        {
-          LogMessage *msg = (LogMessage *) l->data;
-          const gchar *msg_text = log_msg_get_value(msg, LM_V_MESSAGE, NULL);
-
-          fprintf(stderr, "  #\t%s\n", msg_text);
-        }
-    } else {
-        fprintf(stderr, "  # No internal messeges grabbed!\n");
-    }
+  display_grabbed_messages();
 
   return FALSE;
 }

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -51,6 +51,7 @@ void stop_stopwatch_and_display_result(gchar *message_template, ...);
 void reset_grabbed_messages(void);
 void start_grabbing_messages(void);
 void stop_grabbing_messages(void);
+void display_grabbed_messages(void);
 gboolean assert_grabbed_messages_contain_non_fatal(const gchar *pattern, const gchar *error_message, ...);
 
 #define assert_grabbed_messages_contain(pattern, error_message, ...) (assert_grabbed_messages_contain_non_fatal(pattern, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -34,6 +34,8 @@ modules_afmongodb_libafmongodb_la_DEPENDENCIES	=	\
 
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb: \
 	modules/afmongodb/libafmongodb.la
+
+include modules/afmongodb/tests/Makefile.am
 else
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb:
 endif

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -2,7 +2,7 @@ DIST_SUBDIRS 					+= @LIBMONGO_SUBDIRS@
 
 if LIBMONGO_INTERNAL
 CLEAN_SUBDIRS					+= @LIBMONGO_SUBDIRS@
-lmc_EXTRA_DEPS					= @LIBMONGO_SUBDIRS@/src/libmongoc-1.0.la
+lmc_EXTRA_DEPS					= @LIBMONGO_SUBDIRS@/libmongoc-1.0.la
 
 $(lmc_EXTRA_DEPS):
 	${MAKE} -C modules/afmongodb/mongo-c-driver

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -25,6 +25,18 @@ modules_afmongodb_libafmongodb_la_SOURCES	=	\
 	modules/afmongodb/afmongodb-parser.c		\
 	modules/afmongodb/afmongodb-parser.h		\
 	${DUMMY_C}
+
+if ENABLE_LEGACY_MONGODB_OPTIONS
+modules_afmongodb_libafmongodb_la_SOURCES	+=	\
+	modules/afmongodb/afmongodb-legacy-uri.c			\
+	modules/afmongodb/afmongodb-legacy-uri.h			\
+	modules/afmongodb/afmongodb-legacy-grammar.c			\
+	modules/afmongodb/afmongodb-legacy-grammar.h			\
+	modules/afmongodb/afmongodb-legacy-private.h				\
+	modules/afmongodb/host-list.c				\
+	modules/afmongodb/host-list.h
+endif
+
 modules_afmongodb_libafmongodb_la_LIBADD	=	\
 	$(MODULE_DEPS_LIBS) $(LIBMONGO_LIBS)
 modules_afmongodb_libafmongodb_la_LDFLAGS	=	\

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -21,6 +21,7 @@ modules_afmongodb_libafmongodb_la_SOURCES	=	\
 	modules/afmongodb/afmongodb-grammar.y		\
 	modules/afmongodb/afmongodb.c			\
 	modules/afmongodb/afmongodb.h			\
+	modules/afmongodb/afmongodb-private.h			\
 	modules/afmongodb/afmongodb-parser.c		\
 	modules/afmongodb/afmongodb-parser.h		\
 	${DUMMY_C}

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -47,6 +47,12 @@
 %token KW_MONGODB
 %token KW_URI
 %token KW_COLLECTION
+%token KW_SERVERS
+%token KW_SAFE_MODE
+%token KW_PATH
+%token KW_PASSWORD
+%token KW_USERNAME
+%token KW_DATABASE
 
 %%
 
@@ -72,6 +78,7 @@ afmongodb_option
         {
             afmongodb_dd_set_collection(last_driver, $3); free($3);
         }
+    | afmongodb_legacy_option
     | value_pair_option
         {
             afmongodb_dd_set_value_pairs(last_driver, $1);
@@ -79,6 +86,59 @@ afmongodb_option
     | dest_driver_option
     | threaded_dest_driver_option
     | { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
+    ;
+
+afmongodb_legacy_option
+    : KW_IFDEF
+        {
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+        }
+    | KW_SERVERS '(' string_list ')'
+        {
+            CHECK_ERROR(afmongodb_dd_validate_network_combination(last_driver), @3,
+                         "Can't mix path() & servers()");
+            afmongodb_dd_set_servers(last_driver, $3);
+        }
+    | KW_HOST '(' string ')'
+        {
+            CHECK_ERROR(afmongodb_dd_validate_network_combination(last_driver), @3,
+                         "Can't mix path() & host()");
+            afmongodb_dd_set_host(last_driver, $3);
+            free($3);
+        }
+    | KW_PORT '(' LL_NUMBER ')'
+        {
+            CHECK_ERROR(afmongodb_dd_validate_network_combination(last_driver), @3,
+                         "Can't mix path() & port()");
+            afmongodb_dd_set_port(last_driver, $3);
+        }
+    | KW_PATH '(' string ')'
+        {
+            CHECK_ERROR(afmongodb_dd_validate_socket_combination(last_driver), @3,
+                          "Can't mix path() with host() or server()");
+            afmongodb_dd_set_path(last_driver, $3);
+            free($3);
+        }
+    | KW_DATABASE '(' string ')'
+        {
+            afmongodb_dd_set_database(last_driver, $3); free($3);
+        }
+    | KW_USERNAME '(' string ')'
+        {
+            afmongodb_dd_set_user(last_driver, $3); free($3);
+        }
+    | KW_PASSWORD '(' string ')'
+        {
+            afmongodb_dd_set_password(last_driver, $3); free($3);
+        }
+    | KW_SAFE_MODE '(' yesno ')'
+        {
+	        afmongodb_dd_set_safe_mode(last_driver, !!$3);
+        }
+    | KW_ENDIF
+        {
+#endif /* SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS */
+        }
     ;
 
 /* INCLUDE_RULES */

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -51,26 +51,35 @@
 %%
 
 start
-        : LL_CONTEXT_DESTINATION KW_MONGODB
-          {
+    : LL_CONTEXT_DESTINATION KW_MONGODB
+        {
             last_driver = *instance = afmongodb_dd_new(configuration);
-          }
-          '(' afmongodb_options ')'         { YYACCEPT; }
-	;
+        }
+        '(' afmongodb_options ')'         { YYACCEPT; }
+    ;
 
 afmongodb_options
-        : afmongodb_option afmongodb_options
-	|
-	;
+    : afmongodb_option afmongodb_options
+    |
+    ;
 
 afmongodb_option
-	: KW_URI '(' string ')'		{ afmongodb_dd_set_uri(last_driver, $3); free($3); }
-	| KW_COLLECTION '(' string ')'		{ afmongodb_dd_set_collection(last_driver, $3); free($3); }
-	| value_pair_option			{ afmongodb_dd_set_value_pairs(last_driver, $1); }
-	| dest_driver_option
-	| threaded_dest_driver_option
-	| { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
-        ;
+    : KW_URI '(' string ')'
+        {
+            afmongodb_dd_set_uri(last_driver, $3); free($3);
+        }
+    | KW_COLLECTION '(' string ')'
+        {
+            afmongodb_dd_set_collection(last_driver, $3); free($3);
+        }
+    | value_pair_option
+        {
+            afmongodb_dd_set_value_pairs(last_driver, $1);
+        }
+    | dest_driver_option
+    | threaded_dest_driver_option
+    | { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
+    ;
 
 /* INCLUDE_RULES */
 

--- a/modules/afmongodb/afmongodb-legacy-grammar.c
+++ b/modules/afmongodb/afmongodb-legacy-grammar.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2010-2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "afmongodb-legacy-grammar.h"
+#include "afmongodb-legacy-private.h"
+
+gboolean
+afmongodb_dd_validate_socket_combination(LogDriver *d)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  if ((self->port != 0 || self->port != MONGO_CONN_LOCAL) && self->address != NULL)
+    return FALSE;
+  if (self->servers)
+    return FALSE;
+
+  return TRUE;
+}
+
+gboolean
+afmongodb_dd_validate_network_combination(LogDriver *d)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  if (self->port == MONGO_CONN_LOCAL && self->address != NULL)
+    return FALSE;
+
+  return TRUE;
+}
+
+void
+afmongodb_dd_set_user(LogDriver *d, const gchar *user)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once("WARNING: Using username() option is deprecated in mongodb driver,"
+      " please use uri() instead");
+
+  g_free(self->user);
+  self->user = g_strdup(user);
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_password(LogDriver *d, const gchar *password)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once("WARNING: Using password() option is deprecated in mongodb driver,"
+      " please use uri() instead");
+
+  g_free(self->password);
+  self->password = g_strdup(password);
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_host(LogDriver *d, const gchar *host)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once(
+      "WARNING: Using host() option is deprecated in mongodb driver, please use uri() instead");
+
+  g_free(self->address);
+  self->address = g_strdup(host);
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_port(LogDriver *d, gint port)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once(
+      "WARNING: Using port() option is deprecated in mongodb driver, please use uri() instead");
+
+  self->port = port;
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_servers(LogDriver *d, GList *servers)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once(
+      "WARNING: Using servers() option is deprecated in mongodb driver, please use uri() instead");
+
+  string_list_free(self->servers);
+  self->servers = servers;
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_path(LogDriver *d, const gchar *path)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once(
+      "WARNING: Using path() option is deprecated in mongodb driver, please use uri() instead");
+
+  g_free(self->address);
+  self->address = g_strdup(path);
+  self->port = MONGO_CONN_LOCAL;
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_database(LogDriver *d, const gchar *database)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once("WARNING: Using database() option is deprecated in mongodb driver,"
+      " please use uri() instead");
+
+  g_free(self->db);
+  self->db = g_strdup(database);
+  self->is_legacy = TRUE;
+}
+
+void
+afmongodb_dd_set_safe_mode(LogDriver *d, gboolean state)
+{
+  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  msg_warning_once("WARNING: Using safe_mode() option is deprecated in mongodb driver,"
+      " please use uri() instead");
+
+  self->safe_mode = state;
+  self->is_legacy = TRUE;
+}

--- a/modules/afmongodb/afmongodb-legacy-grammar.h
+++ b/modules/afmongodb/afmongodb-legacy-grammar.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2012 Balabit
- * Copyright (c) 2010-2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2010-2016 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,20 +20,21 @@
  *
  */
 
-#ifndef AFMONGODB_PARSER_H_INCLUDED
-#define AFMONGODB_PARSER_H_INCLUDED
+#ifndef AFMONGODB_LEGACY_GRAMMAR_H_
+#define AFMONGODB_LEGACY_GRAMMAR_H_
 
 #include "syslog-ng.h"
-#include "cfg-parser.h"
-#include "cfg-lexer.h"
-#include "afmongodb.h"
+#include "driver.h"
 
-#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
-#include "afmongodb-legacy-grammar.h"
-#endif
-
-extern CfgParser afmongodb_parser;
-
-CFG_PARSER_DECLARE_LEXER_BINDING(afmongodb_, LogDriver **)
+gboolean afmongodb_dd_validate_socket_combination(LogDriver *d);
+gboolean afmongodb_dd_validate_network_combination(LogDriver *d);
+void afmongodb_dd_set_servers(LogDriver *d, GList *servers);
+void afmongodb_dd_set_host(LogDriver *d, const gchar *host);
+void afmongodb_dd_set_port(LogDriver *d, gint port);
+void afmongodb_dd_set_database(LogDriver *d, const gchar *database);
+void afmongodb_dd_set_user(LogDriver *d, const gchar *user);
+void afmongodb_dd_set_password(LogDriver *d, const gchar *password);
+void afmongodb_dd_set_safe_mode(LogDriver *d, gboolean state);
+void afmongodb_dd_set_path(LogDriver *d, const gchar *path);
 
 #endif

--- a/modules/afmongodb/afmongodb-legacy-private.h
+++ b/modules/afmongodb/afmongodb-legacy-private.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2012 Balabit
- * Copyright (c) 2010-2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2010-2016 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,20 +20,12 @@
  *
  */
 
-#ifndef AFMONGODB_PARSER_H_INCLUDED
-#define AFMONGODB_PARSER_H_INCLUDED
+#ifndef AFMONGODB_LEGACY_PRIVATE_H_
+#define AFMONGODB_LEGACY_PRIVATE_H_
 
 #include "syslog-ng.h"
-#include "cfg-parser.h"
-#include "cfg-lexer.h"
-#include "afmongodb.h"
+#include "afmongodb-private.h"
 
-#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
-#include "afmongodb-legacy-grammar.h"
-#endif
-
-extern CfgParser afmongodb_parser;
-
-CFG_PARSER_DECLARE_LEXER_BINDING(afmongodb_, LogDriver **)
+#define MONGO_CONN_LOCAL -1
 
 #endif

--- a/modules/afmongodb/afmongodb-legacy-uri.c
+++ b/modules/afmongodb/afmongodb-legacy-uri.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2010-2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "afmongodb-legacy-uri.h"
+#include "afmongodb-legacy-private.h"
+#include "host-list.h"
+
+#define DEFAULTHOST "127.0.0.1"
+#define SOCKET_TIMEOUT_FOR_MONGO_CONNECTION_IN_MILLISECS 60000
+
+static gboolean
+_parse_addr(const char *str, char **host, gint *port)
+{
+  if (!host || !port)
+    {
+      msg_debug("Host or port reference should not be NULL");
+      return FALSE;
+    }
+  char *proto_str = g_strdup_printf("mongodb://%s", str);
+  mongoc_uri_t *uri = mongoc_uri_new(proto_str);
+  if (!uri)
+    {
+      msg_error("Cannot parse MongoDB URI", evt_tag_str("uri", proto_str));
+      g_free(proto_str);
+      return FALSE;
+    }
+
+  const mongoc_host_list_t *hosts = mongoc_uri_get_hosts(uri);
+  if (!hosts || hosts->next)
+    {
+      if (hosts)
+        msg_error("Multiple hosts found in MongoDB URI", evt_tag_str("uri", proto_str));
+      else
+        msg_error("No host found in MongoDB URI", evt_tag_str("uri", proto_str));
+      g_free(proto_str);
+      mongoc_uri_destroy(uri);
+      return FALSE;
+    }
+  *port = hosts->port;
+  *host = g_strdup(hosts->host);
+  mongoc_uri_destroy(uri);
+  if (!*host)
+    {
+      msg_error("NULL hostname", evt_tag_str("uri", proto_str));
+      g_free(proto_str);
+      return FALSE;
+    }
+  g_free(proto_str);
+  return TRUE;
+}
+
+static gboolean
+_append_legacy_servers(MongoDBDestDriver *self)
+{
+  if (self->port != MONGO_CONN_LOCAL)
+    {
+      if (self->address || self->port)
+        {
+          gchar *host = NULL;
+          gint port = 0;
+          if (!_parse_addr(self->address, &host, &port) || (!host))
+            {
+              msg_error("Cannot parse the primary host",
+                        evt_tag_str("primary", self->address),
+                        evt_tag_str("driver", self->super.super.super.id));
+              return FALSE;
+            }
+          g_free(host);
+
+          port = self->port ? self->port : MONGOC_DEFAULT_PORT;
+          const gchar *address = self->address ? self->address : DEFAULTHOST;
+          gchar *srv = g_strdup_printf("%s:%d", address, port);
+          self->servers = g_list_prepend(self->servers, srv);
+          g_free(self->address);
+          self->address = NULL;
+          self->port = MONGOC_DEFAULT_PORT;
+        }
+
+      if (self->servers)
+        {
+          GList *l;
+
+          for (l = self->servers; l; l = g_list_next(l))
+            {
+              gchar *host = NULL;
+              gint port = MONGOC_DEFAULT_PORT;
+
+              if (!_parse_addr(l->data, &host, &port))
+                {
+                  msg_warning("Cannot parse MongoDB server address, ignoring",
+                              evt_tag_str("address", l->data),
+                              evt_tag_str("driver", self->super.super.super.id));
+                  continue;
+                }
+              host_list_append(&self->recovery_cache, host, port);
+              msg_verbose("Added MongoDB server seed",
+                          evt_tag_str("host", host),
+                          evt_tag_int("port", port),
+                          evt_tag_str("driver", self->super.super.super.id));
+              g_free(host);
+            }
+        }
+      else
+        {
+          gchar *localhost = g_strdup_printf(DEFAULTHOST ":%d", MONGOC_DEFAULT_PORT);
+          self->servers = g_list_append(NULL, localhost);
+          host_list_append(&self->recovery_cache, DEFAULTHOST, MONGOC_DEFAULT_PORT);
+        }
+
+      if (!_parse_addr(g_list_nth_data(self->servers, 0), &self->address, &self->port))
+        {
+          msg_error("Cannot parse the primary host",
+                    evt_tag_str("primary", g_list_nth_data(self->servers, 0)),
+                    evt_tag_str("driver", self->super.super.super.id));
+          return FALSE;
+        }
+    }
+  else
+    {
+      if (!self->address)
+        {
+          msg_error("Cannot parse address",
+                    evt_tag_str("primary", g_list_nth_data(self->servers, 0)),
+                    evt_tag_str("driver", self->super.super.super.id));
+          return FALSE;
+        }
+      host_list_append(&self->recovery_cache, self->address, 0);
+    }
+  return TRUE;
+}
+
+typedef struct _AppendServerState {
+  GString *uri_str;
+  gboolean *have_uri;
+  gboolean have_path;
+} AppendServerState;
+
+static gboolean
+_append_server(gpointer user_data, const char *host, gint port)
+{
+  AppendServerState *state = (AppendServerState *)user_data;
+  if (state->have_path || *state->have_uri)
+    g_string_append_printf(state->uri_str, ",");
+  if (port)
+    {
+      *state->have_uri = TRUE;
+      if (state->have_path)
+        {
+          msg_warning("Cannot specify both a domain socket and address");
+          return FALSE;
+        }
+      g_string_append_printf(state->uri_str, "%s:%d", host, port);
+    }
+  else
+    {
+      state->have_path = TRUE;
+      if (*state->have_uri)
+        {
+          msg_warning("Cannot specify both a domain socket and address");
+          return FALSE;
+        }
+      g_string_append_printf(state->uri_str, "%s", host);
+    }
+  return TRUE;
+}
+
+static gboolean
+_append_servers(GString *uri_str, const HostList *host_list, gboolean *have_uri)
+{
+  *have_uri = FALSE;
+  AppendServerState state = {uri_str, have_uri, FALSE};
+  return host_list_iterate(host_list, _append_server, &state);
+}
+
+static gboolean
+_check_auth_options(MongoDBDestDriver *self)
+{
+  if (self->user || self->password)
+    {
+      if (!self->user || !self->password)
+        {
+          msg_error("Neither the username, nor the password can be empty");
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+
+gboolean
+_build_uri_from_legacy_options(MongoDBDestDriver *self)
+{
+    if (!_append_legacy_servers(self))
+      return FALSE;
+
+    self->uri_str = g_string_new("mongodb://");
+
+    if (self->user && self->password)
+      g_string_append_printf(self->uri_str, "%s:%s@", self->user, self->password);
+
+    if (!self->recovery_cache)
+      {
+        msg_error("Error in host server list", evt_tag_str("driver", self->super.super.super.id));
+        return FALSE;
+      }
+
+    gboolean have_uri;
+    if (!_append_servers(self->uri_str, self->recovery_cache, &have_uri))
+      return FALSE;
+
+    if (have_uri)
+      g_string_append_printf(self->uri_str, "/%s", self->db);
+
+    if (self->safe_mode)
+      g_string_append_printf(self->uri_str,
+                             "?wtimeoutMS=%d",
+                             SOCKET_TIMEOUT_FOR_MONGO_CONNECTION_IN_MILLISECS);
+    else
+      g_string_append(self->uri_str, "?w=0&safe=false");
+
+    g_string_append_printf(self->uri_str,
+                           "&socketTimeoutMS=%d&connectTimeoutMS=%d",
+                           SOCKET_TIMEOUT_FOR_MONGO_CONNECTION_IN_MILLISECS,
+                           SOCKET_TIMEOUT_FOR_MONGO_CONNECTION_IN_MILLISECS);
+
+    return TRUE;
+}
+
+gboolean
+afmongodb_dd_create_uri_from_legacy(MongoDBDestDriver *self)
+{
+  if (!_check_auth_options(self))
+    return FALSE;
+
+  if (self->uri_str && self->is_legacy)
+    {
+      msg_error("Error: either specify a MongoDB URI (and optional collection)"
+          " or only legacy options", evt_tag_str("driver", self->super.super.super.id));
+      return FALSE;
+    }
+  else if (self->is_legacy)
+    return _build_uri_from_legacy_options(self);
+  else
+    return TRUE;
+}
+
+void
+afmongodb_dd_init_legacy(MongoDBDestDriver *self)
+{
+  self->db = g_strdup("syslog");
+  self->safe_mode = TRUE;
+}
+
+void
+afmongodb_dd_free_legacy(MongoDBDestDriver *self)
+{
+  g_free(self->db);
+  g_free(self->user);
+  g_free(self->password);
+  g_free(self->address);
+  string_list_free(self->servers);
+  host_list_free(self->recovery_cache);
+  self->recovery_cache = NULL;
+}

--- a/modules/afmongodb/afmongodb-legacy-uri.h
+++ b/modules/afmongodb/afmongodb-legacy-uri.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2012 Balabit
- * Copyright (c) 2010-2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2010-2016 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,20 +20,14 @@
  *
  */
 
-#ifndef AFMONGODB_PARSER_H_INCLUDED
-#define AFMONGODB_PARSER_H_INCLUDED
+#ifndef AFMONGODB_LEGACY_URI_H_
+#define AFMONGODB_LEGACY_URI_H_
 
 #include "syslog-ng.h"
-#include "cfg-parser.h"
-#include "cfg-lexer.h"
-#include "afmongodb.h"
+#include "afmongodb-private.h"
 
-#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
-#include "afmongodb-legacy-grammar.h"
-#endif
-
-extern CfgParser afmongodb_parser;
-
-CFG_PARSER_DECLARE_LEXER_BINDING(afmongodb_, LogDriver **)
+void afmongodb_dd_init_legacy(MongoDBDestDriver *self);
+void afmongodb_dd_free_legacy(MongoDBDestDriver *self);
+gboolean afmongodb_dd_create_uri_from_legacy(MongoDBDestDriver *self);
 
 #endif

--- a/modules/afmongodb/afmongodb-parser.c
+++ b/modules/afmongodb/afmongodb-parser.c
@@ -32,6 +32,18 @@ static CfgLexerKeyword afmongodb_keywords[] = {
   { "mongodb", KW_MONGODB },
   { "uri", KW_URI },
   { "collection", KW_COLLECTION },
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+  { "servers", KW_SERVERS, KWS_OBSOLETE, "Use the uri() option instead of servers()" },
+  { "database", KW_DATABASE, KWS_OBSOLETE, "Use the uri() option instead of database()" },
+  { "username", KW_USERNAME, KWS_OBSOLETE,
+    "Use the uri() option instead of username() and password()" },
+  { "password", KW_PASSWORD, KWS_OBSOLETE,
+    "Use the uri() option instead of username() and password()" },
+  { "safe_mode", KW_SAFE_MODE, KWS_OBSOLETE, "Use the uri() option instead of safe_mode()" },
+  { "host", KW_HOST, KWS_OBSOLETE, "Use the uri() option instead of host() and port()" },
+  { "port", KW_PORT, KWS_OBSOLETE, "Use the uri() option instead of host() and port()" },
+  { "path", KW_PATH, KWS_OBSOLETE, "Use the uri() option instead of path()" },
+#endif
   { }
 };
 

--- a/modules/afmongodb/afmongodb-parser.c
+++ b/modules/afmongodb/afmongodb-parser.c
@@ -29,10 +29,10 @@ extern int afmongodb_debug;
 int afmongodb_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 
 static CfgLexerKeyword afmongodb_keywords[] = {
-  { "mongodb",			KW_MONGODB },
-  { "uri",                      KW_URI },
-  { "collection",		KW_COLLECTION },
-  { NULL }
+  { "mongodb", KW_MONGODB },
+  { "uri", KW_URI },
+  { "collection", KW_COLLECTION },
+  { }
 };
 
 CfgParser afmongodb_parser =

--- a/modules/afmongodb/afmongodb-parser.h
+++ b/modules/afmongodb/afmongodb-parser.h
@@ -24,6 +24,7 @@
 #ifndef AFMONGODB_PARSER_H_INCLUDED
 #define AFMONGODB_PARSER_H_INCLUDED
 
+#include "syslog-ng.h"
 #include "cfg-parser.h"
 #include "cfg-lexer.h"
 #include "afmongodb.h"

--- a/modules/afmongodb/afmongodb-private.h
+++ b/modules/afmongodb/afmongodb-private.h
@@ -29,6 +29,10 @@
 #include "string-list.h"
 #include "value-pairs/value-pairs.h"
 
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+#include "host-list.h"
+#endif
+
 typedef struct _MongoDBDestDriver
 {
   LogThrDestDriver super;
@@ -38,6 +42,16 @@ typedef struct _MongoDBDestDriver
   gchar *coll;
   GString *uri_str;
 
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+  GList *servers;
+  gchar *address;
+  gint port;
+
+  gboolean safe_mode;
+  gchar *user;
+  gchar *password;
+#endif
+
   LogTemplateOptions template_options;
 
   time_t last_msg_stamp;
@@ -45,6 +59,12 @@ typedef struct _MongoDBDestDriver
   ValuePairs *vp;
 
   /* Writer-only stuff */
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+  HostList *recovery_cache;
+  gboolean is_legacy;
+  gchar *db;
+#endif
+
   const gchar *const_db;
   mongoc_uri_t *uri_obj;
   mongoc_client_t *client;

--- a/modules/afmongodb/afmongodb-private.h
+++ b/modules/afmongodb/afmongodb-private.h
@@ -36,7 +36,7 @@ typedef struct _MongoDBDestDriver
   /* Shared between main/writer; only read by the writer, never
    written */
   gchar *coll;
-  GString *uri;
+  GString *uri_str;
 
   LogTemplateOptions template_options;
 
@@ -45,7 +45,7 @@ typedef struct _MongoDBDestDriver
   ValuePairs *vp;
 
   /* Writer-only stuff */
-  const gchar *db;
+  const gchar *const_db;
   mongoc_uri_t *uri_obj;
   mongoc_client_t *client;
   mongoc_collection_t *coll_obj;

--- a/modules/afmongodb/afmongodb-private.h
+++ b/modules/afmongodb/afmongodb-private.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010-2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef AFMONGODB_PRIVATE_H_
+#define AFMONGODB_PRIVATE_H_
+
+#include "syslog-ng.h"
+#include "mongoc.h"
+#include "logthrdestdrv.h"
+#include "string-list.h"
+#include "value-pairs/value-pairs.h"
+
+typedef struct _MongoDBDestDriver
+{
+  LogThrDestDriver super;
+
+  /* Shared between main/writer; only read by the writer, never
+   written */
+  gchar *coll;
+  GString *uri;
+
+  LogTemplateOptions template_options;
+
+  time_t last_msg_stamp;
+
+  ValuePairs *vp;
+
+  /* Writer-only stuff */
+  const gchar *db;
+  mongoc_uri_t *uri_obj;
+  mongoc_client_t *client;
+  mongoc_collection_t *coll_obj;
+
+  GString *current_value;
+  bson_t *bson;
+} MongoDBDestDriver;
+
+#endif

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -78,7 +78,7 @@ afmongodb_dd_set_value_pairs(LogDriver *d, ValuePairs *vp)
  */
 
 static gchar *
-afmongodb_dd_format_stats_instance(LogThrDestDriver *d)
+_format_stats_instance(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
   static gchar persist_name[1024];
@@ -88,7 +88,7 @@ afmongodb_dd_format_stats_instance(LogThrDestDriver *d)
 }
 
 static gchar *
-afmongodb_dd_format_persist_name(LogThrDestDriver *d)
+_format_persist_name(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
   static gchar persist_name[1024];
@@ -98,7 +98,7 @@ afmongodb_dd_format_persist_name(LogThrDestDriver *d)
 }
 
 static void
-afmongodb_dd_disconnect(LogThrDestDriver *s)
+_worker_disconnect(LogThrDestDriver *s)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
@@ -107,7 +107,7 @@ afmongodb_dd_disconnect(LogThrDestDriver *s)
 }
 
 static gboolean
-afmongodb_dd_connect(MongoDBDestDriver *self, gboolean reconnect)
+_connect(MongoDBDestDriver *self, gboolean reconnect)
 {
   if (reconnect && self->client)
     return TRUE;
@@ -137,10 +137,10 @@ afmongodb_dd_connect(MongoDBDestDriver *self, gboolean reconnect)
  * Worker thread
  */
 static gboolean
-afmongodb_vp_obj_start(const gchar *name,
-                       const gchar *prefix, gpointer *prefix_data,
-                       const gchar *prev, gpointer *prev_data,
-                       gpointer user_data)
+_vp_obj_start(const gchar *name,
+                 const gchar *prefix, gpointer *prefix_data,
+                 const gchar *prev, gpointer *prev_data,
+                 gpointer user_data)
 {
   bson_t *o;
 
@@ -153,10 +153,10 @@ afmongodb_vp_obj_start(const gchar *name,
 }
 
 static gboolean
-afmongodb_vp_obj_end(const gchar *name,
-                     const gchar *prefix, gpointer *prefix_data,
-                     const gchar *prev, gpointer *prev_data,
-                     gpointer user_data)
+_vp_obj_end(const gchar *name,
+               const gchar *prefix, gpointer *prefix_data,
+               const gchar *prev, gpointer *prev_data,
+               gpointer user_data)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)user_data;
   bson_t *root;
@@ -177,9 +177,8 @@ afmongodb_vp_obj_end(const gchar *name,
 }
 
 static gboolean
-afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
-                           TypeHint type, const gchar *value, gsize value_len,
-                           gpointer *prefix_data, gpointer user_data)
+_vp_process_value(const gchar *name, const gchar *prefix, TypeHint type,
+                  const gchar *value, gsize value_len, gpointer *prefix_data, gpointer user_data)
 {
   bson_t *o;
   MongoDBDestDriver *self = (MongoDBDestDriver *)user_data;
@@ -291,7 +290,7 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
 }
 
 static void
-afmongodb_worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
+_worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
@@ -305,21 +304,21 @@ afmongodb_worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static worker_insert_result_t
-afmongodb_worker_insert (LogThrDestDriver *s, LogMessage *msg)
+_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
   gboolean success;
   gboolean drop_silently = self->template_options.on_error & ON_ERROR_SILENT;
 
-  if (!afmongodb_dd_connect(self, TRUE))
+  if (!_connect(self, TRUE))
     return WORKER_INSERT_RESULT_NOT_CONNECTED;
 
   bson_reinit(self->bson);
 
   success = value_pairs_walk(self->vp,
-                             afmongodb_vp_obj_start,
-                             afmongodb_vp_process_value,
-                             afmongodb_vp_obj_end,
+                             _vp_obj_start,
+                             _vp_process_value,
+                             _vp_obj_end,
                              msg, self->super.seq_num,
                              LTZ_SEND,
                              &self->template_options,
@@ -365,11 +364,11 @@ afmongodb_worker_insert (LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-afmongodb_worker_thread_init(LogThrDestDriver *d)
+_worker_thread_init(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
-  afmongodb_dd_connect(self, FALSE);
+  _connect(self, FALSE);
 
   self->current_value = g_string_sized_new(256);
 
@@ -377,7 +376,7 @@ afmongodb_worker_thread_init(LogThrDestDriver *d)
 }
 
 static void
-afmongodb_worker_thread_deinit(LogThrDestDriver *d)
+_worker_thread_deinit(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
@@ -391,7 +390,7 @@ afmongodb_worker_thread_deinit(LogThrDestDriver *d)
  */
 
 static void
-afmongodb_dd_init_value_pairs_dot_to_underscore_transformation(MongoDBDestDriver *self)
+_init_value_pairs_dot_to_underscore_transformation(MongoDBDestDriver *self)
 {
   ValuePairsTransformSet *vpts;
 
@@ -402,7 +401,7 @@ afmongodb_dd_init_value_pairs_dot_to_underscore_transformation(MongoDBDestDriver
 }
 
 static gboolean
-afmongodb_dd_init(LogPipe *s)
+_init(LogPipe *s)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
@@ -412,7 +411,7 @@ afmongodb_dd_init(LogPipe *s)
 
   log_template_options_init(&self->template_options, cfg);
 
-  afmongodb_dd_init_value_pairs_dot_to_underscore_transformation(self);
+  _init_value_pairs_dot_to_underscore_transformation(self);
 
   self->uri_obj = mongoc_uri_new (self->uri);
   if (!self->uri_obj)
@@ -442,7 +441,7 @@ afmongodb_dd_init(LogPipe *s)
 }
 
 static void
-afmongodb_dd_free(LogPipe *d)
+_free(LogPipe *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
@@ -459,7 +458,7 @@ afmongodb_dd_free(LogPipe *d)
 }
 
 static void
-afmongodb_dd_queue_method(LogThrDestDriver *d)
+_logthrdest_queue_method(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
@@ -479,18 +478,18 @@ afmongodb_dd_new(GlobalConfig *cfg)
 
   log_threaded_dest_driver_init_instance(&self->super, cfg);
 
-  self->super.super.super.super.init = afmongodb_dd_init;
-  self->super.super.super.super.free_fn = afmongodb_dd_free;
-  self->super.queue_method = afmongodb_dd_queue_method;
+  self->super.super.super.super.init = _init;
+  self->super.super.super.super.free_fn = _free;
+  self->super.queue_method = _logthrdest_queue_method;
 
-  self->super.worker.thread_init = afmongodb_worker_thread_init;
-  self->super.worker.thread_deinit = afmongodb_worker_thread_deinit;
-  self->super.worker.disconnect = afmongodb_dd_disconnect;
-  self->super.worker.insert = afmongodb_worker_insert;
-  self->super.format.stats_instance = afmongodb_dd_format_stats_instance;
-  self->super.format.persist_name = afmongodb_dd_format_persist_name;
+  self->super.worker.thread_init = _worker_thread_init;
+  self->super.worker.thread_deinit = _worker_thread_deinit;
+  self->super.worker.disconnect = _worker_disconnect;
+  self->super.worker.insert = _worker_insert;
+  self->super.format.stats_instance = _format_stats_instance;
+  self->super.format.persist_name = _format_persist_name;
   self->super.stats_source = SCS_MONGODB;
-  self->super.messages.retry_over = afmongodb_worker_retry_over_message;
+  self->super.messages.retry_over = _worker_retry_over_message;
 
   afmongodb_dd_set_collection(&self->super.super.super, "messages");
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -174,7 +174,7 @@ _vp_obj_end(const gchar *name,
       bson_t *d = (bson_t *)*prefix_data;
 
       bson_append_document(root, name, -1, d);
-      bson_free(d);
+      bson_destroy(d);
     }
   return FALSE;
 }
@@ -420,7 +420,8 @@ _worker_thread_deinit(LogThrDestDriver *d)
 
   g_string_free(self->current_value, TRUE);
 
-  bson_free(self->bson);
+  bson_destroy(self->bson);
+  self->bson = NULL;
 }
 
 /*

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -55,8 +55,10 @@ afmongodb_dd_set_uri(LogDriver *d, const gchar *uri)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
-  g_string_free(self->uri_str, TRUE);
-  self->uri_str = g_string_new(uri);
+  if (self->uri_str)
+    g_string_assign(self->uri_str, uri);
+  else
+    self->uri_str = g_string_new(uri);
 }
 
 void
@@ -418,8 +420,11 @@ _worker_thread_deinit(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
-  g_string_free(self->current_value, TRUE);
-  self->current_value = NULL;
+  if (self->current_value)
+    {
+      g_string_free(self->current_value, TRUE);
+      self->current_value = NULL;
+    }
 
   bson_destroy(self->bson);
   self->bson = NULL;
@@ -466,7 +471,11 @@ _free(LogPipe *d)
 
   log_template_options_destroy(&self->template_options);
 
-  g_string_free(self->uri_str, TRUE);
+  if (self->uri_str)
+    {
+      g_string_free(self->uri_str, TRUE);
+      self->uri_str = NULL;
+    }
   g_free(self->coll);
   value_pairs_unref(self->vp);
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -34,6 +34,10 @@
 
 #include <time.h>
 
+#define DEFAULT_URI \
+      "mongodb://127.0.0.1:27017/syslog"\
+      "?wtimeoutMS=60000&socketTimeoutMS=60000&connectTimeoutMS=60000"
+
 /*
  * Configuration
  */
@@ -366,6 +370,9 @@ gboolean
 afmongodb_dd_private_uri_init(LogDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
+
+  if (!self->uri_str)
+    self->uri_str = g_string_new(DEFAULT_URI);
 
   self->uri_obj = mongoc_uri_new(self->uri_str->str);
   if (!self->uri_obj)

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 Balabit
+ * Copyright (c) 2010-2016 Balabit
  * Copyright (c) 2010-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -40,12 +40,6 @@
 
 typedef struct
 {
-  gchar *name;
-  LogTemplate *value;
-} MongoDBField;
-
-typedef struct
-{
   LogThrDestDriver super;
 
   /* Shared between main/writer; only read by the writer, never
@@ -76,7 +70,7 @@ typedef struct
 LogTemplateOptions *
 afmongodb_dd_get_template_options(LogDriver *s)
 {
-  MongoDBDestDriver *self = (MongoDBDestDriver *) s;
+  MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
   return &self->template_options;
 }
@@ -104,7 +98,7 @@ afmongodb_dd_set_value_pairs(LogDriver *d, ValuePairs *vp)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
-  value_pairs_unref (self->vp);
+  value_pairs_unref(self->vp);
   self->vp = vp;
 }
 
@@ -147,11 +141,11 @@ afmongodb_dd_connect(MongoDBDestDriver *self, gboolean reconnect)
   if (reconnect && self->client)
     return TRUE;
 
-  self->client = mongoc_client_new_from_uri (self->uri_obj);
+  self->client = mongoc_client_new_from_uri(self->uri_obj);
+
   if (!self->client)
     {
-      msg_error("Error connecting to MongoDB",
-                evt_tag_str ("driver", self->super.super.super.id));
+      msg_error("Error connecting to MongoDB", evt_tag_str("driver", self->super.super.super.id));
       return FALSE;
     }
 
@@ -160,8 +154,8 @@ afmongodb_dd_connect(MongoDBDestDriver *self, gboolean reconnect)
   if (!self->coll_obj)
     {
       msg_error("Error getting specified MongoDB collection",
-                evt_tag_str ("collection", self->coll),
-                evt_tag_str ("driver", self->super.super.super.id));
+                evt_tag_str("collection", self->coll),
+                evt_tag_str("driver", self->super.super.super.id));
       return FALSE;
     }
 
@@ -205,8 +199,8 @@ afmongodb_vp_obj_end(const gchar *name,
     {
       bson_t *d = (bson_t *)*prefix_data;
 
-      bson_append_document (root, name, -1, d);
-      bson_free (d);
+      bson_append_document(root, name, -1, d);
+      bson_free(d);
     }
   return FALSE;
 }
@@ -231,15 +225,14 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
       {
         gboolean b;
 
-        if (type_cast_to_boolean (value, &b, NULL))
-          bson_append_bool (o, name, -1, b);
+        if (type_cast_to_boolean(value, &b, NULL))
+          bson_append_bool(o, name, -1, b);
         else
           {
-            gboolean r = type_cast_drop_helper(self->template_options.on_error,
-                                               value, "boolean");
+            gboolean r = type_cast_drop_helper(self->template_options.on_error, value, "boolean");
 
             if (fallback)
-              bson_append_utf8 (o, name, -1, value, value_len);
+              bson_append_utf8(o, name, -1, value, value_len);
             else
               return r;
           }
@@ -249,15 +242,14 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
       {
         gint32 i;
 
-        if (type_cast_to_int32 (value, &i, NULL))
-          bson_append_int32 (o, name, -1, i);
+        if (type_cast_to_int32(value, &i, NULL))
+          bson_append_int32(o, name, -1, i);
         else
           {
-            gboolean r = type_cast_drop_helper(self->template_options.on_error,
-                                               value, "int32");
+            gboolean r = type_cast_drop_helper(self->template_options.on_error, value, "int32");
 
             if (fallback)
-              bson_append_utf8 (o, name, -1, value, value_len);
+              bson_append_utf8(o, name, -1, value, value_len);
             else
               return r;
           }
@@ -267,12 +259,11 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
       {
         gint64 i;
 
-        if (type_cast_to_int64 (value, &i, NULL))
-          bson_append_int64 (o, name, -1, i);
+        if (type_cast_to_int64(value, &i, NULL))
+          bson_append_int64(o, name, -1, i);
         else
           {
-            gboolean r = type_cast_drop_helper(self->template_options.on_error,
-                                               value, "int64");
+            gboolean r = type_cast_drop_helper(self->template_options.on_error, value, "int64");
 
             if (fallback)
               bson_append_utf8(o, name, -1, value, value_len);
@@ -286,12 +277,11 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
       {
         gdouble d;
 
-        if (type_cast_to_double (value, &d, NULL))
-          bson_append_double (o, name, -1, d);
+        if (type_cast_to_double(value, &d, NULL))
+          bson_append_double(o, name, -1, d);
         else
           {
-            gboolean r = type_cast_drop_helper(self->template_options.on_error,
-                                               value, "double");
+            gboolean r = type_cast_drop_helper(self->template_options.on_error, value, "double");
             if (fallback)
               bson_append_utf8(o, name, -1, value, value_len);
             else
@@ -304,12 +294,11 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
       {
         guint64 i;
 
-        if (type_cast_to_datetime_int (value, &i, NULL))
-          bson_append_date_time (o, name, -1, (gint64)i);
+        if (type_cast_to_datetime_int(value, &i, NULL))
+          bson_append_date_time(o, name, -1, (gint64)i);
         else
           {
-            gboolean r = type_cast_drop_helper(self->template_options.on_error,
-                                               value, "datetime");
+            gboolean r = type_cast_drop_helper(self->template_options.on_error, value, "datetime");
 
             if (fallback)
               bson_append_utf8(o, name, -1, value, value_len);
@@ -321,7 +310,7 @@ afmongodb_vp_process_value(const gchar *name, const gchar *prefix,
       }
     case TYPE_HINT_STRING:
     case TYPE_HINT_LITERAL:
-      bson_append_utf8 (o, name, -1, value, value_len);
+      bson_append_utf8(o, name, -1, value, value_len);
       break;
     default:
       return TRUE;
@@ -335,13 +324,13 @@ afmongodb_worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
-  msg_error("Multiple failures while inserting this record into the database, "
-            "message dropped",
-            evt_tag_str("driver", self->super.super.super.id),
-            evt_tag_int("number_of_retries", s->retries.max),
-            evt_tag_value_pairs("message", self->vp, msg,
-                                self->super.seq_num,
-                                LTZ_SEND, &self->template_options));
+  msg_error(
+      "Multiple failures while inserting this record into the database, "
+      "message dropped",
+      evt_tag_str("driver", self->super.super.super.id),
+      evt_tag_int("number_of_retries", s->retries.max),
+      evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
+                          LTZ_SEND, &self->template_options));
 }
 
 static worker_insert_result_t
@@ -354,7 +343,7 @@ afmongodb_worker_insert (LogThrDestDriver *s, LogMessage *msg)
   if (!afmongodb_dd_connect(self, TRUE))
     return WORKER_INSERT_RESULT_NOT_CONNECTED;
 
-  bson_reinit (self->bson);
+  bson_reinit(self->bson);
 
   success = value_pairs_walk(self->vp,
                              afmongodb_vp_obj_start,
@@ -370,8 +359,7 @@ afmongodb_worker_insert (LogThrDestDriver *s, LogMessage *msg)
       if (!drop_silently)
         {
           msg_error("Failed to format message for MongoDB, dropping message",
-                    evt_tag_value_pairs("message", self->vp, msg,
-                                        self->super.seq_num,
+                    evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
                                         LTZ_SEND, &self->template_options),
                     evt_tag_str("driver", self->super.super.super.id));
         }
@@ -381,15 +369,12 @@ afmongodb_worker_insert (LogThrDestDriver *s, LogMessage *msg)
     {
       bson_error_t error;
       msg_debug("Outgoing message to MongoDB destination",
-                evt_tag_value_pairs("message", self->vp, msg,
-                                    self->super.seq_num,
-                                    LTZ_SEND, &self->template_options),
+                evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num, LTZ_SEND,
+                                    &self->template_options),
                 evt_tag_str("driver", self->super.super.super.id));
 
-      success = mongoc_collection_insert (self->coll_obj, MONGOC_INSERT_NONE,
-                                          (const bson_t *) self->bson,
-                                          NULL,
-                                          &error);
+      success = mongoc_collection_insert(self->coll_obj, MONGOC_INSERT_NONE, (const bson_t *)self->bson,
+                                         NULL, &error);
       if (!success)
         {
           msg_error("Network error while inserting into MongoDB",
@@ -425,9 +410,9 @@ afmongodb_worker_thread_deinit(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
-  g_string_free (self->current_value, TRUE);
+  g_string_free(self->current_value, TRUE);
 
-  bson_free (self->bson);
+  bson_free(self->bson);
 }
 
 /*
@@ -439,7 +424,7 @@ afmongodb_dd_init_value_pairs_dot_to_underscore_transformation(MongoDBDestDriver
 {
   ValuePairsTransformSet *vpts;
 
- /* Always replace a leading dot with an underscore. */
+  /* Always replace a leading dot with an underscore. */
   vpts = value_pairs_transform_set_new(".*");
   value_pairs_transform_set_add_func(vpts, value_pairs_new_transform_replace_prefix(".", "_"));
   value_pairs_add_transforms(self->vp, vpts);
@@ -497,8 +482,8 @@ afmongodb_dd_free(LogPipe *d)
   value_pairs_unref(self->vp);
 
   mongoc_uri_destroy(self->uri_obj);
-  mongoc_collection_destroy (self->coll_obj);
-  mongoc_cleanup ();
+  mongoc_collection_destroy(self->coll_obj);
+  mongoc_cleanup();
   log_threaded_dest_driver_free(d);
 }
 
@@ -507,7 +492,7 @@ afmongodb_dd_queue_method(LogThrDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
-  self->last_msg_stamp = cached_g_current_time_sec ();
+  self->last_msg_stamp = cached_g_current_time_sec();
 }
 
 /*
@@ -519,7 +504,7 @@ afmongodb_dd_new(GlobalConfig *cfg)
 {
   MongoDBDestDriver *self = g_new0(MongoDBDestDriver, 1);
 
-  mongoc_init ();
+  mongoc_init();
 
   log_threaded_dest_driver_init_instance(&self->super, cfg);
 
@@ -536,12 +521,12 @@ afmongodb_dd_new(GlobalConfig *cfg)
   self->super.stats_source = SCS_MONGODB;
   self->super.messages.retry_over = afmongodb_worker_retry_over_message;
 
-  afmongodb_dd_set_collection((LogDriver *)self, "messages");
+  afmongodb_dd_set_collection(&self->super.super.super, "messages");
 
   log_template_options_defaults(&self->template_options);
   afmongodb_dd_set_value_pairs(&self->super.super.super, value_pairs_new_default(cfg));
 
-  return (LogDriver *)self;
+  return &self->super.super.super;
 }
 
 extern CfgParser afmongodb_dd_parser;

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -25,43 +25,14 @@
 #include "afmongodb.h"
 #include "afmongodb-parser.h"
 #include "messages.h"
-#include "string-list.h"
 #include "stats/stats-registry.h"
 #include "logmsg/nvtable.h"
 #include "logqueue.h"
-#include "value-pairs/value-pairs.h"
 #include "value-pairs/evttag.h"
 #include "plugin.h"
 #include "plugin-types.h"
-#include "logthrdestdrv.h"
 
-#include "mongoc.h"
 #include <time.h>
-
-typedef struct
-{
-  LogThrDestDriver super;
-
-  /* Shared between main/writer; only read by the writer, never
-     written */
-  gchar *coll;
-  gchar *uri;
-
-  LogTemplateOptions template_options;
-
-  time_t last_msg_stamp;
-
-  ValuePairs *vp;
-
-  /* Writer-only stuff */
-  const gchar *db;
-  mongoc_uri_t *uri_obj;
-  mongoc_client_t *client;
-  mongoc_collection_t *coll_obj;
-
-  GString *current_value;
-  bson_t *bson;
-} MongoDBDestDriver;
 
 /*
  * Configuration

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -419,6 +419,7 @@ _worker_thread_deinit(LogThrDestDriver *d)
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
   g_string_free(self->current_value, TRUE);
+  self->current_value = NULL;
 
   bson_destroy(self->bson);
   self->bson = NULL;
@@ -469,8 +470,10 @@ _free(LogPipe *d)
   g_free(self->coll);
   value_pairs_unref(self->vp);
 
-  mongoc_uri_destroy(self->uri_obj);
-  mongoc_collection_destroy(self->coll_obj);
+  if (self->uri_obj)
+    mongoc_uri_destroy(self->uri_obj);
+  if (self->coll_obj)
+    mongoc_collection_destroy(self->coll_obj);
   mongoc_cleanup();
   log_threaded_dest_driver_free(d);
 }

--- a/modules/afmongodb/afmongodb.h
+++ b/modules/afmongodb/afmongodb.h
@@ -36,4 +36,6 @@ void afmongodb_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
 
 LogTemplateOptions *afmongodb_dd_get_template_options(LogDriver *s);
 
+gboolean afmongodb_dd_private_uri_init(LogDriver *self);
+
 #endif

--- a/modules/afmongodb/afmongodb.h
+++ b/modules/afmongodb/afmongodb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 Balabit
+ * Copyright (c) 2010-2016 Balabit
  * Copyright (c) 2010-2013 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 #ifndef AFMONGODB_H_INCLUDED
 #define AFMONGODB_H_INCLUDED
 
+#include "syslog-ng.h"
 #include "driver.h"
 #include "value-pairs/value-pairs.h"
 
@@ -32,7 +33,6 @@ LogDriver *afmongodb_dd_new(GlobalConfig *cfg);
 void afmongodb_dd_set_uri(LogDriver *d, const gchar *uri);
 void afmongodb_dd_set_collection(LogDriver *d, const gchar *collection);
 void afmongodb_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
-void afmongodb_dd_set_retries(LogDriver *d, gint retries);
 
 LogTemplateOptions *afmongodb_dd_get_template_options(LogDriver *s);
 

--- a/modules/afmongodb/host-list.c
+++ b/modules/afmongodb/host-list.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "host-list.h"
+
+typedef struct _MongoDBHostPort
+{
+  char *host;
+  gint port;
+} MongoDBHostPort;
+
+static MongoDBHostPort *
+_new_host_port(const char *host, gint port)
+{
+  MongoDBHostPort *hp = g_new0(MongoDBHostPort, 1);
+  hp->host = g_strdup(host);
+  hp->port = port;
+  return hp;
+}
+
+static void
+_free_host_port(gpointer data)
+{
+  MongoDBHostPort *hp = (MongoDBHostPort *)data;
+  g_free(hp->host);
+  hp->host = NULL;
+  g_free(hp);
+}
+
+gboolean
+host_list_append(HostList **list, const char *host, gint port)
+{
+  if (!list)
+    return FALSE;
+  *list = g_list_append(*list, _new_host_port(host, port));
+  return TRUE;
+}
+
+gboolean
+host_list_iterate(const HostList *host_list, HostListProcessor processor, gpointer user_data)
+{
+  for (const GList *iterator = host_list; iterator; iterator = iterator->next)
+    {
+      const MongoDBHostPort *hp = (const MongoDBHostPort *)iterator->data;
+      if (!processor(user_data, hp->host, hp->port))
+        return FALSE;
+    }
+  return TRUE;
+}
+
+void
+host_list_free(HostList *host_list)
+{
+  g_list_free_full(host_list, (GDestroyNotify)&_free_host_port);
+}

--- a/modules/afmongodb/host-list.h
+++ b/modules/afmongodb/host-list.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2012 Balabit
- * Copyright (c) 2010-2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2016 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,20 +20,18 @@
  *
  */
 
-#ifndef AFMONGODB_PARSER_H_INCLUDED
-#define AFMONGODB_PARSER_H_INCLUDED
+#ifndef HOST_LIST_H_
+#define HOST_LIST_H_
 
 #include "syslog-ng.h"
-#include "cfg-parser.h"
-#include "cfg-lexer.h"
-#include "afmongodb.h"
+#include <glib.h>
 
-#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
-#include "afmongodb-legacy-grammar.h"
-#endif
+typedef GList HostList;
 
-extern CfgParser afmongodb_parser;
+typedef gboolean (*HostListProcessor)(gpointer user_data, const char *host, gint port);
 
-CFG_PARSER_DECLARE_LEXER_BINDING(afmongodb_, LogDriver **)
+gboolean host_list_append(HostList **list, const char *host, gint port);
+gboolean host_list_iterate(const HostList *host_list, HostListProcessor processor, gpointer user_data);
+void host_list_free(HostList *host_list);
 
 #endif

--- a/modules/afmongodb/tests/Makefile.am
+++ b/modules/afmongodb/tests/Makefile.am
@@ -1,0 +1,13 @@
+modules_afmongodb_tests_TESTS          = \
+       modules/afmongodb/tests/test-mongodb-config
+
+check_PROGRAMS                         += ${modules_afmongodb_tests_TESTS}
+
+modules_afmongodb_tests_test_mongodb_config_CFLAGS = \
+    $(LIBMONGO_CFLAGS) \
+    $(TEST_CFLAGS)
+
+modules_afmongodb_tests_test_mongodb_config_LDADD        = \
+    $(TEST_LDADD) \
+    -dlpreopen $(top_builddir)/modules/afmongodb/libafmongodb.la \
+    ${lmc_EXTRA_DEPS}

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -187,6 +187,111 @@ _test_uri_error(void)
                        " uri='mongodb://127.0.0.1:27017/'");
 }
 
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+#define UNSAFEOPTS "?w=0&safe=false&socketTimeoutMS=60000&connectTimeoutMS=60000"
+
+static void
+_test_legacy_correct(void)
+{
+  GList *servers = g_list_append(NULL, g_strdup("127.0.0.2:27018"));
+  servers = g_list_append(servers, g_strdup("localhost:1234"));
+  afmongodb_dd_set_servers(mongodb, servers);
+  _expect_uri_in_log("servers_multi", "127.0.0.2:27018,localhost:1234/syslog" SAFEOPTS,
+                     "syslog", "messages");
+
+  servers = g_list_append(NULL, g_strdup("127.0.0.2"));
+  afmongodb_dd_set_servers(mongodb, servers);
+  _expect_uri_in_log("servers_single", "127.0.0.2:27017/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_host(mongodb, "localhost");
+  _expect_uri_in_log("host", "localhost:27017/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_host(mongodb, "localhost");
+  afmongodb_dd_set_port(mongodb, 1234);
+  _expect_uri_in_log("host_port", "localhost:1234/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_port(mongodb, 27017);
+  _expect_uri_in_log("port_default", "127.0.0.1:27017/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_port(mongodb, 1234);
+  _expect_uri_in_log("port", "127.0.0.1:1234/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_path(mongodb, "/tmp/mongo.sock");
+  _expect_uri_in_log("path", "/tmp/mongo.sock" SAFEOPTS, "tmp/mongo.sock", "messages");
+
+  afmongodb_dd_set_database(mongodb, "syslog-ng");
+  _expect_uri_in_log("database", "127.0.0.1:27017/syslog-ng" SAFEOPTS, "syslog-ng", "messages");
+
+  afmongodb_dd_set_safe_mode(mongodb, TRUE);
+  _expect_uri_in_log("safe_mode_true", "127.0.0.1:27017/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_safe_mode(mongodb, FALSE);
+  _expect_uri_in_log("safe_mode_false", "127.0.0.1:27017/syslog" UNSAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_user(mongodb, "user");
+  afmongodb_dd_set_password(mongodb, "password");
+  _expect_uri_in_log("user_password", "user:password@127.0.0.1:27017/syslog" SAFEOPTS,
+                     "syslog", "messages");
+
+  afmongodb_dd_set_collection(mongodb, "messages2");
+  afmongodb_dd_set_safe_mode(mongodb, FALSE);
+  _expect_uri_in_log("collection_safe_mode", "127.0.0.1:27017/syslog" UNSAFEOPTS,
+                     "syslog", "messages2");
+
+  afmongodb_dd_set_user(mongodb, "");
+  afmongodb_dd_set_password(mongodb, "password");
+  _expect_uri_in_log("empty_user", ":password@127.0.0.1:27017/syslog" SAFEOPTS,
+                     "syslog", "messages");
+
+  afmongodb_dd_set_user(mongodb, "user");
+  afmongodb_dd_set_password(mongodb, "");
+  _expect_uri_in_log("empty_password", "user:@127.0.0.1:27017/syslog" SAFEOPTS,
+                     "syslog", "messages");
+
+  afmongodb_dd_set_user(mongodb, "");
+  afmongodb_dd_set_password(mongodb, "");
+  _expect_uri_in_log("empty_user_password", ":@127.0.0.1:27017/syslog" SAFEOPTS,
+                     "syslog", "messages");
+
+  afmongodb_dd_set_user(mongodb, "127.0.0.1:27017/syslog?dont-care=");
+  afmongodb_dd_set_password(mongodb, "");
+  _expect_uri_in_log("hijacked_user", "127.0.0.1:27017/syslog?dont-care=:@127.0.0.1:27017/syslog"
+                     SAFEOPTS, "syslog", "messages");
+}
+
+static void
+_test_legacy_error(void)
+{
+  afmongodb_dd_set_safe_mode(mongodb, FALSE);
+  afmongodb_dd_set_uri(mongodb, "mongodb://127.0.0.1:27017/syslog");
+  _expect_error_in_log("uri_safe_mode", "Error: either specify a MongoDB URI "
+                      "(and optional collection) or only legacy options;");
+
+  afmongodb_dd_set_host(mongodb, "?");
+  _expect_error_in_log("host_invalid", "Cannot parse MongoDB URI; uri=");
+
+  afmongodb_dd_set_host(mongodb, "");
+  _expect_error_in_log("host_none", "Cannot parse the primary host; primary=\'\'");
+
+  afmongodb_dd_set_host(mongodb, "localhost,127.0.0.1");
+  _expect_error_in_log("host_multi", "Multiple hosts found in MongoDB URI; uri=");
+
+  GList *servers = g_list_append(NULL, g_strdup("localhost,127.0.0.1"));
+  afmongodb_dd_set_servers(mongodb, servers);
+  _expect_error_in_log("servers_multi", "Multiple hosts found in MongoDB URI; uri=");
+
+  servers = g_list_append(NULL, g_strdup(""));
+  afmongodb_dd_set_servers(mongodb, servers);
+  _expect_error_in_log("servers_none", "Cannot parse MongoDB URI; uri=");
+
+  afmongodb_dd_set_password(mongodb, "password");
+  _expect_error_in_log("missing_user", "Neither the username, nor the password can be empty;");
+
+  afmongodb_dd_set_user(mongodb, "user");
+  _expect_error_in_log("missing_password", "Neither the username, nor the password can be empty;");
+}
+#endif
+
 static void
 _setup(void)
 {
@@ -232,6 +337,11 @@ main(int argc, char **argv)
   _test_stats_name();
   _test_uri_correct();
   _test_uri_error();
+
+#if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
+  _test_legacy_correct();
+  _test_legacy_error();
+#endif
 
   _teardown();
   return _tests_failed;

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2016 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "testutils.h"
+#include "mainloop.h"
+#include "modules/afmongodb/afmongodb-parser.h"
+#include "logthrdestdrv.h"
+
+static int _tests_failed = 0;
+static GlobalConfig *test_cfg;
+static LogDriver *mongodb;
+
+#define SAFEOPTS "?wtimeoutMS=60000&socketTimeoutMS=60000&connectTimeoutMS=60000"
+
+static void
+_before_test(void)
+{
+  start_grabbing_messages();
+  mongodb = afmongodb_dd_new(test_cfg);
+}
+
+static gboolean
+_after_test(void)
+{
+  gboolean uri_init_ok = afmongodb_dd_private_uri_init(mongodb);
+  stop_grabbing_messages();
+  return uri_init_ok;
+}
+
+static void
+_free_test(void)
+{
+  reset_grabbed_messages();
+  if (mongodb)
+    {
+      log_pipe_unref(&mongodb->super);
+      mongodb = NULL;
+    }
+}
+
+typedef gboolean (*Checks)(const gchar *user_data);
+
+static gboolean
+_execute(const gchar *testcase, Checks checks, const gchar *user_data)
+{
+  gboolean uri_init_ok = _after_test();
+
+  testcase_begin("%s(%s, %s)", __FUNCTION__, testcase, user_data);
+  if (!checks(user_data))
+    _tests_failed = 1;
+  reset_grabbed_messages();
+  testcase_end();
+
+  _free_test();
+  _before_test();
+  return uri_init_ok;
+}
+
+static gboolean
+_execute_find_text_in_log(const gchar *pattern)
+{
+  return assert_grabbed_messages_contain_non_fatal(pattern, "mismatch", NULL);
+}
+
+static void
+_log_error(const gchar *message)
+{
+  fprintf(stderr, "error: %s\n", message);
+}
+
+static void
+_execute_correct(const gchar *testcase, Checks checks, const gchar *user_data)
+{
+  if (!_execute(testcase, checks, user_data))
+    {
+      _log_error("expected the subject to succeed, but it failed");
+      _tests_failed = 1;
+    }
+}
+
+static void
+_execute_failing(const gchar *testcase, Checks checks, const gchar *user_data)
+{
+  if (_execute(testcase, checks, user_data))
+    {
+      _log_error("expected the subject to fail, but it succeeded");
+      _tests_failed = 1;
+    }
+}
+
+static void
+_expect_error_in_log(const gchar *testcase, const gchar *pattern)
+{
+  _execute_failing(testcase, _execute_find_text_in_log, pattern);
+}
+
+static void
+_expect_uri_in_log(const gchar *testcase, const gchar *uri, const gchar *db, const gchar *coll)
+{
+  GString *pattern = g_string_sized_new(0);
+  g_string_append_printf(pattern,
+                         "Initializing MongoDB destination;"
+                         " uri='mongodb://%s', db='%s', collection='%s'",
+                         uri, db, coll);
+  _execute_correct(testcase, _execute_find_text_in_log, pattern->str);
+  g_string_free(pattern, TRUE);
+}
+
+static gboolean
+_execute_compare_persist_name(const gchar *expected_name)
+{
+  LogThrDestDriver *self = (LogThrDestDriver *)mongodb;
+  const gchar *name = self->format.persist_name(self);
+  return assert_nstring_non_fatal(name, -1, expected_name, -1, "mismatch");
+}
+
+static void
+_test_persist_name(void)
+{
+  afmongodb_dd_set_uri(mongodb, "mongodb://127.0.0.2:27018,localhost:1234/syslog"
+                       SAFEOPTS "&replicaSet=x");
+  _execute_correct("persist", _execute_compare_persist_name,
+                   "afmongodb(127.0.0.2:27018,syslog,x,messages)");
+}
+
+static gboolean
+_execute_compare_stats_name(const gchar *expected_name)
+{
+  LogThrDestDriver *self = (LogThrDestDriver *)mongodb;
+  const gchar *name = self->format.stats_instance(self);
+  return assert_nstring_non_fatal(name, -1, expected_name, -1, "mismatch");
+}
+
+static void
+_test_stats_name(void)
+{
+  afmongodb_dd_set_uri(mongodb, "mongodb://127.0.0.2:27018,localhost:1234/syslog"
+                       SAFEOPTS "&replicaSet=x");
+  _execute_correct("stats", _execute_compare_stats_name,
+                   "mongodb,127.0.0.2:27018,syslog,x,messages");
+}
+
+static void
+_test_uri_correct(void)
+{
+  _expect_uri_in_log("default_uri", "127.0.0.1:27017/syslog" SAFEOPTS, "syslog", "messages");
+
+  afmongodb_dd_set_uri(mongodb, "mongodb:///tmp/mongo.sock");
+  _expect_uri_in_log("socket", "/tmp/mongo.sock", "tmp/mongo.sock", "messages");
+
+  afmongodb_dd_set_uri(mongodb, "mongodb://localhost:1234/syslog-ng");
+  _expect_uri_in_log("uri", "localhost:1234/syslog-ng", "syslog-ng", "messages");
+
+  afmongodb_dd_set_collection(mongodb, "messages2");
+  _expect_uri_in_log("collection", "127.0.0.1:27017/syslog" SAFEOPTS, "syslog", "messages2");
+}
+
+static void
+_test_uri_error(void)
+{
+  afmongodb_dd_set_uri(mongodb, "INVALID-URI");
+  _expect_error_in_log("invalid_uri", "Error parsing MongoDB URI; uri='INVALID-URI'");
+
+  afmongodb_dd_set_uri(mongodb, "mongodb://127.0.0.1:27017/");
+  _expect_error_in_log("missing_db", "Missing DB name from MongoDB URI;"
+                       " uri='mongodb://127.0.0.1:27017/'");
+}
+
+static void
+_setup(void)
+{
+  msg_init(FALSE);
+  g_thread_init(NULL);
+  syntax_only = FALSE;
+  debug_flag = TRUE;
+  verbose_flag = TRUE;
+  trace_flag = TRUE;
+
+  log_msg_registry_init();
+
+  test_cfg = cfg_new(0x0308);
+  g_assert(test_cfg);
+
+  const gchar *persist_filename = "";
+  test_cfg->state = persist_state_new(persist_filename);
+
+  _before_test();
+}
+
+static void
+_teardown(void)
+{
+  _free_test();
+  if (test_cfg->persist)
+    {
+      persist_config_free(test_cfg->persist);
+      test_cfg->persist = NULL;
+    }
+  cfg_free(test_cfg);
+
+  log_msg_registry_deinit();
+  msg_deinit();
+}
+
+int
+main(int argc, char **argv)
+{
+  _setup();
+
+  _test_persist_name();
+  _test_stats_name();
+  _test_uri_correct();
+  _test_uri_error();
+
+  _teardown();
+  return _tests_failed;
+}


### PR DESCRIPTION
`modules/afmongodb`, `configure.ac`: `ENABLE_LEGACY_MONGODB_OPTIONS`
This re-adds additional support for previous syntax used by libmongo-client
before we started using `mongo-c-driver` and its URI syntax exclusively.

I.e., so additionally to `uri()` and `collection()`, now the following
keywords should work again:

* `servers()`
* `safe_mode()`
* `path()`
* `password()`
* `username()`
* `database()`

Note that these are plainly translated to a connection URI without
much sanity checking or preserving their former semantic meaning.
So various aspects of the MongoDB connection like health checks, retries,
error reporting and synchronicity will still follow the slightly altered
semantics of `mongo-c-driver`.

In the future, theoretically it is enough to revert this single commit
to remove support.
(This is one reason I did not opt for OOP & inheritance to implement this)

Fixes #893

----
I will factor out the system level tests to simple ones and amend this PR with a testing commit.