### PR TITLE
make xmllint dependency explicit in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
       libnet1-dev
       libriemann-client-dev
       libwrap0-dev
+      libxml2-utils
       pkg-config
       sqlite3
       xsltproc


### PR DESCRIPTION
If someone installs dependencies based on .travis.yml, he or she might miss libxml2 because it is not added there expliticly. Right now patterndb unit tests pass on Travis, because it is installed there by dedfault. But on other machines it might be missing. (Fixes #1087)

Please, note that there is another PR in syslog-ng/syslog-ng-docker, which adds the same lib to the dockerfile.

Signed-off-by: Noémi Ványi <sitbackandwait@gmail.com>