### PR TITLE
Fix deserialization of GSockAddr

### DIFF
--- a/lib/logmsg/gsockaddr-serialize.c
+++ b/lib/logmsg/gsockaddr-serialize.c
@@ -24,6 +24,8 @@
 
 #include "gsockaddr-serialize.h"
 
+#include <string.h>
+
 static gboolean
 _serialize_ipv4(GSockAddr* addr, SerializeArchive* sa)
 {
@@ -84,6 +86,7 @@ static gboolean
 _deserialize_ipv4(SerializeArchive *sa, GSockAddr **addr)
 {
   struct sockaddr_in sin;
+  memset(&sin, 0, sizeof(sin));
 
   sin.sin_family = AF_INET;
   if (!serialize_read_blob(sa, (gchar *) &sin.sin_addr, sizeof(sin.sin_addr)) ||
@@ -101,6 +104,7 @@ _deserialize_ipv6(SerializeArchive *sa, GSockAddr **addr)
 {
   gboolean result = FALSE;
   struct sockaddr_in6 sin6;
+  memset(&sin6, 0, sizeof(sin6));
 
   sin6.sin6_family = AF_INET6;
   if (serialize_read_blob(sa, (gchar *) &sin6.sin6_addr, sizeof(sin6.sin6_addr)) &&

--- a/lib/logmsg/tests/test_gsockaddr_serialize.c
+++ b/lib/logmsg/tests/test_gsockaddr_serialize.c
@@ -58,7 +58,7 @@ test_inet()
   assert_true(g_sockaddr_deserialize(sa, &read_addr), "FAILED TO READ BACK");
 
   assert_nstring((const gchar *)g_sockaddr_inet_get_sa(addr), addr->salen,
-                 (const gchar *)g_sockaddr_inet_get_sa(addr), read_addr->salen,
+                 (const gchar *)g_sockaddr_inet_get_sa(read_addr), read_addr->salen,
                  "Bad read struct");
 
   serialize_archive_free(sa);
@@ -82,7 +82,7 @@ test_inet6()
   assert_true(g_sockaddr_deserialize(sa, &read_addr), "FAILED TO READ BACK");
 
   assert_nstring((const gchar *)g_sockaddr_inet6_get_sa(addr), addr->salen,
-                 (const gchar *)g_sockaddr_inet6_get_sa(addr), read_addr->salen,
+                 (const gchar *)g_sockaddr_inet6_get_sa(read_addr), read_addr->salen,
                  "Bad read struct");
 
   serialize_archive_free(sa);


### PR DESCRIPTION
During deserialization, `sockaddr_in` and `sockaddr_in6` should be zeroed out, to avoid uninitialized fields.
