### PR TITLE
java-modules: use local maven repository instead of flat dir

### DIFF
--- a/modules/java-modules/build.gradle
+++ b/modules/java-modules/build.gradle
@@ -5,10 +5,12 @@ subprojects {
     apply plugin: 'eclipse'
 
     repositories {
+        maven {
+          url "/usr/lib/syslog-ng-java-compile-deps-mvn-repo"
+        }
         flatDir {
             dirs syslogDepsDir
             dirs syslogBuildDir + '/common/gradle/libs'
-            dirs '/usr/lib/syslog-ng-java-module-dependency-jars/jars'
         }
       mavenCentral()
       maven {


### PR DESCRIPTION
This is required by OBS (or any offline build system).
Flat dir is not an option anymore as we support both native ElasticSearch 1.x
and 2.x java clients (transport/node/shield modes). The client jars are
conflicting as they are on the same path, so we have to support an offline
dependency  management system.

We had two options:
1. package local gradle cache into a deb package and install it inside OBS
2. convert local gradle cache into a local maven repository and package
that repository, then we can set this as a build dependency

2nd solution is more elegant and future proof (using gradle with
an external cache that is stolen from another version of gradle
is not something I'd trust).

Related project where my converter script is available:
https://github.com/lbudai/gradle_cache_to_local_maven_repo

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>