### PR TITLE
Update native parser bindings

### DIFF
--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -94,3 +94,11 @@ log_pipe_forward_notify(LogPipe *self, gint notify_code, gpointer user_data)
 {
   log_pipe_notify(self->pipe_next, notify_code, user_data);
 }
+
+#ifdef __linux__
+
+void
+__log_pipe_forward_msg(LogPipe *self, LogMessage *msg, const LogPathOptions *path_options)
+__attribute__((alias("log_pipe_forward_msg")));
+
+#endif

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -185,7 +185,7 @@ struct _LogPathOptions
     * ack_needed.
     */
 
-  gboolean ack_needed:1,
+  gboolean ack_needed;
 
   /* The user has requested flow-control on this processing path,
    * which means that the destination should invoke log_msg_ack()
@@ -199,7 +199,7 @@ struct _LogPathOptions
    * required action.
    */
 
-    flow_control_requested:1;
+  gboolean flow_control_requested;
 
   gboolean *matched;
 };

--- a/modules/native/parser.c
+++ b/modules/native/parser.c
@@ -34,7 +34,7 @@ __attribute__((visibility("hidden"))) void
 native_parser_proxy_set_option(struct NativeParserProxy* self, const gchar* key, const gchar* value);
 
 __attribute__((visibility("hidden"))) gboolean
-native_parser_proxy_process(struct NativeParserProxy* this, LogParser *super, LogMessage *pmsg, const gchar *input, gsize input_len);
+native_parser_proxy_process(struct NativeParserProxy* this, LogParser *super, LogMessage *pmsg, const gchar *input);
 
 __attribute__((visibility("hidden"))) int
 native_parser_proxy_init(struct NativeParserProxy* s);
@@ -59,7 +59,7 @@ native_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   ParserNative *self = (ParserNative *) s;
 
   LogMessage *writable_msg = log_msg_make_writable(pmsg, path_options);
-  return native_parser_proxy_process(self->native_object, &self->super, writable_msg, input, input_len);
+  return native_parser_proxy_process(self->native_object, &self->super, writable_msg, input);
 }
 
 void

--- a/modules/native/parser.c
+++ b/modules/native/parser.c
@@ -34,13 +34,13 @@ __attribute__((visibility("hidden"))) void
 native_parser_proxy_set_option(struct NativeParserProxy* self, const gchar* key, const gchar* value);
 
 __attribute__((visibility("hidden"))) gboolean
-native_parser_proxy_process(struct NativeParserProxy* this, LogMessage *pmsg, const gchar *input, gsize input_len);
+native_parser_proxy_process(struct NativeParserProxy* this, LogParser *super, LogMessage *pmsg, const gchar *input, gsize input_len);
 
 __attribute__((visibility("hidden"))) int
 native_parser_proxy_init(struct NativeParserProxy* s);
 
 __attribute__((visibility("hidden"))) struct NativeParserProxy*
-native_parser_proxy_new(LogParser *super);
+native_parser_proxy_new(void);
 
 __attribute__((visibility("hidden"))) struct NativeParserProxy*
 native_parser_proxy_clone(struct NativeParserProxy *self);
@@ -59,7 +59,7 @@ native_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   ParserNative *self = (ParserNative *) s;
 
   LogMessage *writable_msg = log_msg_make_writable(pmsg, path_options);
-  return native_parser_proxy_process(self->native_object, writable_msg, input, input_len);
+  return native_parser_proxy_process(self->native_object, &self->super, writable_msg, input, input_len);
 }
 
 void
@@ -124,7 +124,7 @@ native_parser_new(GlobalConfig *cfg)
   ParserNative *self = (ParserNative*) g_new0(ParserNative, 1);
 
   log_parser_init_instance(&self->super, cfg);
-  self->native_object = native_parser_proxy_new(&self->super);
+  self->native_object = native_parser_proxy_new();
 
   if (!self->native_object)
     {


### PR DESCRIPTION
This PR contains the following changes:
* update native parser bindings
  * https://github.com/balabit/syslog-ng/commit/899b1241eefa10c378696724c33c8609439ac099
  * https://github.com/balabit/syslog-ng/commit/0d595504734af2dc5da528ef7055277af3d00898
* refactor `LogPathOptions` to use booleans instead of bitfields (https://github.com/balabit/syslog-ng/commit/24ebce202564328350cb77e7e1c73be4ef1a9910)