### PR TITLE
Native parser: fail-fast when configuration setting failed

### DIFF
--- a/modules/native/native-grammar.ym
+++ b/modules/native/native-grammar.ym
@@ -40,7 +40,7 @@
 
 #include <string.h>
 
-void native_parser_set_option(LogParser *s, gchar* key, gchar* value);
+gboolean native_parser_set_option(LogParser *s, gchar* key, gchar* value);
 LogParser* native_parser_new(GlobalConfig *cfg);
 
 }
@@ -103,7 +103,8 @@ native_parser_options
 native_parser_option
   : KW_OPTION '(' string string ')'
     {
-      native_parser_set_option(*instance, $3, $4);
+      CHECK_ERROR(native_parser_set_option(*instance, $3, $4), @1, "Failed to set configuration option for native-parser: option(%s, %s)", $3, $4);
+
       free($3);
       free($4);
     }

--- a/modules/native/native-grammar.ym
+++ b/modules/native/native-grammar.ym
@@ -40,9 +40,6 @@
 
 #include <string.h>
 
-gboolean native_parser_set_option(LogParser *s, gchar* key, gchar* value);
-LogParser* native_parser_new(GlobalConfig *cfg);
-
 }
 
 %name-prefix "native_"

--- a/modules/native/parser.c
+++ b/modules/native/parser.c
@@ -30,7 +30,7 @@ struct NativeParserProxy;
 __attribute__((visibility("hidden"))) void
 native_parser_proxy_free(struct NativeParserProxy* this);
 
-__attribute__((visibility("hidden"))) void
+__attribute__((visibility("hidden"))) gboolean
 native_parser_proxy_set_option(struct NativeParserProxy* self, const gchar* key, const gchar* value);
 
 __attribute__((visibility("hidden"))) gboolean
@@ -65,12 +65,12 @@ native_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   return native_parser_proxy_process(self->native_object, &self->super, writable_msg, input);
 }
 
-void
+gboolean
 native_parser_set_option(LogParser *s, gchar* key, gchar* value)
 {    
   ParserNative *self = (ParserNative *)s;
 
-  native_parser_proxy_set_option(self->native_object, key, value);
+  return native_parser_proxy_set_option(self->native_object, key, value);
 }
 
 static gboolean

--- a/modules/native/parser.h
+++ b/modules/native/parser.h
@@ -27,6 +27,6 @@
 
 #include "parser/parser-expr.h"
 
-void native_parser_set_option(LogParser *s, gchar* key, gchar* value);
+gboolean native_parser_set_option(LogParser *s, gchar* key, gchar* value);
 
 #endif

--- a/modules/native/parser.h
+++ b/modules/native/parser.h
@@ -22,11 +22,12 @@
  *
  */
 
-#ifndef NATIVE_PARSER_H_INCLUDED
-#define NATIVE_PARSER_H_INCLUDED
+#ifndef PARSER_H_INCLUDED
+#define PARSER_H_INCLUDED
 
 #include "parser/parser-expr.h"
 
 gboolean native_parser_set_option(LogParser *s, gchar* key, gchar* value);
+LogParser* native_parser_new(GlobalConfig *cfg);
 
 #endif


### PR DESCRIPTION
This PR changes the signature of `native_parser_set_option()` to return with a boolean value and so makes possible to fail-fast in case of an invalid option value.

What's an invalid option value?
* the value is a path and the file doesn't exist
* the value is a regular expression, but it's invalid
* every other native parser specific 

This PR also contains a little refactor (fixing an include guard, removing some duplicated function prototypes).

There are no unit tests for this change, mainly because I don't know any examples where syslog-ng's grammar tested this way.

This PR is the pair of https://github.com/ihrwein/syslog-ng-rust-modules/pull/35