### PR TITLE
Create libsyslog-ng.so symlink on installation with CMake

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -279,7 +279,7 @@ set_target_properties(syslog-ng
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}
     SOVERSION ${SYSLOG_NG_VERSION})
 
-install(TARGETS syslog-ng LIBRARY DESTINATION lib NAMELINK_SKIP)
+install(TARGETS syslog-ng LIBRARY DESTINATION lib)
 
 install(FILES ${LIB_HEADERS} DESTINATION include/syslog-ng)
 


### PR DESCRIPTION
This is a bugfix commit for #1051 

CMake didn't create the `libsyslog-ng.so` symlink during installation so the linker wasn't able to find syslog-ng with `-lsyslog-ng`.