### PR TITLE
elastic-v2: fixed debian packaging

### DIFF
--- a/debian/syslog-ng-mod-elastic.install
+++ b/debian/syslog-ng-mod-elastic.install
@@ -1,2 +1,4 @@
 usr/lib/syslog-ng/*/java-modules/elastic.jar
+usr/lib/syslog-ng/*/java-modules/elastic-v2.jar
+usr/lib/syslog-ng/*/java-modules/elastic-jest-client/*.jar
 usr/share/syslog-ng/include/scl/elasticsearch/*

--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -4,6 +4,7 @@ export GRADLE_OPTS
 
 JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar' -not -path "$(abs_top_builddir)/modules/java-modules/.gradle/*")
+JAVA_MODULES_INSTALLED_JARS=$(shell find $(JAVA_MOD_DST_DIR) -name '*.jar')
 GRADLE_WORKDIR=$(abs_top_builddir)/modules/java-modules/.gradle
 
 java-modules: $(SYSLOG_NG_CORE_JAR)
@@ -22,7 +23,7 @@ java-modules-install-exec-hook: log4j-copy-jar jest-copy-jar
 	cp $(MOD_JARS) $(JAVA_MOD_DST_DIR)
 
 java-modules-uninstall-exec-hook:
-	rm -f $(JAVA_MOD_DST_DIR)/*.jar
+	rm -f $(JAVA_MODULES_INSTALLED_JARS)
 
 java-modules-clean-hook:
 	rm -rf $(abs_top_builddir)/modules/java-modules/*.log

--- a/modules/java-modules/elastic-v2/build.gradle
+++ b/modules/java-modules/elastic-v2/build.gradle
@@ -19,5 +19,5 @@ dependencies {
 ext.jarDestDir = project.hasProperty('jarDestDir') ? project.getProperty('jarDestDir') : '/'
 task copyJestRuntimeDeps(type: Copy) {
     from configurations.jest
-    into jarDestDir
+    into jarDestDir+'/elastic-jest-client'
 }

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -71,7 +71,7 @@ block destination elasticsearch2(
 )
 {
   java(
-    class_path("`module-path`/java-modules/*.jar:`client_lib_dir`/*.jar")
+    class_path("`module-path`/java-modules/*.jar:`module-path`/java-modules/elastic-jest-client/*.jar:`client_lib_dir`/*.jar")
     class_name("org.syslog_ng.elasticsearch_v2.ElasticSearchDestination")
     option("index", `index`)
     option("type", `type`)


### PR DESCRIPTION
elastic-v2 is part of the mod-elastic package (plugin.conf is common
for elastic and elastic-v2 drivers).
Jest client is also added to this package.

This may be a little bit confusing, but I have my own reasons:
 * syslog-ng supports Elastisearch: not 1.7, 2.x, 5, but Elasticsearch
 * elastic and elastic-v2 exists just because the Elasticsearch Java clients
   are not compatible between 1.7.x and 2.x versions (and the bad thing
that the package names are almost identical, but internal representation
has been changed)
 * elastic-v2 could be packaged separately, but we have a http mode extension
   to that which is able to work with both ElasticSearch 1.x, 2.x and Elastic5

So the elastic is only for 1.7.x series, elastic-v2 could work with 2.x series
with node, transport and shield mode, and elastic-v2 http mode could work
with all versions.

References: #1118

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>