### PR TITLE
add-contextual-data: fixed double free bug when csv file contains inv…

### DIFF
--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -257,7 +257,7 @@ context_info_db_import(ContextInfoDB *self, FILE *fp,
     {
       if (line_buf[n - 1] == '\n')
         line_buf[n - 1] = '\0';
-      next_record = scanner->get_next(scanner, line_buf);
+      next_record = contextual_data_record_scanner_get_next(scanner, line_buf);
       if (!next_record)
         {
           context_info_db_purge(self);

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -40,6 +40,14 @@ contextual_data_record_scanner_set_name_prefix(ContextualDataRecordScanner *
 }
 
 void
+contextual_data_record_init(ContextualDataRecord *record)
+{
+  record->selector = NULL;
+  record->name = NULL;
+  record->value = NULL;
+}
+
+void
 contextual_data_record_clean(ContextualDataRecord *record)
 {
   if (record->selector)
@@ -50,6 +58,8 @@ contextual_data_record_clean(ContextualDataRecord *record)
 
   if (record->value)
     g_string_free(record->value, TRUE);
+
+  contextual_data_record_init(record);
 }
 
 ContextualDataRecordScanner *
@@ -69,5 +79,22 @@ create_contextual_data_record_scanner_by_type(const gchar *type)
     msg_warning("Unknown ContextualDataRecordScanner",
                 evt_tag_str("type", type));
 
+
   return scanner;
+}
+
+ContextualDataRecord *
+contextual_data_record_scanner_get_next(ContextualDataRecordScanner *self, const gchar *input)
+{
+  if (!self->get_next)
+    return NULL;
+
+  contextual_data_record_init(&self->last_record);
+  if (!self->get_next(self, input, &self->last_record))
+    {
+      contextual_data_record_clean(&self->last_record);
+      return NULL;
+    }
+
+  return &self->last_record;
 }

--- a/modules/add-contextual-data/contextual-data-record-scanner.h
+++ b/modules/add-contextual-data/contextual-data-record-scanner.h
@@ -39,8 +39,9 @@ struct _ContextualDataRecordScanner
   ContextualDataRecord last_record;
   gpointer scanner;
   const gchar *name_prefix;
-  const ContextualDataRecord *(*get_next) (ContextualDataRecordScanner *self,
-                                           const gchar *input);
+  const gboolean (*get_next) (ContextualDataRecordScanner *self,
+                              const gchar *input,
+                              ContextualDataRecord *record);
   void (*free_fn) (ContextualDataRecordScanner *self);
 };
 
@@ -51,9 +52,13 @@ void
 contextual_data_record_scanner_set_name_prefix(ContextualDataRecordScanner *
                                                self, const gchar *prefix);
 
+void contextual_data_record_init(ContextualDataRecord *record);
 void contextual_data_record_clean(ContextualDataRecord *record);
 
 ContextualDataRecordScanner
 *create_contextual_data_record_scanner_by_type(const gchar *type);
+
+ContextualDataRecord *
+contextual_data_record_scanner_get_next(ContextualDataRecordScanner *self, const gchar *input);
 
 #endif

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.c
@@ -44,10 +44,9 @@ _fetch_next_with_prefix(ContextualDataRecordScanner *record_scanner,
   CSVScanner *line_scanner = (CSVScanner *) record_scanner->scanner;
   if (!csv_scanner_scan_next(line_scanner))
     {
-      contextual_data_record_clean(&record_scanner->last_record);
       return FALSE;
     }
-  gchar* next = _csv_scanner_dup_current_value_with_prefix(line_scanner, prefix);
+  gchar *next = _csv_scanner_dup_current_value_with_prefix(line_scanner, prefix);
   *target = g_string_new(next);
   g_free(next);
 
@@ -56,7 +55,7 @@ _fetch_next_with_prefix(ContextualDataRecordScanner *record_scanner,
 
 static gboolean
 _fetch_next_without_prefix(ContextualDataRecordScanner *
-                                  record_scanner, GString **target)
+                           record_scanner, GString **target)
 {
   return _fetch_next_with_prefix(record_scanner, target, NULL);
 }
@@ -68,32 +67,22 @@ _is_whole_record_parsed(CSVScanner *line_scanner)
   return csv_scanner_is_scan_finished(line_scanner);
 }
 
-static gboolean
-_get_next_record(ContextualDataRecordScanner *s, const gchar *input,
-                 ContextualDataRecord *next_record)
+const gboolean
+get_next_record(ContextualDataRecordScanner *s, const gchar *input, ContextualDataRecord *record)
 {
   CSVScanner *line_scanner = (CSVScanner *) s->scanner;
   csv_scanner_input(line_scanner, input);
 
-  if (!_fetch_next_without_prefix(s, &next_record->selector))
+  if (!_fetch_next_without_prefix(s, &record->selector))
     return FALSE;
 
-  if (!_fetch_next_with_prefix(s, &next_record->name, s->name_prefix))
+  if (!_fetch_next_with_prefix(s, &record->name, s->name_prefix))
     return FALSE;
 
-  if (!_fetch_next_without_prefix(s, &next_record->value))
+  if (!_fetch_next_without_prefix(s, &record->value))
     return FALSE;
 
   return _is_whole_record_parsed(line_scanner);
-}
-
-const ContextualDataRecord *
-get_next_record(ContextualDataRecordScanner *self, const gchar *input)
-{
-  if (!_get_next_record(self, input, &self->last_record))
-    return NULL;
-
-  return &self->last_record;
 }
 
 static void

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -288,6 +288,29 @@ test_import_with_invalid_csv_content(void)
   contextual_data_record_scanner_free(scanner);
 }
 
+static void
+test_import_with_csv_contains_invalid_line(void)
+{
+  gchar csv_content[] = "selector1,name1,value1\n"
+                        ",,value1.1\n";
+  FILE *fp = fmemopen(csv_content, strlen(csv_content) + 1, "r");
+  ContextInfoDB *db = context_info_db_new();
+
+  ContextualDataRecordScanner *scanner =
+    create_contextual_data_record_scanner_by_type("csv");
+
+  assert_false(context_info_db_import(db, fp, scanner),
+               "Sucessfully import an invalid CSV file.");
+  assert_false(context_info_db_is_loaded(db),
+               "The context_info_db_is_loaded reports True after a failing import operation. ");
+  assert_false(context_info_db_is_indexed(db),
+               "The context_info_db_is_indexed reports True after failing import&load operations.");
+
+  fclose(fp);
+  context_info_db_free(db);
+  contextual_data_record_scanner_free(scanner);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -299,6 +322,7 @@ main(int argc, char **argv)
   CONTEXT_INFO_DB_TESTCASE(test_inserted_nv_pairs);
   CONTEXT_INFO_DB_TESTCASE(test_import_with_valid_csv);
   CONTEXT_INFO_DB_TESTCASE(test_import_with_invalid_csv_content);
+  CONTEXT_INFO_DB_TESTCASE(test_import_with_csv_contains_invalid_line);
 
   return 0;
 }


### PR DESCRIPTION
…alid line

Reproduction:
* create a csv file that contains two lines
* first is valid, second line invalid (even selector cannot be fetch)

syslog-ng won't start as the csv file is invalid, but the way it stops
not what someone could expect double free or corruption...

Reason:
* when scanner reads the first record, it inserts the record into the
ContextInfoDB (the record is added to the g_array)
* when the scanner reads the second, the invalid record, it will free the
content of the last_record (as it could be in a partially loaded state
which means that we allocate memory for example selector, but we cannot
fetch the name: in this case we have to free the selector as during reload
we would have memory leak), but when the selector is invalid (the first item
we fetch), the last_record will contain pointers that are already passed to
the g_array
* the problem is that when we call the purge_db function, it will free
the g_array which then will free the same memory

Solution:
* move handling responsibility of last_record to the parent class
* get_next_record in parent class should have to init/clean the
last_record to avoid shared state...

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>