### PR TITLE
Add $(sum), $(min) and $(max) template functions

### DIFF
--- a/libtest/template_lib.c
+++ b/libtest/template_lib.c
@@ -182,23 +182,32 @@ assert_template_format_with_escaping(const gchar *template, gboolean escaping,
 void
 assert_template_format_with_context(const gchar *template, const gchar *expected)
 {
-  LogTemplate *templ = compile_template(template, FALSE);
-  if (!templ)
-    return;
-
   LogMessage *msg;
-  GString *res = g_string_sized_new(128);
-  const gchar *context_id = "test-context-id";
   LogMessage *context[2];
 
   msg = create_sample_message();
   context[0] = context[1] = msg;
 
-  log_template_format_with_context(templ, context, 2, NULL, LTZ_LOCAL, 999, context_id, res);
+  assert_template_format_with_context_msgs(template, expected, context, 2);
+
+  log_msg_unref(msg);
+}
+
+void
+assert_template_format_with_context_msgs(const gchar *template, const gchar *expected,
+                                         LogMessage **msgs, gint num_messages)
+{
+  LogTemplate *templ = compile_template(template, FALSE);
+  if (!templ)
+    return;
+
+  GString *res = g_string_sized_new(128);
+  const gchar *context_id = "test-context-id";
+
+  log_template_format_with_context(templ, msgs, num_messages, NULL, LTZ_LOCAL, 999, context_id, res);
   expect_nstring(res->str, res->len, expected, strlen(expected), "context template test failed, template=%s", template);
   log_template_unref(templ);
   g_string_free(res, TRUE);
-  log_msg_unref(msg);
 }
 
 void

--- a/libtest/template_lib.h
+++ b/libtest/template_lib.h
@@ -36,6 +36,7 @@ void assert_template_format_with_escaping(const gchar *template, gboolean escapi
 void assert_template_format_with_escaping_msg(const gchar *template, gboolean escaping,
                                      const gchar *expected, LogMessage *msg);
 void assert_template_format_with_context(const gchar *template, const gchar *expected);
+void assert_template_format_with_context_msgs(const gchar *template, const gchar *expected, LogMessage **msgs, gint num_messages);
 void assert_template_failure(const gchar *template, const gchar *expected_failure);
 
 LogMessage *create_empty_message(void);

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -69,6 +69,7 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_num_multi, "*"),
   TEMPLATE_FUNCTION_PLUGIN(tf_num_div, "/"),
   TEMPLATE_FUNCTION_PLUGIN(tf_num_mod, "%"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_num_sum, "sum"),
 
   /* ip-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_ipv4_to_int, "ipv4-to-int"),

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -70,6 +70,8 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_num_div, "/"),
   TEMPLATE_FUNCTION_PLUGIN(tf_num_mod, "%"),
   TEMPLATE_FUNCTION_PLUGIN(tf_num_sum, "sum"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_num_min, "min"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_num_max, "max"),
 
   /* ip-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_ipv4_to_int, "ipv4-to-int"),

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -130,3 +130,76 @@ tf_num_mod(LogMessage *msg, gint argc, GString *argv[], GString *result)
 }
 
 TEMPLATE_FUNCTION_SIMPLE(tf_num_mod);
+
+
+static GString *
+_get_gstring_scratch_buffer(const LogTemplateInvokeArgs *args,
+                            gsize initial_capacity)
+{
+  if (args->bufs->len == 0)
+    g_ptr_array_add(args->bufs, g_string_sized_new(initial_capacity));
+
+  return (GString *) g_ptr_array_index(args->bufs, 0);
+}
+
+static gboolean
+_tf_num_parse_arg_with_message(const TFSimpleFuncState *state,
+                               LogMessage *message,
+                               const LogTemplateInvokeArgs *args,
+                               gint64 *number)
+{
+  GString *formatted_template = _get_gstring_scratch_buffer(args, 64);
+  gint on_error = args->opts->on_error;
+
+  log_template_format(state->argv[0], message, args->opts, args->tz,
+    args->seq_num, args->context_id, formatted_template);
+
+  if (!parse_number_with_suffix(formatted_template->str, number))
+    {
+      if (!(on_error & ON_ERROR_SILENT))
+        msg_error("Parsing failed, template function's argument is not a number",
+                  evt_tag_str("arg", formatted_template->str));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+tf_num_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
+               gint argc, gchar *argv[], GError **error)
+{
+  g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+  if (argc != 2)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+        "$(%s) requires only one argument", argv[0]);
+      return FALSE;
+    }
+
+  return tf_simple_func_prepare(self, s, parent, argc, argv, error);
+}
+
+static void
+tf_num_sum_call(LogTemplateFunction *self, gpointer s,
+                const LogTemplateInvokeArgs *args, GString *result)
+{
+  TFSimpleFuncState *state = (TFSimpleFuncState *) s;
+  gint64 number;
+  gint64 sum = 0;
+
+  gint message_index;
+  for (message_index = 0; message_index < args->num_messages; ++message_index)
+    {
+      LogMessage *message = args->messages[message_index];
+      if (_tf_num_parse_arg_with_message(state, message, args, &number))
+        sum += number;
+    }
+
+  format_int64_padded(result, 0, ' ', 10, sum);
+}
+
+TEMPLATE_FUNCTION(TFSimpleFuncState, tf_num_sum,
+                  tf_num_prepare, NULL, tf_num_sum_call,
+                  tf_simple_func_free_state, NULL);

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -34,6 +34,29 @@ add_dummy_template_to_configuration(void)
   cfg_tree_add_template(&configuration->tree, dummy);
 }
 
+static void
+_log_msg_free(gpointer msg)
+{
+  log_msg_unref((LogMessage *) msg);
+}
+
+static GPtrArray *
+create_log_messages_with_values(const gchar *name, const gchar **values)
+{
+  LogMessage *message;
+  GPtrArray *messages = g_ptr_array_new_with_free_func(_log_msg_free);
+
+  const gchar **value;
+  for (value = values; *value != NULL; ++value)
+    {
+      message = create_empty_message();
+      log_msg_set_value_by_name(message, name, *value, -1);
+      g_ptr_array_add(messages, message);
+    }
+
+  return messages;
+}
+
 void
 test_cond_funcs(void)
 {
@@ -139,6 +162,68 @@ test_numeric_funcs(void)
 }
 
 void
+test_numeric_aggregate_simple(void)
+{
+  const gchar *numbers[] = { "1", "-1", "3", NULL };
+  GPtrArray *messages = create_log_messages_with_values("NUMBER", numbers);
+
+  assert_template_format_with_context_msgs("$(sum ${NUMBER})", "3",
+    (LogMessage **) messages->pdata, messages->len);
+
+  assert_template_format_with_context_msgs("$(min ${NUMBER})", "-1",
+    (LogMessage **) messages->pdata, messages->len);
+
+  assert_template_format_with_context_msgs("$(max ${NUMBER})", "3",
+    (LogMessage **) messages->pdata, messages->len);
+
+  g_ptr_array_free(messages, TRUE);
+}
+
+void
+test_numeric_aggregate_invalid_values(void)
+{
+  const gchar *numbers[] = { "abc", "1", "c", "2", "", NULL };
+  GPtrArray *messages = create_log_messages_with_values("NUMBER", numbers);
+
+  assert_template_format_with_context_msgs("$(sum ${NUMBER})", "3",
+    (LogMessage **) messages->pdata, messages->len);
+
+  assert_template_format_with_context_msgs("$(min ${NUMBER})", "1",
+    (LogMessage **) messages->pdata, messages->len);
+
+  assert_template_format_with_context_msgs("$(max ${NUMBER})", "2",
+    (LogMessage **) messages->pdata, messages->len);
+
+  g_ptr_array_free(messages, TRUE);
+}
+
+void
+test_numeric_aggregate_full_invalid_values(void)
+{
+  const gchar *numbers[] = { "abc", "184467440737095516160", "c", "", NULL };
+  GPtrArray *messages = create_log_messages_with_values("NUMBER", numbers);
+
+  assert_template_format_with_context_msgs("$(sum ${NUMBER})", "",
+    (LogMessage **) messages->pdata, messages->len);
+
+  assert_template_format_with_context_msgs("$(min ${NUMBER})", "",
+    (LogMessage **) messages->pdata, messages->len);
+
+  assert_template_format_with_context_msgs("$(max ${NUMBER})", "",
+    (LogMessage **) messages->pdata, messages->len);
+
+  g_ptr_array_free(messages, TRUE);
+}
+
+void
+test_numeric_aggregate_funcs(void)
+{
+  test_numeric_aggregate_simple();
+  test_numeric_aggregate_invalid_values();
+  test_numeric_aggregate_full_invalid_values();
+}
+
+void
 test_misc_funcs(void)
 {
   unsetenv("OHHELLO");
@@ -166,6 +251,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   test_cond_funcs();
   test_str_funcs();
   test_numeric_funcs();
+  test_numeric_aggregate_funcs();
   test_misc_funcs();
   test_tf_template();
 


### PR DESCRIPTION
This PR contains three new template functions, which can be used together with correlation plugins such as [correlation-parser](https://github.com/ihrwein/syslog-ng-rust-modules/tree/master/correlation-parser/correlation), [grouping-by() parser](https://czanik.blogs.balabit.com/2016/04/the-grouping_by-parser-in-syslog-ng-3-8/) and [PatternDB](https://www.balabit.com/sites/default/files/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html-single/index.html#patterndb-correlation).
These correlation plugins create message contexts that contain multiple messages.

The newly introduced `$(sum)`, `$(min)` and `$(max)` functions receive one argument, and operate on message contexts. The argument of the template function will be used to calculate the summation, the minimum and the maximum value of the context.

----

Example usage with the `grouping-by()` parser:
```
parser p_groupingby {
  grouping_by(
    key("${KEY}")
    timeout(5)
    aggregate(
      value("MAX" "$(max ${NUMBER})")
      inherit-mode("none")
    )
    inject-mode("pass-through")
  );
};
```
This parser groups messages based on their `${KEY}` value.
After the group is complete (timeout is reached), the aggregation will be triggered and `${MAX}` will contain the maximum value of the `${NUMBER}` fields in the message group.