### PR TITLE
cfg-tree: fix a potential crash in reload logic

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1036,6 +1036,8 @@ cfg_tree_compile(CfgTree *self)
   gint i;
 
   /* resolve references within the configuration */
+  if (self->compiled)
+    return TRUE;
 
   for (i = 0; i < self->rules->len; i++)
     {
@@ -1054,6 +1056,7 @@ cfg_tree_compile(CfgTree *self)
           return FALSE;
         }
     }
+  self->compiled = TRUE;
   return TRUE;
 }
 

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1105,6 +1105,7 @@ cfg_tree_stop(CfgTree *self)
 void
 cfg_tree_init_instance(CfgTree *self, GlobalConfig *cfg)
 {
+  memset(self, 0, sizeof(*self));
   self->initialized_pipes = g_ptr_array_new();
   self->objects = g_hash_table_new_full(cfg_tree_objects_hash, cfg_tree_objects_equal, NULL, (GDestroyNotify) log_expr_node_free);
   self->templates = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify) log_template_unref);

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -157,6 +157,7 @@ typedef struct _CfgTree
   /* list of top-level rules */
   GPtrArray *rules;
   GHashTable *templates;
+  gboolean compiled;
 } CfgTree;
 
 gboolean cfg_tree_add_object(CfgTree *self, LogExprNode *rule);


### PR DESCRIPTION
this branch fixes #1065 

cfg_tree_compile() is not idempotent for at least two reasons:
  * it stores the pipes to be initialized in an array, which will grow
    for each cfg_tree_compile() calls
  * it uses PIF_INLINED to indicate if a LogPipe was pasted directly into
    the config rather than cloned

But cfg_tree_start() invokes cfg_tree_compile() unconditionally, which
means that if a config is initialized multiple times, cfg_tree_compile()
will accumulate cruft in its state.

Issue #1065 on github explains one case where syslog-ng crashes on reload:
https://github.com/balabit/syslog-ng/issues/1065

This patch fixes this problem by guarding the compile function with
a variable, which ensures that the body of the function is executed only
once.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>