### PR TITLE
PatternDB: fixed fastpath of empty patterndb

### DIFF
--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -587,15 +587,23 @@ pattern_db_get_timer_wheel(PatternDB *self)
 }
 
 static gboolean
+_pattern_db_is_empty(PatternDB *self)
+{
+  return (G_UNLIKELY(!self->ruleset) || self->ruleset->is_empty);
+}
+
+static gboolean
 _pattern_db_process(PatternDB *self, PDBLookupParams *lookup, GArray *dbg_list)
 {
   PDBRule *rule;
   LogMessage *msg = lookup->msg;
 
-  if (G_UNLIKELY(!self->ruleset))
-    return FALSE;
-
   g_static_rw_lock_reader_lock(&self->lock);
+  if (_pattern_db_is_empty(self))
+    {
+      g_static_rw_lock_reader_unlock(&self->lock);
+      return FALSE;
+    }
   rule = pdb_lookup_ruleset(self->ruleset, lookup, dbg_list);
   g_static_rw_lock_reader_unlock(&self->lock);
   if (rule)

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -81,6 +81,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
           return;
         }
 
+      state->ruleset->is_empty = FALSE;
       state->in_ruleset = TRUE;
       state->first_program = TRUE;
       state->program_patterns = g_array_new(0, 0, sizeof(PDBProgramPattern));

--- a/modules/dbparser/pdb-ruleset.c
+++ b/modules/dbparser/pdb-ruleset.c
@@ -27,6 +27,7 @@ PDBRuleSet *
 pdb_rule_set_new(void)
 {
   PDBRuleSet *self = g_new0(PDBRuleSet, 1);
+  self->is_empty = TRUE;
 
   return self;
 }

--- a/modules/dbparser/pdb-ruleset.h
+++ b/modules/dbparser/pdb-ruleset.h
@@ -32,6 +32,7 @@ typedef struct _PDBRuleSet
   RNode *programs;
   gchar *version;
   gchar *pub_date;
+  gboolean is_empty;
 } PDBRuleSet;
 
 PDBRuleSet *pdb_rule_set_new(void);


### PR DESCRIPTION
If no ruleset is present, patterndb wont try to find any matching pattern.

Signed-off-by: Peter Gyorko <peter.gyorko@balabit.com>
Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>
Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>