### PR TITLE
parser: fix invalid pointer usage in log_parser_process_message()

### DIFF
--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -58,7 +58,7 @@ log_parser_process_message(LogParser *self, LogMessage **pmsg, const LogPathOpti
        */
 
       value = log_msg_get_value(msg, LM_V_MESSAGE, &value_len);
-      success = self->process(self, &msg, path_options, value, value_len);
+      success = self->process(self, pmsg, path_options, value, value_len);
       nv_table_unref(payload);
     }
   else
@@ -66,7 +66,7 @@ log_parser_process_message(LogParser *self, LogMessage **pmsg, const LogPathOpti
       GString *input = g_string_sized_new(256);
 
       log_template_format(self->template, msg, NULL, LTZ_LOCAL, 0, NULL, input);
-      success = self->process(self, &msg, path_options, input->str, input->len);
+      success = self->process(self, pmsg, path_options, input->str, input->len);
       g_string_free(input, TRUE);
     }
 


### PR DESCRIPTION
In #1102, `log_parser_process_message()` was extracted from `log_parser_queue()` to make it possible to invoke template processing from outside code.

Unfortunately, this transformation is not fully equivalent. `self->process()` can create a new LogMessage instance (`log_msg_clone_cow()`).
In this case, only the local `msg` pointer will be updated, `*pmsg` will remain unchanged.

This PR fixes this issue by passing the original `pmsg` variable to the `process()` function.