### PR TITLE
python: introduce flush-lines option

### DIFF
--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -89,6 +89,10 @@ python_option
           {
             python_dd_set_value_pairs(last_driver, $1);
           }
+        | KW_FLUSH_LINES '(' LL_NUMBER ')'
+          {
+            python_dd_set_flush_lines(last_driver, $3);
+          }
         | dest_driver_option
         | { last_template_options = python_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/python/sngexample.py
+++ b/modules/python/sngexample.py
@@ -42,8 +42,8 @@ class LogDestination(object):
         """This method is called at deinitialization time"""
         pass
 
-    def send(self, msg):
-        """Send a message to the target service
+    def send(self, msgs):
+        """Send a list of messages to the target service
 
         It should return True to indicate success, False will suspend the
         destination for a period specified by the time-reopen() option."""
@@ -51,6 +51,6 @@ class LogDestination(object):
 
 
 class DummyPythonDest(LogDestination):
-    def send(self, msg):
-        print('queue', msg)
+    def send(self, msgs):
+        print('queue', msgs)
         return True


### PR DESCRIPTION
!!! EXPERIMENTAL FEATURE !!!

Syslog-ng python destination respects `flush-lines(<INT>)` option. It
uses `Py_ListObject` to queue incoming messages to the destination and
if the maximum size is reached it sends them to one of the workers as a
python list.

If `flush-lines(1)` is set, the list passed to one of the workers will
contain only one message.

If `flush-lines` is not set, python destination will use `cfg` default.

_Further improvements_:
- make python destination respect `flush-timeout` option
- do not drop messages on reload with different `flush-lines` value

_This feature was needed_ in order to make developers write destinations
that can send batched events.

_Example was modified_ according to the changes.

ref #1006

Signed-off-by: Gergő Nagy grigori.grant@gmail.com
