### PR TITLE
32bit wide NVHandle with unittests

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1672,7 +1672,7 @@ log_msg_registry_init(void)
 {
   gint i;
 
-  logmsg_registry = nv_registry_new(builtin_value_names);
+  logmsg_registry = nv_registry_new(builtin_value_names, NVHANDLE_MAX_VALUE);
   nv_registry_add_alias(logmsg_registry, LM_V_MESSAGE, "MSG");
   nv_registry_add_alias(logmsg_registry, LM_V_MESSAGE, "MSGONLY");
   nv_registry_add_alias(logmsg_registry, LM_V_HOST, "FULLHOST");

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -69,9 +69,10 @@ nv_registry_alloc_handle(NVRegistry *self, const gchar *name)
                 evt_tag_str("value", name));
       goto exit;
     }
-  else if (self->names->len >= 65535)
+  else if (self->names->len >= NVHANDLE_MAX_VALUE)
     {
-      msg_error("Hard wired limit of 65535 name-value pairs have been reached, all further name-value pair will expand to nothing",
+      msg_error("Hard wired limit of name-value pairs have been reached, all further name-value pair will expand to nothing",
+                evt_tag_printf("limit", "%"G_GUINT32_FORMAT, NVHANDLE_MAX_VALUE),
                 evt_tag_str("value", name));
       goto exit;
     }

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -69,10 +69,10 @@ nv_registry_alloc_handle(NVRegistry *self, const gchar *name)
                 evt_tag_str("value", name));
       goto exit;
     }
-  else if (self->names->len >= NVHANDLE_MAX_VALUE)
+  else if (self->names->len >= self->nvhandle_max_value)
     {
       msg_error("Hard wired limit of name-value pairs have been reached, all further name-value pair will expand to nothing",
-                evt_tag_printf("limit", "%"G_GUINT32_FORMAT, NVHANDLE_MAX_VALUE),
+                evt_tag_printf("limit", "%"G_GUINT32_FORMAT, self->nvhandle_max_value),
                 evt_tag_str("value", name));
       goto exit;
     }
@@ -121,11 +121,12 @@ nv_registry_foreach(NVRegistry *self, GHFunc callback, gpointer user_data)
 }
 
 NVRegistry *
-nv_registry_new(const gchar **static_names)
+nv_registry_new(const gchar **static_names, guint32 nvhandle_max_value)
 {
   NVRegistry *self = g_new0(NVRegistry, 1);
   gint i;
 
+  self->nvhandle_max_value = nvhandle_max_value;
   self->name_map = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
   self->names = g_array_new(FALSE, FALSE, sizeof(NVHandleDesc));
   for (i = 0; static_names[i]; i++)

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -36,6 +36,8 @@ typedef struct _NVHandleDesc NVHandleDesc;
 typedef gboolean (*NVTableForeachFunc)(NVHandle handle, const gchar *name, const gchar *value, gssize value_len, gpointer user_data);
 typedef gboolean (*NVTableForeachEntryFunc)(NVHandle handle, NVEntry *entry, NVIndexEntry *index_entry, gpointer user_data);
 
+#define NVHANDLE_MAX_VALUE ((NVHandle)-1)
+
 struct _NVIndexEntry
 {
   NVHandle handle;

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -57,6 +57,7 @@ struct _NVRegistry
   gint num_static_names;
   GArray *names;
   GHashTable *name_map;
+  guint32 nvhandle_max_value;
 };
 
 extern const gchar *null_string;
@@ -66,7 +67,7 @@ NVHandle nv_registry_get_handle(NVRegistry *self, const gchar *name);
 NVHandle nv_registry_alloc_handle(NVRegistry *self, const gchar *name);
 void nv_registry_set_handle_flags(NVRegistry *self, NVHandle handle, guint16 flags);
 void nv_registry_foreach(NVRegistry *self, GHFunc callback, gpointer user_data);
-NVRegistry *nv_registry_new(const gchar **static_names);
+NVRegistry *nv_registry_new(const gchar **static_names, guint32 nvhandle_max_value);
 void nv_registry_free(NVRegistry *self);
 
 static inline guint16

--- a/lib/logmsg/tests/test_nvtable.c
+++ b/lib/logmsg/tests/test_nvtable.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+
 /* NVRegistry */
 /* testcases:
  *
@@ -38,6 +39,7 @@
  *   - adding an alias and looking up an NV pair by alias should return the same handle
  *   - NV pairs cannot have the zero-length string as a name
  *   - NV pairs cannot have names longer than 255 characters
+ *   - no more than predefined number of NV pairs are supported
  *   -
  */
 
@@ -46,11 +48,84 @@
     {                                                                   \
       if (!(cond))                                                      \
         {                                                               \
-          fprintf(stderr, "Assertion %s failed at line %d", #cond, __LINE__); \
+          fprintf(stderr, "Assertion %s failed at line %d\n", #cond, __LINE__); \
           exit(1);                                                      \
         }                                                               \
     }                                                                   \
   while (0)
+
+#define TEST_NVHANDLE_MAX_VALUE 10
+
+static void
+test_nv_registry()
+{
+  NVRegistry *reg;
+  gint i, j;
+  NVHandle handle, prev_handle;
+  const gchar *name;
+  gssize len;
+  const gchar *builtins[] = { "BUILTIN1", "BUILTIN2", "BUILTIN3", NULL };
+
+  reg = nv_registry_new(builtins, TEST_NVHANDLE_MAX_VALUE);
+
+  for (i = 0; builtins[i]; i++)
+    {
+      handle = nv_registry_alloc_handle(reg, builtins[i]);
+      TEST_ASSERT(handle == (i+1));
+      name = nv_registry_get_handle_name(reg, handle, &len);
+      TEST_ASSERT(strcmp(name, builtins[i]) == 0);
+      TEST_ASSERT(strlen(name) == len);
+    }
+
+  for (i = 4; i < TEST_NVHANDLE_MAX_VALUE + 1; i++)
+    {
+      gchar dyn_name[16];
+
+      g_snprintf(dyn_name, sizeof(dyn_name), "DYN%05d", i);
+
+      /* try to look up the same name multiple times */
+      prev_handle = 0;
+      for (j = 0; j < 4; j++)
+        {
+          handle = nv_registry_alloc_handle(reg, dyn_name);
+          TEST_ASSERT(prev_handle == 0 || (handle == prev_handle));
+          prev_handle = handle;
+        }
+      name = nv_registry_get_handle_name(reg, handle, &len);
+      TEST_ASSERT(strcmp(name, dyn_name) == 0);
+      TEST_ASSERT(strlen(name) == len);
+
+      g_snprintf(dyn_name, sizeof(dyn_name), "ALIAS%05d", i);
+      nv_registry_add_alias(reg, handle, dyn_name);
+      handle = nv_registry_alloc_handle(reg, dyn_name);
+      TEST_ASSERT(handle == prev_handle);
+    }
+
+  for (i = TEST_NVHANDLE_MAX_VALUE; i >= 4; i--)
+    {
+      gchar dyn_name[16];
+
+      g_snprintf(dyn_name, sizeof(dyn_name), "DYN%05d", i);
+
+      /* try to look up the same name multiple times */
+      prev_handle = 0;
+      for (j = 0; j < 4; j++)
+        {
+          handle = nv_registry_alloc_handle(reg, dyn_name);
+          TEST_ASSERT(prev_handle == 0 || (handle == prev_handle));
+          prev_handle = handle;
+        }
+      name = nv_registry_get_handle_name(reg, handle, &len);
+      TEST_ASSERT(strcmp(name, dyn_name) == 0);
+      TEST_ASSERT(strlen(name) == len);
+    }
+
+  fprintf(stderr, "One error message about too many values is to be expected\n");
+  handle = nv_registry_alloc_handle(reg, "too-many-values");
+  TEST_ASSERT(handle == 0);
+
+  nv_registry_free(reg);
+}
 
 /*
  * NVTable:
@@ -877,6 +952,7 @@ int
 main(int argc, char *argv[])
 {
   app_startup();
+  test_nv_registry();
   test_nvtable();
   app_shutdown();
   return 0;

--- a/lib/logmsg/tests/test_nvtable.c
+++ b/lib/logmsg/tests/test_nvtable.c
@@ -30,7 +30,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-
 /* NVRegistry */
 /* testcases:
  *
@@ -39,7 +38,6 @@
  *   - adding an alias and looking up an NV pair by alias should return the same handle
  *   - NV pairs cannot have the zero-length string as a name
  *   - NV pairs cannot have names longer than 255 characters
- *   - no more than 65535 NV pairs are supported
  *   -
  */
 
@@ -53,77 +51,6 @@
         }                                                               \
     }                                                                   \
   while (0)
-
-static void
-test_nv_registry()
-{
-  NVRegistry *reg;
-  gint i, j;
-  NVHandle handle, prev_handle;
-  const gchar *name;
-  gssize len;
-  const gchar *builtins[] = { "BUILTIN1", "BUILTIN2", "BUILTIN3", NULL };
-
-  reg = nv_registry_new(builtins);
-
-  for (i = 0; builtins[i]; i++)
-    {
-      handle = nv_registry_alloc_handle(reg, builtins[i]);
-      TEST_ASSERT(handle == (i+1));
-      name = nv_registry_get_handle_name(reg, handle, &len);
-      TEST_ASSERT(strcmp(name, builtins[i]) == 0);
-      TEST_ASSERT(strlen(name) == len);
-    }
-
-  for (i = 4; i < 65536; i++)
-    {
-      gchar dyn_name[16];
-
-      g_snprintf(dyn_name, sizeof(dyn_name), "DYN%05d", i);
-
-      /* try to look up the same name multiple times */
-      prev_handle = 0;
-      for (j = 0; j < 4; j++)
-        {
-          handle = nv_registry_alloc_handle(reg, dyn_name);
-          TEST_ASSERT(prev_handle == 0 || (handle == prev_handle));
-          prev_handle = handle;
-        }
-      name = nv_registry_get_handle_name(reg, handle, &len);
-      TEST_ASSERT(strcmp(name, dyn_name) == 0);
-      TEST_ASSERT(strlen(name) == len);
-
-      g_snprintf(dyn_name, sizeof(dyn_name), "ALIAS%05d", i);
-      nv_registry_add_alias(reg, handle, dyn_name);
-      handle = nv_registry_alloc_handle(reg, dyn_name);
-      TEST_ASSERT(handle == prev_handle);
-    }
-
-  for (i = 65534; i >= 4; i--)
-    {
-      gchar dyn_name[16];
-
-      g_snprintf(dyn_name, sizeof(dyn_name), "DYN%05d", i);
-
-      /* try to look up the same name multiple times */
-      prev_handle = 0;
-      for (j = 0; j < 4; j++)
-        {
-          handle = nv_registry_alloc_handle(reg, dyn_name);
-          TEST_ASSERT(prev_handle == 0 || (handle == prev_handle));
-          prev_handle = handle;
-        }
-      name = nv_registry_get_handle_name(reg, handle, &len);
-      TEST_ASSERT(strcmp(name, dyn_name) == 0);
-      TEST_ASSERT(strlen(name) == len);
-    }
-
-  fprintf(stderr, "One error message about too many values is to be expected\n");
-  handle = nv_registry_alloc_handle(reg, "too-many-values");
-  TEST_ASSERT(handle == 0);
-
-  nv_registry_free(reg);
-}
 
 /*
  * NVTable:
@@ -950,7 +877,6 @@ int
 main(int argc, char *argv[])
 {
   app_startup();
-  test_nv_registry();
   test_nvtable();
   app_shutdown();
   return 0;


### PR DESCRIPTION
This PR continues the work started in #1126. This PR contains a modification so the deleted unit tests can be kept.