### PR TITLE
elasticsearch2: added an option for skipping cluster health check

### DIFF
--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -50,6 +50,8 @@ public class ElasticSearchOptions {
 	public static String CLIENT_MODE_TRANSPORT = "transport";
 	public static String CLIENT_MODE_NODE = "node";
 	public static String CLIENT_MODE_SHIELD = "shield";
+	public static String SKIP_CLUSTER_HEALTH_CHECK = "skip_cluster_health_check";
+	public static String SKIP_CLUSTER_HEALTH_CHECK_DEFAULT = "false";
 	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE, CLIENT_MODE_SHIELD));
 
 	public static String CLIENT_MODE_DEFAULT = CLIENT_MODE_TRANSPORT;
@@ -120,9 +122,14 @@ public class ElasticSearchOptions {
         	return options.get(CONCURRENT_REQUESTS).getValueAsInteger();
         }	
 
+        public boolean getSkipClusterHealthCheck() {
+                return options.get(SKIP_CLUSTER_HEALTH_CHECK).getValueAsBoolean();
+        }
+
 	private void fillOptions() {
 		fillStringOptions();
 		fillTemplateOptions();
+		fillBooleanOptions();
 	}
 
 	private void fillTemplateOptions() {
@@ -140,5 +147,9 @@ public class ElasticSearchOptions {
 		options.put(new EnumOptionDecorator(new StringOption(owner, CLIENT_MODE, CLIENT_MODE_DEFAULT), CLIENT_MODES));
 		options.put(new StringOption(owner, CONFIG_FILE));
 		options.put(new IntegerRangeCheckOptionDecorator(new StringOption(owner, CONCURRENT_REQUESTS, CONCURRENT_REQUESTS_DEFAULT), 0, Integer.MAX_VALUE));
+	}
+
+	private void fillBooleanOptions() {
+	        options.put(new BooleanOptionDecorator(new StringOption(owner, SKIP_CLUSTER_HEALTH_CHECK, SKIP_CLUSTER_HEALTH_CHECK_DEFAULT)));
 	}
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -58,6 +58,10 @@ public abstract class ESClient {
 
 	public void connect() throws ElasticsearchException {
 		String clusterName = getClusterName();
+		if (options.getSkipClusterHealthCheck()) {
+		        logger.warn("Skip cluster health check during connection.");
+		        return;
+		}
 		logger.info("connecting to cluster, cluster_name='" + clusterName + "'");
 		if (!waitForStatus(ClusterHealthStatus.GREEN)) {
 			logger.debug("Failed to wait for green");

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -59,10 +59,10 @@ public abstract class ESClient {
 	public void connect() throws ElasticsearchException {
 		String clusterName = getClusterName();
 		if (options.getSkipClusterHealthCheck()) {
-		        logger.warn("Skip cluster health check during connection.");
+		        logger.warn("Skip checking cluster state, cluster_name='" + clusterName + '"');
 		        return;
 		}
-		logger.info("connecting to cluster, cluster_name='" + clusterName + "'");
+		logger.info("Checking cluster state..., cluster_name='" + clusterName + "'");
 		if (!waitForStatus(ClusterHealthStatus.GREEN)) {
 			logger.debug("Failed to wait for green");
 			logger.debug("Wait for read yellow status...");
@@ -72,7 +72,7 @@ public abstract class ESClient {
 				throw new ElasticsearchException("Can't connect to cluster: " + clusterName);
 			}
 		}
-		logger.info("conneted to cluster, cluster_name='" + clusterName + "'");
+		logger.info("Cluster is ready to work, cluster_name='" + clusterName + "'");
 	}
 
 	public final boolean open() {

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -66,6 +66,7 @@ block destination elasticsearch2(
   resource("")
   client_lib_dir("")
   concurrent_requests("1")
+  skip_cluster_health_check("")
 )
 {
   java(
@@ -82,6 +83,7 @@ block destination elasticsearch2(
     option("resource", `resource`)
     option("custom_id", `custom_id`)
     option("concurrent_requests", `concurrent_requests`)
+    option("skip_cluster_health_check", `skip_cluster_health_check`)
     `__VARARGS__`
   );
 };


### PR DESCRIPTION
This patch makes it possible to index documents when the cluster state is
yellow, or even red. This could be only possible when the index you want
to use is writable.

How to use?
Add `skip_cluster_health_check("true")` to your elasticsearch2 destination.

Fixes: #968

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>