### PR TITLE
F/fix make func-test typos that keeps us from enabling it in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,68 @@ install:
   - curl http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04/Release.key | sudo apt-key add -
   - echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_12.04 ./" | sudo tee --append /etc/apt/sources.list.d/syslog-ng-obs.list
   - sudo apt-get update -qq
-  - sudo apt-get install -qq pkg-config flex bison xsltproc docbook-xsl libivykis-dev libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libjson0-dev libwrap0-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev gradle-2.2.1 autoconf-archive
+  - sudo apt-get install -qq
+      autoconf-archive
+      bison
+      docbook-xsl
+      flex
+      gradle-2.2.1
+      libcap-dev
+      libdbd-sqlite3
+      libdbi0-dev
+      libesmtp-dev
+      libevtlog-dev
+      libgeoip-dev
+      libglib2.0-dev
+      libhiredis-dev
+      libivykis-dev
+      libjson0-dev
+      libnet1-dev
+      libriemann-client-dev
+      libwrap0-dev
+      pkg-config
+      sqlite3
+      xsltproc
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh
   - unset PYTHON_CFLAGS # HACK
-  - ./configure CFLAGS=-Werror --with-ivykis=internal --prefix=$HOME/install/syslog-ng --enable-pacct --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl --enable-extra-warnings
-  - . tests/build-log-cflags-propagation.sh;
-    exec_prop_check "make -j V=1 --keep-going";
-    S=$?;
-    if [ "$S" = "42" -o "$S" = "0" ]; then
-      return $S;
-    else
-      make V=1; false;
-    fi # to make error messages more readable on error
+  - ./configure
+      CFLAGS=-Werror
+      --prefix=$HOME/install/syslog-ng
+      --with-ivykis=internal
+      --with-mongoc=internal
+      --with-librabbitmq=internal
+      --with-jsonc=system
+      --disable-env-wrapper
+      --disable-memtrace
+      --enable-tcp-wrapper
+      --enable-linux-caps
+      --disable-sun-streams
+      --enable-all-modules
+      --disable-sql
+      --enable-pacct
+      --enable-manpages
+      --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
+      --enable-extra-warnings
 script:
-  - if [ "$CC" = "gcc" ]; then
-      . tests/build-log-cflags-propagation.sh;
+  - . tests/build-log-cflags-propagation.sh;
+    if [ "$CC" = "gcc" ]; then
       export DISTCHECK_CONFIGURE_FLAGS="CFLAGS=-Werror --enable-extra-warnings";
       exec_prop_check "make distcheck V=1 --keep-going";
     else
-      make func-test V=1;
+      exec_prop_check "make -j V=1 --keep-going install";
+      S=$?;
+      if [ "$S" = "0" ]; then
+        . scripts/get-libjvm-path.sh || return $?;
+        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$JNI_LIBDIR";
+        make func-test V=1;
+      elif [ "$S" = "42" ]; then
+        return $S;
+      else
+        make V=1;
+        return $S;
+      fi;
     fi
 compiler:
   - gcc
@@ -52,7 +93,10 @@ matrix:
       script:
         - mkdir build
         - cd build
-        - cmake -DCMAKE_C_FLAGS=-Werror -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng ..
+        - cmake
+            -DCMAKE_C_FLAGS=-Werror
+            -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
+            ..
         - make -j install
 
 branches:

--- a/configure.ac
+++ b/configure.ac
@@ -732,9 +732,14 @@ dnl ***************************************************************************
 dnl libdbi headers/libraries
 dnl ***************************************************************************
 if test "x$enable_sql" = "xyes" || test "x$enable_sql" = "xauto"; then
-	PKG_CHECK_MODULES(LIBDBI, dbi >= $LIBDBI_MIN_VERSION,, with_libdbi="")
+	PKG_CHECK_MODULES(LIBDBI, dbi >= $LIBDBI_MIN_VERSION, with_libdbi="1", with_libdbi="0")
+	if test "$with_libdbi" -eq 0; then
+		dnl if libdbi has no .pc file (e.g., Ubuntu Precise), try it without one
+		AC_CHECK_LIB(dbi, dbi_initialize_r, LIBDBI_LIBS="-ldbi"; LIBDBI_CFLAGS="-I/usr/include/dbi"; with_libdbi="1")
+	fi
+
 	AC_MSG_CHECKING(whether to enable SQL support)
-	if test "x$LIBDBI_LIBS" != "x"; then
+	if test "$with_libdbi" -eq 1; then
 		enable_sql="yes"
 		AC_MSG_RESULT(yes)
 	elif test "x$enable_sql" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,7 @@ if test "x$enable_all_modules" != "xauto"; then
    state="$enable_all_modules"
 
    MODULES="spoof_source sun_streams sql pacct mongodb json amqp stomp \
-            redis systemd geoip riemann ipv6 smtp"
+            redis systemd geoip riemann ipv6 smtp native python java java_modules"
    for mod in ${MODULES}; do
        modstate=$(eval echo \$enable_${mod})
        if test "x$modstate" = "xauto"; then

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1276,6 +1276,7 @@ afsql_dd_init(LogPipe *s)
 
   if (!dbi_initialized)
     {
+      errno = 0;
       gint rc = dbi_initialize_r(NULL, &dbi_instance);
 
       if (rc < 0)

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -28,7 +28,7 @@
 #include "mainloop-worker.h"
 #include "string-list.h"
 
-#include <dbi/dbi.h>
+#include <dbi.h>
 
 enum
 {

--- a/modules/python/sngexample.py
+++ b/modules/python/sngexample.py
@@ -34,7 +34,7 @@ class LogDestination(object):
         """Check if the connection to the target is able to receive messages"""
         return True
 
-    def init(self, args):
+    def init(self):
         """This method is called at initialization time"""
         return True
 

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -101,7 +101,7 @@ source_systemd_journal_option
     }
   | KW_TIME_ZONE '(' string ')'
     {
-      if (last_journal_reader_options->recv_time_zone);
+      if (last_journal_reader_options->recv_time_zone)
         free(last_journal_reader_options->recv_time_zone);
       last_journal_reader_options->recv_time_zone = strdup($3);
       free($3);

--- a/modules/systemd-journal/tests/Makefile.am
+++ b/modules/systemd-journal/tests/Makefile.am
@@ -10,6 +10,6 @@ modules_systemd_journal_tests_test_systemd_journal_SOURCES = \
 	modules/systemd-journal/tests/test-source.h \
 	modules/systemd-journal/tests/test-source.c
 
-modules_systemd_journal_tests_test_systemd_journal_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/systemd-journal
+modules_systemd_journal_tests_test_systemd_journal_CFLAGS = $(TEST_CFLAGS) $(libsystemd_CFLAGS) -I$(top_srcdir)/modules/systemd-journal
 modules_systemd_journal_tests_test_systemd_journal_LDADD = $(TEST_LDADD) $(IVYKIS_LIBS)
 endif

--- a/scripts/get-libjvm-path.sh
+++ b/scripts/get-libjvm-path.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#############################################################################
+# Copyright (c) 2016 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+recursive_readlink() {
+  local READLINK_TARGET="$1"
+  while test -L "$READLINK_TARGET"; do
+    local READLINK_TARGET=$(readlink "$READLINK_TARGET")
+  done
+  echo "$READLINK_TARGET"
+}
+
+JAVAC_BIN="`which javac`"
+JAVAC_BIN="`recursive_readlink "$JAVAC_BIN"`"
+if test -e "$JAVA_HOME_CHECKER"; then
+  JNI_HOME=`$JAVA_HOME_CHECKER`
+else
+  JNI_HOME=`echo $JAVAC_BIN | sed "s~/bin/javac$~/~"`
+fi
+JNI_LIBDIR=`find $JNI_HOME \( -name "libjvm.so" -or -name "libjvm.dylib" \) \
+        | sed "s-/libjvm\.so-/-" \
+        | sed "s-/libjvm\.dylib-/-" | head -n 1`

--- a/tests/functional/test_sql.py
+++ b/tests/functional/test_sql.py
@@ -67,7 +67,8 @@ def check_env():
         soext='.sl'
 
     found = False
-    paths = (os.environ.get('dbd_dir', None), '/usr/local/lib/dbd', '/usr/lib/dbd', '/usr/lib64/dbd/', '/opt/syslog-ng/lib/dbd')
+    paths = (os.environ.get('dbd_dir', None), '/usr/local/lib/dbd', '/usr/lib/dbd',
+        '/usr/lib64/dbd/', '/opt/syslog-ng/lib/dbd', '/usr/lib/x86_64-linux-gnu/dbd')
     for pth in paths:
         if pth and os.path.isfile('%s/libdbdsqlite3%s' % (pth, soext)):
             found = True


### PR DESCRIPTION
These are the core fixes that are needed to enable `func_test` in Travis. As enabling all tests in Travis leads to a longer discussion, I have separated the fixes themselves here. They are mostly typos and version incompatibilities.

https://github.com/balabit/syslog-ng/pull/982 can be merged on top of this one.

I will do some quick adjustments now, but after this one gets a green light, it is ready for review.