### PR TITLE
F/ctx template funcs2 - mean operator, further stylistic improvements to #1037

### DIFF
--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -72,6 +72,7 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_num_sum, "sum"),
   TEMPLATE_FUNCTION_PLUGIN(tf_num_min, "min"),
   TEMPLATE_FUNCTION_PLUGIN(tf_num_max, "max"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_num_average, "average"),
 
   /* ip-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_ipv4_to_int, "ipv4-to-int"),

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -21,7 +21,7 @@
  *
  */
 
-typedef gint64 (*AggregateFunc)(gint64, gint64);
+typedef gboolean (*AggregateFunc)(gpointer, gint64);
 
 static gboolean
 tf_num_parse(gint argc, GString *argv[],
@@ -183,22 +183,45 @@ tf_num_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
   return tf_simple_func_prepare(self, s, parent, argc, argv, error);
 }
 
-static gboolean
-_tf_num_get_first_valid_arg(const TFSimpleFuncState *state,
-                            const LogTemplateInvokeArgs *args,
-                            gint *message_index, gint64 *number)
+static gint
+_tf_num_filter_iterate(const TFSimpleFuncState *state,
+        const LogTemplateInvokeArgs *args,
+        gint message_index,
+        AggregateFunc aggregate,
+        gpointer accumulator)
 {
-  for (*message_index = 0; *message_index < args->num_messages; (*message_index)++)
+  for (; message_index < args->num_messages; message_index++)
     {
-      LogMessage *message = args->messages[*message_index];
-
-      if (_tf_num_parse_arg_with_message(state, message, args, number))
-        {
-          (*message_index)++;
-          return TRUE;
-        }
+      LogMessage *message = args->messages[message_index];
+      gint64 number;
+      if ((_tf_num_parse_arg_with_message(state, message, args, &number) &&
+          (!aggregate(accumulator, number))))
+        return message_index;
     }
 
+  return -1;
+}
+
+static gboolean
+_tf_num_filter(const TFSimpleFuncState *state,
+        const LogTemplateInvokeArgs *args,
+        AggregateFunc start,
+        AggregateFunc aggregate,
+        gpointer accumulator)
+{
+  gint first = _tf_num_filter_iterate(state, args, 0, start, accumulator);
+  if (first < 0)
+    return FALSE;
+
+  _tf_num_filter_iterate(state, args, first + 1, aggregate, accumulator);
+  return TRUE;
+}
+
+static gboolean
+_tf_num_store_first(gpointer accumulator, gint64 element)
+{
+  gint64 *acc = (gint64 *)accumulator;
+  *acc = element;
   return FALSE;
 }
 
@@ -207,73 +230,67 @@ _tf_num_aggregation(TFSimpleFuncState *state, const LogTemplateInvokeArgs *args,
                     AggregateFunc aggregate, GString *result)
 {
   gint64 accumulator;
-  gint message_index;
-  if (!_tf_num_get_first_valid_arg(state, args, &message_index, &accumulator))
+  if (!_tf_num_filter(state, args, _tf_num_store_first, aggregate, &accumulator))
     return;
-
-  for (; message_index < args->num_messages; ++message_index)
-    {
-      LogMessage *message = args->messages[message_index];
-
-      gint64 number;
-      if (_tf_num_parse_arg_with_message(state, message, args, &number))
-        accumulator = aggregate(accumulator, number);
-    }
 
   format_int64_padded(result, 0, ' ', 10, accumulator);
 }
 
-static gint64
-_sum(gint64 accumulator, gint64 element)
+static gboolean
+_tf_num_sum(gpointer accumulator, gint64 element)
 {
-  return accumulator + element;
+  gint64 *acc = (gint64 *)accumulator;
+  *acc += element;
+  return TRUE;
 }
 
 static void
 tf_num_sum_call(LogTemplateFunction *self, gpointer s,
                 const LogTemplateInvokeArgs *args, GString *result)
 {
-  _tf_num_aggregation((TFSimpleFuncState *) s, args, _sum, result);
+  _tf_num_aggregation((TFSimpleFuncState *) s, args, _tf_num_sum, result);
 }
 
 TEMPLATE_FUNCTION(TFSimpleFuncState, tf_num_sum,
                   tf_num_prepare, NULL, tf_num_sum_call,
                   tf_simple_func_free_state, NULL);
 
-static gint64
-_minimum(gint64 accumulator, gint64 element)
+static gboolean
+_tf_num_minimum(gpointer accumulator, gint64 element)
 {
-  if (element < accumulator)
-    accumulator = element;
+  gint64 *acc = (gint64 *)accumulator;
+  if (element < *acc)
+    *acc = element;
 
-  return accumulator;
+  return TRUE;
 }
 
 static void
 tf_num_min_call(LogTemplateFunction *self, gpointer s,
                 const LogTemplateInvokeArgs *args, GString *result)
 {
-  _tf_num_aggregation((TFSimpleFuncState *) s, args, _minimum, result);
+  _tf_num_aggregation((TFSimpleFuncState *) s, args, _tf_num_minimum, result);
 }
 
 TEMPLATE_FUNCTION(TFSimpleFuncState, tf_num_min,
                   tf_num_prepare, NULL, tf_num_min_call,
                   tf_simple_func_free_state, NULL);
 
-static gint64
-_maximum(gint64 accumulator, gint64 element)
+static gboolean
+_tf_num_maximum(gpointer accumulator, gint64 element)
 {
-  if (element > accumulator)
-    accumulator = element;
+  gint64 *acc = (gint64 *)accumulator;
+  if (element > *acc)
+    *acc = element;
 
-  return accumulator;
+  return TRUE;
 }
 
 static void
 tf_num_max_call(LogTemplateFunction *self, gpointer s,
                 const LogTemplateInvokeArgs *args, GString *result)
 {
-  _tf_num_aggregation((TFSimpleFuncState *) s, args, _maximum, result);
+  _tf_num_aggregation((TFSimpleFuncState *) s, args, _tf_num_maximum, result);
 }
 
 TEMPLATE_FUNCTION(TFSimpleFuncState, tf_num_max,

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -197,6 +197,7 @@ test_numeric_aggregate_simple(void)
         { "$(sum ${NUMBER})", "3" },
         { "$(min ${NUMBER})", "-1" },
         { "$(max ${NUMBER})", "3" },
+        { "$(average ${NUMBER})", "1" },
         { }
       });
 }
@@ -211,6 +212,7 @@ test_numeric_aggregate_invalid_values(void)
         { "$(sum ${NUMBER})", "3" },
         { "$(min ${NUMBER})", "1" },
         { "$(max ${NUMBER})", "2" },
+        { "$(average ${NUMBER})", "1" },
         { }
       });
 }
@@ -225,6 +227,7 @@ test_numeric_aggregate_full_invalid_values(void)
         { "$(sum ${NUMBER})", "" },
         { "$(min ${NUMBER})", "" },
         { "$(max ${NUMBER})", "" },
+        { "$(average ${NUMBER})", "" },
         { }
       });
 }

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -168,58 +168,65 @@ test_numeric_funcs(void)
   assert_template_format("$(- 10000000000 5000000000)", "5000000000");
 }
 
+typedef struct
+{
+  const gchar *macro;
+  const gchar *result;
+} MacroAndResult;
+
+static void
+_test_macros_with_context(const gchar *id, const gchar *numbers[], const MacroAndResult test_cases[])
+{
+  GPtrArray *messages = create_log_messages_with_values(id, numbers);
+
+  for (MacroAndResult *test_case = test_cases; test_case->macro; test_case++)
+    assert_template_format_with_context_msgs(
+        test_case->macro, test_case->result,
+        (LogMessage **)messages->pdata, messages->len);
+
+  free_log_message_array(messages);
+}
+
 void
 test_numeric_aggregate_simple(void)
 {
-  const gchar *numbers[] = { "1", "-1", "3", NULL };
-  GPtrArray *messages = create_log_messages_with_values("NUMBER", numbers);
-
-  assert_template_format_with_context_msgs("$(sum ${NUMBER})", "3",
-    (LogMessage **) messages->pdata, messages->len);
-
-  assert_template_format_with_context_msgs("$(min ${NUMBER})", "-1",
-    (LogMessage **) messages->pdata, messages->len);
-
-  assert_template_format_with_context_msgs("$(max ${NUMBER})", "3",
-    (LogMessage **) messages->pdata, messages->len);
-
-  free_log_message_array(messages);
+  _test_macros_with_context(
+      "NUMBER", (const gchar *[]) { "1", "-1", "3", NULL },
+      (const MacroAndResult[])
+      {
+        { "$(sum ${NUMBER})", "3" },
+        { "$(min ${NUMBER})", "-1" },
+        { "$(max ${NUMBER})", "3" },
+        { }
+      });
 }
 
 void
 test_numeric_aggregate_invalid_values(void)
 {
-  const gchar *numbers[] = { "abc", "1", "c", "2", "", NULL };
-  GPtrArray *messages = create_log_messages_with_values("NUMBER", numbers);
-
-  assert_template_format_with_context_msgs("$(sum ${NUMBER})", "3",
-    (LogMessage **) messages->pdata, messages->len);
-
-  assert_template_format_with_context_msgs("$(min ${NUMBER})", "1",
-    (LogMessage **) messages->pdata, messages->len);
-
-  assert_template_format_with_context_msgs("$(max ${NUMBER})", "2",
-    (LogMessage **) messages->pdata, messages->len);
-
-  free_log_message_array(messages);
+  _test_macros_with_context(
+      "NUMBER", (const gchar *[]) { "abc", "1", "c", "2", "", NULL },
+      (const MacroAndResult[])
+      {
+        { "$(sum ${NUMBER})", "3" },
+        { "$(min ${NUMBER})", "1" },
+        { "$(max ${NUMBER})", "2" },
+        { }
+      });
 }
 
 void
 test_numeric_aggregate_full_invalid_values(void)
 {
-  const gchar *numbers[] = { "abc", "184467440737095516160", "c", "", NULL };
-  GPtrArray *messages = create_log_messages_with_values("NUMBER", numbers);
-
-  assert_template_format_with_context_msgs("$(sum ${NUMBER})", "",
-    (LogMessage **) messages->pdata, messages->len);
-
-  assert_template_format_with_context_msgs("$(min ${NUMBER})", "",
-    (LogMessage **) messages->pdata, messages->len);
-
-  assert_template_format_with_context_msgs("$(max ${NUMBER})", "",
-    (LogMessage **) messages->pdata, messages->len);
-
-  free_log_message_array(messages);
+  _test_macros_with_context(
+      "NUMBER", (const gchar *[]) { "abc", "184467440737095516160", "c", "", NULL },
+      (const MacroAndResult[])
+      {
+        { "$(sum ${NUMBER})", "" },
+        { "$(min ${NUMBER})", "" },
+        { "$(max ${NUMBER})", "" },
+        { }
+      });
 }
 
 void


### PR DESCRIPTION
Further improvements to #1037:
* Rename a few static functions
* Abstract out iteration when finding first element and aggregating
* Implement numeric mean (average)
* Refactor test cases to reduce redundancy