### PR TITLE
afprog: Don't kill our own process group

### DIFF
--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -52,7 +52,7 @@ _terminate_process_group_by_pid(const pid_t pid)
               evt_tag_int("pid", pid));
 
   pid_t pgid = getpgid(pid);
-  if (pgid != -1)
+  if (pgid != -1 && pgid != getpgrp())
     killpg(pgid, SIGTERM);
 }
 


### PR DESCRIPTION
If, for some reason, the program source/destination failed to set up its
own process group, we need to make sure we do not run killpg() on that
process group, as it would kill ourselves.

Signed-off-by: Henrik Grindal Bakken <henribak@cisco.com>