### PR TITLE
F/file perms extract from cfg

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1147,17 +1147,17 @@ dest_writer_options_flags
 
 file_perm_option
 	: KW_OWNER '(' string_or_number ')'	{ file_perm_options_set_file_uid(last_file_perm_options, $3); free($3); }
-	| KW_OWNER '(' ')'	                { file_perm_options_set_file_uid(last_file_perm_options, "-2"); }
+	| KW_OWNER '(' ')'	                { file_perm_options_dont_change_file_uid(last_file_perm_options); }
 	| KW_GROUP '(' string_or_number ')'	{ file_perm_options_set_file_gid(last_file_perm_options, $3); free($3); }
-	| KW_GROUP '(' ')'	                { file_perm_options_set_file_gid(last_file_perm_options, "-2"); }
+	| KW_GROUP '(' ')'	                { file_perm_options_dont_change_file_gid(last_file_perm_options); }
 	| KW_PERM '(' LL_NUMBER ')'		{ file_perm_options_set_file_perm(last_file_perm_options, $3); }
-	| KW_PERM '(' ')'		        { file_perm_options_set_file_perm(last_file_perm_options, -2); }
+	| KW_PERM '(' ')'		        { file_perm_options_dont_change_file_perm(last_file_perm_options); }
         | KW_DIR_OWNER '(' string_or_number ')'	{ file_perm_options_set_dir_uid(last_file_perm_options, $3); free($3); }
-	| KW_DIR_OWNER '(' ')'	                { file_perm_options_set_dir_uid(last_file_perm_options, "-2"); }
+	| KW_DIR_OWNER '(' ')'	                { file_perm_options_dont_change_dir_uid(last_file_perm_options); }
 	| KW_DIR_GROUP '(' string_or_number ')'	{ file_perm_options_set_dir_gid(last_file_perm_options, $3); free($3); }
-	| KW_DIR_GROUP '(' ')'	                { file_perm_options_set_dir_gid(last_file_perm_options, "-2"); }
+	| KW_DIR_GROUP '(' ')'	                { file_perm_options_dont_change_dir_gid(last_file_perm_options); }
 	| KW_DIR_PERM '(' LL_NUMBER ')'		{ file_perm_options_set_dir_perm(last_file_perm_options, $3); }
-	| KW_DIR_PERM '(' ')'		        { file_perm_options_set_dir_perm(last_file_perm_options, -2); }
+	| KW_DIR_PERM '(' ')'		        { file_perm_options_dont_change_dir_perm(last_file_perm_options); }
         ;
 
 template_option

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -905,18 +905,6 @@ options_item
 	| KW_LOG_MSG_SIZE '(' LL_NUMBER ')'	{ configuration->log_msg_size = $3; }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ configuration->keep_timestamp = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ configuration->create_dirs = $3; }
-	| KW_OWNER '(' string_or_number ')'	{ cfg_file_owner_set(configuration, $3); free($3); }
-	| KW_OWNER '(' ')'	                { cfg_file_owner_set(configuration, "-2"); }
-	| KW_GROUP '(' string_or_number ')'	{ cfg_file_group_set(configuration, $3); free($3); }
-	| KW_GROUP '(' ')'                    	{ cfg_file_group_set(configuration, "-2"); }
-	| KW_PERM '(' LL_NUMBER ')'		{ cfg_file_perm_set(configuration, $3); }
-	| KW_PERM '(' ')'		        { cfg_file_perm_set(configuration, -2); }
-	| KW_DIR_OWNER '(' string_or_number ')'	{ cfg_dir_owner_set(configuration, $3); free($3); }
-	| KW_DIR_OWNER '('  ')'	                { cfg_dir_owner_set(configuration, "-2"); }
-	| KW_DIR_GROUP '(' string_or_number ')'	{ cfg_dir_group_set(configuration, $3); free($3); }
-	| KW_DIR_GROUP '('  ')'	                { cfg_dir_group_set(configuration, "-2"); }
-	| KW_DIR_PERM '(' LL_NUMBER ')'		{ cfg_dir_perm_set(configuration, $3); }
-	| KW_DIR_PERM '('  ')'		        { cfg_dir_perm_set(configuration, -2); }
         | KW_CUSTOM_DOMAIN '(' string ')'       { configuration->custom_domain = g_strdup($3); free($3); }
 	| KW_FILE_TEMPLATE '(' string ')'	{ configuration->file_template_name = g_strdup($3); free($3); }
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
@@ -925,6 +913,7 @@ options_item
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option
 	| { last_dns_cache_options = &configuration->dns_cache_options; } dns_cache_option
+	| global_file_perm_option
 	;
 
 stat_option
@@ -1163,6 +1152,21 @@ file_perm_option
 	| KW_GROUP '(' ')'	                { file_perm_options_set_file_gid(last_file_perm_options, "-2"); }
 	| KW_PERM '(' LL_NUMBER ')'		{ file_perm_options_set_file_perm(last_file_perm_options, $3); }
 	| KW_PERM '(' ')'		        { file_perm_options_set_file_perm(last_file_perm_options, -2); }
+        ;
+
+global_file_perm_option
+	: KW_OWNER '(' string_or_number ')'	{ cfg_file_owner_set(configuration, $3); free($3); }
+	| KW_OWNER '(' ')'	                { cfg_file_owner_set(configuration, "-2"); }
+	| KW_GROUP '(' string_or_number ')'	{ cfg_file_group_set(configuration, $3); free($3); }
+	| KW_GROUP '(' ')'                    	{ cfg_file_group_set(configuration, "-2"); }
+	| KW_PERM '(' LL_NUMBER ')'		{ cfg_file_perm_set(configuration, $3); }
+	| KW_PERM '(' ')'		        { cfg_file_perm_set(configuration, -2); }
+	| KW_DIR_OWNER '(' string_or_number ')'	{ cfg_dir_owner_set(configuration, $3); free($3); }
+	| KW_DIR_OWNER '('  ')'	                { cfg_dir_owner_set(configuration, "-2"); }
+	| KW_DIR_GROUP '(' string_or_number ')'	{ cfg_dir_group_set(configuration, $3); free($3); }
+	| KW_DIR_GROUP '('  ')'	                { cfg_dir_group_set(configuration, "-2"); }
+	| KW_DIR_PERM '(' LL_NUMBER ')'		{ cfg_dir_perm_set(configuration, $3); }
+	| KW_DIR_PERM '('  ')'		        { cfg_dir_perm_set(configuration, -2); }
         ;
 
 file_dir_perm_option

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -913,7 +913,7 @@ options_item
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option
 	| { last_dns_cache_options = &configuration->dns_cache_options; } dns_cache_option
-	| { last_file_perm_options = &configuration->file_perm_options; } global_file_perm_option
+	| { last_file_perm_options = &configuration->file_perm_options; } file_perm_option
 	;
 
 stat_option
@@ -1152,20 +1152,6 @@ file_perm_option
 	| KW_GROUP '(' ')'	                { file_perm_options_set_file_gid(last_file_perm_options, "-2"); }
 	| KW_PERM '(' LL_NUMBER ')'		{ file_perm_options_set_file_perm(last_file_perm_options, $3); }
 	| KW_PERM '(' ')'		        { file_perm_options_set_file_perm(last_file_perm_options, -2); }
-        ;
-
-global_file_perm_option
-        : file_perm_option
-	| KW_DIR_OWNER '(' string_or_number ')'	{ cfg_dir_owner_set(configuration, $3); free($3); }
-	| KW_DIR_OWNER '('  ')'	                { cfg_dir_owner_set(configuration, "-2"); }
-	| KW_DIR_GROUP '(' string_or_number ')'	{ cfg_dir_group_set(configuration, $3); free($3); }
-	| KW_DIR_GROUP '('  ')'	                { cfg_dir_group_set(configuration, "-2"); }
-	| KW_DIR_PERM '(' LL_NUMBER ')'		{ cfg_dir_perm_set(configuration, $3); }
-	| KW_DIR_PERM '('  ')'		        { cfg_dir_perm_set(configuration, -2); }
-        ;
-
-file_dir_perm_option
-        : file_perm_option
         | KW_DIR_OWNER '(' string_or_number ')'	{ file_perm_options_set_dir_uid(last_file_perm_options, $3); free($3); }
 	| KW_DIR_OWNER '(' ')'	                { file_perm_options_set_dir_uid(last_file_perm_options, "-2"); }
 	| KW_DIR_GROUP '(' string_or_number ')'	{ file_perm_options_set_dir_gid(last_file_perm_options, $3); free($3); }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -913,7 +913,7 @@ options_item
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option
 	| { last_dns_cache_options = &configuration->dns_cache_options; } dns_cache_option
-	| global_file_perm_option
+	| { last_file_perm_options = &configuration->file_perm_options; } global_file_perm_option
 	;
 
 stat_option
@@ -1155,12 +1155,7 @@ file_perm_option
         ;
 
 global_file_perm_option
-	: KW_OWNER '(' string_or_number ')'	{ cfg_file_owner_set(configuration, $3); free($3); }
-	| KW_OWNER '(' ')'	                { cfg_file_owner_set(configuration, "-2"); }
-	| KW_GROUP '(' string_or_number ')'	{ cfg_file_group_set(configuration, $3); free($3); }
-	| KW_GROUP '(' ')'                    	{ cfg_file_group_set(configuration, "-2"); }
-	| KW_PERM '(' LL_NUMBER ')'		{ cfg_file_perm_set(configuration, $3); }
-	| KW_PERM '(' ')'		        { cfg_file_perm_set(configuration, -2); }
+        : file_perm_option
 	| KW_DIR_OWNER '(' string_or_number ')'	{ cfg_dir_owner_set(configuration, $3); free($3); }
 	| KW_DIR_OWNER '('  ')'	                { cfg_dir_owner_set(configuration, "-2"); }
 	| KW_DIR_GROUP '(' string_or_number ')'	{ cfg_dir_group_set(configuration, $3); free($3); }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -107,30 +107,6 @@ cfg_ts_format_value(gchar *format)
 }
 
 void
-cfg_file_owner_set(GlobalConfig *self, gchar *owner)
-{
-  if (!resolve_user(owner, &self->file_perm_options.file_uid))
-    msg_error("Error resolving user",
-               evt_tag_str("user", owner),
-               NULL);
-}
-
-void
-cfg_file_group_set(GlobalConfig *self, gchar *group)
-{
-  if (!resolve_group(group, &self->file_perm_options.file_gid))
-    msg_error("Error resolving group",
-               evt_tag_str("group", group),
-               NULL);
-}
-
-void
-cfg_file_perm_set(GlobalConfig *self, gint perm)
-{
-  self->file_perm_options.file_perm = perm;
-}
-
-void
 cfg_dir_owner_set(GlobalConfig *self, gchar *owner)
 {
   if (!resolve_user(owner, &self->file_perm_options.dir_uid))

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -109,7 +109,7 @@ cfg_ts_format_value(gchar *format)
 void
 cfg_file_owner_set(GlobalConfig *self, gchar *owner)
 {
-  if (!resolve_user(owner, &self->file_uid))
+  if (!resolve_user(owner, &self->file_perm_options.file_uid))
     msg_error("Error resolving user",
                evt_tag_str("user", owner),
                NULL);
@@ -118,7 +118,7 @@ cfg_file_owner_set(GlobalConfig *self, gchar *owner)
 void
 cfg_file_group_set(GlobalConfig *self, gchar *group)
 {
-  if (!resolve_group(group, &self->file_gid))
+  if (!resolve_group(group, &self->file_perm_options.file_gid))
     msg_error("Error resolving group",
                evt_tag_str("group", group),
                NULL);
@@ -127,13 +127,13 @@ cfg_file_group_set(GlobalConfig *self, gchar *group)
 void
 cfg_file_perm_set(GlobalConfig *self, gint perm)
 {
-  self->file_perm = perm;
+  self->file_perm_options.file_perm = perm;
 }
 
 void
 cfg_dir_owner_set(GlobalConfig *self, gchar *owner)
 {
-  if (!resolve_user(owner, &self->dir_uid))
+  if (!resolve_user(owner, &self->file_perm_options.dir_uid))
     msg_error("Error resolving user",
                evt_tag_str("user", owner),
                NULL);
@@ -142,7 +142,7 @@ cfg_dir_owner_set(GlobalConfig *self, gchar *owner)
 void
 cfg_dir_group_set(GlobalConfig *self, gchar *group)
 {
-  if (!resolve_group(group, &self->dir_gid))
+  if (!resolve_group(group, &self->file_perm_options.dir_gid))
     msg_error("Error resolving group",
                evt_tag_str("group", group),
                NULL);
@@ -151,7 +151,7 @@ cfg_dir_group_set(GlobalConfig *self, gchar *group)
 void
 cfg_dir_perm_set(GlobalConfig *self, gint perm)
 {
-  self->dir_perm = perm;
+  self->file_perm_options.dir_perm = perm;
 }
 
 void
@@ -358,12 +358,7 @@ cfg_new(gint version)
   self->log_fifo_size = 10000;
   self->log_msg_size = 8192;
 
-  self->file_uid = 0;
-  self->file_gid = 0;
-  self->file_perm = 0600;
-  self->dir_uid = 0;
-  self->dir_gid = 0;
-  self->dir_perm = 0700;
+  file_perm_options_global_defaults(&self->file_perm_options);
 
   dns_cache_options_defaults(&self->dns_cache_options);
   self->threaded = TRUE;

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -107,30 +107,6 @@ cfg_ts_format_value(gchar *format)
 }
 
 void
-cfg_dir_owner_set(GlobalConfig *self, gchar *owner)
-{
-  if (!resolve_user(owner, &self->file_perm_options.dir_uid))
-    msg_error("Error resolving user",
-               evt_tag_str("user", owner),
-               NULL);
-}
-
-void
-cfg_dir_group_set(GlobalConfig *self, gchar *group)
-{
-  if (!resolve_group(group, &self->file_perm_options.dir_gid))
-    msg_error("Error resolving group",
-               evt_tag_str("group", group),
-               NULL);
-}
-
-void
-cfg_dir_perm_set(GlobalConfig *self, gint perm)
-{
-  self->file_perm_options.dir_perm = perm;
-}
-
-void
 cfg_bad_hostname_set(GlobalConfig *self, gchar *bad_hostname_re)
 {
   if (self->bad_hostname_re)

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -123,9 +123,6 @@ void cfg_bad_hostname_set(GlobalConfig *self, gchar *bad_hostname_re);
 gint cfg_lookup_mark_mode(gchar *mark_mode);
 void cfg_set_mark_mode(GlobalConfig *self, gchar *mark_mode);
 
-void cfg_dir_owner_set(GlobalConfig *self, gchar *owner);
-void cfg_dir_group_set(GlobalConfig *self, gchar *group);
-void cfg_dir_perm_set(GlobalConfig *self, gint perm);
 gint cfg_tz_convert_value(gchar *convert);
 gint cfg_ts_format_value(gchar *format);
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -35,6 +35,7 @@
 #include "type-hinting.h"
 #include "stats/stats.h"
 #include "dnscache.h"
+#include "file-perms.h"
 
 #include <sys/types.h>
 #include <regex.h>
@@ -93,14 +94,7 @@ struct _GlobalConfig
   gint log_msg_size;
 
   gboolean create_dirs;
-  gint file_uid;
-  gint file_gid;
-  gint file_perm;
-  
-  gint dir_uid;
-  gint dir_gid;
-  gint dir_perm;
-
+  FilePermOptions file_perm_options;
   gboolean use_uniqid;
 
   gboolean keep_timestamp;  

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -119,9 +119,6 @@ struct _GlobalConfig
 
 gboolean cfg_allow_config_dups(GlobalConfig *self);
 
-void cfg_file_owner_set(GlobalConfig *self, gchar *owner);
-void cfg_file_group_set(GlobalConfig *self, gchar *group);
-void cfg_file_perm_set(GlobalConfig *self, gint perm);
 void cfg_bad_hostname_set(GlobalConfig *self, gchar *bad_hostname_re);
 gint cfg_lookup_mark_mode(gchar *mark_mode);
 void cfg_set_mark_mode(GlobalConfig *self, gchar *mark_mode);

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -33,6 +33,8 @@
 #include <string.h>
 #include <errno.h>
 
+#define DONTCHANGE -2
+
 void
 file_perm_options_set_file_uid(FilePermOptions *self, const gchar *file_uid)
 {
@@ -43,6 +45,12 @@ file_perm_options_set_file_uid(FilePermOptions *self, const gchar *file_uid)
                  evt_tag_str("user", file_uid),
                  NULL);
     }
+}
+
+void
+file_perm_options_dont_change_file_uid(FilePermOptions *self)
+{
+  self->file_uid = DONTCHANGE;
 }
 
 void
@@ -58,9 +66,21 @@ file_perm_options_set_file_gid(FilePermOptions *self, const gchar *file_gid)
 }
 
 void
+file_perm_options_dont_change_file_gid(FilePermOptions *self)
+{
+  self->file_gid = DONTCHANGE;
+}
+
+void
 file_perm_options_set_file_perm(FilePermOptions *self, gint file_perm)
 {
   self->file_perm = file_perm;
+}
+
+void
+file_perm_options_dont_change_file_perm(FilePermOptions *self)
+{
+  self->file_perm = DONTCHANGE;
 }
 
 void
@@ -76,6 +96,12 @@ file_perm_options_set_dir_uid(FilePermOptions *self, const gchar *dir_uid)
 }
 
 void
+file_perm_options_dont_change_dir_uid(FilePermOptions *self)
+{
+  self->dir_uid = DONTCHANGE;
+}
+
+void
 file_perm_options_set_dir_gid(FilePermOptions *self, const gchar *dir_gid)
 {
   self->dir_gid = 0;
@@ -88,9 +114,21 @@ file_perm_options_set_dir_gid(FilePermOptions *self, const gchar *dir_gid)
 }
 
 void
+file_perm_options_dont_change_dir_gid(FilePermOptions *self)
+{
+  self->dir_gid = DONTCHANGE;
+}
+
+void
 file_perm_options_set_dir_perm(FilePermOptions *self, gint dir_perm)
 {
   self->dir_perm = dir_perm;
+}
+
+void
+file_perm_options_dont_change_dir_perm(FilePermOptions *self)
+{
+  self->dir_perm = DONTCHANGE;
 }
 
 void

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -152,20 +152,36 @@ file_perm_options_global_defaults(FilePermOptions *self)
 }
 
 void
-file_perm_options_init(FilePermOptions *self, FilePermOptions *global_options)
+file_perm_options_inherit_from(FilePermOptions *self, const FilePermOptions *from)
 {
   if (self->file_uid == -1)
-    self->file_uid = global_options->file_uid;
+    self->file_uid = from->file_uid;
   if (self->file_gid == -1)
-    self->file_gid = global_options->file_gid;
+    self->file_gid = from->file_gid;
   if (self->file_perm == -1)
-    self->file_perm = global_options->file_perm;
+    self->file_perm = from->file_perm;
   if (self->dir_uid == -1)
-    self->dir_uid = global_options->dir_uid;
+    self->dir_uid = from->dir_uid;
   if (self->dir_gid == -1)
-    self->dir_gid = global_options->dir_gid;
+    self->dir_gid = from->dir_gid;
   if (self->dir_perm == -1)
-    self->dir_perm = global_options->dir_perm;
+    self->dir_perm = from->dir_perm;
+}
+
+void
+file_perm_options_inherit_dont_change(FilePermOptions *self)
+{
+  FilePermOptions dont_change =
+  {
+    .file_uid = DONTCHANGE,
+    .file_gid = DONTCHANGE,
+    .file_perm = DONTCHANGE,
+    .dir_uid = DONTCHANGE,
+    .dir_gid = DONTCHANGE,
+    .dir_perm = DONTCHANGE,
+  };
+
+  file_perm_options_inherit_from(self, &dont_change);
 }
 
 gboolean

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -103,20 +103,31 @@ file_perm_options_defaults(FilePermOptions *self)
 }
 
 void
-file_perm_options_init(FilePermOptions *self, GlobalConfig *cfg)
+file_perm_options_global_defaults(FilePermOptions *self)
+{
+  self->file_uid = 0;
+  self->file_gid = 0;
+  self->file_perm = 0600;
+  self->dir_uid = 0;
+  self->dir_gid = 0;
+  self->dir_perm = 0700;
+}
+
+void
+file_perm_options_init(FilePermOptions *self, FilePermOptions *global_options)
 {
   if (self->file_uid == -1)
-    self->file_uid = cfg->file_uid;
+    self->file_uid = global_options->file_uid;
   if (self->file_gid == -1)
-    self->file_gid = cfg->file_gid;
+    self->file_gid = global_options->file_gid;
   if (self->file_perm == -1)
-    self->file_perm = cfg->file_perm;
+    self->file_perm = global_options->file_perm;
   if (self->dir_uid == -1)
-    self->dir_uid = cfg->dir_uid;
+    self->dir_uid = global_options->dir_uid;
   if (self->dir_gid == -1)
-    self->dir_gid = cfg->dir_gid;
+    self->dir_gid = global_options->dir_gid;
   if (self->dir_perm == -1)
-    self->dir_perm = cfg->dir_perm;
+    self->dir_perm = global_options->dir_perm;
 }
 
 gboolean

--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -38,11 +38,17 @@ typedef struct _FilePermOptions
 } FilePermOptions;
 
 void file_perm_options_set_file_uid(FilePermOptions *s, const gchar *file_uid);
+void file_perm_options_dont_change_file_uid(FilePermOptions *s);
 void file_perm_options_set_file_gid(FilePermOptions *s, const gchar *file_gid);
+void file_perm_options_dont_change_file_gid(FilePermOptions *s);
 void file_perm_options_set_file_perm(FilePermOptions *s, gint file_perm);
+void file_perm_options_dont_change_file_perm(FilePermOptions *s);
 void file_perm_options_set_dir_uid(FilePermOptions *s, const gchar *dir_uid);
+void file_perm_options_dont_change_dir_uid(FilePermOptions *s);
 void file_perm_options_set_dir_gid(FilePermOptions *s, const gchar *dir_gid);
+void file_perm_options_dont_change_dir_gid(FilePermOptions *s);
 void file_perm_options_set_dir_perm(FilePermOptions *s, gint dir_perm);
+void file_perm_options_dont_change_dir_perm(FilePermOptions *s);
 
 void file_perm_options_defaults(FilePermOptions *self);
 void file_perm_options_global_defaults(FilePermOptions *self);

--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -45,7 +45,8 @@ void file_perm_options_set_dir_gid(FilePermOptions *s, const gchar *dir_gid);
 void file_perm_options_set_dir_perm(FilePermOptions *s, gint dir_perm);
 
 void file_perm_options_defaults(FilePermOptions *self);
-void file_perm_options_init(FilePermOptions *self, GlobalConfig *cfg);
+void file_perm_options_global_defaults(FilePermOptions *self);
+void file_perm_options_init(FilePermOptions *self, FilePermOptions *global_options);
 
 gboolean file_perm_options_apply_file(const FilePermOptions *self, gchar *name);
 gboolean file_perm_options_apply_dir(const FilePermOptions *self, gchar *name);

--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -52,7 +52,8 @@ void file_perm_options_dont_change_dir_perm(FilePermOptions *s);
 
 void file_perm_options_defaults(FilePermOptions *self);
 void file_perm_options_global_defaults(FilePermOptions *self);
-void file_perm_options_init(FilePermOptions *self, FilePermOptions *global_options);
+void file_perm_options_inherit_from(FilePermOptions *self, const FilePermOptions *from);
+void file_perm_options_inherit_dont_change(FilePermOptions *self);
 
 gboolean file_perm_options_apply_file(const FilePermOptions *self, gchar *name);
 gboolean file_perm_options_apply_dir(const FilePermOptions *self, gchar *name);

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -469,7 +469,7 @@ affile_dd_init(LogPipe *s)
   if (self->time_reap == -1)
     self->time_reap = cfg->time_reap;
   
-  file_perm_options_init(&self->file_perm_options, &cfg->file_perm_options);
+  file_perm_options_inherit_from(&self->file_perm_options, &cfg->file_perm_options);
   log_writer_options_init(&self->writer_options, cfg, 0);
               
   if (self->filename_is_a_template)

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -469,7 +469,7 @@ affile_dd_init(LogPipe *s)
   if (self->time_reap == -1)
     self->time_reap = cfg->time_reap;
   
-  file_perm_options_init(&self->file_perm_options, cfg);
+  file_perm_options_init(&self->file_perm_options, &cfg->file_perm_options);
   log_writer_options_init(&self->writer_options, cfg, 0);
               
   if (self->filename_is_a_template)

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -172,7 +172,7 @@ dest_affile_options
 dest_affile_option
 	: dest_writer_option
 	| dest_driver_option
-        | file_dir_perm_option
+        | file_perm_option
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
 	| KW_OVERWRITE_IF_OLDER '(' LL_NUMBER ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -255,7 +255,7 @@ source_afunix_options
 	;
 
 source_afunix_option
-        : file_dir_perm_option
+        : file_perm_option
 	| source_afsocket_stream_params		{}
 	| source_reader_option			{}
 	| socket_option				{}

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -98,6 +98,7 @@ afunix_sd_init(LogPipe *s)
   if (self->pass_unix_credentials == -1)
     self->pass_unix_credentials = cfg->pass_unix_credentials;
 
+  file_perm_options_inherit_dont_change(&self->file_perm_options);
   afunix_sd_set_pass_unix_credentials(self, self->pass_unix_credentials);
 
   return afsocket_sd_init_method(s) &&
@@ -129,7 +130,8 @@ afunix_sd_new_instance(TransportMapper *transport_mapper, gchar *filename, Globa
 
   self->filename = g_strdup(filename);
   file_perm_options_defaults(&self->file_perm_options);
-  self->file_perm_options.file_perm = 0666;
+  file_perm_options_set_file_perm(&self->file_perm_options, 0666);
+
   self->pass_unix_credentials = -1;
   self->create_dirs = -1;
 


### PR DESCRIPTION
This series extracts a few members from GlobalConfig and uses the FilePermOptions structure instead.

Again a step in decoupling GlobalConfig dependency from various parts of syslog-ng.

Since testing is lacking in the area, I split up the series into really small baby steps that should be possible to validate by reviewing it.

Let's see what travis thinks about it :)
