### PR TITLE
lib/logproto/logproto-server.c: refer to utf8 as utf-8

### DIFF
--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -138,7 +138,7 @@ log_proto_server_options_set_encoding(LogProtoServerOptions *self, const gchar *
   self->encoding = g_strdup(encoding);
 
   /* validate encoding */
-  convert = g_iconv_open("utf8", encoding);
+  convert = g_iconv_open("utf-8", encoding);
   if (convert == (GIConv) -1)
     return FALSE;
   g_iconv_close(convert);


### PR DESCRIPTION
Although, most libc implementations provide a native iconv with various
aliases, libiconv does not know about the alias `utf8`.
Neither does glib provide this alias if compiled with libiconv.

Furthermore, be advised that the user can only specify in the syslog-ng
config those iconv codes which are supported by the local iconv or
libiconv.

Fixes #1048

Regression introduced:

3fa60288548b54bcfad7b42deb145ef2eafa029c
"logproto: handle invalid encoding() options at parsing time"