### PR TITLE
Fix incorrectly checked integer underflow/overflow

### DIFF
--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -151,8 +151,7 @@ _parse_number(const gchar *s, gchar **endptr, gint64 *d)
   errno = 0;
   val = strtoll(s, endptr, 10);
 
-  if ((errno == ERANGE && (val == LLONG_MAX || val == LLONG_MIN))
-      || (errno != 0 && val == 0))
+  if (errno == ERANGE || errno == EINVAL)
     return FALSE;
 
   if (*endptr == s)

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -151,7 +151,7 @@ _parse_number(const gchar *s, gchar **endptr, gint64 *d)
   errno = 0;
   val = strtoll(s, endptr, 10);
 
-  if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN))
+  if ((errno == ERANGE && (val == LLONG_MAX || val == LLONG_MIN))
       || (errno != 0 && val == 0))
     return FALSE;
 


### PR DESCRIPTION
From manpage:

> If an underflow occurs, strtol() returns LONG_MIN. If an overflow occurs, strtol() returns LONG_MAX. In both cases, errno is set to ERANGE. Precisely the same holds for strtoll() (with LLONG_MIN and LLONG_MAX instead of LONG_MIN and LONG_MAX).

>The implementation may also set errno to EINVAL in case no conversion was performed (no digits seen, and 0 returned).

Fixes #1083