### PR TITLE
Fix invalid handling of UTF-8 strings

### DIFF
--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -32,6 +32,16 @@
 GString *g_string_assign_len(GString *s, const gchar *val, gint len);
 void g_string_steal(GString *s);
 
+static inline GString *
+g_string_append_unichar_optimized(GString *string, gunichar wc)
+{
+  if (wc < 0x80)
+    g_string_append_c(string, (gchar) wc);
+  else
+    g_string_append_unichar(string, wc);
+
+  return string;
+}
 
 /*
  * DO NOT USE THIS MACRO UNLESS STRICTLY NECESSARY FOR PERFORMANCE REASONS.

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -39,7 +39,7 @@ _is_character_unsafe(gunichar uchar, const gchar *unsafe_chars)
 static inline void
 _append_unichar(GString *string, gunichar wc)
 {
-  if (wc < 0xc0)
+  if (wc < 0x80)
     g_string_append_c(string, (gchar) wc);
   else
     g_string_append_unichar(string, wc);

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -36,15 +36,6 @@ _is_character_unsafe(gunichar uchar, const gchar *unsafe_chars)
   return _strchr_optimized_for_single_char_haystack(unsafe_chars, (gchar) uchar) != NULL;
 }
 
-static inline void
-_append_unichar(GString *string, gunichar wc)
-{
-  if (wc < 0x80)
-    g_string_append_c(string, (gchar) wc);
-  else
-    g_string_append_unichar(string, wc);
-}
-
 /**
  * This function escapes an unsanitized input (e.g. that can contain binary
  * characters, and produces an escaped format that can be deescaped in need,
@@ -102,7 +93,7 @@ _append_escaped_utf8_character(GString *escaped_output, const gchar **raw,
         else if (_is_character_unsafe(uchar, unsafe_chars))
           g_string_append_printf(escaped_output, "\\%c", (gchar) uchar);
         else
-          _append_unichar(escaped_output, uchar);
+          g_string_append_unichar_optimized(escaped_output, uchar);
         break;
     }
   *raw = g_utf8_next_char(char_ptr);

--- a/modules/cef/format-cef-extension.c
+++ b/modules/cef/format-cef-extension.c
@@ -66,7 +66,7 @@ tf_cef_is_valid_key(const gchar *str)
 static inline void
 tf_cef_append_unichar(GString *string, gunichar wc)
 {
-  if (wc < 0xc0)
+  if (wc < 0x80)
     g_string_append_c(string, (gchar) wc);
   else
     g_string_append_unichar(string, wc);

--- a/modules/cef/format-cef-extension.c
+++ b/modules/cef/format-cef-extension.c
@@ -25,6 +25,7 @@
 #include "value-pairs/value-pairs.h"
 #include "value-pairs/cmdline.h"
 #include "syslog-ng.h"
+#include "str-utils.h"
 #include "format-cef-extension.h"
 
 typedef struct _TFCefState
@@ -64,15 +65,6 @@ tf_cef_is_valid_key(const gchar *str)
 }
 
 static inline void
-tf_cef_append_unichar(GString *string, gunichar wc)
-{
-  if (wc < 0x80)
-    g_string_append_c(string, (gchar) wc);
-  else
-    g_string_append_unichar(string, wc);
-}
-
-static inline void
 tf_cef_append_escaped(GString *escaped_string, const gchar *str, gsize str_len)
 {
   const gchar *char_ptr;
@@ -106,7 +98,7 @@ tf_cef_append_escaped(GString *escaped_string, const gchar *str, gsize str_len)
           if (uchar < 32)
             g_string_append_printf(escaped_string, "\\u%04x", uchar);
           else
-            tf_cef_append_unichar(escaped_string, uchar);
+            g_string_append_unichar_optimized(escaped_string, uchar);
           break;
         }
       char_ptr = g_utf8_next_char(str);

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -124,6 +124,19 @@ test_format_json_on_error(void)
 
 }
 
+void
+test_format_json_with_utf8(void)
+{
+  LogMessage *msg = create_empty_message();
+  log_msg_set_value_by_name(msg, "UTF8-C2", "\xc2\xbf \xc2\xb6 \xc2\xa9 \xc2\xb1", -1); // ¿ ¶ © ±
+  log_msg_set_value_by_name(msg, "UTF8-C3", "\xc3\x88 \xc3\x90", -1); // È Ð
+
+  assert_template_format_msg("$(format-json MSG=\"${UTF8-C2}\")", "{\"MSG\":\"\xc2\xbf \xc2\xb6 \xc2\xa9 \xc2\xb1\"}", msg);
+  assert_template_format_msg("$(format-json MSG=\"${UTF8-C3}\")", "{\"MSG\":\"\xc3\x88 \xc3\x90\"}", msg);
+
+  log_msg_unref(msg);
+}
+
 int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
@@ -138,6 +151,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   test_format_json_rekey();
   test_format_json_with_type_hints();
   test_format_json_on_error();
+  test_format_json_with_utf8();
 
   deinit_template_tests();
   app_shutdown();


### PR DESCRIPTION
This issue can cause invalid UTF-8 characters in `format-cef-extension`, `format-welf` and `format-json`.

`g_utf8_get_char_validated()` converts a sequence of bytes encoded as UTF-8 to a Unicode character (`gunichar` --> UTF-32), so checking for an UTF-8 leading byte (`< 0xc0`) is not an option here.
`0x80` can be used instead.

This is a performance optimization, where we can append the given unichar with `g_string_append_c()` if it fits in 7 bits.
In all other cases, conversion is required (`g_string_append_unichar()`).

Partial fix for #999