### PR TITLE
Fix finding JNI library

### DIFF
--- a/m4/check_java_support.m4
+++ b/m4/check_java_support.m4
@@ -77,7 +77,7 @@ AC_DEFUN([AX_CHECK_JAVA_VERSION],
       if test -e "$JAVA_HOME_CHECKER"; then
         JNI_HOME=`$JAVA_HOME_CHECKER`
       else
-        JNI_HOME=`echo $JAVAC_BIN | sed "s/\(.*\)[[/]]bin[[/]]java.*/\1/"`
+        JNI_HOME=`echo $JAVAC_BIN | sed "s/\(.*\)[[/]]bin[[/]]java.*/\1\//"`
       fi
 
       JNI_LIBDIR=`find $JNI_HOME \( -name "libjvm.so" -or -name "libjvm.dylib" \) \


### PR DESCRIPTION
Fixes #1002

The find command does not search in symlink directories by default.
Adding a trailing slash after the path solves the problem.
In this case, the find command starts from the target of the symbolic link, not from the symbolic link itself.