### PR TITLE
java-modules: gradle: removed unnecessary dependency

### DIFF
--- a/modules/java-modules/elastic-v2/build.gradle
+++ b/modules/java-modules/elastic-v2/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'org.hamcrest:hamcrest-core:1.3'
     compile 'log4j:log4j:1.2.17'
-    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
     jest 'io.searchbox:jest:2.0.2'
 }
 

--- a/modules/java-modules/elastic/build.gradle
+++ b/modules/java-modules/elastic/build.gradle
@@ -7,6 +7,5 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'org.hamcrest:hamcrest-core:1.3'
     compile 'log4j:log4j:1.2.17'
-    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
 }
 

--- a/modules/java-modules/hdfs/build.gradle
+++ b/modules/java-modules/hdfs/build.gradle
@@ -1,7 +1,6 @@
 project.buildDir = syslogBuildDir+'/hdfs/gradle'
 
 dependencies {
-    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
     compile 'org.apache.hadoop:hadoop-hdfs:2.7.1'
     compile 'org.apache.hadoop:hadoop-common:2.7.1'
     compile name: 'syslog-ng-common'

--- a/modules/java-modules/http/build.gradle
+++ b/modules/java-modules/http/build.gradle
@@ -1,7 +1,6 @@
 project.buildDir = syslogBuildDir+'/http/gradle'
 
 dependencies {
-    compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
     compile name: 'syslog-ng-common'
     compile name: 'syslog-ng-core'
     compile 'junit:junit:4.12'

--- a/modules/java-modules/kafka/build.gradle
+++ b/modules/java-modules/kafka/build.gradle
@@ -1,7 +1,6 @@
 project.buildDir = syslogBuildDir + '/kafka/gradle'
 
 dependencies {
-  compile fileTree(dir: "/usr/lib/syslog-ng-java-module-dependency-jars/jars", includes: ['*.jar'])
   compile 'org.apache.kafka:kafka-clients:0.9.0.0'
   compile name: 'syslog-ng-common'
   compile name: 'syslog-ng-core'


### PR DESCRIPTION
Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>

The dependencies in `fileTree()` are conflicts with the local maven repo (on those machines where both of the dependencies are installed).

Please, merge.