### PR TITLE
logmsg: add log_msg_new_local() function

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1143,6 +1143,18 @@ log_msg_new_empty(void)
   return self;
 }
 
+LogMessage *
+log_msg_new_local(void)
+{
+  LogMessage *self = log_msg_new_empty();
+
+  self->flags |= LF_LOCAL;
+
+  self->timestamps[LM_TS_STAMP] = self->timestamps[LM_TS_RECVD];
+
+  return self;
+}
+
 static void
 log_msg_clone_ack(LogMessage *msg, AckType ack_type)
 {

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -294,6 +294,7 @@ LogMessage *log_msg_new(const gchar *msg, gint length,
 LogMessage *log_msg_new_mark(void);
 LogMessage *log_msg_new_internal(gint prio, const gchar *msg);
 LogMessage *log_msg_new_empty(void);
+LogMessage *log_msg_new_local(void);
 
 void log_msg_add_ack(LogMessage *msg, const LogPathOptions *path_options);
 void log_msg_ack(LogMessage *msg, const LogPathOptions *path_options, AckType ack_type);

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -303,10 +303,22 @@ test_log_msg_get_value_with_time_related_macro(void)
 }
 
 static void
+test_local_logmsg_created_with_the_right_flags_and_timestamps(void)
+{
+  LogMessage *msg = log_msg_new_local();
+
+  gboolean are_equals = log_stamp_eq(&msg->timestamps[LM_TS_STAMP], &msg->timestamps[LM_TS_RECVD]);
+
+  assert_true((msg->flags & LF_LOCAL) != 0, "LogMessage created by log_msg_new_local() should have LF_LOCAL flag set");
+  assert_true(are_equals, "The timestamps in a LogMessage created by log_msg_new_local() should be equals");
+}
+
+static void
 test_misc_stuff(void)
 {
   MSG_TESTCASE(test_log_msg_get_value_with_time_related_macro);
   MSG_TESTCASE(test_log_msg_set_value_indirect_with_self_referencing_handle_results_in_a_nonindirect_value);
+  MSG_TESTCASE(test_local_logmsg_created_with_the_right_flags_and_timestamps);
 }
 
 int

--- a/lib/logstamp.c
+++ b/lib/logstamp.c
@@ -136,3 +136,11 @@ log_stamp_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_of
   g_string_truncate(target, 0);
   log_stamp_append_format(stamp, target, ts_format, zone_offset, frac_digits);
 }
+
+gboolean
+log_stamp_eq(const LogStamp *a, const LogStamp *b)
+{
+  return a->tv_sec == b->tv_sec &&
+         a->tv_usec == b->tv_usec &&
+         a->zone_offset == b->zone_offset;
+}

--- a/lib/logstamp.h
+++ b/lib/logstamp.h
@@ -44,6 +44,7 @@ typedef struct _LogStamp
 
 void log_stamp_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
 void log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
+gboolean log_stamp_eq(const LogStamp *a, const LogStamp *b);
 
 
 #endif

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -567,21 +567,17 @@ log_writer_emit_suppress_summary(LogWriter *self)
 
   msg_debug("Suppress timer elapsed, emitting suppression summary");
 
-  m = log_msg_new_empty();
-  m->timestamps[LM_TS_STAMP] = m->timestamps[LM_TS_RECVD];
-  m->pri = self->last_msg->pri;
-  m->flags = LF_INTERNAL | LF_LOCAL;
+  len = g_snprintf(buf, sizeof(buf), "Last message '%.20s' repeated %d times, suppressed by syslog-ng on %s",
+                   log_msg_get_value(self->last_msg, LM_V_MESSAGE, NULL),
+                   self->last_msg_count,
+                   get_local_hostname_fqdn());
+
+  m = log_msg_new_internal(self->last_msg->pri, buf);
 
   p = log_msg_get_value(self->last_msg, LM_V_HOST, &len);
   log_msg_set_value(m, LM_V_HOST, p, len);
   p = log_msg_get_value(self->last_msg, LM_V_PROGRAM, &len);
   log_msg_set_value(m, LM_V_PROGRAM, p, len);
-
-  len = g_snprintf(buf, sizeof(buf), "Last message '%.20s' repeated %d times, suppressed by syslog-ng on %s",
-                   log_msg_get_value(self->last_msg, LM_V_MESSAGE, NULL),
-                   self->last_msg_count,
-                   get_local_hostname_fqdn());
-  log_msg_set_value(m, LM_V_MESSAGE, buf, len);
 
   path_options.ack_needed = FALSE;
 

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -153,10 +153,8 @@ _generate_message_inheriting_properties_from_the_last_message(LogMessage *msg)
 static LogMessage *
 _generate_new_message_with_timestamp_of_the_triggering_message(LogStamp *msgstamp)
 {
-  LogMessage *genmsg;
+  LogMessage *genmsg = log_msg_new_local();
 
-  genmsg = log_msg_new_empty();
-  genmsg->flags |= LF_LOCAL;
   genmsg->timestamps[LM_TS_STAMP] = *msgstamp;
   return genmsg;
 }


### PR DESCRIPTION
This function creates a new LogMessage with LF_LOCAL flag and its
timestamps are initialized to the same value.

Reason: $YEAR and other time related macros use timestamps[LM_TS_STAMP]
timestamp. If that timestamp isn't initialized (-1), then $YEAR is
evaluated to 1969.

I handle LogMessage instances as opaque pointers, so I don't have access
to their flags. LogMessage doesn't have setter and getter methods for
its flags and I don't want to modify them after an instance is created,
so this is the simplest and less intrusive solution I could think of.

Signed-off-by: Tibor Benke <tibor.benke@balabit.com>