### PR TITLE
Fix a linker related problem in systemd-journal's tests

### DIFF
--- a/modules/systemd-journal/tests/Makefile.am
+++ b/modules/systemd-journal/tests/Makefile.am
@@ -11,5 +11,5 @@ modules_systemd_journal_tests_test_systemd_journal_SOURCES = \
 	modules/systemd-journal/tests/test-source.c
 
 modules_systemd_journal_tests_test_systemd_journal_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/systemd-journal
-modules_systemd_journal_tests_test_systemd_journal_LDADD = $(TEST_LDADD)
+modules_systemd_journal_tests_test_systemd_journal_LDADD = $(TEST_LDADD) $(IVYKIS_LIBS)
 endif


### PR DESCRIPTION
The ivykis library wasn't linked to the test binary.

  CCLD     modules/systemd-journal/tests/test_systemd_journal
/usr/bin/ld: modules/systemd-journal/tests/modules_systemd_journal_tests_test_systemd_journal-test_systemd_journal.o: undefined reference to symbol 'iv_task_registered@@IVYKIS_0.29'
/tmp/pe7-tibi/install/lib/libivykis.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[3]: *** [modules/systemd-journal/tests/test_systemd_journal] Error 1
make[2]: *** [check-am] Error 2
make[1]: *** [check-recursive] Error 1
make: *** [check] Error 2

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>