### PR TITLE
Added ElasticSearch Destination HTTP Implementation

### DIFF
--- a/modules/java-modules/elastic-http/README.md
+++ b/modules/java-modules/elastic-http/README.md
@@ -1,0 +1,20 @@
+ElasticSearch HTTP Destination
+==============================
+
+This is a simple ElasticSearch HTTP destination using the Jest library. Although it support bulk insert (flush_limit), unfortunately it doesn't support flush timeout.
+
+Example configuration:
+```
+destination d_test {
+  java(
+    class_path("`module-path`/java-modules/*.jar:/install/jest-jars/*.jar")
+    class_name("org.syslog_ng.elasticsearch_http.ElasticSearchHTTPDestination")
+    option("index", "logs-$YEAR.$MONTH.$DAY")
+    option("message_template", "$(format-json --scope rfc5424 --exclude DATE --key ISODATE --pair @timestamp=$ISODATE)")
+    option("type", "logs")
+    option("cluster_url", "http://localhost:9200")
+    option("flush_limit", "100")
+  );
+};
+
+```

--- a/modules/java-modules/elastic-http/build.gradle
+++ b/modules/java-modules/elastic-http/build.gradle
@@ -1,0 +1,12 @@
+project.buildDir = syslogBuildDir+'/elastic-http/gradle'
+
+dependencies {
+    compile 'io.searchbox:jest:1.0.2'
+    compile name: 'syslog-ng-common'
+    compile name: 'syslog-ng-core'
+    compile 'junit:junit:4.12'
+    compile 'org.hamcrest:hamcrest-core:1.3'
+    compile 'log4j:log4j:1.2.17'
+    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
+}
+

--- a/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/ElasticSearchHTTPDestination.java
+++ b/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/ElasticSearchHTTPDestination.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2015 Viktor Tusa <tusavik@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_http;
+
+import org.syslog_ng.LogMessage;
+import org.syslog_ng.LogTemplate;
+import org.syslog_ng.StructuredLogDestination;
+import org.syslog_ng.elasticsearch_http.ElasticSearchHTTPOptions;
+import org.syslog_ng.options.InvalidOptionException;
+import org.syslog_ng.logging.SyslogNgInternalLogger;
+import org.apache.log4j.Logger;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.JestClient;
+import io.searchbox.core.Index;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.NodesInfo;
+import io.searchbox.client.config.HttpClientConfig;
+import org.syslog_ng.elasticsearch_http.messageprocessor.ESHTTPSingleMessageProcessor;
+import org.syslog_ng.elasticsearch_http.messageprocessor.ESHTTPBulkMessageProcessor;
+import org.syslog_ng.elasticsearch_http.messageprocessor.ESHTTPMessageProcessor;
+
+
+import java.util.Set;
+import java.util.LinkedHashSet;
+
+import java.io.IOException;
+
+public class ElasticSearchHTTPDestination extends StructuredLogDestination {
+
+	JestClient client;
+	ElasticSearchHTTPOptions options;
+	Logger logger;
+	ESHTTPMessageProcessor messageProcessor;
+
+	public ElasticSearchHTTPDestination(long handle) {
+		super(handle);
+		logger = Logger.getRootLogger();
+		SyslogNgInternalLogger.register(logger);
+		options = new ElasticSearchHTTPOptions(this);
+	}
+
+	private ESHTTPMessageProcessor createMessageProcessor()
+	{
+		if (options.getFlushLimit() > 1)
+			return new ESHTTPBulkMessageProcessor(options, client);
+		else
+			return new ESHTTPSingleMessageProcessor(options, client);
+	}
+
+	@Override
+	protected boolean init() {
+		boolean result = false;
+		logger.debug("Initializing ESHTTP Destination");
+		try {
+			options.init();
+			String connectionUrl = options.getClusterUrl();
+			JestClientFactory clientFactory = new JestClientFactory();
+			clientFactory.setHttpClientConfig(new HttpClientConfig
+			       .Builder(connectionUrl)
+			       .multiThreaded(false)
+			       .build());
+			client = clientFactory.getObject();
+			messageProcessor = createMessageProcessor();
+			messageProcessor.init();
+			getClusterName();
+			result = true;
+		}
+		catch (Exception | Error e){
+			logger.error(e.getMessage());
+			logger.error(e.getClass().getName());
+			return false;
+		}
+		return result;
+	}
+
+	@Override
+	protected boolean isOpened() {
+		return true;
+	}
+
+	@Override
+	protected boolean open() {
+		return true;
+	}
+
+	private Index createIndex(LogMessage msg) {
+		String formattedMessage = options.getMessageTemplate().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+		String customId = options.getCustomId().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+		String indexName = options.getIndex().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+		String type = options.getType().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+		logger.debug("Outgoing log entry, json='" + formattedMessage + "'");
+		Index index = new Index.Builder(formattedMessage).index(indexName).type(type).id(customId).build();
+		return index;
+	}
+
+	@Override
+	protected boolean send(LogMessage msg) {
+		Index index = createIndex(msg);
+	 	boolean result = messageProcessor.send(index);	
+		return result;
+	}
+	
+
+	@Override
+	protected void close() {
+		messageProcessor.flush();
+	}
+
+        private String getClusterName() {
+		try {
+			NodesInfo nodesinfo = new NodesInfo.Builder().build();
+			JestResult result = client.execute(nodesinfo);
+			return result.getValue("cluster_name").toString();
+		} 
+		catch (IOException e) {
+			return "unnamed";
+		}
+		
+	}
+
+	@Override
+	protected String getNameByUniqOptions() {
+		return String.format("ElasticSearch,%s,%s", getClusterName(), options.getIndex().getValue());
+	}
+
+	@Override
+	protected void deinit() {
+		client.shutdownClient();
+		options.deinit();
+	}
+}

--- a/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/ElasticSearchHTTPOptions.java
+++ b/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/ElasticSearchHTTPOptions.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2016 Viktor Tusa <tusavik@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_http;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.syslog_ng.LogDestination;
+import org.syslog_ng.options.*;
+
+public class ElasticSearchHTTPOptions {
+
+	public static String CLUSTER_URL = "cluster_url";
+	public static String CLUSTER = "cluster";
+	public static String INDEX = "index";
+	public static String TYPE = "type";
+	public static String MESSAGE_TEMPLATE = "message_template";
+	public static String CUSTOM_ID = "custom_id";
+	public static String FLUSH_LIMIT = "flush_limit";
+	public static String CONFIG_FILE = "resource";
+	public static String CONCURRENT_REQUESTS = "concurrent_requests";
+
+	public static String CLUSTER_URL_DEFAULT = "http://localhost:9200";
+	public static String MESSAGE_TEMPLATE_DEFAULT = "$(format-json --scope rfc5424 --exclude DATE --key ISODATE)";
+	public static String FLUSH_LIMIT_DEFAULT = "5000";
+
+	public static String CONCURRENT_REQUESTS_DEFAULT = "1";
+
+	private LogDestination owner;
+	private Options options;
+
+	public ElasticSearchHTTPOptions(LogDestination owner) {
+		this.owner = owner;
+		options = new Options();
+		fillOptions();
+	}
+
+	public void init() throws InvalidOptionException {
+		options.validate();
+	}
+
+	public void deinit() {
+		options.deinit();
+	}
+
+	public Option getOption(String optionName) {
+		return options.get(optionName);
+	}
+
+	public TemplateOption getMessageTemplate() {
+		return options.getTemplateOption(MESSAGE_TEMPLATE);
+	}
+
+	public TemplateOption getCustomId() {
+		return options.getTemplateOption(CUSTOM_ID);
+	}
+
+	public TemplateOption getIndex() {
+		return options.getTemplateOption(INDEX);
+	}
+
+	public TemplateOption getType() {
+		return options.getTemplateOption(TYPE);
+	}
+
+	public String getClusterUrl() {
+		return options.get(CLUSTER_URL).getValue();
+	}
+
+	public String getCluster() {
+		return options.get(CLUSTER).getValue();
+	}
+
+	public int getFlushLimit() {
+		return options.get(FLUSH_LIMIT).getValueAsInteger();
+	}
+
+	public String getConfigFile() {
+		return options.get(CONFIG_FILE).getValue();
+	}
+
+        public int getConcurrentRequests() {
+        	return options.get(CONCURRENT_REQUESTS).getValueAsInteger();
+        }	
+
+	private void fillOptions() {
+		fillStringOptions();
+		fillTemplateOptions();
+	}
+
+	private void fillTemplateOptions() {
+		options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, INDEX))));
+		options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, TYPE))));
+		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, MESSAGE_TEMPLATE, MESSAGE_TEMPLATE_DEFAULT)));
+		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, CUSTOM_ID)));
+	}
+
+	private void fillStringOptions() {
+		options.put(new StringOption(owner, CLUSTER));
+		options.put(new StringOption(owner, CLUSTER_URL, CLUSTER_URL_DEFAULT));
+		options.put(new IntegerRangeCheckOptionDecorator(new StringOption(owner, FLUSH_LIMIT, FLUSH_LIMIT_DEFAULT), -1, Integer.MAX_VALUE));
+		options.put(new StringOption(owner, CONFIG_FILE));
+		options.put(new IntegerRangeCheckOptionDecorator(new StringOption(owner, CONCURRENT_REQUESTS, CONCURRENT_REQUESTS_DEFAULT), 0, Integer.MAX_VALUE));
+	}
+}

--- a/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/messageprocessor/ESHTTPBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/messageprocessor/ESHTTPBulkMessageProcessor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2016 Viktor Tusa <tusavik@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_http.messageprocessor;
+
+import org.apache.log4j.Logger;
+import io.searchbox.core.Index;
+import io.searchbox.core.Bulk;
+import io.searchbox.client.JestClient;
+import org.syslog_ng.elasticsearch_http.ElasticSearchHTTPOptions;
+
+import java.io.IOException;
+
+public class ESHTTPBulkMessageProcessor extends ESHTTPMessageProcessor {
+
+	private Bulk.Builder bulk;
+	private int flushLimit;
+	private int messageCounter;
+
+	public ESHTTPBulkMessageProcessor(ElasticSearchHTTPOptions options, JestClient client) {
+		super(options, client);
+	}
+
+	@Override
+	public void init() {
+		bulk = new Bulk.Builder();
+		messageCounter = 0;
+		flushLimit = options.getFlushLimit();
+	}
+
+	@Override
+	public boolean send(Index index) {
+		if (messageCounter >= flushLimit)
+		{
+			flush();
+		}
+		bulk = bulk.addAction(index);
+		messageCounter++;
+		return true;
+	}
+
+        @Override
+	public void flush() {
+		logger.debug("Flushing messages for ESHTTP destination");
+		Bulk bulkActions = bulk.build();
+		try {
+                        client.execute(bulkActions);
+                }
+                catch (IOException e)
+                {
+                        logger.error(e.getMessage());
+                }
+		bulk = new Bulk.Builder();
+		messageCounter = 0;
+	}
+
+}

--- a/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/messageprocessor/ESHTTPMessageProcessor.java
+++ b/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/messageprocessor/ESHTTPMessageProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2016 Viktor Tusa <tusavik@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_http.messageprocessor;
+
+import org.apache.log4j.Logger;
+import io.searchbox.core.Index;
+import io.searchbox.client.JestClient;
+import org.syslog_ng.elasticsearch_http.ElasticSearchHTTPOptions;
+
+public abstract class ESHTTPMessageProcessor {
+	protected ElasticSearchHTTPOptions options;
+	protected JestClient client;
+	protected Logger logger;
+
+
+	public ESHTTPMessageProcessor(ElasticSearchHTTPOptions options, JestClient client) {
+		this.options = options;
+		this.client = client;
+		logger = Logger.getRootLogger();
+	}
+
+	public void init() {
+
+	}
+
+	public void flush() {
+
+	}
+
+	public void deinit() {
+
+	}
+
+	public abstract boolean send(Index req);
+
+}

--- a/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/messageprocessor/ESHTTPSingleMessageProcessor.java
+++ b/modules/java-modules/elastic-http/src/main/java/org/syslog_ng/elasticsearch_http/messageprocessor/ESHTTPSingleMessageProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2016 Viktor Tusa <tusavik@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_http.messageprocessor;
+
+import org.apache.log4j.Logger;
+import io.searchbox.core.Index;
+import io.searchbox.client.JestClient;
+import org.syslog_ng.elasticsearch_http.ElasticSearchHTTPOptions;
+
+import java.io.IOException;
+
+public class ESHTTPSingleMessageProcessor extends ESHTTPMessageProcessor {
+
+	public ESHTTPSingleMessageProcessor(ElasticSearchHTTPOptions options, JestClient client) {
+		super(options, client);
+	}
+
+	@Override
+	public boolean send(Index req) {
+		boolean result = true;
+		try {
+                        client.execute(req);
+                }
+                catch (IOException e)
+                {
+                        logger.error(e.getMessage());
+                        result = false;
+                }
+		return result;
+	}
+
+}

--- a/modules/java-modules/settings.gradle
+++ b/modules/java-modules/settings.gradle
@@ -1,1 +1,1 @@
-include 'dummy', 'common', 'hdfs', 'kafka', 'elastic', 'http', 'elastic-v2'
+include 'dummy', 'common', 'hdfs', 'kafka', 'elastic', 'http', 'elastic-v2', 'elastic-http'

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -46,7 +46,7 @@ modules/native
  GPLv2+_SSL
 tests
 modules/java/(tools|[^/]*$)
-modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
+modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|elastic-http|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
 scl
 scripts


### PR DESCRIPTION
This ES Destination uses the Jest library and the HTTP API of the
ElasticSearch Cluster. It uses different options for connections
that the other ES destinations, namely the host and port options
were elminated and cluster_url option was introduced.

The index, message_template, type options remained the same.