### PR TITLE
Fix LL_IDENTIFIER double frees in the grammar

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1101,6 +1101,16 @@ cfg_token_block_new()
 void
 cfg_token_block_free(CfgTokenBlock *self)
 {
+  if (self->pos < self->tokens->len)
+    {
+      for (gint i = self->pos; i < self->tokens->len; i++)
+        {
+          YYSTYPE *token = &g_array_index(self->tokens, YYSTYPE, i);
+
+          cfg_lexer_free_token(token);
+        }
+    }
+
   g_array_free(self->tokens, TRUE);
   g_free(self);
 }

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1101,14 +1101,6 @@ cfg_token_block_new()
 void
 cfg_token_block_free(CfgTokenBlock *self)
 {
-  gint i;
-
-  for (i = 0; i < self->tokens->len; i++)
-    {
-      YYSTYPE *token = &g_array_index(self->tokens, YYSTYPE, i);
-
-      cfg_lexer_free_token(token);
-    }
   g_array_free(self->tokens, TRUE);
   g_free(self);
 }


### PR DESCRIPTION
We can reproduce an other double free in the grammer related to LL_IDENTIFIER-s and
yydestruct()/maual frees in the grammar actions. Fortunately, this problem is only reproducible with native-parser (AFAIK)
which is not widely used (currently).

I modified the grammar of csv-parser to reproduce the problem without any native-parser based
parsers.

The double free will occur depending on the optional free() call/configuration validation.

The memory allocation and first free() call happen on the same place in both cases.

## First case - manual free()

In the first case, the second free() call is triggered manually (and the syntax is valid!).

Configuration:

```
@version: 3.8
@include "scl.conf"

log {
        parser {
                #csv-parser(kutya());
                csv-parser();
        };
};
```

Cherry-pick 8fec099bbe6be2aea68fa841599e778140d37709.

Backtrace:

```
[2016-05-24T10:00:04.073766] Module loaded and initialized successfully; module='csvparser'
==7521== Invalid free() / delete / delete[] / realloc()
==7521==    at 0x4C2CE2B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7521==    by 0x8288AD0: csvparser_parse (csvparser-grammar.y:381)
==7521==    by 0x4E822BF: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4E82A4B: plugin_parse_config (plugin.c:216)
==7521==    by 0x4EC3922: parser_expr_parse (parser-expr-grammar.y:375)
==7521==    by 0x4EAB80F: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4EAD3F4: main_parse (cfg-grammar.y:630)
==7521==    by 0x4E62D08: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4E63AFB: cfg_run_parser (cfg.c:367)
==7521==    by 0x4E63D3E: cfg_read_config (cfg.c:439)
==7521==    by 0x4E7D656: main_loop_read_and_init_config (mainloop.c:444)
==7521==    by 0x401B55: main (main.c:261)
==7521==  Address 0x6ff9cc0 is 0 bytes inside a block of size 11 free'd
==7521==    at 0x4C2CE2B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7521==    by 0x4E660CC: cfg_lexer_free_token (cfg-lexer.c:740)
==7521==    by 0x4E66F2F: cfg_token_block_free (cfg-lexer.c:1110)
==7521==    by 0x4E6626F: cfg_lexer_lex (cfg-lexer.c:789)
==7521==    by 0x82875C2: csvparser_lex (csvparser-parser.c:57)
==7521==    by 0x8288549: csvparser_parse (csvparser-grammar.c:2599)
==7521==    by 0x4E822BF: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4E82A4B: plugin_parse_config (plugin.c:216)
==7521==    by 0x4EC3922: parser_expr_parse (parser-expr-grammar.y:375)
==7521==    by 0x4EAB80F: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4EAD3F4: main_parse (cfg-grammar.y:630)
==7521==    by 0x4E62D08: cfg_parser_parse (cfg-parser.h:83)
==7521==  Block was alloc'd at
==7521==    at 0x4C2BBCF: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7521==    by 0x54A23C9: strdup (strdup.c:42)
==7521==    by 0x4E64BBC: cfg_lexer_lookup_keyword (cfg-lexer.c:219)
==7521==    by 0x4E829CF: plugin_parse_config (plugin.c:205)
==7521==    by 0x4EC3922: parser_expr_parse (parser-expr-grammar.y:375)
==7521==    by 0x4EAB80F: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4EAD3F4: main_parse (cfg-grammar.y:630)
==7521==    by 0x4E62D08: cfg_parser_parse (cfg-parser.h:83)
==7521==    by 0x4E63AFB: cfg_run_parser (cfg.c:367)
==7521==    by 0x4E63D3E: cfg_read_config (cfg.c:439)
==7521==    by 0x4E7D656: main_loop_read_and_init_config (mainloop.c:444)
==7521==    by 0x401B55: main (main.c:261)
```

## Second case - free() call by yydestruct()

An other interesting case is when we don't free the LL_IDENTIFIER manually, but there is
a syntax error in the configuration. That will trigger an yydestruct() call, which causes
the double free.

Configuration:

```
@version: 3.8
@include "scl.conf"

log {
        parser {
		# csv-parser doesn't have dog() parameter -> syntax error
                csv-parser(dog());
        };
};
```

Cherry-pick 8fec099bbe6be2aea68fa841599e778140d37709 and 6109fa65217852a4722c9226bb6a5e8d781a431f.

Backtrace:

```
==7839== Invalid free() / delete / delete[] / realloc()
==7839==    at 0x4C2CE2B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7839==    by 0x8287FAE: yydestruct (csvparser-grammar.y:290)
==7839==    by 0x82896B0: csvparser_parse (csvparser-grammar.c:2976)
==7839==    by 0x4E822BF: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4E82A4B: plugin_parse_config (plugin.c:216)
==7839==    by 0x4EC3922: parser_expr_parse (parser-expr-grammar.y:375)
==7839==    by 0x4EAB80F: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4EAD3F4: main_parse (cfg-grammar.y:630)
==7839==    by 0x4E62D08: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4E63AFB: cfg_run_parser (cfg.c:367)
==7839==    by 0x4E63D3E: cfg_read_config (cfg.c:439)
==7839==    by 0x4E7D656: main_loop_read_and_init_config (mainloop.c:444)
==7839==  Address 0x6ff9cc0 is 0 bytes inside a block of size 11 free'd
==7839==    at 0x4C2CE2B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7839==    by 0x4E660CC: cfg_lexer_free_token (cfg-lexer.c:740)
==7839==    by 0x4E66F2F: cfg_token_block_free (cfg-lexer.c:1110)
==7839==    by 0x4E6626F: cfg_lexer_lex (cfg-lexer.c:789)
==7839==    by 0x82875C2: csvparser_lex (csvparser-parser.c:57)
==7839==    by 0x8288549: csvparser_parse (csvparser-grammar.c:2599)
==7839==    by 0x4E822BF: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4E82A4B: plugin_parse_config (plugin.c:216)
==7839==    by 0x4EC3922: parser_expr_parse (parser-expr-grammar.y:375)
==7839==    by 0x4EAB80F: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4EAD3F4: main_parse (cfg-grammar.y:630)
==7839==    by 0x4E62D08: cfg_parser_parse (cfg-parser.h:83)
==7839==  Block was alloc'd at
==7839==    at 0x4C2BBCF: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7839==    by 0x54A23C9: strdup (strdup.c:42)
==7839==    by 0x4E64BBC: cfg_lexer_lookup_keyword (cfg-lexer.c:219)
==7839==    by 0x4E829CF: plugin_parse_config (plugin.c:205)
==7839==    by 0x4EC3922: parser_expr_parse (parser-expr-grammar.y:375)
==7839==    by 0x4EAB80F: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4EAD3F4: main_parse (cfg-grammar.y:630)
==7839==    by 0x4E62D08: cfg_parser_parse (cfg-parser.h:83)
==7839==    by 0x4E63AFB: cfg_run_parser (cfg.c:367)
==7839==    by 0x4E63D3E: cfg_read_config (cfg.c:439)
==7839==    by 0x4E7D656: main_loop_read_and_init_config (mainloop.c:444)
==7839==    by 0x401B55: main (main.c:261)
```
