### PR TITLE
F/fix parsing empty last argument in templates

### DIFF
--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -300,6 +300,7 @@ static gboolean
 log_template_compiler_process_arg_list(LogTemplateCompiler *self, GPtrArray *result)
 {
   GString *arg_buf = g_string_sized_new(32);
+  gboolean arg_buf_has_a_value = FALSE;
   gint parens = 1;
   self->cursor++;
 
@@ -332,19 +333,22 @@ log_template_compiler_process_arg_list(LogTemplateCompiler *self, GPtrArray *res
               g_string_free(arg_buf, TRUE);
               return FALSE;
             }
+          arg_buf_has_a_value = TRUE;
           continue;
         }
       else if (parens == 1 && (*self->cursor == ' ' || *self->cursor == '\t'))
         {
           g_ptr_array_add(result, g_strndup(arg_buf->str, arg_buf->len));
           g_string_truncate(arg_buf, 0);
+          arg_buf_has_a_value = FALSE;
           while (*self->cursor && (*self->cursor == ' ' || *self->cursor == '\t'))
             self->cursor++;
           continue;
         }
       log_template_compiler_append_and_increment(self, arg_buf);
+      arg_buf_has_a_value = TRUE;
     }
-  if (arg_buf->len > 0)
+  if (arg_buf_has_a_value)
     {
       g_ptr_array_add(result, g_strndup(arg_buf->str, arg_buf->len));
     }

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -297,6 +297,15 @@ test_user_template_function(void)
   log_template_unref(template);
 }
 
+static void
+test_template_function_args(void)
+{
+  assert_template_format("$(echo foo bar)", "foo bar");
+  assert_template_format("$(echo 'foobar' \"barfoo\")", "foobar barfoo");
+  assert_template_format("$(echo foo '' bar)", "foo  bar");
+  assert_template_format("$(echo foo '')", "foo ");
+}
+
 int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
@@ -319,6 +328,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   test_compat();
   test_multi_thread();
   test_escaping();
+  test_template_function_args();
   test_user_template_function();
   /* multi-threaded expansion */
 

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -239,6 +239,13 @@ vp_cmdline_parse_subkeys(const gchar *option_name, const gchar *value,
   ValuePairs *vp = (ValuePairs *) args[1];
   ValuePairsTransformSet *vpts = (ValuePairsTransformSet *) args[2];
 
+  if (!value[0])
+    {
+      g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                  "Error parsing value-pairs: --subkeys requires a non-empty argument");
+      return FALSE;
+    }
+
   GString *prefix = g_string_new(value);
   g_string_append_c(prefix, '*');
   value_pairs_add_glob_pattern(vp, prefix->str, TRUE);

--- a/libtest/template_lib.c
+++ b/libtest/template_lib.c
@@ -219,7 +219,7 @@ assert_template_failure(const gchar *template, const gchar *expected_error)
                "compilation failure expected to template,"
                " but success was returned, template=%s, expected_error=%s\n",
                template, expected_error);
-  expect_true(strstr(error->message, expected_error) != NULL,
+  expect_true(strstr(error ? error->message : "", expected_error) != NULL,
               "FAIL: compilation error doesn't match, error=%s, expected_error=%s\n",
               error->message, expected_error);
   g_clear_error(&error);

--- a/modules/cef/tests/test-format-cef-extension.c
+++ b/modules/cef/tests/test-format-cef-extension.c
@@ -197,9 +197,9 @@ _test_prefix(void)
   assert_template_failure("$(format-cef-extension --subkeys)",
                          "Missing argument for --subkeys");
   assert_template_failure("$(format-cef-extension --subkeys '')",
-                         "Missing argument for --subkeys");
+                         "Error parsing value-pairs: --subkeys requires a non-empty argument");
   assert_template_failure("$(format-cef-extension --subkeys \"\")",
-                         "Missing argument for --subkeys");
+                         "Error parsing value-pairs: --subkeys requires a non-empty argument");
 }
 
 static void


### PR DESCRIPTION
This is a bugfix I had sitting in one of my in-progress branches, that can be merged without the rest. I think this is eligible even for 3.8, as it is a low-risk bugfix with test coverage. However it'd be nice if @bkil-syslogng could review this as it changes both $(format-cef-extension) and the --subkeys option in value-pairs, both of which were authored by him.

    template: fix parsing of empty strings as the last argument of template functions
    
    This patch fixes parsing of empty strings if they occur as the last
    argument of a template function:
    
    $(echo '')
    
    This was parsed as a template function with zero arguments, e.g. the last
    empty string was skipped.