### PR TITLE
logmsg: don't release "original" from the cleared message

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1050,11 +1050,6 @@ log_msg_clear(LogMessage *self)
     }
   self->saddr = NULL;
 
-  if (self->original)
-    {
-      log_msg_unref(self->original);
-      self->original = NULL;
-    }
   self->flags |= LF_STATE_OWN_MASK;
 }
 


### PR DESCRIPTION
This patch fixes a potential SIGSEGV for code that uses log_msg_clear()
in production (e.g. syslog-parser()).

The role of log_msg_clear() is to clear up all name-value pairs,
SDATA, tags and sockaddr in order to reset the message into its
default state.

In this function we also relinquished self->original, which points
to the message where we cloned the current one from.

The problem with this was that it actually breaks the acknowledgement
logic, as ack_func was not reset at the same time.

It would be a layering violation to reset it back to its original value,
I simply remove dropping the link to self->original, which is only going to
be used for acks and nothing really else.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>