### PR TITLE
F/remove msg error etc null sentinel.sh, run on http module

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -173,8 +173,7 @@ _insert(LogThrDestDriver *s, LogMessage *msg)
 
   if ((ret = curl_easy_perform(self->curl)) != CURLE_OK) {
       msg_error("curl: error sending HTTP request",
-                evt_tag_str("error", curl_easy_strerror(ret)),
-                NULL);
+                evt_tag_str("error", curl_easy_strerror(ret)));
 
       if (body_rendered)
         g_string_free(body_rendered, TRUE);
@@ -255,8 +254,7 @@ http_dd_set_method(LogDriver *d, const gchar *method)
   else
     {
       msg_warning("Unsupported method is set(Only POST and PUT are supported), default method POST will be used",
-                  evt_tag_str("method", method),
-                  NULL);
+                  evt_tag_str("method", method));
       self->method_type = METHOD_TYPE_POST;
     }
 }
@@ -342,7 +340,7 @@ http_dd_new(GlobalConfig *cfg)
   curl_global_init(CURL_GLOBAL_ALL);
 
   if (!(self->curl = curl_easy_init())) {
-    msg_error("curl: cannot initialize libcurl", NULL, NULL);
+    msg_error("curl: cannot initialize libcurl", NULL);
 
     return NULL;
   }

--- a/scripts/rm-extra-msg-sentinel.sh
+++ b/scripts/rm-extra-msg-sentinel.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#############################################################################
+# Copyright (c) 2016 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+echo "Removing extra NULL sentinel after msg_error etc. macros in $PWD" >&2
+
+find . -iname .git -prune -false -o -type f -exec \
+ sed --regexp-extended --silent --in-place --expression "
+     1h
+     1! H
+     $ {
+      g
+     s~(\<msg_(fatal|error|warning|notice|info|progress|verbose|debug|trace|warning_once)\
+\s*\([^;]*),\s*NULL\s*\)\s*[;]~\1);~g
+     p
+    }
+    " {} +

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -49,3 +49,4 @@ modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
 scl
+scripts

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -50,3 +50,5 @@ modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
 scl
 scripts
+ GPLv2+_SSL,non-balabit
+modules/http


### PR DESCRIPTION
msg_error("description", evt_tag_str("when", "before"), NULL);
msg_error("description", evt_tag_str("when", "after"));

This was the automated transformation done in this pull request:
#941 "F/remove msg error etc null sentinel"

f36548b
"dropped extra NULL sentinel at msg_*() call sites"

It was copied from the commit message verbatim, but it may be improved
in the future.