### PR TITLE
F/mongodb makefile cleanup

### DIFF
--- a/modules/afamqp/Makefile.am
+++ b/modules/afamqp/Makefile.am
@@ -5,15 +5,12 @@ if LIBRABBITMQ_INTERNAL
 CLEAN_SUBDIRS 				+= @LIBRABBITMQ_SUBDIRS@
 lr_EXTRA_DEPS = modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
 
-modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la:
+$(lr_EXTRA_DEPS):
 	${MAKE} -C modules/afamqp/rabbitmq-c
 
 endif
 
 if ENABLE_AMQP
-AMQP_DUMMY_C_DEPS			 =	\
-	$(lr_EXTRA_DEPS)
-
 module_LTLIBRARIES			+= modules/afamqp/libafamqp.la
 
 modules_afamqp_libafamqp_la_CFLAGS	= 	\
@@ -21,7 +18,6 @@ modules_afamqp_libafamqp_la_CFLAGS	= 	\
 	-I$(top_srcdir)/modules/afamqp 		\
 	-I$(top_builddir)/modules/afamqp
 modules_afamqp_libafamqp_la_SOURCES	= 	\
-	modules/afamqp/dummy.c			\
 	modules/afamqp/afamqp-grammar.y		\
 	modules/afamqp/afamqp.c			\
 	modules/afamqp/afamqp.h			\
@@ -41,17 +37,13 @@ else
 modules/afamqp modules/afamqp/ mod-afamqp mod-amqp:
 endif
 
-modules/afamqp/dummy.c: ${AMQP_DUMMY_C_DEPS}
-	$(AM_V_GEN) touch $@
-
 BUILT_SOURCES				+=	\
 		modules/afamqp/afamqp-grammar.y \
 		modules/afamqp/afamqp-grammar.c \
-		modules/afamqp/afamqp-grammar.h \
-		modules/afamqp/dummy.c
+		modules/afamqp/afamqp-grammar.h
 
 EXTRA_DIST				+=	\
-		modules/afamqp/afamqp-grammar.ym \
+		modules/afamqp/afamqp-grammar.ym	\
 		modules/afamqp/rabbitmq-c/configure.gnu
 
 .PHONY: modules/afamqp/ mod-afamqp mod-amqp

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -28,7 +28,7 @@ modules_afmongodb_libafmongodb_la_LIBADD	=	\
 modules_afmongodb_libafmongodb_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afmongodb_libafmongodb_la_DEPENDENCIES	=	\
-	$(MODULE_DEPS_LIBS) ${lmc_EXTRA_DEPS}
+	$(MODULE_DEPS_LIBS) $(lmc_EXTRA_DEPS)
 
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb: \
 	modules/afmongodb/libafmongodb.la
@@ -36,14 +36,11 @@ else
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb:
 endif
 
-modules/afmongodb/dummy.c: ${lmc_EXTRA_DEPS}
-	$(AM_V_GEN) touch $@
-
 BUILT_SOURCES					+=	\
 	modules/afmongodb/afmongodb-grammar.y		\
 	modules/afmongodb/afmongodb-grammar.c		\
-	modules/afmongodb/afmongodb-grammar.h		\
-	modules/afmongodb/dummy.c
+	modules/afmongodb/afmongodb-grammar.h
+
 EXTRA_DIST					+=	\
 	modules/afmongodb/afmongodb-grammar.ym		\
 	modules/afmongodb/mongo-c-driver/configure.gnu

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -1,10 +1,10 @@
-DIST_SUBDIRS 					+= modules/afmongodb/mongo-c-driver
+DIST_SUBDIRS 					+= @LIBMONGO_SUBDIRS@
 
 if LIBMONGO_INTERNAL
 CLEAN_SUBDIRS					+= @LIBMONGO_SUBDIRS@
-lmc_EXTRA_DEPS					= modules/afmongodb/mongo-c-driver/src/libmongoc-1.0.la
+lmc_EXTRA_DEPS					= @LIBMONGO_SUBDIRS@/src/libmongoc-1.0.la
 
-modules/afmongodb/mongo-c-driver/src/libmongoc-1.0.la:
+$(lmc_EXTRA_DEPS):
 	${MAKE} -C modules/afmongodb/mongo-c-driver
 endif
 


### PR DESCRIPTION
This series encodes hard-wired paths into a single variable and also removes the generation of dummy.c, which was a phony target.

I am not exactly sure what the original intention was behind those, but I think it is better this way.

@algernon, you seem to have created this solution in the first place. The original commit 27ac7d49 states that make dist failed otherwise.

I just did a make dist with --disable-mongodb, which really turned off ENABLE_MONGODB but still the tarball produced by make dist did include mongo-c-driver

I am producing a similar patch to afamqp, but first I'd like to have an opinion on this PR.