### PR TITLE
Create X509_* macros for CN, O, OU of the peer certifacate

### DIFF
--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -57,6 +57,10 @@ typedef enum
 typedef gint (*TLSSessionVerifyFunc)(gint ok, X509_STORE_CTX *ctx, gpointer user_data);
 typedef struct _TLSContext TLSContext;
 
+#define X509_MAX_CN_LEN 64
+#define X509_MAX_O_LEN 64
+#define X509_MAX_OU_LEN 32
+
 typedef struct _TLSSession
 {
   SSL *ssl;
@@ -64,6 +68,13 @@ typedef struct _TLSSession
   TLSSessionVerifyFunc verify_func;
   gpointer verify_data;
   GDestroyNotify verify_data_destroy;
+  struct
+  {
+    int found;
+    gchar o[X509_MAX_O_LEN];
+    gchar ou[X509_MAX_OU_LEN];
+    gchar cn[X509_MAX_CN_LEN];
+  } peer_info;
 } TLSSession;
 
 void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, gpointer verify_data, GDestroyNotify verify_destroy);

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -46,6 +46,14 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
    * SSL_ERROR_WANT_WRITE is specified by libssl */
   self->super.cond = G_IO_IN;
 
+  /* if we have found the peer has a certificate */
+  if( self->tls_session->peer_info.found )
+    {
+      log_transport_aux_data_add_nv_pair(aux, ".tls.x509_cn", self->tls_session->peer_info.cn );
+      log_transport_aux_data_add_nv_pair(aux, ".tls.x509_o", self->tls_session->peer_info.o );
+      log_transport_aux_data_add_nv_pair(aux, ".tls.x509_ou", self->tls_session->peer_info.ou );
+    }
+
   do
     {
       rc = SSL_read(self->tls_session->ssl, buf, buflen);


### PR DESCRIPTION
Having macros for these values will allow syslog-ng servers to use attributes from the clients certificate, if presented, in file name paths.

This would allow servers to use values that are unique per client, but unchangeable by the client.

Combined with peer-verify(require-trusted) we can issue clients a certificate with attributes that they cannot change. We can use those values to uniquely identify that client without relying on the client to put an identifier in the actual log message.

