### PR TITLE
F/dbparser convert pdbload to state machine

### DIFF
--- a/doc/xsd/patterndb-4.xsd
+++ b/doc/xsd/patterndb-4.xsd
@@ -180,6 +180,7 @@
                 <xs:unique name="examples">
                     <xs:selector xpath="example"/>
                     <xs:field xpath="test_message"/>
+                    <xs:field xpath="@program"/>
                 </xs:unique>
             </xs:element>
 

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -50,7 +50,6 @@ enum PDBLoaderState
   PDBL_RULE_ACTIONS,
   PDBL_RULE_ACTION,
   PDBL_RULE_ACTION_MESSAGE,
-  PDBL_RULE_ACTION_MESSAGE_TAG,
 
   /* generic states, reused by multiple paths in the XML */
   PDBL_VALUE,
@@ -432,7 +431,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "tag") == 0)
         {
-          state->current_state = PDBL_RULE_ACTION_MESSAGE_TAG;
+          _process_tag_element(state, attribute_names, attribute_values, error);
         }
       else
         {
@@ -673,16 +672,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           pdb_loader_set_error(state, error, "Unexpected </%s> tag, expected a </message>, </values> or </tags>", element_name);
         }
       break;
-    case PDBL_RULE_ACTION_MESSAGE_TAG:
-      if (strcmp(element_name, "tag") == 0)
-        {
-          state->current_state = PDBL_RULE_ACTION_MESSAGE;
-        }
-      else
-        {
-          pdb_loader_set_error(state, error, "Unexpected </%s> tag, expected a </tag>", element_name);
-        }
-      break;
 
     /* generic states reused by multiple locations in the grammar */
 
@@ -761,9 +750,6 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
       program_pattern.pattern = g_strdup(text);
       program_pattern.rule = pdb_rule_ref(state->current_rule);
       g_array_append_val(state->program_patterns, program_pattern);
-      break;
-    case PDBL_RULE_ACTION_MESSAGE_TAG:
-      synthetic_message_add_tag(state->current_message, text);
       break;
     case PDBL_RULE_EXAMPLE:
       break;

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -621,6 +621,19 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </actions>", element_name);
         }
       break;
+    case PDBL_RULE_ACTION:
+      if (strcmp(element_name, "action") == 0)
+        {
+          state->in_action = FALSE;
+          pdb_rule_add_action(state->current_rule, state->current_action);
+          state->current_action = NULL;
+          state->current_state = PDBL_RULE_ACTIONS;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </action>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "value") == 0)
         {
@@ -631,13 +644,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
         }
       else if (strcmp(element_name, "tag") == 0)
         state->in_tag = FALSE;
-      else if (strcmp(element_name, "action") == 0)
-        {
-          state->in_action = FALSE;
-          pdb_rule_add_action(state->current_rule, state->current_action);
-          state->current_action = NULL;
-          state->current_state = PDBL_RULE_ACTIONS;
-        }
       else if (strcmp(element_name, "message") == 0)
         {
           state->current_message = &state->current_rule->msg;

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -440,7 +440,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </patterndb>", element_name);
         }
       break;
-    default:
+    case PDBL_RULESET:
       if (strcmp(element_name, "ruleset") == 0)
         {
           if (!state->in_ruleset)
@@ -470,7 +470,21 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           state->program_patterns = NULL;
           state->current_state = PDBL_PATTERNDB;
         }
-      else if (strcmp(element_name, "examples") == 0)
+      else if (strcmp(element_name, "patterns") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "pattern") == 0)
+        {
+          state->in_pattern = FALSE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </ruleset>, </patterns> or </pattern>", element_name);
+        }
+      break;
+    default:
+      if (strcmp(element_name, "examples") == 0)
         {
           state->current_state = PDBL_RULE;
         }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -547,12 +547,18 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rule>, </patterns>, </pattern>, </description>, </tags>, </tag>, </values> or </value>", element_name);
         }
       break;
-    default:
+    case PDBL_RULE_EXAMPLES:
       if (strcmp(element_name, "examples") == 0)
         {
           state->current_state = PDBL_RULE;
         }
-      else if (strcmp(element_name, "example") == 0)
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </examples>", element_name);
+        }
+      break;
+    default:
+      if (strcmp(element_name, "example") == 0)
         {
           if (!state->in_example)
             {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -65,7 +65,6 @@ typedef struct _PDBLoader
   gboolean in_pattern;
   gboolean in_ruleset;
   gboolean in_tag;
-  gboolean in_example;
   gboolean in_test_msg;
   gboolean in_test_value;
   gboolean in_action;
@@ -290,13 +289,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_EXAMPLES:
       if (strcmp(element_name, "example") == 0)
         {
-          if (state->in_example)
-            {
-              pdb_loader_set_error(state, error, "Unexpected <example> element");
-              return;
-            }
-
-          state->in_example = TRUE;
           state->current_example = g_new0(PDBExample, 1);
           state->current_example->rule = pdb_rule_ref(state->current_rule);
           state->current_state = PDBL_RULE_EXAMPLE;
@@ -309,7 +301,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "test_message") == 0)
         {
-          if (state->in_test_msg || !state->in_example)
+          if (state->in_test_msg)
             {
               pdb_loader_set_error(state, error, "Unexpected <test_message> element");
               return;
@@ -329,7 +321,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "test_value") == 0)
         {
-          if (state->in_test_value || !state->in_example)
+          if (state->in_test_value)
             {
               pdb_loader_set_error(state, error, "Unexpected <test_value> element");
               return;
@@ -583,14 +575,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "example") == 0)
         {
-          if (!state->in_example)
-            {
-              pdb_loader_set_error(state, error, "Unexpected </example> element");
-              return;
-            }
-
-          state->in_example = FALSE;
-
           if (state->load_examples)
             state->examples = g_list_prepend(state->examples, state->current_example);
           else

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -493,6 +493,60 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rules>", element_name);
         }
       break;
+    case PDBL_RULE:
+      if (strcmp(element_name, "rule") == 0)
+        {
+          if (!state->in_rule)
+            {
+              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
+              return;
+            }
+
+          state->in_rule = FALSE;
+          if (state->current_rule)
+            {
+              pdb_rule_unref(state->current_rule);
+              state->current_rule = NULL;
+            }
+          state->current_message = NULL;
+          state->current_state = PDBL_RULES;
+        }
+      else if (strcmp(element_name, "patterns") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "pattern") == 0)
+        {
+          state->in_pattern = FALSE;
+        }
+      else if (strcmp(element_name, "description") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "tags") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "tag") == 0)
+        {
+          state->in_tag = FALSE;
+        }
+      else if (strcmp(element_name, "values") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "value") == 0)
+        {
+          if (state->value_name)
+            g_free(state->value_name);
+
+          state->value_name = NULL;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rule>, </patterns>, </pattern>, </description>, </tags>, </tag>, </values> or </value>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "examples") == 0)
         {
@@ -540,23 +594,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
             g_free(state->test_value_name);
 
           state->test_value_name = NULL;
-        }
-      else if (strcmp(element_name, "rule") == 0)
-        {
-          if (!state->in_rule)
-            {
-              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
-              return;
-            }
-
-          state->in_rule = FALSE;
-          if (state->current_rule)
-            {
-              pdb_rule_unref(state->current_rule);
-              state->current_rule = NULL;
-            }
-          state->current_message = NULL;
-          state->current_state = PDBL_RULES;
         }
       else if (strcmp(element_name, "value") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -557,7 +557,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </examples>", element_name);
         }
       break;
-    default:
+    case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "example") == 0)
         {
           if (!state->in_example)
@@ -586,6 +586,10 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
           state->in_test_msg = FALSE;
         }
+      else if (strcmp(element_name, "test_values") == 0)
+        {
+          /* */
+        }
       else if (strcmp(element_name, "test_value") == 0)
         {
           if (!state->in_test_value)
@@ -601,7 +605,13 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
           state->test_value_name = NULL;
         }
-      else if (strcmp(element_name, "value") == 0)
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </example>, </test_message>, </test_value>", element_name);
+        }
+      break;
+    default:
+      if (strcmp(element_name, "value") == 0)
         {
           if (state->value_name)
             g_free(state->value_name);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -664,6 +664,9 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </message>", element_name);
         }
       break;
+    default:
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected state %d, tag <%s>", state->current_state, element_name);
+      break;
     }
 }
 

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -67,7 +67,6 @@ typedef struct _PDBLoader
   SyntheticMessage *current_message;
   enum PDBLoaderState current_state;
   gboolean first_program;
-  gboolean in_test_msg;
   gboolean in_test_value;
   gboolean load_examples;
   GList *examples;
@@ -295,14 +294,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "test_message") == 0)
         {
-          if (state->in_test_msg)
-            {
-              pdb_loader_set_error(state, error, "Unexpected <test_message> element");
-              return;
-            }
-
-          state->in_test_msg = TRUE;
-
           for (i = 0; attribute_names[i]; i++)
             {
               if (strcmp(attribute_names[i], "program") == 0)
@@ -607,13 +598,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_EXAMPLE_TEST_MESSAGE:
       if (strcmp(element_name, "test_message") == 0)
         {
-          if (!state->in_test_msg)
-            {
-              pdb_loader_set_error(state, error, "Unexpected </test_message> element");
-              return;
-            }
-
-          state->in_test_msg = FALSE;
           state->current_state = PDBL_RULE_EXAMPLE;
         }
       else
@@ -773,10 +757,7 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
         }
       break;
     case PDBL_RULE_EXAMPLE_TEST_MESSAGE:
-      if (state->in_test_msg)
-        {
-          state->current_example->message = g_strdup(text);
-        }
+      state->current_example->message = g_strdup(text);
       break;
     default:
       if (!_is_whitespace_only(text, text_len))

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -37,6 +37,7 @@ enum PDBLoaderState
   PDBL_INITIAL = 0,
   PDBL_PATTERNDB,
   PDBL_RULESET,
+  PDBL_RULES,
 };
 
 /* arguments passed to the markup parser functions */
@@ -134,6 +135,24 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else
         {
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <ruleset>", element_name);
+        }
+      break;
+    case PDBL_RULESET:
+      if (strcmp(element_name, "rules") == 0)
+        {
+          state->current_state = PDBL_RULES;
+        }
+      else if (strcmp(element_name, "patterns") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "pattern") == 0)
+        {
+          state->in_pattern = TRUE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <rules>, <patterns> or <pattern>", element_name);
         }
       break;
     default:
@@ -380,6 +399,10 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
             g_free(state->test_value_name);
 
           state->test_value_name = NULL;
+        }
+      else if (strcmp(element_name, "rules") == 0)
+        {
+          state->current_state = PDBL_RULESET;
         }
       else if (strcmp(element_name, "rule") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -428,13 +428,19 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
   switch (state->current_state)
     {
-    default:
+    case PDBL_PATTERNDB:
       if (strcmp(element_name, "patterndb") == 0)
         {
           g_hash_table_foreach(state->ruleset_patterns, _populate_ruleset_radix, state);
           g_hash_table_remove_all(state->ruleset_patterns);
           state->current_state = PDBL_INITIAL;
         }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </patterndb>", element_name);
+        }
+      break;
+    default:
       if (strcmp(element_name, "ruleset") == 0)
         {
           if (!state->in_ruleset)

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -634,21 +634,36 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </action>", element_name);
         }
       break;
-    default:
-      if (strcmp(element_name, "value") == 0)
+    case PDBL_RULE_ACTION_MESSAGE:
+      if (strcmp(element_name, "message") == 0)
+        {
+          state->current_message = &state->current_rule->msg;
+          state->current_state = PDBL_RULE_ACTION;
+        }
+      else if (strcmp(element_name, "values") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "value") == 0)
         {
           if (state->value_name)
             g_free(state->value_name);
 
           state->value_name = NULL;
         }
-      else if (strcmp(element_name, "tag") == 0)
-        state->in_tag = FALSE;
-      else if (strcmp(element_name, "message") == 0)
+      else if (strcmp(element_name, "tags") == 0)
         {
-          state->current_message = &state->current_rule->msg;
-          state->current_state = PDBL_RULE_ACTION;
+          /* valid, but we don't do anything */
         }
+      else if (strcmp(element_name, "tag") == 0)
+        {
+          state->in_tag = FALSE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </message>", element_name);
+        }
+      break;
     }
 }
 

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -64,7 +64,6 @@ typedef struct _PDBLoader
   SyntheticMessage *current_message;
   enum PDBLoaderState current_state;
   gboolean first_program;
-  gboolean in_pattern;
   gboolean in_tag;
   gboolean in_test_msg;
   gboolean in_test_value;
@@ -183,7 +182,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "pattern") == 0)
         {
-          state->in_pattern = TRUE;
           state->current_state = PDBL_RULESET_PATTERN;
         }
       else
@@ -240,7 +238,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else if (strcmp(element_name, "pattern") == 0)
         {
           state->current_state = PDBL_RULE_PATTERN;
-          state->in_pattern = TRUE;
         }
       else if (strcmp(element_name, "description") == 0)
         {
@@ -483,7 +480,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULESET_PATTERN:
       if (strcmp(element_name, "pattern") == 0)
         {
-          state->in_pattern = FALSE;
           state->current_state = PDBL_RULESET;
         }
       else

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -610,6 +610,17 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </example>, </test_message>, </test_value>", element_name);
         }
       break;
+    case PDBL_RULE_ACTIONS:
+      if (strcmp(element_name, "actions") == 0)
+        {
+          g_assert(state->current_state == PDBL_RULE_ACTIONS);
+          state->current_state = PDBL_RULE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </actions>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "value") == 0)
         {
@@ -626,11 +637,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           pdb_rule_add_action(state->current_rule, state->current_action);
           state->current_action = NULL;
           state->current_state = PDBL_RULE_ACTIONS;
-        }
-      else if (strcmp(element_name, "actions") == 0)
-        {
-          g_assert(state->current_state == PDBL_RULE_ACTIONS);
-          state->current_state = PDBL_RULE;
         }
       else if (strcmp(element_name, "message") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -483,6 +483,16 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </ruleset>, </patterns> or </pattern>", element_name);
         }
       break;
+    case PDBL_RULES:
+      if (strcmp(element_name, "rules") == 0)
+        {
+          state->current_state = PDBL_RULESET;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rules>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "examples") == 0)
         {
@@ -530,10 +540,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
             g_free(state->test_value_name);
 
           state->test_value_name = NULL;
-        }
-      else if (strcmp(element_name, "rules") == 0)
-        {
-          state->current_state = PDBL_RULESET;
         }
       else if (strcmp(element_name, "rule") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -308,6 +308,34 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <message>", element_name);
         }
       break;
+    case PDBL_RULE_ACTION_MESSAGE:
+      if (strcmp(element_name, "values") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "value") == 0)
+        {
+          if (attribute_names[0] && g_str_equal(attribute_names[0], "name"))
+            state->value_name = g_strdup(attribute_values[0]);
+          else
+            {
+              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute in rule %s", state->current_rule->rule_id);
+              return;
+            }
+        }
+      else if (strcmp(element_name, "tags") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "tag") == 0)
+        {
+          state->in_tag = TRUE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <values>, <value>, <tags> or <tag>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "example") == 0)
         {
@@ -354,25 +382,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
               msg_error("No name is specified for test_value",
                         evt_tag_str("rule_id", state->current_rule->rule_id));
               g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<test_value> misses name attribute");
-              return;
-            }
-        }
-      else if (strcmp(element_name, "pattern") == 0)
-        {
-          state->in_pattern = TRUE;
-        }
-      else if (strcmp(element_name, "tag") == 0)
-        {
-          state->in_tag = TRUE;
-        }
-      else if (strcmp(element_name, "value") == 0)
-        {
-          if (attribute_names[0] && g_str_equal(attribute_names[0], "name"))
-            state->value_name = g_strdup(attribute_values[0]);
-          else
-            {
-              msg_error("No name is specified for value", evt_tag_str("rule_id", state->current_rule->rule_id));
-              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute");
               return;
             }
         }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -618,8 +618,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
           state->value_name = NULL;
         }
-      else if (strcmp(element_name, "pattern") == 0)
-        state->in_pattern = FALSE;
       else if (strcmp(element_name, "tag") == 0)
         state->in_tag = FALSE;
       else if (strcmp(element_name, "action") == 0)

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -703,7 +703,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
         }
       break;
     default:
-      pdb_loader_set_error(state, error, "Unexpected state %d, tag <%s>", state->current_state, element_name);
+      pdb_loader_set_error(state, error, "Unexpected state %d, tag </%s>", state->current_state, element_name);
       break;
     }
 }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -66,7 +66,6 @@ typedef struct _PDBLoader
   SyntheticMessage *current_message;
   enum PDBLoaderState current_state;
   gboolean first_program;
-  gboolean in_tag;
   gboolean in_test_msg;
   gboolean in_test_value;
   gboolean load_examples;
@@ -251,7 +250,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = TRUE;
           state->current_state = PDBL_RULE_TAG;
         }
       else if (strcmp(element_name, "values") == 0)
@@ -403,7 +401,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = TRUE;
           state->current_state = PDBL_RULE_ACTION_MESSAGE_TAG;
         }
       else
@@ -543,7 +540,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_TAG:
       if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = FALSE;
           state->current_state = PDBL_RULE;
         }
       else
@@ -668,7 +664,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_ACTION_MESSAGE_TAG:
       if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = FALSE;
           state->current_state = PDBL_RULE_ACTION_MESSAGE;
         }
       else

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -82,6 +82,19 @@ typedef struct _PDBProgramPattern
   PDBRule *rule;
 } PDBProgramPattern;
 
+static gboolean
+_is_whitespace_only(const gchar *text, gsize text_len)
+{
+  gint i;
+
+  for (i = 0; i < text_len; i++)
+    {
+      if (!g_ascii_isspace(text[i]))
+        return FALSE;
+    }
+  return TRUE;
+}
+
 void
 pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name, const gchar **attribute_names,
                          const gchar **attribute_values, gpointer user_data, GError **error)
@@ -793,6 +806,8 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
         }
       break;
     default:
+      if (!_is_whitespace_only(text, text_len))
+        g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected text node in state %d, text=[[%s]]", state->current_state, text);
       break;
     }
 }

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -525,12 +525,16 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
      <examples>\
        <example>\
          <test_message program='prog1'>simple-message-with-rate-limited-action</test_message>\
+         <test_values>\
+            <test_value name='PROGRAM'>prog1</test_value>\
+            <test_value name='MESSAGE'>foobar</test_value>\
+         </test_values>\
        </example>\
        <example>\
          <test_message program='prog2'>simple-message-with-rate-limited-action</test_message>\
        </example>\
      </examples>\
-    </rule>\
+   </rule>\
   </rules>\
  </ruleset>\
 </patterndb>";

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -522,6 +522,14 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
          </message>\
        </action>\
      </actions>\
+     <examples>\
+       <example>\
+         <test_message program='prog1'>simple-message-with-rate-limited-action</test_message>\
+       </example>\
+       <example>\
+         <test_message program='prog2'>simple-message-with-rate-limited-action</test_message>\
+       </example>\
+     </examples>\
     </rule>\
   </rules>\
  </ruleset>\


### PR DESCRIPTION
This series of patches converts the patterndb XML loader code to be a state machine to make it
somewhat easier to understand. This also improves error handling by not accepting XML documents that are semantically incorrect.

SAX parsing is not my favourite, but using a single state helps separation (e.g. SRP) and code reusability. 

I still have a few dozen patches in the queue that will take this and allow reusing states by removing the current in_XXXX gboolean variables in PDBLoader.