### PR TITLE
Fix segmentation fault when including SCLs

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -489,7 +489,6 @@ cfg_lexer_include_file_glob_at(CfgLexer *self, const gchar *pattern)
 #ifndef SYSLOG_NG_HAVE_GLOB_NOMAGIC
           if (!__glob_pattern_p (pattern))
             {
-              self->include_depth++;
               return cfg_lexer_include_file_add(self, pattern);
             }
 #endif
@@ -498,7 +497,6 @@ cfg_lexer_include_file_glob_at(CfgLexer *self, const gchar *pattern)
       return TRUE;
     }
 
-  self->include_depth++;
   for (i = 0; i < globbuf.gl_pathc; i++)
     {
       cfg_lexer_include_file_add(self, globbuf.gl_pathv[i]);
@@ -514,6 +512,8 @@ cfg_lexer_include_file_glob(CfgLexer *self, const gchar *filename_)
 {
   const gchar *path = cfg_args_get(self->globals, "include-path");
   gboolean process = FALSE;
+
+  self->include_depth++;
 
   if (filename_[0] == '/' || !path)
     process = cfg_lexer_include_file_glob_at(self, filename_);
@@ -534,9 +534,14 @@ cfg_lexer_include_file_glob(CfgLexer *self, const gchar *filename_)
       g_strfreev(dirs);
     }
   if (process)
-    return cfg_lexer_start_next_include(self);
+    {
+      return cfg_lexer_start_next_include(self);
+    }
   else
-    return TRUE;
+    {
+      self->include_depth--;
+      return TRUE;
+    }
 }
 
 gboolean

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -375,7 +375,8 @@ cfg_lexer_include_file_simple(CfgLexer *self, const gchar *filename)
                 }
               level->file.files = g_slist_insert_sorted(level->file.files, full_filename, (GCompareFunc) strcmp);
               msg_debug("Adding include file",
-                        evt_tag_str("filename", entry));
+                        evt_tag_str("filename", entry),
+                        evt_tag_int("depth", self->include_depth));
             }
         }
       g_dir_close(dir);
@@ -465,7 +466,8 @@ cfg_lexer_include_file_add(CfgLexer *self, const gchar *fn)
                                             (GCompareFunc) strcmp);
 
   msg_debug("Adding include file",
-            evt_tag_str("filename", fn));
+            evt_tag_str("filename", fn),
+            evt_tag_int("depth", self->include_depth));
 
   return TRUE;
 }


### PR DESCRIPTION
Let's suppose we have a config file which includes files this way:

`scl/*/*.conf`

If we create a `scl/e/e.conf` file under `etc`, this glob pattern is
expanded as:

```
etc/scl/e/e.conf
share/syslog-ng/include/scl/a/a.conf
share/syslog-ng/include/scl/b/b.conf
```

We have to place these files on the same include stack level, as they were
expanded from the same pattern.

syslog-ng pushed on the include stack every time it evaluated a new
include-path prefix (etc and share/syslog-ng/include/scl). This mishandling caused the SEGFAULT (though I didn't track it down exactly why).

I moved the include stack level increasing one level upper, so it's
increased only once. If syslog-ng isn't able to include a file (so the
top of the stack is unused), we restore the stack to it's original state.