### PR TITLE
afstreams: include missing header (errno.h)

### DIFF
--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -47,6 +47,7 @@ typedef struct _AFStreamsSourceDriver
 #include <sys/strlog.h>
 #include <fcntl.h>
 #include <string.h>
+#include <errno.h>
 
 #if SYSLOG_NG_HAVE_DOOR_H
 #include <door.h>


### PR DESCRIPTION
After this small change I was able to compile syslog-ng on Oracle Solaris 11.
( the environment setup was a little bit s*ck, if someone interested in the details , I'll share my experiences )