### PR TITLE
F/json parser clone misses template

### DIFF
--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -36,10 +36,10 @@ log_parser_set_template(LogParser *self, LogTemplate *template)
   self->template = template;
 }
 
-static void
-log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+gboolean
+log_parser_process_message(LogParser *self, LogMessage **pmsg, const LogPathOptions *path_options)
 {
-  LogParser *self = (LogParser *) s;
+  LogMessage *msg = *pmsg;
   gboolean success;
 
   if (G_LIKELY(!self->template))
@@ -69,6 +69,17 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       success = self->process(self, &msg, path_options, input->str, input->len);
       g_string_free(input, TRUE);
     }
+
+  return success;
+}
+
+static void
+log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+{
+  LogParser *self = (LogParser *) s;
+  gboolean success;
+
+  success = log_parser_process_message(self, &msg, path_options);
   msg_debug("Message parsing complete",
             evt_tag_int("result", success),
             evt_tag_str("rule", self->name),

--- a/lib/parser/parser-expr.h
+++ b/lib/parser/parser-expr.h
@@ -54,4 +54,6 @@ log_parser_process(LogParser *self, LogMessage **pmsg, const LogPathOptions *pat
   return self->process(self, pmsg, path_options, input, input_len);
 }
 
+gboolean log_parser_process_message(LogParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
+
 #endif

--- a/modules/geoip/Makefile.am
+++ b/modules/geoip/Makefile.am
@@ -37,3 +37,5 @@ EXTRA_DIST					+=	\
 	modules/geoip/tfgeoip.c
 
 .PHONY: modules/geoip/ mod-geoip
+
+include modules/geoip/tests/Makefile.am

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -139,6 +139,7 @@ geoip_parser_clone(LogPipe *s)
 
   geoip_parser_set_database(&cloned->super, self->database);
   geoip_parser_set_prefix(&cloned->super, self->prefix);
+  log_parser_set_template(&cloned->super, log_template_ref(self->super.template));
   geoip_parser_reset_fields(cloned);
 
   return &cloned->super.super;

--- a/modules/geoip/tests/Makefile.am
+++ b/modules/geoip/tests/Makefile.am
@@ -1,0 +1,11 @@
+modules_geoip_tests_TESTS		= \
+	modules/geoip/tests/test_geoip_parser
+
+check_PROGRAMS				+= ${modules_geoip_tests_TESTS}
+
+modules_geoip_tests_test_geoip_parser_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/geoip
+modules_geoip_tests_test_geoip_parser_LDADD	= $(TEST_LDADD)
+modules_geoip_tests_test_geoip_parser_LDFLAGS	= \
+	$(PREOPEN_SYSLOGFORMAT)		  \
+	-dlpreopen $(top_builddir)/modules/geoip/libgeoip-plugin.la
+modules_geoip_tests_test_geoip_parser_DEPENDENCIES = $(top_builddir)/modules/geoip/libgeoip-plugin.la

--- a/modules/geoip/tests/test_geoip_parser.c
+++ b/modules/geoip/tests/test_geoip_parser.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+#include "testutils.h"
+#include "geoip-parser.h"
+#include "apphook.h"
+#include "msg_parse_lib.h"
+
+#define geoip_parser_testcase_begin(func, args)             \
+  do                                                            \
+    {                                                           \
+      testcase_begin("%s(%s)", func, args);                     \
+      geoip_parser = geoip_parser_new(configuration); 		\
+    }                                                           \
+  while (0)
+
+#define geoip_parser_testcase_end()                           \
+  do                                                            \
+    {                                                           \
+      log_pipe_deinit(&geoip_parser->super);			\
+      log_pipe_unref(&geoip_parser->super);                     \
+      testcase_end();                                           \
+    }                                                           \
+  while (0)
+
+#define KV_PARSER_TESTCASE(x, ...) \
+  do {                                                          \
+      geoip_parser_testcase_begin(#x, #__VA_ARGS__);  		\
+      x(__VA_ARGS__);                                           \
+      geoip_parser_testcase_end();                              \
+  } while(0)
+
+LogParser *geoip_parser;
+
+static LogMessage *
+parse_geoip_into_log_message_no_check(const gchar *input)
+{
+  LogMessage *msg;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogParser *cloned_parser;
+  gboolean success;
+
+  cloned_parser = (LogParser *) log_pipe_clone(&geoip_parser->super);
+  log_pipe_init(&cloned_parser->super);
+  msg = log_msg_new_empty();
+  log_msg_set_value(msg, LM_V_MESSAGE, input, -1);
+  success = log_parser_process_message(cloned_parser, &msg, &path_options);
+  if (!success)
+    {
+      log_msg_unref(msg);
+      msg = NULL;
+    }
+  log_pipe_deinit(&cloned_parser->super);
+  log_pipe_unref(&cloned_parser->super);
+  return msg;
+}
+
+static LogMessage *
+parse_geoip_into_log_message(const gchar *input)
+{
+  LogMessage *msg;
+
+  msg = parse_geoip_into_log_message_no_check(input);
+  assert_not_null(msg, "expected geoip-parser success and it returned failure, input=%s", input);
+  return msg;
+}
+
+static void
+test_geoip_parser_basics(void)
+{
+  LogMessage *msg;
+
+  msg = parse_geoip_into_log_message("217.20.130.99");
+  assert_log_message_value(msg, log_msg_get_value_handle(".geoip.country_code"), "HU");
+  log_msg_unref(msg);
+
+  geoip_parser_set_prefix(geoip_parser, ".prefix.");
+  msg = parse_geoip_into_log_message("217.20.130.99");
+  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.country_code"), "HU");
+  log_msg_unref(msg);
+}
+
+static void
+test_geoip_parser_uses_template_to_parse_input(void)
+{
+  LogMessage *msg;
+  LogTemplate *template;
+
+  template = log_template_new(NULL, NULL);
+  log_template_compile(template, "217.20.130.99", NULL);
+  log_parser_set_template(geoip_parser, template);
+  msg = parse_geoip_into_log_message("8.8.8.8");
+  assert_log_message_value(msg, log_msg_get_value_handle(".geoip.country_code"), "HU");
+  log_msg_unref(msg);
+}
+
+static void
+test_geoip_parser(void)
+{
+  KV_PARSER_TESTCASE(test_geoip_parser_basics);
+  KV_PARSER_TESTCASE(test_geoip_parser_uses_template_to_parse_input);
+}
+
+int
+main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+{
+  app_startup();
+
+  test_geoip_parser();
+  app_shutdown();
+  return 0;
+}

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -254,6 +254,7 @@ json_parser_clone(LogPipe *s)
   json_parser_set_prefix(cloned, self->prefix);
   json_parser_set_marker(cloned, self->marker);
   json_parser_set_extract_prefix(cloned, self->extract_prefix);
+  log_parser_set_template(cloned, log_template_ref(self->super.template));
 
   return &cloned->super;
 }

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -97,6 +97,7 @@ kv_parser_clone(LogPipe *s)
 
   cloned = kv_parser_new(s->cfg, kv_scanner_clone(self->kv_scanner));
   kv_parser_set_prefix(cloned, self->prefix);
+  log_parser_set_template(cloned, log_template_ref(self->super.template));
 
   return &cloned->super;
 }

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -57,7 +57,8 @@ parse_kv_into_log_message_no_check(const gchar *kv)
 
   cloned_parser = (LogParser *) log_pipe_clone(&kv_parser->super);
   msg = log_msg_new_empty();
-  if (!log_parser_process(cloned_parser, &msg, &path_options, kv, strlen(kv)))
+  log_msg_set_value(msg, LM_V_MESSAGE, kv, -1);
+  if (!log_parser_process_message(cloned_parser, &msg, &path_options))
     {
       log_msg_unref(msg);
       log_pipe_unref(&cloned_parser->super);
@@ -89,6 +90,20 @@ test_kv_parser_basics(void)
   kv_parser_set_prefix(kv_parser, ".prefix.");
   msg = parse_kv_into_log_message("foo=bar");
   assert_log_message_value(msg, log_msg_get_value_handle(".prefix.foo"), "bar");
+  log_msg_unref(msg);
+}
+
+static void
+test_kv_parser_uses_template_to_parse_input(void)
+{
+  LogMessage *msg;
+  LogTemplate *template;
+
+  template = log_template_new(NULL, NULL);
+  log_template_compile(template, "foo=bar", NULL);
+  log_parser_set_template(kv_parser, template);
+  msg = parse_kv_into_log_message("foo=this-value-doesnot-matter-as-template-overrides");
+  assert_log_message_value(msg, log_msg_get_value_handle("foo"), "bar");
   log_msg_unref(msg);
 }
 
@@ -125,6 +140,7 @@ test_kv_parser(void)
 {
   KV_PARSER_TESTCASE(test_kv_parser_basics);
   KV_PARSER_TESTCASE(test_kv_parser_audit);
+  KV_PARSER_TESTCASE(test_kv_parser_uses_template_to_parse_input);
 }
 
 int


### PR DESCRIPTION
This branch should fix #1101 and improve test coverage for json-parser(), kv-parser() and geoip-parser(). It also fixes the same cloning issue in all three of them.
