### PR TITLE
dbparser: add XML validation in test_patterndb

### DIFF
--- a/doc/xsd/patterndb-4.xsd
+++ b/doc/xsd/patterndb-4.xsd
@@ -390,6 +390,7 @@
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:string">
+              <xs:enumeration value="context"/>
               <xs:enumeration value="TRUE"/>
               <xs:enumeration value="FALSE"/>
             </xs:restriction>

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -7,6 +7,8 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/patterndb.h				\
 	modules/dbparser/pdb-error.c				\
 	modules/dbparser/pdb-error.h				\
+	modules/dbparser/pdb-file.c				\
+	modules/dbparser/pdb-file.h				\
 	modules/dbparser/pdb-load.c				\
 	modules/dbparser/pdb-load.h				\
 	modules/dbparser/pdb-rule.c				\

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -5,6 +5,8 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/radix.h				\
 	modules/dbparser/patterndb.c				\
 	modules/dbparser/patterndb.h				\
+	modules/dbparser/pdb-error.c				\
+	modules/dbparser/pdb-error.h				\
 	modules/dbparser/pdb-load.c				\
 	modules/dbparser/pdb-load.h				\
 	modules/dbparser/pdb-rule.c				\

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -28,7 +28,6 @@
 #include "patterndb.h"
 
 #define PATH_PATTERNDB_FILE     SYSLOG_NG_PATH_LOCALSTATEDIR "/patterndb.xml"
-#define PATH_XSDDIR             SYSLOG_NG_PATH_XSDDIR
 
 typedef struct _LogDBParser LogDBParser;
 

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -21,7 +21,9 @@
  *
  */
 #include "pdb-action.h"
+#include "pdb-error.h"
 #include "filter/filter-expr-parser.h"
+
 #include <stdlib.h>
 
 void
@@ -32,7 +34,7 @@ pdb_action_set_condition(PDBAction *self, GlobalConfig *cfg, const gchar *filter
   lexer = cfg_lexer_new_buffer(filter_string, strlen(filter_string));
   if (!cfg_run_parser(cfg, lexer, &filter_expr_parser, (gpointer *) &self->condition, NULL))
     {
-      g_set_error(error, 0, 1, "Error compiling conditional expression");
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Error compiling conditional expression");
       self->condition = NULL;
       return;
     }
@@ -72,7 +74,7 @@ pdb_action_set_trigger(PDBAction *self, const gchar *trigger, GError **error)
   else if (strcmp(trigger, "timeout") == 0)
     self->trigger = RAT_TIMEOUT;
   else
-    g_set_error(error, 0, 1, "Unknown trigger type: %s", trigger);
+    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown trigger type: %s", trigger);
 }
 
 void
@@ -87,7 +89,7 @@ pdb_action_set_message_inheritance(PDBAction *self, const gchar *inherit_propert
            inherit_properties[0] == '0')
     self->content.inherit_mode = RAC_MSG_INHERIT_NONE;
   else
-    g_set_error(error, 0, 1, "Unknown inheritance type: %s", inherit_properties);
+    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inheritance type: %s", inherit_properties);
 }
 
 

--- a/modules/dbparser/pdb-error.c
+++ b/modules/dbparser/pdb-error.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "pdb-error.h"
+
+GQuark
+pdb_error_quark(void)
+{
+  return g_quark_from_static_string("syslog-ng-error-quark");
+}

--- a/modules/dbparser/pdb-error.h
+++ b/modules/dbparser/pdb-error.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef PDB_ERROR_H_INCLUDED
+#define PDB_ERROR_H_INCLUDED
+
+#include "syslog-ng.h"
+
+#define PDB_ERROR pdb_error_quark()
+
+GQuark pdb_error_quark(void);
+
+typedef enum
+{
+  PDB_ERROR_FAILED,
+} PDBError;
+
+#endif

--- a/modules/dbparser/pdb-file.c
+++ b/modules/dbparser/pdb-file.c
@@ -45,12 +45,15 @@ pdb_file_detect_version(const gchar *pdbfile, GError **error)
 
   while (fgets(line, sizeof(line), pdb))
     {
-      if (strstr(line, "<patterndb"))
+      gchar *patterndb_tag;
+
+      patterndb_tag = strstr(line, "<patterndb");
+      if (patterndb_tag)
         {
           gchar *version, *start_quote, *end_quote;
 
           /* ok, we do have the patterndb tag, look for the version attribute */
-          version = strstr(line, "version=");
+          version = strstr(patterndb_tag, "version=");
 
           if (!version)
             goto exit;

--- a/modules/dbparser/pdb-file.c
+++ b/modules/dbparser/pdb-file.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 1998-2016 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "pdb-file.h"
+#include "pdb-error.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+gint
+pdb_file_detect_version(const gchar *pdbfile, GError **error)
+{
+  FILE *pdb;
+  gchar line[1024];
+  gint result = 0;
+
+  pdb = fopen(pdbfile, "r");
+  if (!pdb)
+    {
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Error opening file %s (%s)", pdbfile, g_strerror(errno));
+      return 0;
+    }
+
+  while (fgets(line, sizeof(line), pdb))
+    {
+      if (strstr(line, "<patterndb"))
+        {
+          gchar *version, *start_quote, *end_quote;
+
+          /* ok, we do have the patterndb tag, look for the version attribute */
+          version = strstr(line, "version=");
+
+          if (!version)
+            goto exit;
+          start_quote = version + 8;
+          end_quote = strchr(start_quote + 1, *start_quote);
+          if (!end_quote)
+            {
+              goto exit;
+            }
+          *end_quote = 0;
+          result = strtoll(start_quote + 1, NULL, 0);
+          break;
+        }
+    }
+ exit:
+  fclose(pdb);
+  if (!result)
+    {
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED,
+                  "Error detecting pdbfile version, <patterndb> version attribute not found or <patterndb> is not on its own line");
+    }
+  return result;
+}

--- a/modules/dbparser/pdb-file.h
+++ b/modules/dbparser/pdb-file.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 1998-2016 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DBPARSER_PDB_FILE_H_INCLUDED
+#define DBPARSER_PDB_FILE_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+gint pdb_file_detect_version(const gchar *pdbfile, GError **error);
+
+#endif

--- a/modules/dbparser/pdb-file.h
+++ b/modules/dbparser/pdb-file.h
@@ -27,5 +27,6 @@
 #include "syslog-ng.h"
 
 gint pdb_file_detect_version(const gchar *pdbfile, GError **error);
+gboolean pdb_file_validate(const gchar *filename, GError **error);
 
 #endif

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -26,6 +26,7 @@
 #include "pdb-action.h"
 #include "pdb-example.h"
 #include "pdb-ruleset.h"
+#include "pdb-error.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -77,7 +78,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_ruleset)
         {
-          *error = g_error_new(1, 1, "Unexpected <ruleset> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <ruleset> element");
           return;
         }
 
@@ -90,7 +91,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_example || !state->in_rule)
         {
-          *error = g_error_new(1, 1, "Unexpected <example> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <example> element");
           return;
         }
 
@@ -102,7 +103,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_test_msg || !state->in_example)
         {
-          *error = g_error_new(1, 1, "Unexpected <test_message> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <test_message> element");
           return;
         }
 
@@ -118,7 +119,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_test_value || !state->in_example)
         {
-          *error = g_error_new(1, 1, "Unexpected <test_value> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <test_value> element");
           return;
         }
 
@@ -130,7 +131,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         {
           msg_error("No name is specified for test_value",
                     evt_tag_str("rule_id", state->current_rule->rule_id));
-          *error = g_error_new(1, 0, "<test_value> misses name attribute");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "<test_value> misses name attribute");
           return;
         }
     }
@@ -138,7 +139,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_rule)
         {
-          *error = g_error_new(1, 0, "Unexpected <rule> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <rule> element");
           return;
         }
 
@@ -165,7 +166,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
 
       if (!state->current_rule->rule_id)
         {
-          *error = g_error_new(1, 0, "No id attribute for rule element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "No id attribute for rule element");
           pdb_rule_unref(state->current_rule);
           state->current_rule = NULL;
           return;
@@ -190,7 +191,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else
         {
           msg_error("No name is specified for value", evt_tag_str("rule_id", state->current_rule->rule_id));
-          *error = g_error_new(1, 0, "<value> misses name attribute");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute");
           return;
         }
     }
@@ -210,12 +211,12 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (state->ruleset->version && atoi(state->ruleset->version) < 2)
         {
-          *error = g_error_new(1, 0, "patterndb version too old, this version of syslog-ng only supports v3 and v4 formatted patterndb files, please upgrade it using pdbtool");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "patterndb version too old, this version of syslog-ng only supports v3 and v4 formatted patterndb files, please upgrade it using pdbtool");
           return;
         }
-      else if (state->ruleset->version && atoi(state->ruleset->version) > 4)
+      else if (state->ruleset->version && atoi(state->ruleset->version) > 5)
         {
-          *error = g_error_new(1, 0, "patterndb version too new, this version of syslog-ng supports v3 and v4 formatted patterndb files.");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "patterndb version too new, this version of syslog-ng supports v3, v4 & v5 formatted patterndb files.");
           return;
         }
     }
@@ -223,7 +224,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (!state->current_rule)
         {
-          *error = g_error_new(1, 0, "Unexpected <action> element, it must be inside a rule");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <action> element, it must be inside a rule");
           return;
         }
       state->current_action = pdb_action_new(state->action_id++);
@@ -248,7 +249,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       if (!state->in_action)
         {
-          *error = g_error_new(1, 0, "Unexpected <message> element, it must be inside an action");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <message> element, it must be inside an action");
           return;
         }
       state->current_action->content_type = RAC_MESSAGE;
@@ -284,7 +285,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_ruleset)
         {
-          *error = g_error_new(1, 0, "Unexpected </ruleset> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </ruleset> element");
           return;
         }
 
@@ -312,7 +313,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_example)
         {
-          *error = g_error_new(1, 0, "Unexpected </example> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </example> element");
           return;
         }
 
@@ -329,7 +330,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_test_msg)
         {
-          *error = g_error_new(1, 0, "Unexpected </test_message> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </test_message> element");
           return;
         }
 
@@ -339,7 +340,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_test_value)
         {
-          *error = g_error_new(1, 0, "Unexpected </test_value> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </test_value> element");
           return;
         }
 
@@ -354,7 +355,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_rule)
         {
-          *error = g_error_new(1, 0, "Unexpected </rule> element");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
           return;
         }
 
@@ -430,7 +431,7 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
                 }
               else if (program != state->current_program)
                 {
-                  *error = g_error_new(1, 0, "Joining rulesets with mismatching program name sets, program=%s", text);
+                  *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Joining rulesets with mismatching program name sets, program=%s", text);
                   return;
                 }
             }
@@ -440,7 +441,7 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
     {
       if (!state->in_rule)
         {
-          *error = g_error_new(1, 0, "Unexpected <tag> element, must be within a rule");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <tag> element, must be within a rule");
           return;
         }
       synthetic_message_add_tag(state->current_message, text);
@@ -449,12 +450,12 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
     {
       if (!state->in_rule)
         {
-          *error = g_error_new(1, 0, "Unexpected <value> element, must be within a rule");
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <value> element, must be within a rule");
           return;
         }
       if (!synthetic_message_add_value_template_string(state->current_message, state->cfg, state->value_name, text, &err))
         {
-          *error = g_error_new(1, 0, "Error compiling value template, rule=%s, name=%s, value=%s, error=%s",
+          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Error compiling value template, rule=%s, name=%s, value=%s, error=%s",
                                state->current_rule->rule_id, state->value_name, text, err->message);
           return;
         }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -78,7 +78,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_ruleset)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <ruleset> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <ruleset> element");
           return;
         }
 
@@ -91,7 +91,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_example || !state->in_rule)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <example> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <example> element");
           return;
         }
 
@@ -103,7 +103,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_test_msg || !state->in_example)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <test_message> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <test_message> element");
           return;
         }
 
@@ -119,7 +119,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_test_value || !state->in_example)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <test_value> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <test_value> element");
           return;
         }
 
@@ -131,7 +131,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         {
           msg_error("No name is specified for test_value",
                     evt_tag_str("rule_id", state->current_rule->rule_id));
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "<test_value> misses name attribute");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<test_value> misses name attribute");
           return;
         }
     }
@@ -139,7 +139,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (state->in_rule)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <rule> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <rule> element");
           return;
         }
 
@@ -166,7 +166,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
 
       if (!state->current_rule->rule_id)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "No id attribute for rule element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "No id attribute for rule element");
           pdb_rule_unref(state->current_rule);
           state->current_rule = NULL;
           return;
@@ -191,7 +191,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else
         {
           msg_error("No name is specified for value", evt_tag_str("rule_id", state->current_rule->rule_id));
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute");
           return;
         }
     }
@@ -211,12 +211,12 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (state->ruleset->version && atoi(state->ruleset->version) < 2)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "patterndb version too old, this version of syslog-ng only supports v3 and v4 formatted patterndb files, please upgrade it using pdbtool");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "patterndb version too old, this version of syslog-ng only supports v3 and v4 formatted patterndb files, please upgrade it using pdbtool");
           return;
         }
       else if (state->ruleset->version && atoi(state->ruleset->version) > 5)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "patterndb version too new, this version of syslog-ng supports v3, v4 & v5 formatted patterndb files.");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "patterndb version too new, this version of syslog-ng supports v3, v4 & v5 formatted patterndb files.");
           return;
         }
     }
@@ -224,7 +224,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     {
       if (!state->current_rule)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <action> element, it must be inside a rule");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <action> element, it must be inside a rule");
           return;
         }
       state->current_action = pdb_action_new(state->action_id++);
@@ -249,7 +249,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       if (!state->in_action)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <message> element, it must be inside an action");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <message> element, it must be inside an action");
           return;
         }
       state->current_action->content_type = RAC_MESSAGE;
@@ -285,7 +285,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_ruleset)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </ruleset> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </ruleset> element");
           return;
         }
 
@@ -313,7 +313,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_example)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </example> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </example> element");
           return;
         }
 
@@ -330,7 +330,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_test_msg)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </test_message> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </test_message> element");
           return;
         }
 
@@ -340,7 +340,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_test_value)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </test_value> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </test_value> element");
           return;
         }
 
@@ -355,7 +355,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     {
       if (!state->in_rule)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
           return;
         }
 
@@ -431,7 +431,7 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
                 }
               else if (program != state->current_program)
                 {
-                  *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Joining rulesets with mismatching program name sets, program=%s", text);
+                  g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Joining rulesets with mismatching program name sets, program=%s", text);
                   return;
                 }
             }
@@ -441,7 +441,7 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
     {
       if (!state->in_rule)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <tag> element, must be within a rule");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <tag> element, must be within a rule");
           return;
         }
       synthetic_message_add_tag(state->current_message, text);
@@ -450,12 +450,12 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
     {
       if (!state->in_rule)
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <value> element, must be within a rule");
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <value> element, must be within a rule");
           return;
         }
       if (!synthetic_message_add_value_template_string(state->current_message, state->cfg, state->value_name, text, &err))
         {
-          *error = g_error_new(PDB_ERROR, PDB_ERROR_FAILED, "Error compiling value template, rule=%s, name=%s, value=%s, error=%s",
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Error compiling value template, rule=%s, name=%s, value=%s, error=%s",
                                state->current_rule->rule_id, state->value_name, text, err->message);
           return;
         }

--- a/modules/dbparser/pdb-rule.c
+++ b/modules/dbparser/pdb-rule.c
@@ -21,6 +21,7 @@
  *
  */
 #include "pdb-rule.h"
+#include "pdb-error.h"
 
 void
 pdb_rule_set_class(PDBRule *self, const gchar *class)
@@ -69,7 +70,7 @@ pdb_rule_set_context_scope(PDBRule *self, const gchar *scope, GError **error)
   if (context_scope < 0)
     {
       self->context_scope = RCS_GLOBAL;
-      g_set_error(error, 0, 1, "Unknown context scope: %s", scope);
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown context scope: %s", scope);
     }
   else
     self->context_scope = context_scope;

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -707,20 +707,12 @@ pdbtool_test(int argc, char *argv[])
 
       if (test_validate)
         {
-          gchar cmd[1024];
-          gint version;
+          GError *error = NULL;
 
-          version = pdb_file_detect_version(argv[arg_pos], NULL);
-          if (!version)
+          if (!pdb_file_validate(argv[arg_pos], &error))
             {
-              fprintf(stderr, "%s: Unable to detect patterndb version, please write the <patterndb> tag on a single line\n", argv[arg_pos]);
-              failed_to_validate = TRUE;
-	      continue;
-            }
-          g_snprintf(cmd, sizeof(cmd), "xmllint --noout --nonet --schema %s/patterndb-%d.xsd %s", get_installation_path_for(PATH_XSDDIR), version, argv[arg_pos]);
-          if (system(cmd) != 0)
-            {
-              fprintf(stderr, "%s: xmllint returned an error, the executed command was: %s", argv[arg_pos], cmd);
+              fprintf(stderr, "%s: error validating pdb file: %s\n", argv[arg_pos], error->message);
+              g_clear_error(&error);
               failed_to_validate = TRUE;
 	      continue;
             }

--- a/modules/dbparser/tests/test_parsers_e2e.c
+++ b/modules/dbparser/tests/test_parsers_e2e.c
@@ -38,18 +38,22 @@ do { \
 
 
 gchar *pdb_parser_skeleton_prefix ="<?xml version='1.0' encoding='UTF-8'?>\
-          <patterndb version='3' pub_date='2010-02-22'>\
-            <ruleset name='test1_program' id='480de478-d4a6-4a7f-bea4-0c0245d361e1'>\
-                <pattern>test</pattern>\
-                    <rule id='1' class='test1' provider='my'>\
-                        <patterns>\
-                         <pattern>";
+<patterndb version='4' pub_date='2010-02-22'>\
+  <ruleset name='test1_program' id='480de478-d4a6-4a7f-bea4-0c0245d361e1'>\
+    <patterns>\
+      <pattern>test</pattern>\
+    </patterns>\
+    <rules>\
+      <rule id='1' class='test1' provider='my'>\
+        <patterns>\
+          <pattern>" /* HERE COMES THE GENERATED PATTERN */ ;
 
-gchar *pdb_parser_skeleton_postfix =  "</pattern>\
-                      </patterns>\
-                    </rule>\
-            </ruleset>\
-        </patterndb>";
+gchar *pdb_parser_skeleton_postfix =  /* HERE IS THE GENERATED PATTERN */ "</pattern>\
+        </patterns>\
+      </rule>\
+    </rules>\
+  </ruleset>\
+</patterndb>";
 
 
 void

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -65,7 +65,6 @@ _load_pattern_db_from_string(gchar *pdb)
   g_file_set_contents(filename, pdb, strlen(pdb), NULL);
 
   assert_true(pattern_db_reload_ruleset(patterndb, configuration, filename), "Error loading ruleset [[[%s]]]", pdb);
-  assert_string(pattern_db_get_ruleset_version(patterndb), "3", "Invalid version");
   assert_string(pattern_db_get_ruleset_pub_date(patterndb), "2010-02-22", "Invalid pubdate");
 }
 
@@ -280,23 +279,25 @@ assert_msg_matches_and_output_message_has_tag(const gchar *pattern, gint ndx, co
   assert_msg_matches_and_output_message_has_tag_with_timeout(pattern, 0, ndx, tag, set);
 }
 
-gchar *pdb_conflicting_rules_with_different_parsers = "<patterndb version='3' pub_date='2010-02-22'>\
+gchar *pdb_conflicting_rules_with_different_parsers = "<patterndb version='4' pub_date='2010-02-22'>\
  <ruleset name='testset' id='1'>\
   <patterns>\
    <pattern>prog1</pattern>\
    <pattern>prog2</pattern>\
   </patterns>\
-  <!-- different parsers at the same location -->\
-  <rule provider='test' id='11' class='short'>\
-   <patterns>\
-    <pattern>pattern @ESTRING:foo1: @</pattern>\
-   </patterns>\
-  </rule>\
-  <rule provider='test' id='12' class='long'>\
-   <patterns>\
-    <pattern>pattern @ESTRING:foo2: @tail</pattern>\
-   </patterns>\
-  </rule>\
+  <rules>\
+    <!-- different parsers at the same location -->\
+    <rule provider='test' id='11' class='short'>\
+     <patterns>\
+      <pattern>pattern @ESTRING:foo1: @</pattern>\
+     </patterns>\
+    </rule>\
+    <rule provider='test' id='12' class='long'>\
+     <patterns>\
+      <pattern>pattern @ESTRING:foo2: @tail</pattern>\
+     </patterns>\
+    </rule>\
+  </rules>\
  </ruleset>\
 </patterndb>";
 
@@ -316,23 +317,25 @@ test_conflicting_rules_with_different_parsers(void)
   _destroy_pattern_db();
 }
 
-gchar *pdb_conflicting_rules_with_the_same_parsers = "<patterndb version='3' pub_date='2010-02-22'>\
+gchar *pdb_conflicting_rules_with_the_same_parsers = "<patterndb version='4' pub_date='2010-02-22'>\
  <ruleset name='testset' id='1'>\
   <patterns>\
    <pattern>prog1</pattern>\
    <pattern>prog2</pattern>\
   </patterns>\
-  <!-- different parsers at the same location -->\
-  <rule provider='test' id='11' class='short'>\
-   <patterns>\
-    <pattern>pattern @ESTRING:foo: @</pattern>\
-   </patterns>\
-  </rule>\
-  <rule provider='test' id='12' class='long'>\
-   <patterns>\
-    <pattern>pattern @ESTRING:foo: @tail</pattern>\
-   </patterns>\
-  </rule>\
+  <rules>\
+    <!-- different parsers at the same location -->\
+    <rule provider='test' id='11' class='short'>\
+     <patterns>\
+      <pattern>pattern @ESTRING:foo: @</pattern>\
+     </patterns>\
+    </rule>\
+    <rule provider='test' id='12' class='long'>\
+     <patterns>\
+      <pattern>pattern @ESTRING:foo: @tail</pattern>\
+     </patterns>\
+    </rule>\
+  </rules>\
  </ruleset>\
 </patterndb>";
 
@@ -356,137 +359,157 @@ test_conflicting_rules_with_the_same_parsers(void)
 /* pdb skeleton used to test patterndb rule actions. E.g. whenever a rule
  * matches, certain actions described in the rule need to be performed.
  * This tests those */
-gchar *pdb_ruletest_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
+gchar *pdb_ruletest_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
  <ruleset name='testset' id='1'>\
   <patterns>\
     <pattern>prog1</pattern>\
     <pattern>prog2</pattern>\
   </patterns>\
-  <rule provider='test' id='10' class='system' context-scope='program'>\
-   <patterns>\
-    <pattern>simple-message</pattern>\
-   </patterns>\
-   <tags>\
-    <tag>simple-msg-tag1</tag>\
-    <tag>simple-msg-tag2</tag>\
-   </tags>\
-   <values>\
-    <value name='simple-msg-value-1'>value1</value>\
-    <value name='simple-msg-value-2'>value2</value>\
-    <value name='simple-msg-host'>${HOST}</value>\
-   </values>\
-  </rule>\
-  <rule provider='test' id='10a' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>correllated-message-based-on-pid</pattern>\
-   </patterns>\
-   <values>\
-    <value name='correllated-msg-context-id'>${CONTEXT_ID}</value>\
-    <value name='correllated-msg-context-length'>$(context-length)</value>\
-   </values>\
-  </rule>\
-  <rule provider='test' id='10b' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>correllated-message-with-action-on-match</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='match'>\
-       <message>\
-         <value name='MESSAGE'>generated-message-on-match</value>\
-         <value name='context-id'>${CONTEXT_ID}</value>\
-         <tags>\
-           <tag>correllated-msg-tag</tag>\
-         </tags>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='10c' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>correllated-message-with-action-on-timeout</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='timeout'>\
-       <message>\
-         <value name='MESSAGE'>generated-message-on-timeout</value>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='10d' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>correllated-message-with-action-condition</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='match' condition='\"${PID}\" ne \"" MYPID "\"' >\
-       <message>\
-         <value name='MESSAGE'>not-generated-message</value>\
-       </message>\
-     </action>\
-     <action trigger='match' condition='\"${PID}\" eq \"" MYPID "\"' >\
-       <message>\
-         <value name='MESSAGE'>generated-message-on-condition</value>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='10e' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>correllated-message-with-rate-limited-action</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='match' rate='1/60'>\
-       <message>\
-         <value name='MESSAGE'>generated-message-rate-limit</value>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='11b' class='violation'>\
-   <patterns>\
-    <pattern>simple-message-with-action-on-match</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='match'>\
-       <message>\
-         <value name='MESSAGE'>generated-message-on-match</value>\
-         <value name='context-id'>${CONTEXT_ID}</value>\
-         <tags>\
-           <tag>simple-msg-tag</tag>\
-         </tags>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='11d' class='violation'>\
-   <patterns>\
-    <pattern>simple-message-with-action-condition</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='match' condition='\"${PID}\" ne \"" MYPID "\"' >\
-       <message>\
-         <value name='MESSAGE'>not-generated-message</value>\
-       </message>\
-     </action>\
-     <action trigger='match' condition='\"${PID}\" eq \"" MYPID "\"' >\
-       <message>\
-         <value name='MESSAGE'>generated-message-on-condition</value>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='11e' class='violation'>\
-   <patterns>\
-    <pattern>simple-message-with-rate-limited-action</pattern>\
-   </patterns>\
-   <actions>\
-     <action trigger='match' rate='1/60'>\
-       <message>\
-         <value name='MESSAGE'>generated-message-rate-limit</value>\
-       </message>\
-     </action>\
-   </actions>\
-  </rule>\
+  <rules>\
+    <rule provider='test' id='10' class='system' context-scope='program'>\
+     <patterns>\
+      <pattern>simple-message</pattern>\
+     </patterns>\
+     <tags>\
+      <tag>simple-msg-tag1</tag>\
+      <tag>simple-msg-tag2</tag>\
+     </tags>\
+     <values>\
+      <value name='simple-msg-value-1'>value1</value>\
+      <value name='simple-msg-value-2'>value2</value>\
+      <value name='simple-msg-host'>${HOST}</value>\
+     </values>\
+    </rule>\
+    <rule provider='test' id='10a' class='system' context-scope='program' context-id='$PID' context-timeout='60'>\
+     <patterns>\
+      <pattern>correllated-message-based-on-pid</pattern>\
+     </patterns>\
+     <values>\
+      <value name='correllated-msg-context-id'>${CONTEXT_ID}</value>\
+      <value name='correllated-msg-context-length'>$(context-length)</value>\
+     </values>\
+    </rule>\
+    <rule provider='test' id='10b' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+     <patterns>\
+      <pattern>correllated-message-with-action-on-match</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match'>\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-on-match</value>\
+             <value name='context-id'>${CONTEXT_ID}</value>\
+           </values>\
+           <tags>\
+             <tag>correllated-msg-tag</tag>\
+           </tags>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+    <rule provider='test' id='10c' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+     <patterns>\
+      <pattern>correllated-message-with-action-on-timeout</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='timeout'>\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-on-timeout</value>\
+           </values>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+    <rule provider='test' id='10d' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+     <patterns>\
+      <pattern>correllated-message-with-action-condition</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match' condition='\"${PID}\" ne \"" MYPID "\"' >\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>not-generated-message</value>\
+           </values>\
+         </message>\
+       </action>\
+       <action trigger='match' condition='\"${PID}\" eq \"" MYPID "\"' >\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-on-condition</value>\
+           </values>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+    <rule provider='test' id='10e' class='violation' context-scope='program' context-id='$PID' context-timeout='60'>\
+     <patterns>\
+      <pattern>correllated-message-with-rate-limited-action</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match' rate='1/60'>\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-rate-limit</value>\
+           </values>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+    <rule provider='test' id='11b' class='violation'>\
+     <patterns>\
+      <pattern>simple-message-with-action-on-match</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match'>\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-on-match</value>\
+             <value name='context-id'>${CONTEXT_ID}</value>\
+           </values>\
+           <tags>\
+             <tag>simple-msg-tag</tag>\
+           </tags>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+    <rule provider='test' id='11d' class='violation'>\
+     <patterns>\
+      <pattern>simple-message-with-action-condition</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match' condition='\"${PID}\" ne \"" MYPID "\"' >\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>not-generated-message</value>\
+           </values>\
+         </message>\
+       </action>\
+       <action trigger='match' condition='\"${PID}\" eq \"" MYPID "\"' >\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-on-condition</value>\
+           </values>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+    <rule provider='test' id='11e' class='violation'>\
+     <patterns>\
+      <pattern>simple-message-with-rate-limited-action</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match' rate='1/60'>\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-rate-limit</value>\
+           </values>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
+  </rules>\
  </ruleset>\
 </patterndb>";
 
@@ -634,31 +657,35 @@ test_patterndb_rule(void)
   _destroy_pattern_db();
 }
 
-gchar *pdb_inheritance_enabled_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
- <ruleset name='testset' id='1'>\
-  <patterns>\
-   <pattern>prog2</pattern>\
-  </patterns>\
-  <rule provider='test' id='11' class='system'>\
-   <patterns>\
-    <pattern>pattern-with-inheritance-enabled</pattern>\
-   </patterns>\
-   <tags>\
-    <tag>basetag1</tag>\
-    <tag>basetag2</tag>\
-   </tags>\
-   <actions>\
-    <action trigger='match'>\
-     <message inherit-properties='TRUE'>\
-      <value name='actionkey'>actionvalue</value>\
-      <tags>\
-       <tag>actiontag</tag>\
-      </tags>\
-     </message>\
-    </action>\
-   </actions>\
-  </rule>\
- </ruleset>\
+gchar *pdb_inheritance_enabled_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
+  <ruleset name='testset' id='1'>\
+    <patterns>\
+      <pattern>prog2</pattern>\
+    </patterns>\
+    <rules>\
+      <rule provider='test' id='11' class='system'>\
+        <patterns>\
+          <pattern>pattern-with-inheritance-enabled</pattern>\
+        </patterns>\
+        <tags>\
+          <tag>basetag1</tag>\
+          <tag>basetag2</tag>\
+        </tags>\
+        <actions>\
+          <action trigger='match'>\
+            <message inherit-properties='TRUE'>\
+              <values>\
+                <value name='actionkey'>actionvalue</value>\
+              </values>\
+              <tags>\
+                <tag>actiontag</tag>\
+              </tags>\
+            </message>\
+          </action>\
+        </actions>\
+      </rule>\
+    </rules>\
+  </ruleset>\
 </patterndb>";
 
 void
@@ -675,30 +702,34 @@ test_patterndb_message_property_inheritance_enabled()
   _destroy_pattern_db();
 }
 
-gchar *pdb_inheritance_disabled_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
- <ruleset name='testset' id='1'>\
-  <patterns>\
-   <pattern>prog2</pattern>\
-  </patterns>\
-  <rule provider='test' id='12' class='system'>\
-   <patterns>\
-    <pattern>pattern-with-inheritance-disabled</pattern>\
-   </patterns>\
-   <tags>\
-    <tag>basetag1</tag>\
-    <tag>basetag2</tag>\
-   </tags>\
-   <actions>\
-    <action trigger='match'>\
-     <message inherit-properties='FALSE'>\
-      <value name='actionkey'>actionvalue</value>\
-      <tags>\
-       <tag>actiontag</tag>\
-      </tags>\
-     </message>\
-    </action>\
-   </actions>\
-  </rule>\
+gchar *pdb_inheritance_disabled_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
+  <ruleset name='testset' id='1'>\
+    <patterns>\
+      <pattern>prog2</pattern>\
+    </patterns>\
+    <rules>\
+      <rule provider='test' id='12' class='system'>\
+        <patterns>\
+          <pattern>pattern-with-inheritance-disabled</pattern>\
+        </patterns>\
+        <tags>\
+          <tag>basetag1</tag>\
+          <tag>basetag2</tag>\
+        </tags>\
+        <actions>\
+          <action trigger='match'>\
+            <message inherit-properties='FALSE'>\
+              <values>\
+                <value name='actionkey'>actionvalue</value>\
+              </values>\
+              <tags>\
+                <tag>actiontag</tag>\
+              </tags>\
+            </message>\
+          </action>\
+        </actions>\
+      </rule>\
+    </rules>\
  </ruleset>\
 </patterndb>";
 
@@ -716,32 +747,37 @@ test_patterndb_message_property_inheritance_disabled()
   _destroy_pattern_db();
 }
 
-gchar *pdb_inheritance_context_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
- <ruleset name='testset' id='1'>\
-  <patterns>\
-   <pattern>prog2</pattern>\
-  </patterns>\
-  <rule provider='test' id='11' class='system' context-scope='program'\
-        context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>pattern-with-inheritance-context</pattern>\
-   </patterns>\
-   <tags>\
-    <tag>basetag1</tag>\
-    <tag>basetag2</tag>\
-   </tags>\
-   <actions>\
-    <action trigger='timeout'>\
-     <message inherit-properties='context'>\
-      <value name='MESSAGE'>action message</value>\
-      <tags>\
-       <tag>actiontag</tag>\
-      </tags>\
-     </message>\
-    </action>\
-   </actions>\
-  </rule>\
- </ruleset>\
+gchar *pdb_inheritance_context_skeleton = "\
+<patterndb version='4' pub_date='2010-02-22'>\
+  <ruleset name='testset' id='1'>\
+    <patterns>\
+      <pattern>prog2</pattern>\
+    </patterns>\
+    <rules>\
+      <rule provider='test' id='11' class='system' context-scope='program'\
+           context-id='$PID' context-timeout='60'>\
+        <patterns>\
+          <pattern>pattern-with-inheritance-context</pattern>\
+        </patterns>\
+        <tags>\
+          <tag>basetag1</tag>\
+          <tag>basetag2</tag>\
+        </tags>\
+        <actions>\
+          <action trigger='timeout'>\
+            <message inherit-properties='context'>\
+              <values>\
+                <value name='MESSAGE'>action message</value>\
+              </values>\
+              <tags>\
+                <tag>actiontag</tag>\
+              </tags>\
+            </message>\
+          </action>\
+        </actions>\
+     </rule>\
+    </rules>\
+  </ruleset>\
 </patterndb>";
 
 void
@@ -769,54 +805,62 @@ test_patterndb_message_property_inheritance(void)
   test_patterndb_message_property_inheritance_context();
 }
 
-gchar *pdb_msg_count_skeleton = "<patterndb version='3' pub_date='2010-02-22'>\
+gchar *pdb_msg_count_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
  <ruleset name='testset' id='1'>\
   <patterns>\
    <pattern>prog1</pattern>\
    <pattern>prog2</pattern>\
   </patterns>\
-  <rule provider='test' id='13' class='system' context-scope='program'\
-        context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>pattern13</pattern>\
-   </patterns>\
-   <values>\
-    <value name='n13-1'>v13-1</value>\
-   </values>\
-   <actions>\
-    <action condition='\"${n13-1}\" eq \"v13-1\"' trigger='match'>\
-     <message inherit-properties='TRUE'>\
-      <value name='CONTEXT_LENGTH'>$(context-length)</value>\
-     </message>\
-    </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='14' class='system' context-scope='program'\
-        context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>pattern14</pattern>\
-   </patterns>\
-   <actions>\
-    <action condition='\"$(context-length)\" eq \"1\"' trigger='match'>\
-     <message inherit-properties='TRUE'>\
-      <value name='CONTEXT_LENGTH'>$(context-length)</value>\
-     </message>\
-    </action>\
-   </actions>\
-  </rule>\
-  <rule provider='test' id='15' class='system' context-scope='program'\
-        context-id='$PID' context-timeout='60'>\
-   <patterns>\
-    <pattern>pattern15@ANYSTRING:p15@</pattern>\
-   </patterns>\
-   <actions>\
-    <action condition='\"$(context-length)\" eq \"2\"' trigger='match'>\
-     <message inherit-properties='FALSE'>\
-      <value name='fired'>true</value>\
-     </message>\
-    </action>\
-   </actions>\
-  </rule>\
+  <rules>\
+    <rule provider='test' id='13' class='system' context-scope='program'\
+          context-id='$PID' context-timeout='60'>\
+      <patterns>\
+        <pattern>pattern13</pattern>\
+      </patterns>\
+      <values>\
+        <value name='n13-1'>v13-1</value>\
+      </values>\
+      <actions>\
+        <action condition='\"${n13-1}\" eq \"v13-1\"' trigger='match'>\
+          <message inherit-properties='TRUE'>\
+            <values>\
+              <value name='CONTEXT_LENGTH'>$(context-length)</value>\
+            </values>\
+          </message>\
+        </action>\
+      </actions>\
+    </rule>\
+    <rule provider='test' id='14' class='system' context-scope='program'\
+          context-id='$PID' context-timeout='60'>\
+      <patterns>\
+        <pattern>pattern14</pattern>\
+      </patterns>\
+      <actions>\
+        <action condition='\"$(context-length)\" eq \"1\"' trigger='match'>\
+          <message inherit-properties='TRUE'>\
+            <values>\
+              <value name='CONTEXT_LENGTH'>$(context-length)</value>\
+            </values>\
+          </message>\
+        </action>\
+      </actions>\
+    </rule>\
+    <rule provider='test' id='15' class='system' context-scope='program'\
+          context-id='$PID' context-timeout='60'>\
+      <patterns>\
+        <pattern>pattern15@ANYSTRING:p15@</pattern>\
+      </patterns>\
+      <actions>\
+        <action condition='\"$(context-length)\" eq \"2\"' trigger='match'>\
+          <message inherit-properties='FALSE'>\
+            <values>\
+              <value name='fired'>true</value>\
+            </values>\
+          </message>\
+        </action>\
+      </actions>\
+    </rule>\
+  </rules>\
  </ruleset>\
 </patterndb>";
 


### PR DESCRIPTION
This series of patches improve test_patterndb test program a lot and also contains a number of refactors, in preparation for the new create-context action in patterndb.

It depends on PR #1004, so that should go in first, but I wanted to submit this separately to facilitate review in smaller batches.