### PR TITLE
split test_patterndb_rule testcase

### DIFF
--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -395,6 +395,25 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
      </action>\
    </actions>\
   </rule>\
+  <rule provider='test' id='10d' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+   <patterns>\
+    <pattern>correllated-message-with-action-condition</pattern>\
+   </patterns>\
+   <actions>\
+     <action trigger='match' condition='\"${PID}\" ne \"" MYPID "\"' >\
+       <message>\
+         <value name='MESSAGE'>not-generated-message</value>\
+       </message>\
+     </action>\
+\
+     <action trigger='match' condition='\"${PID}\" eq \"" MYPID "\"' >\
+       <message>\
+         <value name='MESSAGE'>generated-message-on-condition</value>\
+       </message>\
+     </action>\
+\
+   </actions>\
+  </rule>\
   <rule provider='test' id='11' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
    <patterns>\
     <pattern>pattern11</pattern>\
@@ -502,6 +521,15 @@ test_correllation_rule_with_action_on_timeout(void)
   assert_msg_matches_and_has_tag("correllated-message-with-action-on-timeout", ".classifier.violation", TRUE);
 
   assert_msg_matches_and_output_message_nvpair_equals_with_timeout("correllated-message-with-action-on-timeout", 60, 1, "MESSAGE", "generated-message-on-timeout");
+}
+
+static void
+test_correllation_rule_with_action_condition(void)
+{
+  /* tag assigned based on "class" */
+  assert_msg_matches_and_has_tag("correllated-message-with-action-condition", ".classifier.violation", TRUE);
+
+  assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-action-condition", 1, "MESSAGE", "generated-message-on-condition");
 }
 
 static void

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -344,6 +344,20 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <pattern>prog1</pattern>\
     <pattern>prog2</pattern>\
   </patterns>\
+  <rule provider='test' id='10' class='system' context-scope='program'>\
+   <patterns>\
+    <pattern>simple-message</pattern>\
+   </patterns>\
+   <tags>\
+    <tag>simple-msg-tag1</tag>\
+    <tag>simple-msg-tag2</tag>\
+   </tags>\
+   <values>\
+    <value name='simple-msg-value-1'>value1</value>\
+    <value name='simple-msg-value-2'>value2</value>\
+    <value name='simple-msg-host'>${HOST}</value>\
+   </values>\
+  </rule>\
   <rule provider='test' id='11' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
    <patterns>\
     <pattern>pattern11</pattern>\
@@ -405,6 +419,20 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
   </rule>\
  </ruleset>\
 </patterndb>";
+
+static void
+test_simple_rule_without_context_or_actions(void)
+{
+  /* tag assigned based on "class" */
+  assert_msg_matches_and_has_tag("simple-message", ".classifier.system", TRUE);
+
+  /* tag assignment based on <tags/> */
+  assert_msg_matches_and_nvpair_equals("simple-message", "TAGS", ".classifier.system,simple-msg-tag1,simple-msg-tag2");
+
+  assert_msg_matches_and_nvpair_equals("simple-message", "simple-msg-value-1", "value1");
+  assert_msg_matches_and_nvpair_equals("simple-message", "simple-msg-value-2", "value2");
+  assert_msg_matches_and_nvpair_equals("simple-message", "simple-msg-host", MYHOST);
+}
 
 static void
 test_rule_tag_assignment(void)
@@ -485,6 +513,7 @@ test_patterndb_rule(void)
 {
   _load_pattern_db_from_string(pdb_ruletest_skeleton);
 
+  test_simple_rule_without_context_or_actions();
   test_rule_tag_assignment();
   test_rule_value_assignment();
   test_rule_emit_message_on_match();

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -358,6 +358,15 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <value name='simple-msg-host'>${HOST}</value>\
    </values>\
   </rule>\
+  <rule provider='test' id='10a' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
+   <patterns>\
+    <pattern>correllated-message-based-on-pid</pattern>\
+   </patterns>\
+   <values>\
+    <value name='correllated-msg-context-id'>${CONTEXT_ID}</value>\
+    <value name='correllated-msg-context-length'>$(context-length)</value>\
+   </values>\
+  </rule>\
   <rule provider='test' id='11' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
    <patterns>\
     <pattern>pattern11</pattern>\
@@ -432,6 +441,20 @@ test_simple_rule_without_context_or_actions(void)
   assert_msg_matches_and_nvpair_equals("simple-message", "simple-msg-value-1", "value1");
   assert_msg_matches_and_nvpair_equals("simple-message", "simple-msg-value-2", "value2");
   assert_msg_matches_and_nvpair_equals("simple-message", "simple-msg-host", MYHOST);
+}
+
+static void
+test_correllation_rule_without_actions(void)
+{
+  /* tag assigned based on "class" */
+  assert_msg_matches_and_has_tag("correllated-message-based-on-pid", ".classifier.system", TRUE);
+  assert_msg_matches_and_nvpair_equals("correllated-message-based-on-pid", "correllated-msg-context-id", MYPID);
+  assert_msg_matches_and_nvpair_equals("correllated-message-based-on-pid", "correllated-msg-context-length", "1");
+  _dont_reset_patterndb_state_for_the_next_call();
+  assert_msg_matches_and_nvpair_equals("correllated-message-based-on-pid", "correllated-msg-context-length", "2");
+  _dont_reset_patterndb_state_for_the_next_call();
+  assert_msg_matches_and_nvpair_equals("correllated-message-based-on-pid", "correllated-msg-context-length", "3");
+
 }
 
 static void
@@ -514,6 +537,7 @@ test_patterndb_rule(void)
   _load_pattern_db_from_string(pdb_ruletest_skeleton);
 
   test_simple_rule_without_context_or_actions();
+  test_correllation_rule_without_actions();
   test_rule_tag_assignment();
   test_rule_value_assignment();
   test_rule_emit_message_on_match();

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -383,6 +383,18 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
      </action>\
    </actions>\
   </rule>\
+  <rule provider='test' id='10c' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+   <patterns>\
+    <pattern>correllated-message-with-action-on-timeout</pattern>\
+   </patterns>\
+   <actions>\
+     <action trigger='timeout'>\
+       <message>\
+         <value name='MESSAGE'>generated-message-on-timeout</value>\
+       </message>\
+     </action>\
+   </actions>\
+  </rule>\
   <rule provider='test' id='11' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
    <patterns>\
     <pattern>pattern11</pattern>\
@@ -484,6 +496,15 @@ test_correllation_rule_with_action_on_match(void)
 }
 
 static void
+test_correllation_rule_with_action_on_timeout(void)
+{
+  /* tag assigned based on "class" */
+  assert_msg_matches_and_has_tag("correllated-message-with-action-on-timeout", ".classifier.violation", TRUE);
+
+  assert_msg_matches_and_output_message_nvpair_equals_with_timeout("correllated-message-with-action-on-timeout", 60, 1, "MESSAGE", "generated-message-on-timeout");
+}
+
+static void
 test_rule_tag_assignment(void)
 {
   /* tag assigned based on "class" */
@@ -565,6 +586,7 @@ test_patterndb_rule(void)
   test_simple_rule_without_context_or_actions();
   test_correllation_rule_without_actions();
   test_correllation_rule_with_action_on_match();
+  test_correllation_rule_with_action_on_timeout();
   test_rule_tag_assignment();
   test_rule_value_assignment();
   test_rule_emit_message_on_match();

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -367,6 +367,22 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
     <value name='correllated-msg-context-length'>$(context-length)</value>\
    </values>\
   </rule>\
+  <rule provider='test' id='10b' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+   <patterns>\
+    <pattern>correllated-message-with-action-on-match</pattern>\
+   </patterns>\
+   <actions>\
+     <action trigger='match'>\
+       <message>\
+         <value name='MESSAGE'>generated-message-on-match</value>\
+         <value name='context-id'>${CONTEXT_ID}</value>\
+         <tags>\
+           <tag>correllated-msg-tag</tag>\
+         </tags>\
+       </message>\
+     </action>\
+   </actions>\
+  </rule>\
   <rule provider='test' id='11' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
    <patterns>\
     <pattern>pattern11</pattern>\
@@ -454,7 +470,17 @@ test_correllation_rule_without_actions(void)
   assert_msg_matches_and_nvpair_equals("correllated-message-based-on-pid", "correllated-msg-context-length", "2");
   _dont_reset_patterndb_state_for_the_next_call();
   assert_msg_matches_and_nvpair_equals("correllated-message-based-on-pid", "correllated-msg-context-length", "3");
+}
 
+static void
+test_correllation_rule_with_action_on_match(void)
+{
+  /* tag assigned based on "class" */
+  assert_msg_matches_and_has_tag("correllated-message-with-action-on-match", ".classifier.violation", TRUE);
+
+  assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-action-on-match", 1, "MESSAGE", "generated-message-on-match");
+  assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-action-on-match", 1, "context-id", "999");
+  assert_msg_matches_and_output_message_has_tag("correllated-message-with-action-on-match", 1, "correllated-msg-tag", TRUE);
 }
 
 static void
@@ -538,6 +564,7 @@ test_patterndb_rule(void)
 
   test_simple_rule_without_context_or_actions();
   test_correllation_rule_without_actions();
+  test_correllation_rule_with_action_on_match();
   test_rule_tag_assignment();
   test_rule_value_assignment();
   test_rule_emit_message_on_match();


### PR DESCRIPTION
This series splits test_patterndb_rule testcase to smaller functions, making the tested functions easier
to understand. This is a preparatory step to implement create-context action, which will be posted in a separate branch.