### PR TITLE
Add missing free to native parser's grammar

### DIFF
--- a/modules/native/native-grammar.ym
+++ b/modules/native/native-grammar.ym
@@ -79,7 +79,7 @@ native
   ;
 
 native_parser
-  : LL_IDENTIFIER '(' native_parser_params ')' { $$ = *instance; }
+  : LL_IDENTIFIER '(' native_parser_params ')' { $$ = *instance; free($1); }
   ;
 
 native_parser_params


### PR DESCRIPTION
This PR depends on #1061 (syslog-ng will crash without that PR).

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>