### PR TITLE
Add ability to use templates in both url and message format

### DIFF
--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
@@ -98,12 +98,20 @@ public class HTTPDestination extends StructuredLogDestination {
                 return false;
             }
             responseCode = connection.getResponseCode();
+            if (isHTTPResponseError(responseCode)) {
+                logger.error("HTTP response code error: " + responseCode);
+                return false;
+            }
         } catch (IOException | SecurityException | IllegalStateException e) {
             logger.debug("error in writing message." +
                     (responseCode != 0 ? "Response code is " + responseCode : ""));
             return false;
         }
         return true;
+    }
+
+    private static boolean isHTTPResponseError(int responseCode) {
+        return responseCode >= 400 && responseCode <= 599;
     }
 
     @Override

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
@@ -39,8 +39,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 
-public class HTTPDestination extends TextLogDestination {
-    private URL url;
+public class HTTPDestination extends StructuredLogDestination {
     Logger logger;
     private HTTPDestinationOptions options;
 
@@ -53,7 +52,7 @@ public class HTTPDestination extends TextLogDestination {
 
     @Override
     public String getNameByUniqOptions() {
-        return String.format("HTTPDestination,%s", options.getURL());
+        return String.format("HTTPDestination,%s", options.getURLTemplate());
     }
 
 
@@ -62,12 +61,7 @@ public class HTTPDestination extends TextLogDestination {
         try {
             options.init();
         } catch (InvalidOptionException e) {
-            return false;
-        }
-        try {
-            this.url = new URL(options.getURL());
-        } catch (MalformedURLException e) {
-            logger.error("A properly formatted URL is a required option for this destination");
+            logger.error(e);
             return false;
         }
         return true;
@@ -85,10 +79,14 @@ public class HTTPDestination extends TextLogDestination {
 
 
     @Override
-    public boolean send(String message) {
+    public boolean send(LogMessage msg) {
+        URL url;
         int responseCode = 0;
+        String message;
         try {
-            HttpURLConnection connection = (HttpURLConnection) this.url.openConnection();
+            url = new URL(options.getURLTemplate().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND));
+            message = options.getMessageTemplate().getResolvedString(msg, getTemplateOptionsHandle(), LogTemplate.LTZ_SEND);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod(options.getMethod());
             connection.setRequestProperty("content-length", Integer.toString(message.length()));
             connection.setDoOutput(true);
@@ -99,22 +97,13 @@ public class HTTPDestination extends TextLogDestination {
                 logger.error("error in writing message.");
                 return false;
             }
-
             responseCode = connection.getResponseCode();
-            if (isHTTPResponseError(responseCode)) {
-                logger.error("HTTP response code error: " + responseCode);
-                return false;
-            }
         } catch (IOException | SecurityException | IllegalStateException e) {
             logger.debug("error in writing message." +
                     (responseCode != 0 ? "Response code is " + responseCode : ""));
             return false;
         }
         return true;
-    }
-
-    private static boolean isHTTPResponseError(int responseCode) {
-        return responseCode >= 400 && responseCode <= 599;
     }
 
     @Override
@@ -128,7 +117,6 @@ public class HTTPDestination extends TextLogDestination {
     @Override
     public void deinit() {
     }
-
 
 }
 

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestinationOptions.java
@@ -32,6 +32,8 @@ import org.syslog_ng.options.*;
 public class HTTPDestinationOptions {
 
   public static String URL = "url";
+  public static String TEMPLATE = "template";
+  public static String TEMPLATE_DEFAULT = "$(format-json --scope rfc5424)";
   public static String METHOD  = "method";
   public static String METHOD_DEFAULT  = "PUT";
 
@@ -58,21 +60,29 @@ public class HTTPDestinationOptions {
     return options.get(optionName);
   }
 
-  public String getURL() {
-    return options.get(URL).getValue();
+  public TemplateOption getURLTemplate() {
+    return options.getTemplateOption(URL);
+  }
+
+  public TemplateOption getMessageTemplate() {
+    return options.getTemplateOption(TEMPLATE);
   }
 
   public String getMethod() {
-     return options.get(METHOD).getValue();
+    return options.get(METHOD).getValue();
   }
 
   private void fillOptions() {
     fillStringOptions();
+    fillTemplateOptions();
   }
 
   private void fillStringOptions() {
-		options.put(new RequiredOptionDecorator(new StringOption(owner, URL)));
-		options.put(new EnumOptionDecorator(new StringOption(owner, METHOD, METHOD_DEFAULT), HTTP_METHODS));
+    options.put(new EnumOptionDecorator(new StringOption(owner, METHOD, METHOD_DEFAULT), HTTP_METHODS));
   }
-
+  
+  private void fillTemplateOptions(){
+    options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, URL))));
+    options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, TEMPLATE))));
+  }
 }


### PR DESCRIPTION
eg:
  java(
    class-path("/usr/lib64/syslog-ng/java-modules/*.jar")
    class-name("org.syslog_ng.http.HTTPDestination")
    option("url", "http://host:8080/prefix-${YEAR}.${MONTH}.${DAY}/mailtrack/${macro}/update")
    option("method", "POST")
    option("template", "$(format-json --scope dot_nv_pairs)")
  );