### PR TITLE
F/enable all gcc warnings no error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ install:
 before_script:
   - ./autogen.sh
   - unset PYTHON_CFLAGS # HACK
+  - if [ "$CC" = "gcc" ]; then
+      EXTRA_WARN="--enable-extra-warnings";
+    fi
   - ./configure
       CFLAGS=-Werror
       --prefix=$HOME/install/syslog-ng
@@ -54,7 +57,7 @@ before_script:
       --enable-pacct
       --enable-manpages
       --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
-      --enable-extra-warnings
+      $EXTRA_WARN
 script:
   - . tests/build-log-cflags-propagation.sh;
     if [ "$CC" = "gcc" ]; then

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,8 +42,52 @@ AM_CPPFLAGS		= -I$(top_srcdir)/lib -I$(top_srcdir)/modules -I$(top_builddir)/lib
 AM_CFLAGS =
 if ENABLE_EXTRA_WARNINGS
 AM_CFLAGS += \
-	-Wshadow
-
+	-fno-common \
+	-W \
+	-Wabi \
+	-Wall \
+	-Wcast-align \
+	-Wdeprecated \
+	-Wdeprecated-declarations \
+	-Wextra \
+	-Wimplicit-function-declaration \
+	-Winvalid-pch \
+	-Wmissing-format-attribute \
+	-Woverflow \
+	-Wshadow \
+	-Wstrict-overflow=2 \
+	\
+	-Wno-error=aggregate-return -Waggregate-return \
+	-Wno-error=bad-function-cast -Wbad-function-cast \
+	-Wno-error=cast-qual -Wcast-qual \
+	-Wno-error=conversion -Wconversion \
+	-Wno-error=double-promotion -Wdouble-promotion \
+	-Wno-error=float-equal -Wfloat-equal \
+	-Wno-error=format-nonliteral -Wformat=2 \
+	-Wno-error=inline -Winline \
+	-Wno-error=missing-declarations -Wmissing-declarations \
+	-Wno-error=missing-format-attribute \
+	-Wno-error=missing-prototypes -Wmissing-prototypes \
+	-Wno-error=nested-externs -Wnested-externs \
+	-Wno-error=pointer-arith -Wpointer-arith \
+	-Wno-error=pointer-sign -Wpointer-sign \
+	-Wno-error=redundant-decls -Wredundant-decls \
+	-Wno-error=sign-compare \
+	-Wno-error=sign-conversion -Wsign-conversion \
+	-Wno-error=strict-overflow \
+	-Wno-error=strict-prototypes -Wstrict-prototypes \
+	-Wno-error=suggest-attribute=const -Wsuggest-attribute=const \
+	-Wno-error=suggest-attribute=noreturn -Wsuggest-attribute=noreturn \
+	-Wno-error=suggest-attribute=pure -Wsuggest-attribute=pure \
+	-Wno-error=switch-default -Wswitch-default \
+	-Wno-error=type-limits \
+	-Wno-error=undef -Wundef \
+	-Wno-error=write-strings \
+	\
+	-Wno-missing-field-initializers \
+	-Wno-stack-protector \
+	-Wno-unused-parameter \
+	-Wno-variadic-macros
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest $(AM_CFLAGS)

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -329,7 +329,7 @@ cfg_lexer_unput_string(CfgLexer *self, const char *str)
 }
 
 void
-cfg_lexer_start_block_state(CfgLexer *self, gchar block_boundary[2])
+cfg_lexer_start_block_state(CfgLexer *self, const gchar block_boundary[2])
 {
   memcpy(&self->block_boundary, block_boundary, sizeof(self->block_boundary));
   yy_push_state(block, self->state);

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -154,7 +154,7 @@ cfg_lexer_subst_args(CfgArgs *globals, CfgArgs *defs, CfgArgs *args, const gchar
 /* pattern buffer */
 void cfg_lexer_unput_token(CfgLexer *self, YYSTYPE *yylval);
 
-void cfg_lexer_start_block_state(CfgLexer *self, gchar block_boundary[2]);
+void cfg_lexer_start_block_state(CfgLexer *self, const gchar block_boundary[2]);
 
 void cfg_lexer_append_string(CfgLexer *self, int length, char *str);
 void cfg_lexer_append_char(CfgLexer *self, char c);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -114,7 +114,7 @@ cfg_bad_hostname_set(GlobalConfig *self, gchar *bad_hostname_re)
 }
 
 gint
-cfg_lookup_mark_mode(gchar *mark_mode)
+cfg_lookup_mark_mode(const gchar *mark_mode)
 {
   if (!strcmp(mark_mode, "internal"))
     return MM_INTERNAL;
@@ -133,7 +133,7 @@ cfg_lookup_mark_mode(gchar *mark_mode)
 }
 
 void
-cfg_set_mark_mode(GlobalConfig *self, gchar *mark_mode)
+cfg_set_mark_mode(GlobalConfig *self, const gchar *mark_mode)
 {
   self->mark_mode = cfg_lookup_mark_mode(mark_mode);
 }

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -120,8 +120,8 @@ struct _GlobalConfig
 gboolean cfg_allow_config_dups(GlobalConfig *self);
 
 void cfg_bad_hostname_set(GlobalConfig *self, gchar *bad_hostname_re);
-gint cfg_lookup_mark_mode(gchar *mark_mode);
-void cfg_set_mark_mode(GlobalConfig *self, gchar *mark_mode);
+gint cfg_lookup_mark_mode(const gchar *mark_mode);
+void cfg_set_mark_mode(GlobalConfig *self, const gchar *mark_mode);
 
 gint cfg_tz_convert_value(gchar *convert);
 gint cfg_ts_format_value(gchar *format);

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -61,7 +61,7 @@ filter_netmask_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 }
 
 FilterExprNode *
-filter_netmask_new(gchar *cidr)
+filter_netmask_new(const gchar *cidr)
 {
   FilterNetmask *self = g_new0(FilterNetmask, 1);
   gchar buf[32];

--- a/lib/filter/filter-netmask.h
+++ b/lib/filter/filter-netmask.h
@@ -27,6 +27,6 @@
 
 #include "filter-expr.h"
 
-FilterExprNode *filter_netmask_new(gchar *cidr);
+FilterExprNode *filter_netmask_new(const gchar *cidr);
 
 #endif

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -122,7 +122,7 @@ _eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 }
 
 FilterExprNode *
-filter_netmask6_new(gchar *cidr)
+filter_netmask6_new(const gchar *cidr)
 {
   FilterNetmask6 *self = g_new0(FilterNetmask6, 1);
   struct in6_addr packet_addr;

--- a/lib/filter/filter-netmask6.h
+++ b/lib/filter/filter-netmask6.h
@@ -27,7 +27,7 @@
 
 #include "filter-expr.h"
 
-FilterExprNode *filter_netmask6_new(gchar *cidr);
+FilterExprNode *filter_netmask6_new(const gchar *cidr);
 void get_network_address(unsigned char *ipv6, int prefix, struct in6_addr *network);
 
 #endif

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -71,7 +71,7 @@ filter_re_init(FilterExprNode *s, GlobalConfig *cfg)
 }
 
 gboolean
-filter_re_compile_pattern(FilterRE *self, GlobalConfig *cfg, gchar *re, GError **error)
+filter_re_compile_pattern(FilterRE *self, GlobalConfig *cfg, const gchar *re, GError **error)
 {
   log_matcher_options_init(&self->matcher_options, cfg);
   self->matcher = log_matcher_new(&self->matcher_options);

--- a/lib/filter/filter-re.h
+++ b/lib/filter/filter-re.h
@@ -38,7 +38,7 @@ typedef struct _FilterRE
 
 typedef struct _FilterMatch FilterMatch;
 
-gboolean filter_re_compile_pattern(FilterRE *self, GlobalConfig *cfg, gchar *re, GError **error);
+gboolean filter_re_compile_pattern(FilterRE *self, GlobalConfig *cfg, const gchar *re, GError **error);
 
 FilterRE *filter_re_new(NVHandle value_handle);
 FilterRE *filter_source_new(void);

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -49,19 +49,19 @@ GSockAddr *sender_saddr;
 MsgFormatOptions parse_options;
 
 static gint
-facility_bits(gchar *fac)
+facility_bits(const gchar *fac)
 {
   return 1 << (syslog_name_lookup_facility_by_name(fac) >> 3);
 }
 
 static gint
-level_bits(gchar *lev)
+level_bits(const gchar *lev)
 {
   return 1 << syslog_name_lookup_level_by_name(lev);
 }
 
 static gint
-level_range(gchar *from, gchar *to)
+level_range(const gchar *from, const gchar *to)
 {
   int r1, r2;
 
@@ -71,7 +71,7 @@ level_range(gchar *from, gchar *to)
 }
 
 FilterExprNode *
-compile_pattern(FilterRE *f, gchar *regexp, const gchar *type, gint flags)
+compile_pattern(FilterRE *f, const gchar *regexp, const gchar *type, gint flags)
 {
   gboolean result;
 
@@ -89,25 +89,25 @@ compile_pattern(FilterRE *f, gchar *regexp, const gchar *type, gint flags)
 }
 
 FilterExprNode *
-create_posix_regexp_filter(NVHandle handle, gchar *regexp, gint flags)
+create_posix_regexp_filter(NVHandle handle, const gchar *regexp, gint flags)
 {
   return compile_pattern(filter_re_new(handle), regexp, "posix", flags);
 }
 
 FilterExprNode *
-create_posix_regexp_match(gchar* regexp, gint flags)
+create_posix_regexp_match(const gchar* regexp, gint flags)
 {
   return compile_pattern(filter_match_new(), regexp, "posix", flags);
 }
 
 FilterExprNode *
-create_pcre_regexp_filter(gint field, gchar* regexp, gint flags)
+create_pcre_regexp_filter(gint field, const gchar* regexp, gint flags)
 {
   return compile_pattern(filter_re_new(field), regexp, "pcre", flags);
 }
 
 FilterExprNode *
-create_pcre_regexp_match(gchar* regexp, gint flags)
+create_pcre_regexp_match(const gchar* regexp, gint flags)
 {
   return compile_pattern(filter_match_new(), regexp, "pcre", flags);
 }
@@ -124,7 +124,7 @@ create_template(const gchar *template)
 
 
 void
-testcase(gchar *msg,
+testcase(const gchar *msg,
          FilterExprNode *f,
          gboolean expected_result)
 {
@@ -158,7 +158,7 @@ testcase(gchar *msg,
 }
 
 void
-testcase_with_backref_chk(gchar *msg,
+testcase_with_backref_chk(const gchar *msg,
          FilterExprNode *f,
          gboolean expected_result,
          const gchar *name,

--- a/lib/filter/tests/test_filters_in_list.c
+++ b/lib/filter/tests/test_filters_in_list.c
@@ -45,7 +45,7 @@
 static MsgFormatOptions parse_options;
 
 gboolean
-evaluate_testcase(gchar *msg,
+evaluate_testcase(const gchar *msg,
          FilterExprNode *filter_node)
 {
   LogMessage *log_msg;

--- a/lib/filter/tests/test_filters_netmask6.c
+++ b/lib/filter/tests/test_filters_netmask6.c
@@ -60,7 +60,7 @@ calculate_network6(const gchar* ipv6, int prefix, gchar *calculated_network)
 }
 
 void
-assert_netmask6(const gchar* ipv6, gint prefix, gchar* expected_network)
+assert_netmask6(const gchar* ipv6, gint prefix, const gchar* expected_network)
 {
   char error_msg[64];
   sprintf(error_msg, "prefix: %d", prefix);

--- a/lib/gsocket.c
+++ b/lib/gsocket.c
@@ -50,7 +50,7 @@ g_inet_ntoa(char *buf, size_t bufsize, struct in_addr a)
 }
 
 gint
-g_inet_aton(char *buf, struct in_addr *a)
+g_inet_aton(const char *buf, struct in_addr *a)
 {
   return inet_aton(buf, a);
 }

--- a/lib/gsocket.h
+++ b/lib/gsocket.h
@@ -32,6 +32,6 @@ GIOStatus g_bind(int fd, GSockAddr *addr);
 GIOStatus g_accept(int fd, int *newfd, GSockAddr **addr);
 GIOStatus g_connect(int fd, GSockAddr *remote);
 gchar *g_inet_ntoa(char *buf, size_t bufsize, struct in_addr a);
-gint g_inet_aton(char *buf, struct in_addr *a);
+gint g_inet_aton(const char *buf, struct in_addr *a);
 
 #endif

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -190,7 +190,7 @@ nv_table_resolve_indirect(NVTable *self, NVEntry *entry, gssize *length)
   return referenced_value + entry->vindirect.ofs;
 }
 
-static const inline gchar *
+static inline const gchar *
 nv_table_resolve_entry(NVTable *self, NVEntry *entry, gssize *length)
 {
   if (entry->unset)

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <iv_thread.h>
 
-const QueueType log_queue_fifo_type = "FIFO";
+QueueType log_queue_fifo_type = "FIFO";
 
 /*
  * LogFifo is a scalable first-in-first-output queue implementation, that:

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -34,7 +34,7 @@ typedef void (*LogQueuePushNotifyFunc)(gpointer user_data);
 
 typedef struct _LogQueue LogQueue;
 
-typedef char *QueueType;
+typedef const char *QueueType;
 
 struct _LogQueue
 {

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -651,7 +651,7 @@ CfgFlagHandler log_reader_flag_handlers[] =
 };
 
 gboolean
-log_reader_options_process_flag(LogReaderOptions *options, gchar *flag)
+log_reader_options_process_flag(LogReaderOptions *options, const gchar *flag)
 {
   if (!msg_format_options_process_flag(&options->parse_options, flag))
     return cfg_process_flag(log_reader_flag_handlers, options, flag);

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -66,6 +66,6 @@ void log_reader_options_init(LogReaderOptions *options, GlobalConfig *cfg, const
 void log_reader_options_destroy(LogReaderOptions *options);
 gint log_reader_options_lookup_flag(const gchar *flag);
 void log_reader_options_set_tags(LogReaderOptions *options, GList *tags);
-gboolean log_reader_options_process_flag(LogReaderOptions *options, gchar *flag);
+gboolean log_reader_options_process_flag(LogReaderOptions *options, const gchar *flag);
 
 #endif

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1562,7 +1562,7 @@ log_writer_options_set_template_escape(LogWriterOptions *options, gboolean enabl
 }
 
 void
-log_writer_options_set_mark_mode(LogWriterOptions *options, gchar *mark_mode)
+log_writer_options_set_mark_mode(LogWriterOptions *options, const gchar *mark_mode)
 {
   options->mark_mode = cfg_lookup_mark_mode(mark_mode);
 }

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -91,7 +91,7 @@ void log_writer_options_set_template_escape(LogWriterOptions *options, gboolean 
 void log_writer_options_defaults(LogWriterOptions *options);
 void log_writer_options_init(LogWriterOptions *options, GlobalConfig *cfg, guint32 option_flags);
 void log_writer_options_destroy(LogWriterOptions *options);
-void log_writer_options_set_mark_mode(LogWriterOptions *options, gchar *mark_mode);
+void log_writer_options_set_mark_mode(LogWriterOptions *options, const gchar *mark_mode);
 gint log_writer_options_lookup_flag(const gchar *flag);
 
 #endif

--- a/lib/memtrace.c
+++ b/lib/memtrace.c
@@ -596,7 +596,7 @@ calloc(size_t nmemb, size_t size)
 #else
 
 void 
-z_mem_trace_init(gchar *memtrace_file)
+z_mem_trace_init(const gchar *memtrace_file)
 {
 }
 

--- a/lib/memtrace.h
+++ b/lib/memtrace.h
@@ -25,7 +25,7 @@
 #ifndef ZORP_MEMTRACE_H_INCLUDED
 #define ZORP_MEMTRACE_H_INCLUDED
 
-void z_mem_trace_init(gchar *memtrace_file);
+void z_mem_trace_init(const gchar *memtrace_file);
 void z_mem_trace_stats(void);
 void z_mem_trace_dump(void);
 

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -120,7 +120,7 @@ CfgFlagHandler msg_format_flag_handlers[] =
 };
 
 gboolean
-msg_format_options_process_flag(MsgFormatOptions *options, gchar *flag)
+msg_format_options_process_flag(MsgFormatOptions *options, const gchar *flag)
 {
   return cfg_process_flag(msg_format_flag_handlers, options, flag);
 }

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -84,7 +84,7 @@ void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);
 void msg_format_options_destroy(MsgFormatOptions *parse_options);
 
-gboolean msg_format_options_process_flag(MsgFormatOptions *options, gchar *flag);
+gboolean msg_format_options_process_flag(MsgFormatOptions *options, const gchar *flag);
 
 void msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length);
 

--- a/lib/reloc.c
+++ b/lib/reloc.c
@@ -159,7 +159,7 @@ path_resolver_new(const gchar *sysprefix)
   return &self->super;
 }
 
-static gchar *
+static const gchar *
 lookup_sysprefix(void)
 {
   gchar *v;

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -299,7 +299,7 @@ int
 main(int argc, char **argv)
 {
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   start_grabbing_messages();

--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -223,7 +223,7 @@ _parse_character_with_quotation(CSVScanner *self)
 }
 
 /* searches for str in list and returns the first occurence, otherwise NULL */
-static const gboolean
+static gboolean
 _match_string_delimiters_at_current_position(const char *input, GList *string_delimiters, int *result_length)
 {
   GList *l;

--- a/lib/syslog-names.h
+++ b/lib/syslog-names.h
@@ -38,7 +38,7 @@
 
 struct sl_name
 {
-  char *name;
+  const char *name;
   int value;
 };
 

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -585,7 +585,7 @@ log_macro_expand_simple(GString *result, gint id, const LogMessage *msg)
 }
 
 guint
-log_macro_lookup(gchar *macro, gint len)
+log_macro_lookup(const gchar *macro, gint len)
 {
   gchar buf[256];
   gint macro_id;

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -352,12 +352,11 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
       break;
     case M_SOURCE_IP:
       {
-        gchar *ip;
+        const gchar *ip;
+        gchar buf[MAX_SOCKADDR_STRING];
         
         if(_is_message_source_an_ip_address(msg))
           {
-            gchar buf[MAX_SOCKADDR_STRING];
-
             g_sockaddr_format(msg->saddr, buf, sizeof(buf), GSA_ADDRESS_ONLY);
             ip = buf;
           }
@@ -610,10 +609,10 @@ log_macros_global_init(void)
   g_get_current_time(&app_uptime);
   log_template_options_defaults(&template_options_for_macro_expand);
 
-  macro_hash = g_hash_table_new(g_str_hash, g_str_equal);
+  macro_hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
   for (i = 0; macros[i].name; i++)
     {
-      g_hash_table_insert(macro_hash, macros[i].name,
+      g_hash_table_insert(macro_hash, g_strdup(macros[i].name),
                           GINT_TO_POINTER(macros[i].id));
     }
   return;

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -103,14 +103,14 @@ enum
  */
 typedef struct _LogMacroDef
 {
-  char *name;
+  const char *name;
   int id;
 } LogMacroDef;
 
 extern LogMacroDef macros[];
 
 /* low level macro functions */
-guint log_macro_lookup(gchar *macro, gint len);
+guint log_macro_lookup(const gchar *macro, gint len);
 gboolean log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, const LogMessage *msg);
 gboolean log_macro_expand_simple(GString *result, gint id, const LogMessage *msg);
 

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -308,7 +308,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   configuration->template_options.time_zone_info[LTZ_LOCAL] = time_zone_info_new(NULL);
 
 
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   test_macros();

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -155,10 +155,10 @@ get_template_function_ops(const gchar *name)
 static void
 test_simple_string_literal(void)
 {
-  gchar *text = "Test String";
+  const gchar *text_ = "Test String";
 
-  assert_template_compile(text);
-  assert_compiled_template(text = text, default_value = NULL, macro = M_NONE, type = LTE_MACRO, msg_ref = 0);
+  assert_template_compile(text_);
+  assert_compiled_template(text = text_, default_value = NULL, macro = M_NONE, type = LTE_MACRO, msg_ref = 0);
 }
 
 static void

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -59,17 +59,28 @@ Plugin hello_plugin = TEMPLATE_FUNCTION_PLUGIN(hello, "hello");
     element.type;  \
     element.msg_ref; }
 
-#define assert_compiled_template(text, default_value, spec, type, msg_ref) \
+#define assert_compiled_template(set_text, set_default_value, spec, type, msg_ref) \
   do { \
+    const gchar *text; \
+    set_text; \
+    gchar *text_mut = g_strdup(text); \
+    \
+    const gchar *default_value; \
+    set_default_value; \
+    gchar *default_value_mut = g_strdup(default_value); \
+    \
     LogTemplateElem expected_elem; 																\
                                                                                                                                                                 \
-    fill_expected_template_element(expected_elem, text, default_value, spec, type, msg_ref); 									\
+    fill_expected_template_element(expected_elem, text = text_mut, \
+                                   default_value = default_value_mut, spec, type, msg_ref); \
     assert_gint((current_elem->type), (expected_elem.type), ASSERTION_ERROR("Bad compiled template type")); 							\
     assert_common_element(expected_elem); 															\
     if ((expected_elem.type) == LTE_MACRO) assert_gint(current_elem->macro, expected_elem.macro, ASSERTION_ERROR("Bad compiled template macro")); 		\
     if ((expected_elem.type) == LTE_VALUE) assert_gint(current_elem->value_handle, expected_elem.value_handle, ASSERTION_ERROR("Bad compiled template macro")); \
     if ((expected_elem.type) == LTE_FUNC) assert_gpointer(current_elem->func.ops, expected_elem.func.ops, ASSERTION_ERROR("Bad compiled template macro")); 	\
-  } while (0)
+    g_free(text_mut); \
+    g_free(default_value_mut); \
+} while (0)
 
 
 #define TEMPLATE_TESTCASE(x, ...) do { template_testcase_begin(#x, #__VA_ARGS__); x(__VA_ARGS__); template_testcase_end(); } while(0)

--- a/lib/template/tests/test_template_speed.c
+++ b/lib/template/tests/test_template_speed.c
@@ -108,7 +108,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   app_startup();
 
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   plugin_load_module("syslogformat", configuration, NULL);

--- a/lib/template/tests/test_template_speed.c
+++ b/lib/template/tests/test_template_speed.c
@@ -45,7 +45,7 @@ MsgFormatOptions parse_options;
 #define BENCHMARK_COUNT 10000
 
 void
-testcase(const gchar *msg_str, gboolean syslog_proto, gchar *template)
+testcase(const gchar *msg_str, gboolean syslog_proto, const gchar *template)
 {
   LogTemplate *templ;
   LogMessage *msg;

--- a/lib/tests/test_cfg_lexer_subst.c
+++ b/lib/tests/test_cfg_lexer_subst.c
@@ -212,7 +212,7 @@ test_values_are_resolution_order_args_defaults_globals_env(void)
 {
   CfgLexerSubst *subst = construct_object();
 
-  putenv("env=env_for_env");
+  setenv("env", "env_for_env", TRUE);
   assert_invoke_result(subst, "foo `arg` bar", "foo arg_value bar");
   assert_invoke_result(subst, "foo `def` bar", "foo default_for_def bar");
   assert_invoke_result(subst, "foo `globl` bar", "foo global_for_globl bar");

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -146,7 +146,7 @@ main(int argc, char *argv[])
   GlobalConfig *cfg;
 
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   cfg = cfg_new(VERSION_VALUE);

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -78,8 +78,8 @@ enum
 
 typedef struct
 {
-  gchar *name;
-  gchar *alt_name;
+  const gchar *name;
+  const gchar *alt_name;
   gint type;
   gint id;
 } ValuePairSpec;
@@ -173,7 +173,7 @@ vp_pair_conf_free(VPPairConf *vpc)
 
 
 static gchar *
-vp_transform_apply (ValuePairs *vp, gchar *key)
+vp_transform_apply (ValuePairs *vp, const gchar *key)
 {
   gchar *ckey, *okey = g_strdup(key);
   gint i;
@@ -250,7 +250,7 @@ vp_msg_nvpairs_foreach(NVHandle handle, gchar *name,
 }
 
 static gboolean
-vp_find_in_set(ValuePairs *vp, gchar *name, gboolean exclude)
+vp_find_in_set(ValuePairs *vp, const gchar *name, gboolean exclude)
 {
   guint j;
   gboolean included = exclude;
@@ -897,7 +897,7 @@ value_pairs_init_set(ValuePairSpec *set)
   for (i = 0; set[i].name; i++)
     {
       guint id;
-      gchar *name;
+      const gchar *name;
 
       name = set[i].alt_name ? set[i].alt_name : set[i].name;
 

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -28,11 +28,17 @@
 #include <string.h>
 #include <errno.h>
 
+struct iovec_const
+  {
+    const gchar *iov_base;     /* Pointer to data.  */
+    gsize iov_len;     /* Length of data.  */
+  };
+
 typedef struct
 {
   LogTransport super;
   /* data is stored in a series of data chunks, that are going to be returned as individual reads */
-  struct iovec iov[32];
+  struct iovec_const iov[32];
   gint iov_cnt;
   /* index currently read i/o chunk */
   gint current_iov_ndx;
@@ -47,7 +53,7 @@ gssize
 log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTransportAuxData *aux)
 {
   LogTransportMock *self = (LogTransportMock *) s;
-  struct iovec *current_iov;
+  struct iovec_const *current_iov;
 
   if (self->current_iov_ndx >= self->iov_cnt)
     {

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -100,9 +100,9 @@ log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTr
 }
 
 static void
-log_transport_mock_init(LogTransportMock *self, gchar *read_buffer1, gssize read_buffer_length1, va_list va)
+log_transport_mock_init(LogTransportMock *self, const gchar *read_buffer1, gssize read_buffer_length1, va_list va)
 {
-  gchar *buffer;
+  const gchar *buffer;
   gssize length;
 
   self->super.fd = 0;
@@ -123,7 +123,7 @@ log_transport_mock_init(LogTransportMock *self, gchar *read_buffer1, gssize read
       self->iov[self->iov_cnt].iov_base = buffer;
       self->iov[self->iov_cnt].iov_len = length;
       self->iov_cnt++;
-      buffer = va_arg(va, gchar *);
+      buffer = va_arg(va, const gchar *);
       length = va_arg(va, gint);
     }
 
@@ -132,7 +132,7 @@ log_transport_mock_init(LogTransportMock *self, gchar *read_buffer1, gssize read
 }
 
 LogTransport *
-log_transport_mock_stream_new(gchar *read_buffer1, gssize read_buffer_length1, ...)
+log_transport_mock_stream_new(const gchar *read_buffer1, gssize read_buffer_length1, ...)
 {
   LogTransportMock *self = g_new0(LogTransportMock, 1);
   va_list va;
@@ -145,7 +145,7 @@ log_transport_mock_stream_new(gchar *read_buffer1, gssize read_buffer_length1, .
 }
 
 LogTransport *
-log_transport_mock_endless_stream_new(gchar *read_buffer1, gssize read_buffer_length1, ...)
+log_transport_mock_endless_stream_new(const gchar *read_buffer1, gssize read_buffer_length1, ...)
 {
   LogTransportMock *self = g_new0(LogTransportMock, 1);
   va_list va;
@@ -159,7 +159,7 @@ log_transport_mock_endless_stream_new(gchar *read_buffer1, gssize read_buffer_le
 }
 
 LogTransport *
-log_transport_mock_records_new(gchar *read_buffer1, gssize read_buffer_length1, ...)
+log_transport_mock_records_new(const gchar *read_buffer1, gssize read_buffer_length1, ...)
 {
   LogTransportMock *self = g_new0(LogTransportMock, 1);
   va_list va;
@@ -171,7 +171,7 @@ log_transport_mock_records_new(gchar *read_buffer1, gssize read_buffer_length1, 
 }
 
 LogTransport *
-log_transport_mock_endless_records_new(gchar *read_buffer1, gssize read_buffer_length1, ...)
+log_transport_mock_endless_records_new(const gchar *read_buffer1, gssize read_buffer_length1, ...)
 {
   LogTransportMock *self = g_new0(LogTransportMock, 1);
   va_list va;

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -34,15 +34,15 @@
 #define LTM_PADDING		"padd", -1, "padd", -1, "padd", -1, "padd", -1, "padd", -1
 
 LogTransport *
-log_transport_mock_stream_new(gchar *read_buffer1, gssize read_buffer_length1, ...);
+log_transport_mock_stream_new(const gchar *read_buffer1, gssize read_buffer_length1, ...);
 
 LogTransport *
-log_transport_mock_endless_stream_new(gchar *read_buffer1, gssize read_buffer_length1, ...);
+log_transport_mock_endless_stream_new(const gchar *read_buffer1, gssize read_buffer_length1, ...);
 
 LogTransport *
-log_transport_mock_records_new(gchar *read_buffer1, gssize read_buffer_length1, ...);
+log_transport_mock_records_new(const gchar *read_buffer1, gssize read_buffer_length1, ...);
 
 LogTransport *
-log_transport_mock_endless_records_new(gchar *read_buffer1, gssize read_buffer_length1, ...);
+log_transport_mock_endless_records_new(const gchar *read_buffer1, gssize read_buffer_length1, ...);
 
 #endif

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -25,6 +25,8 @@
 #include "msg_parse_lib.h"
 #include "plugin.h"
 
+MsgFormatOptions parse_options;
+
 void
 init_and_load_syslogformat_module()
 {

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -30,7 +30,7 @@
 #include "cfg.h"
 #include "logmsg/logmsg.h"
 
-MsgFormatOptions parse_options;
+extern MsgFormatOptions parse_options;
 
 #define MSG_TESTCASE(x, ...) do { log_message_testcase_begin(#x, #__VA_ARGS__); x(__VA_ARGS__); log_message_testcase_end(); } while(0)
 

--- a/libtest/template_lib.c
+++ b/libtest/template_lib.c
@@ -69,7 +69,7 @@ LogMessage *
 create_empty_message(void)
 {
   LogMessage *msg;
-  char *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]:árvíztűrőtükörfúrógép";
+  const char *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]:árvíztűrőtükörfúrógép";
   GSockAddr *saddr;
 
   saddr = g_sockaddr_inet_new("10.11.12.13", 1010);

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -36,12 +36,12 @@ static gboolean testutils_global_success = TRUE;
 struct timeval start_time_val;
 
 GString *current_testcase_description = NULL;
-gchar *current_testcase_function = NULL;
+const gchar *current_testcase_function = NULL;
 gchar *current_testcase_file = NULL;
 GList *internal_messages = NULL;
 
 static void
-print_failure(const gchar *custom_template, va_list custom_args, gchar *assertion_failure_template, ...)
+print_failure(const gchar *custom_template, va_list custom_args, const gchar *assertion_failure_template, ...)
 {
   testutils_global_success = FALSE;
   va_list assertion_failure_args;
@@ -78,7 +78,7 @@ start_stopwatch(void)
 }
 
 void
-stop_stopwatch_and_display_result(gint iterations, gchar *message_template, ...)
+stop_stopwatch_and_display_result(gint iterations, const gchar *message_template, ...)
 {
   va_list args;
   guint64 diff;
@@ -501,7 +501,7 @@ assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error
 }
 
 gboolean
-assert_msg_field_equals_non_fatal(LogMessage *msg, gchar *field_name, gchar *expected_value, gssize expected_value_len, const gchar *error_message, ...)
+assert_msg_field_equals_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *expected_value, gssize expected_value_len, const gchar *error_message, ...)
 {
   gssize actual_value_len;
   const gchar* actual_value;
@@ -522,7 +522,7 @@ assert_msg_field_equals_non_fatal(LogMessage *msg, gchar *field_name, gchar *exp
 }
 
 gboolean
-assert_msg_field_unset_non_fatal(LogMessage *msg, gchar *field_name, const gchar *error_message, ...)
+assert_msg_field_unset_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *error_message, ...)
 {
   gssize actual_value_len;
   const gchar *actual_value;

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -544,3 +544,12 @@ testutils_deinit(void)
 {
   return testutils_global_success;
 }
+
+gchar *
+basename_const(const gchar *file)
+{
+  gchar *dup_file = g_strdup(file);
+  gchar *base = g_strdup(basename(dup_file));
+  g_free(dup_file);
+  return base;
+}

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -47,7 +47,7 @@
                                  basename(__FILE__), __LINE__, __FUNCTION__, ((message) ? (message) : "")
 
 void start_stopwatch();
-void stop_stopwatch_and_display_result(gint iterations, gchar *message_template, ...);
+void stop_stopwatch_and_display_result(gint iterations, const gchar *message_template, ...);
 
 void reset_grabbed_messages(void);
 void start_grabbing_messages(void);
@@ -72,8 +72,8 @@ gboolean assert_not_null_non_fatal(void *pointer, const gchar *error_message, ..
 gboolean assert_no_error_non_fatal(GError *error, const gchar *error_message, ...);
 gboolean assert_guint32_set_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected, guint32 expected_length, const gchar *error_message, ...);
 gboolean assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error_message, ...);
-gboolean assert_msg_field_equals_non_fatal(LogMessage *msg, gchar *field_name, gchar *expected_value, gssize expected_value_len, const gchar *error_message, ...);
-gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, gchar *field_name, const gchar *error_message, ...);
+gboolean assert_msg_field_equals_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *expected_value, gssize expected_value_len, const gchar *error_message, ...);
+gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *error_message, ...);
 
 
 #define assert_guint16(actual, expected, error_message, ...) (assert_guint16_non_fatal(actual, expected, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
@@ -123,7 +123,7 @@ gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, gchar *field_name, co
 #define assert_msg_field_unset(msg, field_name, error_message, ...) (assert_msg_field_unset_non_fatal(msg, field_name, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
 
 extern GString *current_testcase_description;
-extern gchar *current_testcase_function;
+extern const gchar *current_testcase_function;
 extern gchar *current_testcase_file;
 
 gboolean testutils_deinit(void);
@@ -138,7 +138,7 @@ gboolean testutils_deinit(void);
         } \
       current_testcase_description = g_string_sized_new(0); \
       g_string_printf(current_testcase_description, description_template, ##__VA_ARGS__); \
-      current_testcase_function = (gchar *)(__FUNCTION__); \
+      current_testcase_function = __FUNCTION__; \
       current_testcase_file = basename(__FILE__); \
     } while (0)
 

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -128,6 +128,8 @@ extern gchar *current_testcase_file;
 
 gboolean testutils_deinit(void);
 
+gchar *basename_const(const gchar *file);
+
 #define testcase_begin(description_template, ...) \
     do { \
       if (current_testcase_description != NULL) \
@@ -139,7 +141,7 @@ gboolean testutils_deinit(void);
       current_testcase_description = g_string_sized_new(0); \
       g_string_printf(current_testcase_description, description_template, ##__VA_ARGS__); \
       current_testcase_function = __FUNCTION__; \
-      current_testcase_file = basename(__FILE__); \
+      current_testcase_file = basename_const(__FILE__); \
     } while (0)
 
 #define testcase_end() \
@@ -147,6 +149,7 @@ gboolean testutils_deinit(void);
       g_string_free(current_testcase_description, TRUE); \
       current_testcase_description = NULL; \
       current_testcase_function = NULL; \
+      g_free(current_testcase_file); \
       current_testcase_file = NULL; \
     } while (0)
 

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -94,7 +94,7 @@ _add_context_data_to_message(gpointer pmsg,
                              const ContextualDataRecord *record)
 {
   LogMessage *msg = (LogMessage *) pmsg;
-  log_msg_set_value_by_name(msg, record->name->str, record->value->str, record->value->len);
+  log_msg_set_value_by_name(msg, record->name->str, record->value->str, (gssize)record->value->len);
 }
 
 static gboolean
@@ -261,7 +261,7 @@ _is_initialized(AddContextualData *self)
   return context_info_db_is_loaded(self->context_info_db);
 }
 
-gboolean
+static gboolean
 _compile_selector_template(AddContextualData *self)
 {
   GError *error = NULL;

--- a/modules/add-contextual-data/context-info-db.h
+++ b/modules/add-contextual-data/context-info-db.h
@@ -32,7 +32,7 @@ typedef struct _ContextInfoDB ContextInfoDB;
 typedef void (*ADD_CONTEXT_INFO_CB) (gpointer arg,
                                      const ContextualDataRecord *record);
 
-ContextInfoDB *context_info_db_new();
+ContextInfoDB *context_info_db_new(void);
 void context_info_db_free(ContextInfoDB *self);
 
 ContextInfoDB *context_info_db_ref(ContextInfoDB *self);

--- a/modules/add-contextual-data/contextual-data-record-scanner.h
+++ b/modules/add-contextual-data/contextual-data-record-scanner.h
@@ -39,7 +39,7 @@ struct _ContextualDataRecordScanner
   ContextualDataRecord last_record;
   gpointer scanner;
   const gchar *name_prefix;
-  const gboolean (*get_next) (ContextualDataRecordScanner *self,
+  gboolean (*get_next) (ContextualDataRecordScanner *self,
                               const gchar *input,
                               ContextualDataRecord *record);
   void (*free_fn) (ContextualDataRecordScanner *self);

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.c
@@ -67,8 +67,8 @@ _is_whole_record_parsed(CSVScanner *line_scanner)
   return csv_scanner_is_scan_finished(line_scanner);
 }
 
-const gboolean
-get_next_record(ContextualDataRecordScanner *s, const gchar *input, ContextualDataRecord *record)
+static gboolean
+_get_next_record(ContextualDataRecordScanner *s, const gchar *input, ContextualDataRecord *record)
 {
   CSVScanner *line_scanner = (CSVScanner *) s->scanner;
   csv_scanner_input(line_scanner, input);
@@ -108,7 +108,7 @@ csv_contextual_data_record_scanner_new()
   csv_scanner_options_set_dialect(&self->options, CSV_SCANNER_ESCAPE_NONE);
   csv_scanner_state_init(&self->scanner, &self->options);
   self->super.scanner = &self->scanner;
-  self->super.get_next = get_next_record;
+  self->super.get_next = _get_next_record;
   self->super.free_fn = csv_contextual_data_record_scanner_free;
 
   return &self->super;

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -248,7 +248,7 @@ afamqp_dd_disconnect(LogThrDestDriver *s)
 }
 
 static gboolean
-afamqp_is_ok(AMQPDestDriver *self, gchar *context, amqp_rpc_reply_t ret)
+afamqp_is_ok(AMQPDestDriver *self, const gchar *context, amqp_rpc_reply_t ret)
 {
   switch (ret.reply_type)
     {

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -233,7 +233,7 @@ afsmtp_dd_format_persist_name(const LogPipe *s)
 static void
 _smtp_message_add_recipient_header(smtp_message_t self, AFSMTPRecipient *rcpt, AFSMTPDriver *driver) 
 {
-  gchar *hdr;
+  const gchar *hdr;
   switch (rcpt->type)
     {
     case AFSMTP_RCPT_TYPE_TO:

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -133,7 +133,7 @@ afinet_dd_construct_writer(AFSocketDestDriver *s)
   return writer;
 }
 
-static const gint
+static gint
 _determine_port(const AFInetDestDriver *self)
 {
   gint port = 0;

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -31,8 +31,6 @@
 
 #include <unistd.h>
 
-TransportMapper *transport_mapper;
-
 #define transport_mapper_inet_testcase_begin(init_name, func, args) 	        \
   do                                                            \
     {                                                           \

--- a/modules/cef/tests/test-format-cef-extension.c
+++ b/modules/cef/tests/test-format-cef-extension.c
@@ -218,7 +218,7 @@ int
 main(int argc, char *argv[])
 {
   app_startup();
-  putenv("TZ=UTC");
+  setenv("TZ", "UTC", TRUE);
   tzset();
   init_template_tests();
   plugin_load_module("cef", configuration, NULL);

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -172,7 +172,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
   app_startup();
 
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   configuration = cfg_new(0x0302);

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -35,7 +35,7 @@ typedef struct _DateParser
 } DateParser;
 
 void
-date_parser_set_format(LogParser *s, gchar *format)
+date_parser_set_format(LogParser *s, const gchar *format)
 {
   DateParser *self = (DateParser *) s;
 

--- a/modules/date/date-parser.h
+++ b/modules/date/date-parser.h
@@ -29,7 +29,7 @@
 LogParser *date_parser_new(GlobalConfig *cfg);
 
 void date_parser_set_offset(LogParser *s, goffset offset);
-void date_parser_set_format(LogParser *s, gchar *format);
+void date_parser_set_format(LogParser *s, const gchar *format);
 void date_parser_set_timezone(LogParser *s, gchar *tz);
 void date_parser_set_time_stamp(LogParser *s, LogMessageTimeStamp timestamp);
 

--- a/modules/date/tests/test_date.c
+++ b/modules/date/tests/test_date.c
@@ -73,7 +73,7 @@ setup(void)
   app_startup();
 
   setlocale (LC_ALL, "C");
-  putenv("TZ=CET-1");
+  setenv("TZ", "CET-1", TRUE);
   tzset();
 
   configuration = cfg_new(0x0302);

--- a/modules/dbparser/patternize.c
+++ b/modules/dbparser/patternize.c
@@ -70,7 +70,7 @@ ptz_str2hash(gchar *string, guint modulo, guint seed)
 }
 
 gchar *
-ptz_find_delimiters(gchar *str, gchar *delimdef)
+ptz_find_delimiters(gchar *str, const gchar *delimdef)
 {
   gchar *remainder;
   GString *delimiters = g_string_sized_new(32);
@@ -96,7 +96,7 @@ ptz_find_frequent_words_remove_key_predicate(gpointer key, gpointer value, gpoin
 }
 
 GHashTable *
-ptz_find_frequent_words(GPtrArray *logs, guint support, gchar *delimiters, gboolean two_pass)
+ptz_find_frequent_words(GPtrArray *logs, guint support, const gchar *delimiters, gboolean two_pass)
 {
   int i, j, pass;
   guint *curr_count;
@@ -230,7 +230,7 @@ cluster_free(Cluster *cluster)
 }
 
 GHashTable *
-ptz_find_clusters_slct(GPtrArray *logs, guint support, gchar *delimiters, guint num_of_samples)
+ptz_find_clusters_slct(GPtrArray *logs, guint support, const gchar *delimiters, guint num_of_samples)
 {
   GHashTable *wordlist;
   GHashTable *clusters;
@@ -550,7 +550,7 @@ ptz_print_patterndb_rule(gpointer key, gpointer value, gpointer user_data)
 }
 
 void
-ptz_print_patterndb(GHashTable *clusters, gchar *delimiters, gboolean named_parsers)
+ptz_print_patterndb(GHashTable *clusters, const gchar *delimiters, gboolean named_parsers)
 {
   char date[12], uuid_string[37];
   time_t currtime;
@@ -624,7 +624,7 @@ ptz_load_file(Patternizer *self, gchar *input_file, gboolean no_parse, GError **
 }
 
 Patternizer *
-ptz_new(gdouble support_treshold, guint algo, guint iterate, guint num_of_samples, gchar *delimiters)
+ptz_new(gdouble support_treshold, guint algo, guint iterate, guint num_of_samples, const gchar *delimiters)
 {
   Patternizer *self = g_new0(Patternizer, 1);
 

--- a/modules/dbparser/patternize.h
+++ b/modules/dbparser/patternize.h
@@ -46,7 +46,7 @@ typedef struct _Patternizer
   guint support;
   guint num_of_samples;
   gdouble support_treshold;
-  gchar *delimiters;
+  const gchar *delimiters;
 
   // NOTE: for now, we store all logs read in in the memory.
   // This brings in some obvious constraints and should be solved
@@ -63,16 +63,16 @@ typedef struct _Cluster
 } Cluster;
 
 /* only declared for the test program */
-GHashTable *ptz_find_frequent_words(GPtrArray *logs, guint support, gchar *delimiters, gboolean two_pass);
-GHashTable *ptz_find_clusters_slct(GPtrArray *logs, guint support, gchar *delimiters, guint num_of_samples);
+GHashTable *ptz_find_frequent_words(GPtrArray *logs, guint support, const gchar *delimiters, gboolean two_pass);
+GHashTable *ptz_find_clusters_slct(GPtrArray *logs, guint support, const gchar *delimiters, guint num_of_samples);
 
 
 GHashTable *ptz_find_clusters(Patternizer *self);
-void ptz_print_patterndb(GHashTable *clusters, gchar *delimiters, gboolean named_parsers);
+void ptz_print_patterndb(GHashTable *clusters, const gchar *delimiters, gboolean named_parsers);
 
 gboolean ptz_load_file(Patternizer *self, gchar *input_file, gboolean no_parse, GError **error);
 
-Patternizer *ptz_new(gdouble support_treshold, guint algo, guint iterate, guint num_of_samples, gchar *delimiters);
+Patternizer *ptz_new(gdouble support_treshold, guint algo, guint iterate, guint num_of_samples, const gchar *delimiters);
 void ptz_free(Patternizer *self);
 
 #endif

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -53,7 +53,7 @@
 
 #define BOOL(x) ((x) ? "TRUE" : "FALSE")
 
-static gchar *full_colors[] =
+static const gchar *full_colors[] =
 {
   "\33[01;34m", /* blue */
   "\33[0;33m", /* brown */
@@ -61,7 +61,7 @@ static gchar *full_colors[] =
   "\33[01;31m"  /* red */
 };
 
-static gchar *empty_colors[] =
+static const gchar *empty_colors[] =
 {
   "", "", "", ""
 };
@@ -71,11 +71,11 @@ static gchar *empty_colors[] =
 #define COLOR_LITERAL 2
 #define COLOR_PARTIAL 3
 
-static gchar *no_color = "\33[01;0m";
-static gchar **colors = empty_colors;
+static const gchar *no_color = "\33[01;0m";
+static const gchar **colors = empty_colors;
 
 
-static gchar *patterndb_file = PATH_PATTERNDB_FILE;
+static const gchar *patterndb_file = PATH_PATTERNDB_FILE;
 static gboolean color_out = FALSE;
 
 typedef struct _PdbToolMergeState
@@ -981,7 +981,7 @@ static gdouble support_treshold = 4.0;
 static gboolean iterate_outliers = FALSE;
 static gboolean named_parsers = FALSE;
 static gint num_of_samples = 1;
-static gchar *delimiters = " :&~?![]=,;()'\"";
+static const gchar *delimiters = " :&~?![]=,;()'\"";
 
 static gint
 pdbtool_patternize(int argc, char *argv[])

--- a/modules/dbparser/radix.c
+++ b/modules/dbparser/radix.c
@@ -225,7 +225,7 @@ r_parser_email(guint8 *str, gint *len, const gchar *param, gpointer state, RPars
   gint end;
   int count = 0;
 
-  gchar *email = "!#$%&'*+-/=?^_`{|}~.";
+  const gchar *email = "!#$%&'*+-/=?^_`{|}~.";
 
   *len = 0;
 
@@ -1476,7 +1476,7 @@ r_find_all_applicable_nodes(RNode *root, guint8 *key, gint keylen, RNodeGetValue
  * r_new_node:
  */
 RNode *
-r_new_node(guint8 *key, gpointer value)
+r_new_node(const guint8 *key, gpointer value)
 {
   RNode *node = g_malloc(sizeof(RNode));
 

--- a/modules/dbparser/radix.h
+++ b/modules/dbparser/radix.h
@@ -108,7 +108,7 @@ typedef struct _RDebugInfo
   gint match_len;
 } RDebugInfo;
 
-static inline gchar *
+static inline const gchar *
 r_parser_type_name(guint8 type)
 {
   switch (type)
@@ -146,7 +146,7 @@ r_parser_type_name(guint8 type)
     }
 }
 
-RNode *r_new_node(guint8 *key, gpointer value);
+RNode *r_new_node(const guint8 *key, gpointer value);
 void r_free_node(RNode *node, void (*free_fn)(gpointer data));
 void r_insert_node(RNode *root, guint8 *key, gpointer value, RNodeGetValueFunc value_func);
 RNode *r_find_node(RNode *root, guint8 *key, gint keylen, GArray *matches);

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-const QueueType log_queue_disk_type = "DISK";
+QueueType log_queue_disk_type = "DISK";
 
 static gint64
 _get_length(LogQueue *s)

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -54,7 +54,7 @@ struct _LogQueueDisk
   void (*restart_corrupted)(LogQueueDisk *self);
 };
 
-extern const QueueType log_queue_disk_type;
+extern QueueType log_queue_disk_type;
 
 gboolean log_queue_disk_is_reliable(LogQueue *s);
 const gchar *log_queue_disk_get_filename(LogQueue *self);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -79,7 +79,7 @@ typedef union _QDiskFileHeader
 struct _QDisk
 {
   gchar *filename;
-  gchar *file_id;
+  const gchar *file_id;
   gint fd;
   gint64 read_qout_ofs; /* the size in bytes between read_head and qout_ofs */
   gint64 prev_read_head;
@@ -140,7 +140,7 @@ _next_filename(QDisk *self)
     {
       struct stat st;
 
-      gchar *format = "%s/syslog-ng-%05d.qf";
+      const gchar *format = "%s/syslog-ng-%05d.qf";
       if (self->options->reliable)
         format = "%s/syslog-ng-%05d.rqf";
       g_snprintf(tmpfname, sizeof(tmpfname), format, qdir, i);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -297,7 +297,7 @@ main()
   return 0;
 #endif
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   configuration = cfg_new(0x308);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -88,7 +88,7 @@ int
 main()
 {
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   configuration = cfg_new(0x0308);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -369,7 +369,7 @@ gint
 main(gint argc, gchar **argv)
 {
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   configuration = cfg_new(0x0308);

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -62,7 +62,7 @@ java_machine_ref(void)
   return g_jvm_s;
 }
 
-static void inline
+static inline void
 __jvm_free(JavaVMSingleton *self)
 {
   msg_debug("Java machine free");

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -141,7 +141,7 @@ int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
   app_startup();
-  putenv("TZ=UTC");
+  setenv("TZ", "UTC", TRUE);
   tzset();
   init_template_tests();
   plugin_load_module("json-plugin", configuration, NULL);

--- a/modules/kvformat/tests/test_format_welf.c
+++ b/modules/kvformat/tests/test_format_welf.c
@@ -39,7 +39,7 @@ int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
   app_startup();
-  putenv("TZ=UTC");
+  setenv("TZ", "UTC", TRUE);
   tzset();
   init_template_tests();
   plugin_load_module("kvformat", configuration, NULL);

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -187,7 +187,7 @@ int
 main(void)
 {
   app_startup();
-  putenv("TZ=UTC");
+  setenv("TZ", "UTC", TRUE);
   tzset();
 
   init_and_load_kmsgformat_module();

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -190,9 +190,9 @@ system_sysblock_add_systemd_source(GString *sysblock)
 static void
 system_sysblock_add_linux_kmsg(GString *sysblock)
 {
-  gchar *kmsg = "/proc/kmsg";
+  const gchar *kmsg = "/proc/kmsg";
   int fd;
-  gchar *format = NULL;
+  const gchar *format = NULL;
 
   if ((fd = open("/dev/kmsg", O_RDONLY)) != -1)
     {

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -197,7 +197,7 @@ _set_value_in_message(JournalReaderOptions *options, LogMessage *msg, gchar *key
 }
 
 static const gchar*
-_get_value_from_message(JournalReaderOptions *options, LogMessage *msg,  gchar *key, gssize *value_length)
+_get_value_from_message(JournalReaderOptions *options, LogMessage *msg,  const gchar *key, gssize *value_length)
 {
   gchar name_with_prefix[256];
 
@@ -619,7 +619,7 @@ journal_reader_options_init(JournalReaderOptions *options, GlobalConfig *cfg, co
 
   if (options->prefix == NULL && !cfg_is_config_version_older(cfg, 0x0308))
     {
-      gchar *value = ".journald.";
+      const gchar *value = ".journald.";
       msg_warning("WARNING: Default value changed for the prefix() option of systemd-journal source in " VERSION_3_8,
                   evt_tag_str("old_value", ""),
                   evt_tag_str("new_value", value));

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -125,7 +125,7 @@ version(void)
 {
   if (!get_installer_version(&installer_version) || installer_version == NULL)
     {
-      installer_version = SYSLOG_NG_VERSION;
+      installer_version = g_strdup(SYSLOG_NG_VERSION);
     }
   printf(SYSLOG_NG_PACKAGE_NAME " " SYSLOG_NG_VERSION "\n"
          "Installer-Version: %s\n"

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -38,8 +38,6 @@
 #include <iv_list.h>
 #include <iv_thread.h>
 
-MsgFormatOptions parse_options;
-
 #define OVERFLOW_SIZE 10000
 #define FEEDERS 1
 #define MESSAGES_PER_FEEDER 30000

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -168,7 +168,7 @@ void
 setup(void)
 {
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
   init_and_load_syslogformat_module();
 }

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -141,7 +141,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   configuration = cfg_new(0x0300);
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   plugin_load_module("syslogformat", configuration, NULL);

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -31,8 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-MsgFormatOptions parse_options;
-
 static LogMessage *
 _create_log_message(const gchar *log)
 {

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -152,7 +152,7 @@ void
 setup(void)
 {
   app_startup();
-  putenv("TZ=MET-1METDST");
+  setenv("TZ", "MET-1METDST", TRUE);
   tzset();
   init_and_load_syslogformat_module();
 }


### PR DESCRIPTION
These improvement enable more static analysis for free (warnings) which could potentially improve the codebase. Because the complete elimination of all relevant warnings is a big undertaking, only those were fixed which were needed to make the project still compile.

Notably, `-pedantic` could not be enabled because Ivykis and the msg_\* macros, but a little refactoring could fix these in the future.

No new PR should introduce further warnings.
