### PR TITLE
F/dbparser action create context

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,3 +1,10 @@
+xsd_DATA	= \
+		doc/xsd/patterndb-1.xsd \
+		doc/xsd/patterndb-2.xsd \
+		doc/xsd/patterndb-3.xsd \
+		doc/xsd/patterndb-4.xsd \
+		doc/xsd/patterndb-5.xsd
+
 EXTRA_DIST	+=  \
 		doc/man/syslog-ng.8.xml \
 		doc/man/syslog-ng.conf.5.xml \
@@ -6,16 +13,8 @@ EXTRA_DIST	+=  \
 		doc/man/syslog-ng-ctl.1.xml \
 		doc/security/bof-2002-09-27.txt \
 		doc/security/dos-2000-11-22.txt \
-		doc/xsd/patterndb-1.xsd \
-		doc/xsd/patterndb-2.xsd \
-		doc/xsd/patterndb-3.xsd \
-		doc/xsd/patterndb-4.xsd
+		$(xsd_DATA)
 
-xsd_DATA	= \
-		doc/xsd/patterndb-1.xsd \
-		doc/xsd/patterndb-2.xsd \
-		doc/xsd/patterndb-3.xsd \
-		doc/xsd/patterndb-4.xsd
 
 if ENABLE_MANPAGES
 man_MANS	+= \

--- a/doc/xsd/patterndb-4.xsd
+++ b/doc/xsd/patterndb-4.xsd
@@ -180,6 +180,7 @@
                 <xs:unique name="examples">
                     <xs:selector xpath="example"/>
                     <xs:field xpath="test_message"/>
+                    <xs:field xpath="@program"/>
                 </xs:unique>
             </xs:element>
 

--- a/doc/xsd/patterndb-5.xsd
+++ b/doc/xsd/patterndb-5.xsd
@@ -279,11 +279,19 @@
 
     <xs:complexType name="actionType">
         <xs:all>
-            <xs:element name="message" type="messageType" minOccurs="1" maxOccurs="1">
+            <xs:element name="message" type="messageType" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The message to be generated when the action
                         triggers.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="create-context" type="createContextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The context to be created when the action is
+                        triggered.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -421,6 +429,51 @@
           </xs:simpleType>
         </xs:attribute>
 
+    </xs:complexType>
+
+    <xs:complexType name="createContextType">
+        <xs:all>
+            <xs:element name="message" type="messageType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The message that gets added to the new context to be
+                        created.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="context-id" type="xs:string"/>
+        <xs:attribute name="context-scope">
+          <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="process">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="program">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="host">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="global">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="context-timeout" type="xs:integer"/>
     </xs:complexType>
 
     <xs:simpleType name="uuidType">

--- a/doc/xsd/patterndb-5.xsd
+++ b/doc/xsd/patterndb-5.xsd
@@ -1,0 +1,486 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="patterndb">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="ruleset" type="rulesetType" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A container to group log patterns for an application/program.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:NMTOKEN" use="required" fixed="5">
+                <xs:annotation>
+                    <xs:documentation>
+                        The schema version of the pattern database.
+                        The current version is '5'.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="pub_date" type="xs:date" use="required">
+                <xs:annotation>
+                    <xs:documentation>
+                        The publication date of the XML file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+        <xs:unique name="ruleset_name">
+            <xs:selector xpath="ruleset"/>
+            <xs:field xpath="@name"/>
+        </xs:unique>
+        <xs:unique name="ids">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@id"/>
+        </xs:unique>
+    </xs:element>
+
+    <xs:complexType name="rulesetType">
+        <xs:all>
+            <xs:element name="description" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        An optional element to attach description to a ruleset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        An optional element to point to a URL related to the ruleset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patterns" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        If an application uses multiple values for its
+                        program name, then you can list them all in a
+                        patterns element containing multiple  pattern
+                        elements.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="pattern" type="patternType" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                  An optional element with a pattern representing the name of the application related
+                                  to the ruleset in the syslog program field.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="pattern" type="patternType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        An optional element with a pattern representing the name of the application related
+                        to the ruleset in the syslog program field.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="rules">
+                <xs:annotation>
+                    <xs:documentation>
+                        The rules in the ruleset.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="rule" type="ruleType" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A rule describes one log event with classifications and details.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="patterns">
+                    <xs:selector xpath="rule/patterns/pattern"/>
+                    <xs:field xpath="."/>
+                </xs:unique>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the application.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="ruleType">
+        <xs:all>
+            <xs:element name="description" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        An optional element to describe the log disposition.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="urls" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Optional elements to point to some external resource for disposition.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="urls">
+                    <xs:selector xpath="url"/>
+                    <xs:field xpath="."/>
+                </xs:unique>
+            </xs:element>
+            <xs:element name="values" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Optional values that are added after template evaluation to messages
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="value" minOccurs="0"  maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="xs:string">
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="rule_values">
+                    <xs:selector xpath="value"/>
+                    <xs:field xpath="@name"/>
+                </xs:unique>
+            </xs:element>
+             <xs:element name="examples" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Optional examples to test rule patterns and configuration
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="example" type="exampleType" minOccurs="0"  maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="examples">
+                    <xs:selector xpath="example"/>
+                    <xs:field xpath="test_message"/>
+                    <xs:field xpath="@program"/>
+                </xs:unique>
+            </xs:element>
+
+            <xs:element name="tags" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Optional keywords that can be used for a freeform grouping of the rules.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="tag" type="xs:token" minOccurs="0"  maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="rule_tags">
+                    <xs:selector xpath="tag"/>
+                    <xs:field xpath="."/>
+                </xs:unique>
+            </xs:element>
+            <xs:element name="actions" minOccurs="0" maxOccurs="1">
+                 <xs:complexType>
+                     <xs:sequence>
+                         <xs:element name="action" type="actionType" minOccurs="1" maxOccurs="unbounded"/>
+                     </xs:sequence>
+                 </xs:complexType>
+            </xs:element>
+            <xs:element name="patterns">
+                <xs:annotation>
+                    <xs:documentation>
+                        Patterns representing the rule. Log messages matching any one of the patterns
+                        are classified to this rule.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="pattern" type="patternType" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A pattern representing the log message.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="provider" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The provider of the rule. To distinguish between who supplied the rule,
+                    or if it has been added to the xml by a local user.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="context-id" type="xs:string"/>
+        <xs:attribute name="context-scope">
+          <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="process">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="program">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="host">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="global">
+                        <xs:annotation>
+                            <xs:documentation>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="context-timeout" type="xs:integer"/>
+        <xs:attribute name="class" type="classType">
+            <xs:annotation>
+                <xs:documentation>
+                    The class of the rule.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="actionType">
+        <xs:all>
+            <xs:element name="message" type="messageType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The message to be generated when the action
+                        triggers.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+
+        <xs:attribute name="condition" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter expression guarding the triggering of this
+                    action. If the filter evaluates to TRUE the action is
+                    executed, otherwise it is skipped.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="rate" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum rate at which this action is executed.
+                    Excess actions are ignored.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trigger">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies when the action is to be executed.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="timeout">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Specifies that the action is to be executed when
+                                the correllation timeout elapses without
+                                matching a further rule.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="match">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Specifies that the action is to be executed
+                                immediately as the rule matches.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="messageType">
+        <xs:all>
+            <xs:element name="values" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name-value pairs that make up the message to be
+                        generated.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="value" minOccurs="0"  maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="xs:string">
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="message_values">
+                    <xs:selector xpath="value"/>
+                    <xs:field xpath="@name"/>
+                </xs:unique>
+            </xs:element>
+
+            <xs:element name="tags" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Optional keywords that can be used for a freeform grouping of the rules.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="tag" type="xs:token" minOccurs="0"  maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="message_tags">
+                    <xs:selector xpath="tag"/>
+                    <xs:field xpath="."/>
+                </xs:unique>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="inherit-properties">
+          <xs:annotation>
+            <xs:documentation>
+              If set to TRUE, the original message that triggered the action is
+              cloned, including its name-value pairs and tags.
+              For details, see Section 13.4, Triggering actions for identified messages.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="context"/>
+              <xs:enumeration value="TRUE"/>
+              <xs:enumeration value="FALSE"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+
+    </xs:complexType>
+
+    <xs:simpleType name="uuidType">
+        <xs:annotation>
+            <xs:documentation>
+                This describes a UUID syntax. Currently it is not used for
+                the IDing to avoid enforcing the use of UUIDs, which some
+                users complained about. Once the decision on the rule id
+                format happens this may completely be removed.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z0-9]{8}-([a-zA-Z0-9]{4}-){3}[a-zA-Z0-9]{12}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="patternType">
+        <xs:annotation>
+            <xs:documentation>
+                This type describes a radix/parser pattern which is used to match
+                a program name or a whole log message.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="classType">
+        <xs:annotation>
+            <xs:documentation>
+                The classification class for a single rule.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[\-a-zA-Z0-9_\.%:@\+!\^\\/]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="exampleType">
+        <xs:all>
+            <xs:element name="test_message">
+                <xs:annotation>
+                    <xs:documentation>
+                        The example message to test rule patterns
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="program" type="xs:string" use="optional"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="test_values" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="test_value" minOccurs="0"  maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="xs:string">
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:unique name="test-values">
+                    <xs:selector xpath="test_value"/>
+                    <xs:field xpath="@name"/>
+                </xs:unique>
+            </xs:element>
+            <xs:element name="test_tags" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="test_tag" type="xs:string" minOccurs="0"  maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+</xs:schema>
+
+<!-- vim:expandtab:ts=4:ft=xml
+  -->

--- a/doc/xsd/patterndb-5.xsd
+++ b/doc/xsd/patterndb-5.xsd
@@ -387,6 +387,7 @@
               If set to TRUE, the original message that triggered the action is
               cloned, including its name-value pairs and tags.
               For details, see Section 13.4, Triggering actions for identified messages.
+              NOTE: This attribute is deprecated in favour of inherit-mode.
             </xs:documentation>
           </xs:annotation>
           <xs:simpleType>
@@ -394,6 +395,28 @@
               <xs:enumeration value="context"/>
               <xs:enumeration value="TRUE"/>
               <xs:enumeration value="FALSE"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+
+        <xs:attribute name="inherit-mode">
+          <xs:annotation>
+            <xs:documentation>
+              This attribute is used to control which set of name-value
+              pairs are propagated to the newly generated message. "context"
+              means that the new message is populated with a union of all
+              name-value pairs present in messages in the context.
+              "last-message" means that only name-value pairs of the last
+              message is copied. "none" means that the new message becomes
+              empty initially.
+              For details, see Section 13.4, Triggering actions for identified messages.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="none"/>
+              <xs:enumeration value="context"/>
+              <xs:enumeration value="last-message"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:attribute>

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -29,6 +29,8 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/correllation-context.h			\
 	modules/dbparser/synthetic-message.c			\
 	modules/dbparser/synthetic-message.h			\
+	modules/dbparser/synthetic-context.c			\
+	modules/dbparser/synthetic-context.h			\
 	modules/dbparser/timerwheel.c				\
 	modules/dbparser/timerwheel.h				\
 	modules/dbparser/patternize.c				\

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -163,7 +163,7 @@ synthetic_message_opts
 	;
 
 synthetic_message_opt
-	: KW_INHERIT_MODE '(' inherit_mode ')'                  { grouping_by_set_inherit_properties(last_parser, $3); }
+	: KW_INHERIT_MODE '(' inherit_mode ')'                  { synthetic_message_set_inherit_mode(last_message, $3); }
 	| KW_VALUE '(' string template_content ')'
 	  {
 	    synthetic_message_add_value_template(last_message, $3, $4);

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -40,7 +40,6 @@ typedef struct _GroupingBy
   LogTemplate *key_template;
   gint timeout;
   CorrellationScope scope;
-  SyntheticMessageInheritMode synthetic_message_inherit_mode;
   SyntheticMessage *synthetic_message;
   FilterExprNode *trigger_condition_expr;
   FilterExprNode *where_condition_expr;
@@ -72,14 +71,6 @@ grouping_by_set_timeout(LogParser *s, gint timeout)
   GroupingBy *self = (GroupingBy *) s;
 
   self->timeout = timeout;
-}
-
-void
-grouping_by_set_inherit_properties(LogParser *s, SyntheticMessageInheritMode inherit_mode)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  self->synthetic_message_inherit_mode = inherit_mode;
 }
 
 void
@@ -209,7 +200,7 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
     {
       GString *buffer = g_string_sized_new(256);
 
-      msg = synthetic_message_generate_with_context(self->synthetic_message, self->synthetic_message_inherit_mode, context, buffer);
+      msg = synthetic_message_generate_with_context(self->synthetic_message, context, buffer);
       stateful_parser_emit_synthetic(&self->super, msg);
       log_msg_unref(msg);
       g_string_free(buffer, TRUE);
@@ -440,7 +431,6 @@ grouping_by_new(GlobalConfig *cfg)
   self->super.super.process = grouping_by_process;
   g_static_mutex_init(&self->lock);
   self->scope = RCS_GLOBAL;
-  self->synthetic_message_inherit_mode = RAC_MSG_INHERIT_CONTEXT;
   self->timer_wheel = timer_wheel_new();
   timer_wheel_set_associated_data(self->timer_wheel, self, NULL);
   cached_g_current_time(&self->last_tick);

--- a/modules/dbparser/groupingby.h
+++ b/modules/dbparser/groupingby.h
@@ -33,7 +33,6 @@ void grouping_by_set_synthetic_message(LogParser *s, SyntheticMessage *message);
 void grouping_by_set_trigger_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_where_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_having_condition(LogParser *s, FilterExprNode *filter_expr);
-void grouping_by_set_inherit_properties(LogParser *s, SyntheticMessageInheritMode inherit_mode);
 LogParser *grouping_by_new(GlobalConfig *cfg);
 void grouping_by_global_init(void);
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -254,9 +254,9 @@ LogMessage *
 pdb_generate_message(PDBAction *self, PDBContext *context, LogMessage *msg, GString *buffer)
 {
   if (context)
-    return synthetic_message_generate_with_context(&self->content.message, self->content.inherit_mode, &context->super, buffer);
+    return synthetic_message_generate_with_context(&self->content.message, &context->super, buffer);
   else
-    return synthetic_message_generate_without_context(&self->content.message, self->content.inherit_mode, msg, buffer);
+    return synthetic_message_generate_without_context(&self->content.message, msg, buffer);
 }
 
 void

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -80,24 +80,34 @@ pdb_action_set_trigger(PDBAction *self, const gchar *trigger, GError **error)
 void
 pdb_action_set_message_inherit_properties(PDBAction *self, const gchar *inherit_properties, GError **error)
 {
+  SyntheticMessageInheritMode inherit_mode;
+
   if (strcasecmp(inherit_properties, "context") == 0)
-    self->content.inherit_mode = RAC_MSG_INHERIT_CONTEXT;
+    {
+      inherit_mode = RAC_MSG_INHERIT_CONTEXT;
+    }
   else if (inherit_properties[0] == 'T' || inherit_properties[0] == 't' ||
       inherit_properties[0] == '1')
-    self->content.inherit_mode = RAC_MSG_INHERIT_LAST_MESSAGE;
+    {
+      inherit_mode = RAC_MSG_INHERIT_LAST_MESSAGE;
+    }
   else if (inherit_properties[0] == 'F' || inherit_properties[0] == 'f' ||
            inherit_properties[0] == '0')
-    self->content.inherit_mode = RAC_MSG_INHERIT_NONE;
+    {
+      inherit_mode = RAC_MSG_INHERIT_NONE;
+    }
   else
-    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-properties: %s", inherit_properties);
+    {
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-properties: %s", inherit_properties);
+      return;
+    }
+  synthetic_message_set_inherit_mode(&self->content.message, inherit_mode);
 }
 
 void
 pdb_action_set_message_inherit_mode(PDBAction *self, const gchar *inherit_mode, GError **error)
 {
-  self->content.message.inherit_mode = synthetic_message_lookup_inherit_mode(inherit_mode);
-  if (self->content.message.inherit_mode < 0)
-    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-mode: %s", inherit_mode);
+  synthetic_message_set_inherit_mode_string(&self->content.message, inherit_mode, error);
 }
 
 PDBAction *

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -95,7 +95,16 @@ pdb_action_free(PDBAction *self)
 {
   if (self->condition)
     filter_expr_unref(self->condition);
-  if (self->content_type == RAC_MESSAGE)
-    synthetic_message_deinit(&self->content.message);
+  switch (self->content_type)
+    {
+    case RAC_MESSAGE:
+      synthetic_message_deinit(&self->content.message);
+      break;
+    case RAC_CREATE_CONTEXT:
+      synthetic_context_deinit(&self->content.create_context.context);
+      break;
+    default:
+      g_assert_not_reached();
+    }
   g_free(self);
 }

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -78,7 +78,7 @@ pdb_action_set_trigger(PDBAction *self, const gchar *trigger, GError **error)
 }
 
 void
-pdb_action_set_message_inheritance(PDBAction *self, const gchar *inherit_properties, GError **error)
+pdb_action_set_message_inherit_properties(PDBAction *self, const gchar *inherit_properties, GError **error)
 {
   if (strcasecmp(inherit_properties, "context") == 0)
     self->content.inherit_mode = RAC_MSG_INHERIT_CONTEXT;
@@ -89,9 +89,16 @@ pdb_action_set_message_inheritance(PDBAction *self, const gchar *inherit_propert
            inherit_properties[0] == '0')
     self->content.inherit_mode = RAC_MSG_INHERIT_NONE;
   else
-    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inheritance type: %s", inherit_properties);
+    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-properties: %s", inherit_properties);
 }
 
+void
+pdb_action_set_message_inherit_mode(PDBAction *self, const gchar *inherit_mode, GError **error)
+{
+  self->content.message.inherit_mode = synthetic_message_lookup_inherit_mode(inherit_mode);
+  if (self->content.message.inherit_mode < 0)
+    g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-mode: %s", inherit_mode);
+}
 
 PDBAction *
 pdb_action_new(gint id)

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -77,39 +77,6 @@ pdb_action_set_trigger(PDBAction *self, const gchar *trigger, GError **error)
     g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown trigger type: %s", trigger);
 }
 
-void
-pdb_action_set_message_inherit_properties(PDBAction *self, const gchar *inherit_properties, GError **error)
-{
-  SyntheticMessageInheritMode inherit_mode;
-
-  if (strcasecmp(inherit_properties, "context") == 0)
-    {
-      inherit_mode = RAC_MSG_INHERIT_CONTEXT;
-    }
-  else if (inherit_properties[0] == 'T' || inherit_properties[0] == 't' ||
-      inherit_properties[0] == '1')
-    {
-      inherit_mode = RAC_MSG_INHERIT_LAST_MESSAGE;
-    }
-  else if (inherit_properties[0] == 'F' || inherit_properties[0] == 'f' ||
-           inherit_properties[0] == '0')
-    {
-      inherit_mode = RAC_MSG_INHERIT_NONE;
-    }
-  else
-    {
-      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-properties: %s", inherit_properties);
-      return;
-    }
-  synthetic_message_set_inherit_mode(&self->content.message, inherit_mode);
-}
-
-void
-pdb_action_set_message_inherit_mode(PDBAction *self, const gchar *inherit_mode, GError **error)
-{
-  synthetic_message_set_inherit_mode_string(&self->content.message, inherit_mode, error);
-}
-
 PDBAction *
 pdb_action_new(gint id)
 {

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -62,7 +62,8 @@ typedef struct _PDBAction
 void pdb_action_set_condition(PDBAction *self, GlobalConfig *cfg, const gchar *filter_string, GError **error);
 void pdb_action_set_rate(PDBAction *self, const gchar *rate_);
 void pdb_action_set_trigger(PDBAction *self, const gchar *trigger, GError **error);
-void pdb_action_set_message_inheritance(PDBAction *self, const gchar *inherit_properties, GError **error);
+void pdb_action_set_message_inherit_mode(PDBAction *self, const gchar *inherit_mode, GError **error);
+void pdb_action_set_message_inherit_properties(PDBAction *self, const gchar *inherit_properties, GError **error);
 
 PDBAction *pdb_action_new(gint id);
 void pdb_action_free(PDBAction *self);

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -25,6 +25,7 @@
 
 #include "syslog-ng.h"
 #include "synthetic-message.h"
+#include "synthetic-context.h"
 #include "filter/filter-expr.h"
 
 /* rule action triggers */
@@ -38,7 +39,8 @@ typedef enum
 typedef enum
 {
   RAC_NONE,
-  RAC_MESSAGE
+  RAC_MESSAGE,
+  RAC_CREATE_CONTEXT,
 } PDBActionContentType;
 
 /* a rule may contain one or more actions to be performed */
@@ -53,6 +55,11 @@ typedef struct _PDBAction
   union
   {
     SyntheticMessage message;
+    struct
+    {
+      SyntheticMessage message;
+      SyntheticContext context;
+    } create_context;
   } content;
 } PDBAction;
 

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -52,10 +52,7 @@ typedef struct _PDBAction
   guint8 id;
   union
   {
-    struct {
-      SyntheticMessage message;
-      SyntheticMessageInheritMode inherit_mode;
-    };
+    SyntheticMessage message;
   } content;
 } PDBAction;
 

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -59,8 +59,6 @@ typedef struct _PDBAction
 void pdb_action_set_condition(PDBAction *self, GlobalConfig *cfg, const gchar *filter_string, GError **error);
 void pdb_action_set_rate(PDBAction *self, const gchar *rate_);
 void pdb_action_set_trigger(PDBAction *self, const gchar *trigger, GError **error);
-void pdb_action_set_message_inherit_mode(PDBAction *self, const gchar *inherit_mode, GError **error);
-void pdb_action_set_message_inherit_properties(PDBAction *self, const gchar *inherit_properties, GError **error);
 
 PDBAction *pdb_action_new(gint id);
 void pdb_action_free(PDBAction *self);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -50,7 +50,6 @@ enum PDBLoaderState
   PDBL_RULE_ACTIONS,
   PDBL_RULE_ACTION,
   PDBL_RULE_ACTION_MESSAGE,
-  PDBL_RULE_ACTION_MESSAGE_TAG,
 
   /* generic states, reused by multiple paths in the XML */
   PDBL_VALUE,
@@ -432,7 +431,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "tag") == 0)
         {
-          state->current_state = PDBL_RULE_ACTION_MESSAGE_TAG;
+          _process_tag_element(state, attribute_names, attribute_values, error);
         }
       else
         {
@@ -673,16 +672,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           pdb_loader_set_error(state, error, "Unexpected </%s> tag, expected a </message>, </values> or </tags>", element_name);
         }
       break;
-    case PDBL_RULE_ACTION_MESSAGE_TAG:
-      if (strcmp(element_name, "tag") == 0)
-        {
-          state->current_state = PDBL_RULE_ACTION_MESSAGE;
-        }
-      else
-        {
-          pdb_loader_set_error(state, error, "Unexpected </%s> tag, expected a </tag>", element_name);
-        }
-      break;
 
     /* generic states reused by multiple locations in the grammar */
 
@@ -761,9 +750,6 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
       program_pattern.pattern = g_strdup(text);
       program_pattern.rule = pdb_rule_ref(state->current_rule);
       g_array_append_val(state->program_patterns, program_pattern);
-      break;
-    case PDBL_RULE_ACTION_MESSAGE_TAG:
-      synthetic_message_add_tag(state->current_message, text);
       break;
     case PDBL_RULE_EXAMPLE:
       break;

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -621,6 +621,19 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </actions>", element_name);
         }
       break;
+    case PDBL_RULE_ACTION:
+      if (strcmp(element_name, "action") == 0)
+        {
+          state->in_action = FALSE;
+          pdb_rule_add_action(state->current_rule, state->current_action);
+          state->current_action = NULL;
+          state->current_state = PDBL_RULE_ACTIONS;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </action>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "value") == 0)
         {
@@ -631,13 +644,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
         }
       else if (strcmp(element_name, "tag") == 0)
         state->in_tag = FALSE;
-      else if (strcmp(element_name, "action") == 0)
-        {
-          state->in_action = FALSE;
-          pdb_rule_add_action(state->current_rule, state->current_action);
-          state->current_action = NULL;
-          state->current_state = PDBL_RULE_ACTIONS;
-        }
       else if (strcmp(element_name, "message") == 0)
         {
           state->current_message = &state->current_rule->msg;

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -440,7 +440,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </patterndb>", element_name);
         }
       break;
-    default:
+    case PDBL_RULESET:
       if (strcmp(element_name, "ruleset") == 0)
         {
           if (!state->in_ruleset)
@@ -470,7 +470,21 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           state->program_patterns = NULL;
           state->current_state = PDBL_PATTERNDB;
         }
-      else if (strcmp(element_name, "examples") == 0)
+      else if (strcmp(element_name, "patterns") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "pattern") == 0)
+        {
+          state->in_pattern = FALSE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </ruleset>, </patterns> or </pattern>", element_name);
+        }
+      break;
+    default:
+      if (strcmp(element_name, "examples") == 0)
         {
           state->current_state = PDBL_RULE;
         }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -547,12 +547,18 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rule>, </patterns>, </pattern>, </description>, </tags>, </tag>, </values> or </value>", element_name);
         }
       break;
-    default:
+    case PDBL_RULE_EXAMPLES:
       if (strcmp(element_name, "examples") == 0)
         {
           state->current_state = PDBL_RULE;
         }
-      else if (strcmp(element_name, "example") == 0)
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </examples>", element_name);
+        }
+      break;
+    default:
+      if (strcmp(element_name, "example") == 0)
         {
           if (!state->in_example)
             {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -65,7 +65,6 @@ typedef struct _PDBLoader
   gboolean in_pattern;
   gboolean in_ruleset;
   gboolean in_tag;
-  gboolean in_example;
   gboolean in_test_msg;
   gboolean in_test_value;
   gboolean in_action;
@@ -290,13 +289,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_EXAMPLES:
       if (strcmp(element_name, "example") == 0)
         {
-          if (state->in_example)
-            {
-              pdb_loader_set_error(state, error, "Unexpected <example> element");
-              return;
-            }
-
-          state->in_example = TRUE;
           state->current_example = g_new0(PDBExample, 1);
           state->current_example->rule = pdb_rule_ref(state->current_rule);
           state->current_state = PDBL_RULE_EXAMPLE;
@@ -309,7 +301,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "test_message") == 0)
         {
-          if (state->in_test_msg || !state->in_example)
+          if (state->in_test_msg)
             {
               pdb_loader_set_error(state, error, "Unexpected <test_message> element");
               return;
@@ -329,7 +321,7 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "test_value") == 0)
         {
-          if (state->in_test_value || !state->in_example)
+          if (state->in_test_value)
             {
               pdb_loader_set_error(state, error, "Unexpected <test_value> element");
               return;
@@ -583,14 +575,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "example") == 0)
         {
-          if (!state->in_example)
-            {
-              pdb_loader_set_error(state, error, "Unexpected </example> element");
-              return;
-            }
-
-          state->in_example = FALSE;
-
           if (state->load_examples)
             state->examples = g_list_prepend(state->examples, state->current_example);
           else

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -493,6 +493,60 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rules>", element_name);
         }
       break;
+    case PDBL_RULE:
+      if (strcmp(element_name, "rule") == 0)
+        {
+          if (!state->in_rule)
+            {
+              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
+              return;
+            }
+
+          state->in_rule = FALSE;
+          if (state->current_rule)
+            {
+              pdb_rule_unref(state->current_rule);
+              state->current_rule = NULL;
+            }
+          state->current_message = NULL;
+          state->current_state = PDBL_RULES;
+        }
+      else if (strcmp(element_name, "patterns") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "pattern") == 0)
+        {
+          state->in_pattern = FALSE;
+        }
+      else if (strcmp(element_name, "description") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "tags") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "tag") == 0)
+        {
+          state->in_tag = FALSE;
+        }
+      else if (strcmp(element_name, "values") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "value") == 0)
+        {
+          if (state->value_name)
+            g_free(state->value_name);
+
+          state->value_name = NULL;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rule>, </patterns>, </pattern>, </description>, </tags>, </tag>, </values> or </value>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "examples") == 0)
         {
@@ -540,23 +594,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
             g_free(state->test_value_name);
 
           state->test_value_name = NULL;
-        }
-      else if (strcmp(element_name, "rule") == 0)
-        {
-          if (!state->in_rule)
-            {
-              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </rule> element");
-              return;
-            }
-
-          state->in_rule = FALSE;
-          if (state->current_rule)
-            {
-              pdb_rule_unref(state->current_rule);
-              state->current_rule = NULL;
-            }
-          state->current_message = NULL;
-          state->current_state = PDBL_RULES;
         }
       else if (strcmp(element_name, "value") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -557,7 +557,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </examples>", element_name);
         }
       break;
-    default:
+    case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "example") == 0)
         {
           if (!state->in_example)
@@ -586,6 +586,10 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
           state->in_test_msg = FALSE;
         }
+      else if (strcmp(element_name, "test_values") == 0)
+        {
+          /* */
+        }
       else if (strcmp(element_name, "test_value") == 0)
         {
           if (!state->in_test_value)
@@ -601,7 +605,13 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
           state->test_value_name = NULL;
         }
-      else if (strcmp(element_name, "value") == 0)
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </example>, </test_message>, </test_value>", element_name);
+        }
+      break;
+    default:
+      if (strcmp(element_name, "value") == 0)
         {
           if (state->value_name)
             g_free(state->value_name);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -664,6 +664,9 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </message>", element_name);
         }
       break;
+    default:
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected state %d, tag <%s>", state->current_state, element_name);
+      break;
     }
 }
 

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -67,7 +67,6 @@ typedef struct _PDBLoader
   SyntheticMessage *current_message;
   enum PDBLoaderState current_state;
   gboolean first_program;
-  gboolean in_test_msg;
   gboolean in_test_value;
   gboolean load_examples;
   GList *examples;
@@ -295,14 +294,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_EXAMPLE:
       if (strcmp(element_name, "test_message") == 0)
         {
-          if (state->in_test_msg)
-            {
-              pdb_loader_set_error(state, error, "Unexpected <test_message> element");
-              return;
-            }
-
-          state->in_test_msg = TRUE;
-
           for (i = 0; attribute_names[i]; i++)
             {
               if (strcmp(attribute_names[i], "program") == 0)
@@ -607,13 +598,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_EXAMPLE_TEST_MESSAGE:
       if (strcmp(element_name, "test_message") == 0)
         {
-          if (!state->in_test_msg)
-            {
-              pdb_loader_set_error(state, error, "Unexpected </test_message> element");
-              return;
-            }
-
-          state->in_test_msg = FALSE;
           state->current_state = PDBL_RULE_EXAMPLE;
         }
       else
@@ -773,10 +757,7 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
         }
       break;
     case PDBL_RULE_EXAMPLE_TEST_MESSAGE:
-      if (state->in_test_msg)
-        {
-          state->current_example->message = g_strdup(text);
-        }
+      state->current_example->message = g_strdup(text);
       break;
     default:
       if (!_is_whitespace_only(text, text_len))

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -37,6 +37,7 @@ enum PDBLoaderState
   PDBL_INITIAL = 0,
   PDBL_PATTERNDB,
   PDBL_RULESET,
+  PDBL_RULES,
 };
 
 /* arguments passed to the markup parser functions */
@@ -134,6 +135,24 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else
         {
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <ruleset>", element_name);
+        }
+      break;
+    case PDBL_RULESET:
+      if (strcmp(element_name, "rules") == 0)
+        {
+          state->current_state = PDBL_RULES;
+        }
+      else if (strcmp(element_name, "patterns") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "pattern") == 0)
+        {
+          state->in_pattern = TRUE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <rules>, <patterns> or <pattern>", element_name);
         }
       break;
     default:
@@ -380,6 +399,10 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
             g_free(state->test_value_name);
 
           state->test_value_name = NULL;
+        }
+      else if (strcmp(element_name, "rules") == 0)
+        {
+          state->current_state = PDBL_RULESET;
         }
       else if (strcmp(element_name, "rule") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -428,13 +428,19 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
   switch (state->current_state)
     {
-    default:
+    case PDBL_PATTERNDB:
       if (strcmp(element_name, "patterndb") == 0)
         {
           g_hash_table_foreach(state->ruleset_patterns, _populate_ruleset_radix, state);
           g_hash_table_remove_all(state->ruleset_patterns);
           state->current_state = PDBL_INITIAL;
         }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </patterndb>", element_name);
+        }
+      break;
+    default:
       if (strcmp(element_name, "ruleset") == 0)
         {
           if (!state->in_ruleset)

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -634,21 +634,36 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </action>", element_name);
         }
       break;
-    default:
-      if (strcmp(element_name, "value") == 0)
+    case PDBL_RULE_ACTION_MESSAGE:
+      if (strcmp(element_name, "message") == 0)
+        {
+          state->current_message = &state->current_rule->msg;
+          state->current_state = PDBL_RULE_ACTION;
+        }
+      else if (strcmp(element_name, "values") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "value") == 0)
         {
           if (state->value_name)
             g_free(state->value_name);
 
           state->value_name = NULL;
         }
-      else if (strcmp(element_name, "tag") == 0)
-        state->in_tag = FALSE;
-      else if (strcmp(element_name, "message") == 0)
+      else if (strcmp(element_name, "tags") == 0)
         {
-          state->current_message = &state->current_rule->msg;
-          state->current_state = PDBL_RULE_ACTION;
+          /* valid, but we don't do anything */
         }
+      else if (strcmp(element_name, "tag") == 0)
+        {
+          state->in_tag = FALSE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </message>", element_name);
+        }
+      break;
     }
 }
 

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -64,7 +64,6 @@ typedef struct _PDBLoader
   SyntheticMessage *current_message;
   enum PDBLoaderState current_state;
   gboolean first_program;
-  gboolean in_pattern;
   gboolean in_tag;
   gboolean in_test_msg;
   gboolean in_test_value;
@@ -183,7 +182,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "pattern") == 0)
         {
-          state->in_pattern = TRUE;
           state->current_state = PDBL_RULESET_PATTERN;
         }
       else
@@ -240,7 +238,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else if (strcmp(element_name, "pattern") == 0)
         {
           state->current_state = PDBL_RULE_PATTERN;
-          state->in_pattern = TRUE;
         }
       else if (strcmp(element_name, "description") == 0)
         {
@@ -483,7 +480,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULESET_PATTERN:
       if (strcmp(element_name, "pattern") == 0)
         {
-          state->in_pattern = FALSE;
           state->current_state = PDBL_RULESET;
         }
       else

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -610,6 +610,17 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </example>, </test_message>, </test_value>", element_name);
         }
       break;
+    case PDBL_RULE_ACTIONS:
+      if (strcmp(element_name, "actions") == 0)
+        {
+          g_assert(state->current_state == PDBL_RULE_ACTIONS);
+          state->current_state = PDBL_RULE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </actions>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "value") == 0)
         {
@@ -626,11 +637,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           pdb_rule_add_action(state->current_rule, state->current_action);
           state->current_action = NULL;
           state->current_state = PDBL_RULE_ACTIONS;
-        }
-      else if (strcmp(element_name, "actions") == 0)
-        {
-          g_assert(state->current_state == PDBL_RULE_ACTIONS);
-          state->current_state = PDBL_RULE;
         }
       else if (strcmp(element_name, "message") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -483,6 +483,16 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </ruleset>, </patterns> or </pattern>", element_name);
         }
       break;
+    case PDBL_RULES:
+      if (strcmp(element_name, "rules") == 0)
+        {
+          state->current_state = PDBL_RULESET;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected </%s> tag, expected a </rules>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "examples") == 0)
         {
@@ -530,10 +540,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
             g_free(state->test_value_name);
 
           state->test_value_name = NULL;
-        }
-      else if (strcmp(element_name, "rules") == 0)
-        {
-          state->current_state = PDBL_RULESET;
         }
       else if (strcmp(element_name, "rule") == 0)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -308,6 +308,34 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
           g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <message>", element_name);
         }
       break;
+    case PDBL_RULE_ACTION_MESSAGE:
+      if (strcmp(element_name, "values") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "value") == 0)
+        {
+          if (attribute_names[0] && g_str_equal(attribute_names[0], "name"))
+            state->value_name = g_strdup(attribute_values[0]);
+          else
+            {
+              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute in rule %s", state->current_rule->rule_id);
+              return;
+            }
+        }
+      else if (strcmp(element_name, "tags") == 0)
+        {
+          /* valid, but we don't do anything */
+        }
+      else if (strcmp(element_name, "tag") == 0)
+        {
+          state->in_tag = TRUE;
+        }
+      else
+        {
+          g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected <%s> tag, expected a <values>, <value>, <tags> or <tag>", element_name);
+        }
+      break;
     default:
       if (strcmp(element_name, "example") == 0)
         {
@@ -354,25 +382,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
               msg_error("No name is specified for test_value",
                         evt_tag_str("rule_id", state->current_rule->rule_id));
               g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<test_value> misses name attribute");
-              return;
-            }
-        }
-      else if (strcmp(element_name, "pattern") == 0)
-        {
-          state->in_pattern = TRUE;
-        }
-      else if (strcmp(element_name, "tag") == 0)
-        {
-          state->in_tag = TRUE;
-        }
-      else if (strcmp(element_name, "value") == 0)
-        {
-          if (attribute_names[0] && g_str_equal(attribute_names[0], "name"))
-            state->value_name = g_strdup(attribute_values[0]);
-          else
-            {
-              msg_error("No name is specified for value", evt_tag_str("rule_id", state->current_rule->rule_id));
-              g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "<value> misses name attribute");
               return;
             }
         }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -618,8 +618,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
 
           state->value_name = NULL;
         }
-      else if (strcmp(element_name, "pattern") == 0)
-        state->in_pattern = FALSE;
       else if (strcmp(element_name, "tag") == 0)
         state->in_tag = FALSE;
       else if (strcmp(element_name, "action") == 0)

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -703,7 +703,7 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
         }
       break;
     default:
-      pdb_loader_set_error(state, error, "Unexpected state %d, tag <%s>", state->current_state, element_name);
+      pdb_loader_set_error(state, error, "Unexpected state %d, tag </%s>", state->current_state, element_name);
       break;
     }
 }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -66,7 +66,6 @@ typedef struct _PDBLoader
   SyntheticMessage *current_message;
   enum PDBLoaderState current_state;
   gboolean first_program;
-  gboolean in_tag;
   gboolean in_test_msg;
   gboolean in_test_value;
   gboolean load_examples;
@@ -251,7 +250,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = TRUE;
           state->current_state = PDBL_RULE_TAG;
         }
       else if (strcmp(element_name, "values") == 0)
@@ -403,7 +401,6 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
         }
       else if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = TRUE;
           state->current_state = PDBL_RULE_ACTION_MESSAGE_TAG;
         }
       else
@@ -543,7 +540,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_TAG:
       if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = FALSE;
           state->current_state = PDBL_RULE;
         }
       else
@@ -668,7 +664,6 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
     case PDBL_RULE_ACTION_MESSAGE_TAG:
       if (strcmp(element_name, "tag") == 0)
         {
-          state->in_tag = FALSE;
           state->current_state = PDBL_RULE_ACTION_MESSAGE;
         }
       else

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -82,6 +82,19 @@ typedef struct _PDBProgramPattern
   PDBRule *rule;
 } PDBProgramPattern;
 
+static gboolean
+_is_whitespace_only(const gchar *text, gsize text_len)
+{
+  gint i;
+
+  for (i = 0; i < text_len; i++)
+    {
+      if (!g_ascii_isspace(text[i]))
+        return FALSE;
+    }
+  return TRUE;
+}
+
 void
 pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name, const gchar **attribute_names,
                          const gchar **attribute_values, gpointer user_data, GError **error)
@@ -793,6 +806,8 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
         }
       break;
     default:
+      if (!_is_whitespace_only(text, text_len))
+        g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unexpected text node in state %d, text=[[%s]]", state->current_state, text);
       break;
     }
 }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -176,7 +176,9 @@ _process_message_element(PDBLoader *state,
   for (i = 0; attribute_names[i]; i++)
     {
       if (strcmp(attribute_names[i], "inherit-properties") == 0)
-        pdb_action_set_message_inheritance(state->current_action, attribute_values[i], error);
+        pdb_action_set_message_inherit_properties(state->current_action, attribute_values[i], error);
+      else if (strcmp(attribute_names[i], "inherit-mode") == 0)
+        pdb_action_set_message_inherit_mode(state->current_action, attribute_values[i], error);
     }
   state->current_message = &state->current_action->content.message;
   _push_state(state, PDBL_MESSAGE);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -38,6 +38,7 @@ enum PDBLoaderState
   PDBL_INITIAL = 0,
   PDBL_PATTERNDB,
   PDBL_RULESET,
+  PDBL_RULESET_DESCRIPTION,
   PDBL_RULESET_PATTERN,
   PDBL_RULES,
   PDBL_RULE,
@@ -279,6 +280,10 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
       else if (strcmp(element_name, "pattern") == 0)
         {
           state->current_state = PDBL_RULESET_PATTERN;
+        }
+      else if (strcmp(element_name, "description") == 0)
+        {
+          state->current_state = PDBL_RULESET_DESCRIPTION;
         }
       else
         {
@@ -580,6 +585,16 @@ pdb_loader_end_element(GMarkupParseContext *context, const gchar *element_name, 
           pdb_loader_set_error(state, error, "Unexpected </%s> tag, expected </pattern>", element_name);
         }
       break;
+    case PDBL_RULESET_DESCRIPTION:
+      if (strcmp(element_name, "description") == 0)
+        {
+          state->current_state = PDBL_RULESET;
+        }
+      else
+        {
+          pdb_loader_set_error(state, error, "Unexpected </%s> tag, expected a </description>", element_name);
+        }
+      break;    
     case PDBL_RULES:
       if (strcmp(element_name, "rules") == 0)
         {
@@ -788,6 +803,8 @@ pdb_loader_text(GMarkupParseContext *context, const gchar *text, gsize text_len,
 
   switch (state->current_state)
     {
+    case PDBL_RULESET_DESCRIPTION:
+      break;
     case PDBL_RULESET_PATTERN:
       if (state->first_program)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -176,9 +176,9 @@ _process_message_element(PDBLoader *state,
   for (i = 0; attribute_names[i]; i++)
     {
       if (strcmp(attribute_names[i], "inherit-properties") == 0)
-        pdb_action_set_message_inherit_properties(state->current_action, attribute_values[i], error);
+        synthetic_message_set_inherit_properties_string(target, attribute_values[i], error);
       else if (strcmp(attribute_names[i], "inherit-mode") == 0)
-        pdb_action_set_message_inherit_mode(state->current_action, attribute_values[i], error);
+        synthetic_message_set_inherit_mode_string(target, attribute_values[i], error);
     }
   state->current_message = &state->current_action->content.message;
   _push_state(state, PDBL_MESSAGE);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -199,12 +199,19 @@ _process_create_context_element(PDBLoader *state,
       if (strcmp(attribute_names[i], "context-id") == 0)
         {
           LogTemplate *template;
+          GError *local_error = NULL;
 
           template = log_template_new(state->cfg, NULL);
-          if (log_template_compile(template, attribute_values[i], error))
-            synthetic_context_set_context_id_template(target, template);
+          if (!log_template_compile(template, attribute_values[i], &local_error))
+            {
+              log_template_unref(template);
+              pdb_loader_set_error(state, error,
+                                   "Error compiling create-context context-id, rule=%s, context-id=%s, error=%s",
+                                   state->current_rule->rule_id, attribute_values[i], local_error->message);
+              g_clear_error(&local_error);
+            }
           else
-            log_template_unref(template);
+            synthetic_context_set_context_id_template(target, template);
         }
       else if (strcmp(attribute_names[i], "context-timeout") == 0)
         synthetic_context_set_context_timeout(target, strtol(attribute_values[i], NULL, 0));
@@ -303,12 +310,19 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
               else if (strcmp(attribute_names[i], "context-id") == 0)
                 {
                   LogTemplate *template;
+                  GError *local_error = NULL;
 
                   template = log_template_new(state->cfg, NULL);
-                  if (log_template_compile(template, attribute_values[i], error))
-                    synthetic_context_set_context_id_template(&state->current_rule->context, template);
+                  if (!log_template_compile(template, attribute_values[i], &local_error))
+                    {
+                      log_template_unref(template);
+                      pdb_loader_set_error(state, error,
+                                           "Error compiling context-id template, rule=%s, context-id=%s, error=%s",
+                                           state->current_rule->rule_id, attribute_values[i], local_error->message);
+                      g_clear_error(&local_error);
+                    }
                   else
-                    log_template_unref(template);
+                    synthetic_context_set_context_id_template(&state->current_rule->context, template);
                 }
               else if (strcmp(attribute_names[i], "context-timeout") == 0)
                 synthetic_context_set_context_timeout(&state->current_rule->context, strtol(attribute_values[i], NULL, 0));

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -271,13 +271,15 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
                   LogTemplate *template;
 
                   template = log_template_new(state->cfg, NULL);
-                  log_template_compile(template, attribute_values[i], NULL);
-                  pdb_rule_set_context_id_template(state->current_rule, template);
+                  if (log_template_compile(template, attribute_values[i], error))
+                    synthetic_context_set_context_id_template(&state->current_rule->context, template);
+                  else
+                    log_template_unref(template);
                 }
               else if (strcmp(attribute_names[i], "context-timeout") == 0)
-                pdb_rule_set_context_timeout(state->current_rule, strtol(attribute_values[i], NULL, 0));
+                synthetic_context_set_context_timeout(&state->current_rule->context, strtol(attribute_values[i], NULL, 0));
               else if (strcmp(attribute_names[i], "context-scope") == 0)
-                pdb_rule_set_context_scope(state->current_rule, attribute_values[i], error);
+                synthetic_context_set_context_scope(&state->current_rule->context, attribute_values[i], error);
             }
 
           if (!state->current_rule->rule_id)

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -168,11 +168,11 @@ _process_tag_element(PDBLoader *state,
 static void
 _process_message_element(PDBLoader *state,
                          const gchar **attribute_names, const gchar **attribute_values,
+                         SyntheticMessage *target,
                          GError **error)
 {
   gint i;
 
-  state->current_action->content_type = RAC_MESSAGE;
   for (i = 0; attribute_names[i]; i++)
     {
       if (strcmp(attribute_names[i], "inherit-properties") == 0)
@@ -180,7 +180,7 @@ _process_message_element(PDBLoader *state,
       else if (strcmp(attribute_names[i], "inherit-mode") == 0)
         synthetic_message_set_inherit_mode_string(target, attribute_values[i], error);
     }
-  state->current_message = &state->current_action->content.message;
+  state->current_message = target;
   _push_state(state, PDBL_MESSAGE);
 }
 
@@ -421,7 +421,8 @@ pdb_loader_start_element(GMarkupParseContext *context, const gchar *element_name
     case PDBL_RULE_ACTION:
       if (strcmp(element_name, "message") == 0)
         {
-          _process_message_element(state, attribute_names, attribute_values, error);
+          state->current_action->content_type = RAC_MESSAGE;
+          _process_message_element(state, attribute_names, attribute_values, &state->current_action->content.message, error);
         }
       else
         {

--- a/modules/dbparser/pdb-rule.c
+++ b/modules/dbparser/pdb-rule.c
@@ -73,6 +73,7 @@ pdb_rule_new(void)
 
   g_atomic_counter_set(&self->ref_cnt, 1);
   synthetic_context_init(&self->context);
+  synthetic_message_init(&self->msg);
   return self;
 }
 

--- a/modules/dbparser/pdb-rule.h
+++ b/modules/dbparser/pdb-rule.h
@@ -37,17 +37,12 @@ struct _PDBRule
   gchar *class;
   gchar *rule_id;
   SyntheticMessage msg;
-  gint context_timeout;
-  CorrellationScope context_scope;
-  LogTemplate *context_id_template;
+  SyntheticContext context;
   GPtrArray *actions;
 };
 
 void pdb_rule_set_class(PDBRule *self, const gchar *class);
 void pdb_rule_set_rule_id(PDBRule *self, const gchar *rule_id);
-void pdb_rule_set_context_id_template(PDBRule *self, LogTemplate *context_id_template);
-void pdb_rule_set_context_timeout(PDBRule *self, gint timeout);
-void pdb_rule_set_context_scope(PDBRule *self, const gchar *scope, GError **error);
 void pdb_rule_add_action(PDBRule *self, PDBAction *action);
 gchar *pdb_rule_get_name(PDBRule *self);
 

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -42,6 +42,7 @@
 #include "reloc.h"
 #include "pathutils.h"
 #include "resolved-configurable-paths.h"
+#include "crypto.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -1155,6 +1156,7 @@ main(int argc, char *argv[])
   log_template_global_init();
   log_tags_global_init();
   pattern_db_global_init();
+  crypto_init();
 
   configuration = cfg_new(VERSION_VALUE);
 
@@ -1180,6 +1182,7 @@ main(int argc, char *argv[])
 
   cfg_free(configuration);
   configuration = NULL;
+  crypto_deinit();
   msg_deinit();
   return ret;
 }

--- a/modules/dbparser/synthetic-context.c
+++ b/modules/dbparser/synthetic-context.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "synthetic-context.h"
+#include "pdb-error.h"
+
+#include <string.h>
+
+void
+synthetic_context_set_context_id_template(SyntheticContext *self, LogTemplate *context_id_template)
+{
+  if (self->id_template)
+    log_template_unref(self->id_template);
+  self->id_template = context_id_template;
+}
+
+void
+synthetic_context_set_context_timeout(SyntheticContext *self, gint timeout)
+{
+  self->timeout = timeout;
+}
+
+void
+synthetic_context_set_context_scope(SyntheticContext *self, const gchar *scope, GError **error)
+{
+  int context_scope = correllation_key_lookup_scope(scope);
+  if (context_scope < 0)
+    {
+      self->scope = RCS_GLOBAL;
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown context scope: %s", scope);
+    }
+  else
+    self->scope = context_scope;
+}
+
+void
+synthetic_context_init(SyntheticContext *self)
+{
+  memset(self, 0, sizeof(*self));
+  self->scope = RCS_PROCESS;
+}
+
+void
+synthetic_context_deinit(SyntheticContext *self)
+{
+  if (self->id_template)
+    log_template_unref(self->id_template);
+}

--- a/modules/dbparser/synthetic-context.h
+++ b/modules/dbparser/synthetic-context.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef PATTERNDB_SYNTHETIC_CONTEXT_H_INCLUDED
+#define PATTERNDB_SYNTHETIC_CONTEXT_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "correllation-key.h"
+#include "template/templates.h"
+
+typedef struct _SyntheticContext
+{
+  gint timeout;
+  CorrellationScope scope;
+  LogTemplate *id_template;
+} SyntheticContext;
+
+void synthetic_context_set_context_id_template(SyntheticContext *self, LogTemplate *context_id_template);
+void synthetic_context_set_context_timeout(SyntheticContext *self, gint timeout);
+void synthetic_context_set_context_scope(SyntheticContext *self, const gchar *scope, GError **error);
+
+void synthetic_context_init(SyntheticContext *self);
+void synthetic_context_deinit(SyntheticContext *self);
+
+gint synthetic_context_lookup_context_scope(const gchar *context_scope);
+
+#endif

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -48,6 +48,33 @@ synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const gchar *i
 }
 
 void
+synthetic_message_set_inherit_properties_string(SyntheticMessage *self, const gchar *inherit_properties, GError **error)
+{
+  SyntheticMessageInheritMode inherit_mode;
+
+  if (strcasecmp(inherit_properties, "context") == 0)
+    {
+      inherit_mode = RAC_MSG_INHERIT_CONTEXT;
+    }
+  else if (inherit_properties[0] == 'T' || inherit_properties[0] == 't' ||
+      inherit_properties[0] == '1')
+    {
+      inherit_mode = RAC_MSG_INHERIT_LAST_MESSAGE;
+    }
+  else if (inherit_properties[0] == 'F' || inherit_properties[0] == 'f' ||
+           inherit_properties[0] == '0')
+    {
+      inherit_mode = RAC_MSG_INHERIT_NONE;
+    }
+  else
+    {
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit-properties: %s", inherit_properties);
+      return;
+    }
+  synthetic_message_set_inherit_mode(self, inherit_mode);
+}
+
+void
 synthetic_message_add_tag(SyntheticMessage *self, const gchar *text)
 {
   LogTagId tag;

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -21,11 +21,31 @@
  *
  */
 #include "synthetic-message.h"
-
+#include "pdb-error.h"
 #include "template/templates.h"
 #include "tags.h"
 #include "logmsg/logmsg.h"
 #include "logpipe.h"
+
+void
+synthetic_message_set_inherit_mode(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode)
+{
+  self->inherit_mode = inherit_mode;
+}
+
+gboolean
+synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const gchar *inherit_mode_name, GError **error)
+{
+  gint inherit_mode = synthetic_message_lookup_inherit_mode(inherit_mode_name);
+
+  if (inherit_mode < 0)
+    {
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Unknown inherit mode %s", inherit_mode_name);
+      return FALSE;
+    }
+  synthetic_message_set_inherit_mode(self, inherit_mode);
+  return TRUE;
+}
 
 void
 synthetic_message_add_tag(SyntheticMessage *self, const gchar *text)
@@ -150,11 +170,11 @@ _generate_default_message_from_context(SyntheticMessageInheritMode inherit_mode,
 }
 
 LogMessage *
-synthetic_message_generate_with_context(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode, CorrellationContext *context, GString *buffer)
+synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context, GString *buffer)
 {
   LogMessage *genmsg;
 
-  genmsg = _generate_default_message_from_context(inherit_mode, context);
+  genmsg = _generate_default_message_from_context(self->inherit_mode, context);
   switch (context->key.scope)
     {
       case RCS_PROCESS:
@@ -176,11 +196,11 @@ synthetic_message_generate_with_context(SyntheticMessage *self, SyntheticMessage
 }
 
 LogMessage *
-synthetic_message_generate_without_context(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode, LogMessage *msg, GString *buffer)
+synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg, GString *buffer)
 {
   LogMessage *genmsg;
 
-  genmsg = _generate_default_message(inherit_mode, msg);
+  genmsg = _generate_default_message(self->inherit_mode, msg);
 
   /* no context, which means no correllation. The action
    * rule contains the generated message at @0 and the one
@@ -226,6 +246,7 @@ synthetic_message_new(void)
 {
   SyntheticMessage *self = g_new0(SyntheticMessage, 1);
 
+  self->inherit_mode = RAC_MSG_INHERIT_CONTEXT;
   return self;
 }
 

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -36,16 +36,19 @@ typedef enum
 
 typedef struct _SyntheticMessage
 {
+  SyntheticMessageInheritMode inherit_mode;
   GArray *tags;
   GPtrArray *values;
 } SyntheticMessage;
 
-LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode, LogMessage *msg, GString *buffer);
-LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode, CorrellationContext *context, GString *buffer);
+LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg, GString *buffer);
+LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context, GString *buffer);
 
 
 void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
 gboolean synthetic_message_add_value_template_string(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error);
+void synthetic_message_set_inherit_mode(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode);
+gboolean synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const gchar *inherit_mode_name, GError **error);
 void synthetic_message_add_value_template(SyntheticMessage *self, const gchar *name, LogTemplate *value);
 void synthetic_message_add_tag(SyntheticMessage *self, const gchar *text);
 void synthetic_message_init(SyntheticMessage *self);

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -48,6 +48,7 @@ LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, Corr
 void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
 gboolean synthetic_message_add_value_template_string(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error);
 void synthetic_message_set_inherit_mode(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode);
+void synthetic_message_set_inherit_properties_string(SyntheticMessage *self, const gchar *inherit_properties, GError **error);
 gboolean synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const gchar *inherit_mode_name, GError **error);
 void synthetic_message_add_value_template(SyntheticMessage *self, const gchar *name, LogTemplate *value);
 void synthetic_message_add_tag(SyntheticMessage *self, const gchar *text);

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -525,12 +525,16 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
      <examples>\
        <example>\
          <test_message program='prog1'>simple-message-with-rate-limited-action</test_message>\
+         <test_values>\
+            <test_value name='PROGRAM'>prog1</test_value>\
+            <test_value name='MESSAGE'>foobar</test_value>\
+         </test_values>\
        </example>\
        <example>\
          <test_message program='prog2'>simple-message-with-rate-limited-action</test_message>\
        </example>\
      </examples>\
-    </rule>\
+   </rule>\
   </rules>\
  </ruleset>\
 </patterndb>";

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -522,6 +522,14 @@ gchar *pdb_ruletest_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
          </message>\
        </action>\
      </actions>\
+     <examples>\
+       <example>\
+         <test_message program='prog1'>simple-message-with-rate-limited-action</test_message>\
+       </example>\
+       <example>\
+         <test_message program='prog2'>simple-message-with-rate-limited-action</test_message>\
+       </example>\
+     </examples>\
     </rule>\
   </rules>\
  </ruleset>\

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -375,6 +375,7 @@ test_conflicting_rules_with_the_same_parsers(void)
  * This tests those */
 gchar *pdb_ruletest_skeleton = "<patterndb version='5' pub_date='2010-02-22'>\
  <ruleset name='testset' id='1'>\
+  <description>This is a test set</description>\
   <patterns>\
     <pattern>prog1</pattern>\
     <pattern>prog2</pattern>\


### PR DESCRIPTION
This branch creates a new action in db-parser(), one to create a new context for upcoming messages. It all depends on a number of PRs waiting in the queue.

    
    <rule provider='test' id='12' class='violation'>
      <patterns>
        <pattern>simple-message-with-action-to-create-context</pattern>
      </patterns>
      <actions>
        <action trigger='match'>
          <create-context context-id='1000' context-timeout='60' context-scope='program'>
            <message inherit-properties='context'>
              <values>
                <value name='MESSAGE'>context message</value>
              </values>
            </message>
          </create-context>
        </action>
      </actions>
    </rule>