### PR TITLE
Fix dbparser grouping-by keywords

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -313,7 +313,6 @@ extern struct _StatsOptions *last_stats_options;
 
 /* value pairs */
 %token KW_VALUE_PAIRS                 10500
-%token KW_SELECT                      10501
 %token KW_EXCLUDE                     10502
 %token KW_PAIR                        10503
 %token KW_KEY                         10504

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -44,6 +44,7 @@ static CfgLexerKeyword dbparser_keywords[] =
   { "where",              KW_WHERE },
   { "having",             KW_HAVING },
   { "trigger",            KW_TRIGGER },
+  { "value",              KW_VALUE },
   { NULL }
 };
 

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -31,19 +31,19 @@ int dbparser_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
 
 static CfgLexerKeyword dbparser_keywords[] =
 {
-  { "db_parser",          KW_DB_PARSER, 0x0300 },
-  { "grouping_by",        KW_GROUPING_BY, 0x0307 },
+  { "db_parser",          KW_DB_PARSER },
+  { "grouping_by",        KW_GROUPING_BY },
 
   /* correllate options */
-  { "inject_mode",        KW_INJECT_MODE, 0x0307 },
-  { "key",                KW_KEY, 0x0307 },
-  { "scope",              KW_SCOPE, 0x0307 },
-  { "timeout",            KW_TIMEOUT, 0x0307 },
-  { "aggregate",          KW_AGGREGATE, 0x0307 },
-  { "inherit_mode",       KW_INHERIT_MODE, 0x0307 },
-  { "where",              KW_WHERE, 0x0307 },
-  { "having",             KW_HAVING, 0x0307 },
-  { "trigger",            KW_TRIGGER, 0x0307 },
+  { "inject_mode",        KW_INJECT_MODE },
+  { "key",                KW_KEY },
+  { "scope",              KW_SCOPE },
+  { "timeout",            KW_TIMEOUT },
+  { "aggregate",          KW_AGGREGATE },
+  { "inherit_mode",       KW_INHERIT_MODE },
+  { "where",              KW_WHERE },
+  { "having",             KW_HAVING },
+  { "trigger",            KW_TRIGGER },
   { NULL }
 };
 


### PR DESCRIPTION
This pull request fixes the `value()` option of the `grouping-by()` parser and removes non-existent `kw_req_version` values from dbparser-parser.

This is a completion of PR #828.