### PR TITLE
cfg-lex: initialize yylloc even if we are returning YYEOF

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -303,7 +303,13 @@ word	[^ \#'"\(\)\{\}\\;\r\n\t,|\.@:]
 
 <block_content>[^{}()\"\'\n\r]+   { g_string_append(yyextra->string_buffer, yytext); }
 
-<INITIAL><<EOF>>           { if (!cfg_lexer_start_next_include(yyextra)) yyterminate(); }
+<INITIAL><<EOF>>           {
+                             if (!cfg_lexer_start_next_include(yyextra))
+                               {
+                                 *yylloc = yyextra->include_stack[0].lloc;
+                                 yyterminate();
+                               }
+                           }
 
 %%
 


### PR DESCRIPTION
This patch fixes #1055 

When we return the EOF token, yylloc was not properly initialized, possibly
causing NULL derefs in the error reporter function, if the error is happening
right at the $end token.

Reported-by: Agostino Sarubbo <ago@gentoo.org>
Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>