### PR TITLE
FreeBSD compatibility of 3.8 - fixes #1138

### DIFF
--- a/modules/affile/tests/test_affile_open_file.c
+++ b/modules/affile/tests/test_affile_open_file.c
@@ -24,6 +24,7 @@
 #include "testutils.h"
 #include "affile/affile-common.h"
 #include "lib/messages.h"
+#include "compat/lfs.h"
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/modules/date/strptime-tz.c
+++ b/modules/date/strptime-tz.c
@@ -58,8 +58,8 @@
 #include <string.h>
 #include <stdint.h>
 
-typedef unsigned char u_char;
-typedef unsigned int uint;
+typedef unsigned char _u_char;
+typedef unsigned int _uint;
 
 #define __UNCONST(a)    ((void *)(unsigned long)(const void *)(a))
 
@@ -87,6 +87,15 @@ typedef unsigned int uint;
 
 #define isleap(y) ((((y) % 4) == 0 && ((y) % 100) != 0) || ((y) % 400) == 0)
 #define isleap_sum(a, b)	isleap((a) % 400 + (b) % 400)
+
+#define GET_OFFSET_FROM_UTC *tm_gmtoff = -(timezone)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <sys/param.h>
+#if defined(BSD)
+#define GET_OFFSET_FROM_UTC -(tm->tm_gmtoff)
+#else
+#endif
+#endif
 
 
 typedef struct {
@@ -135,8 +144,8 @@ static const _TimeLocale _DefaultTimeLocale =
 #define _TIME_LOCALE(loc) \
 	(&_DefaultTimeLocale)
 
-static const u_char *conv_num(const unsigned char *, int *, uint, uint);
-static const u_char *find_string(const u_char *, int *, const char * const *,
+static const _u_char *conv_num(const unsigned char *, int *, _uint, _uint);
+static const _u_char *find_string(const _u_char *, int *, const char * const *,
 	const char * const *, int);
 
 
@@ -210,7 +219,7 @@ strptime_with_tz(const char *buf, const char *fmt, struct tm *tm, long *tm_gmtof
 	    day_offset = -1, week_offset = 0, offs;
 	const char *new_fmt;
 
-	bp = (const u_char *)buf;
+	bp = (const _u_char *)buf;
 
 	while (bp != NULL && (c = *fmt++) != '\0') {
 		/* Clear `alternate' modifier prior to new conversion. */
@@ -293,7 +302,7 @@ literal:
 			new_fmt = _TIME_LOCALE(loc)->d_fmt;
 			state |= S_MON | S_MDAY | S_YEAR;
 		    recurse:
-			bp = (const u_char *)strptime_with_tz((const char *)bp,
+			bp = (const _u_char *)strptime_with_tz((const char *)bp,
 							      new_fmt, tm, tm_gmtoff, tm_zone);
 			LEGAL_ALT(ALT_E);
 			continue;
@@ -508,12 +517,10 @@ literal:
 				*tm_zone = gmt;
 				bp += 3;
 			} else {
-				ep = find_string(bp, &i,
-                                                 (const char * const *)tzname,
-                                                 NULL, 2);
-                                if (ep != NULL) {
+				ep = find_string(bp, &i, (const char * const *)tzname, NULL, 2);
+                if (ep != NULL) {
 					tm->tm_isdst = i;
-					*tm_gmtoff = -(timezone);
+					GET_OFFSET_FROM_UTC;
 					*tm_zone = tzname[i];
 				}
 				bp = ep;
@@ -711,14 +718,14 @@ literal:
 }
 
 
-static const u_char *
-conv_num(const unsigned char *buf, int *dest, uint llim, uint ulim)
+static const _u_char *
+conv_num(const unsigned char *buf, int *dest, _uint llim, _uint ulim)
 {
-	uint result = 0;
+	_uint result = 0;
 	unsigned char ch;
 
 	/* The limit also determines the number of valid digits. */
-	uint rulim = ulim;
+	_uint rulim = ulim;
 
 	ch = *buf;
 	if (ch < '0' || ch > '9')
@@ -738,8 +745,8 @@ conv_num(const unsigned char *buf, int *dest, uint llim, uint ulim)
 	return buf;
 }
 
-static const u_char *
-find_string(const u_char *bp, int *tgt, const char * const *n1,
+static const _u_char *
+find_string(const _u_char *bp, int *tgt, const char * const *n1,
 		const char * const *n2, int c)
 {
 	int i;

--- a/modules/dbparser/pdb-file.c
+++ b/modules/dbparser/pdb-file.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/wait.h>
 
 gint
 pdb_file_detect_version(const gchar *pdbfile, GError **error)


### PR DESCRIPTION
Two problems were detected on FreeBSD
- timezone function call incompatibility
- missing header includes in two files

Now, syslog-ng compiles and make check passes. However, I haven't tested syslog-ng with python modules and java modules yet.