### PR TITLE
include geoip tests only when geoip is enabled

### DIFF
--- a/modules/geoip/tests/Makefile.am
+++ b/modules/geoip/tests/Makefile.am
@@ -1,3 +1,4 @@
+if ENABLE_GEOIP
 modules_geoip_tests_TESTS		= \
 	modules/geoip/tests/test_geoip_parser
 
@@ -9,3 +10,4 @@ modules_geoip_tests_test_geoip_parser_LDFLAGS	= \
 	$(PREOPEN_SYSLOGFORMAT)		  \
 	-dlpreopen $(top_builddir)/modules/geoip/libgeoip-plugin.la
 modules_geoip_tests_test_geoip_parser_DEPENDENCIES = $(top_builddir)/modules/geoip/libgeoip-plugin.la
+endif


### PR DESCRIPTION
Previously, when geoip was found on a machine where automake was run, after moving to another machine geoip tests failed while building.

This patch modifies the makefiles, so geoip tests are only run when geoip is enabled.