### PR TITLE
LogQueueFifo: take a reference on logqueue, while the finish callback…

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -221,7 +221,7 @@ log_queue_fifo_move_input(gpointer user_data)
   log_queue_push_notify(&self->super);
   g_static_mutex_unlock(&self->super.lock);
   self->qoverflow_input[thread_id].finish_cb_registered = FALSE;
-  log_queue_unref((LogQueue *)self->qoverflow_input[thread_id].cb.user_data);
+  log_queue_unref(&self->super);
   return NULL;
 }
 

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -268,7 +268,7 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
            * input thread finishes */
 
           main_loop_worker_register_batch_callback(&self->qoverflow_input[thread_id].cb);
-          self->qoverflow_input[thread_id].cb.user_data = log_queue_ref(s);
+          self->qoverflow_input[thread_id].cb.user_data = log_queue_ref(&self->super);
           self->qoverflow_input[thread_id].finish_cb_registered = TRUE;
         }
 

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -179,7 +179,7 @@ log_queue_set_counters(LogQueue *self, StatsCounterItem *stored_messages, StatsC
 void
 log_queue_init_instance(LogQueue *self, const gchar *persist_name)
 {
-  self->ref_cnt = 1;
+  g_atomic_counter_set(&self->ref_cnt, 1);
   self->free_fn = log_queue_free_method;
 
   self->persist_name = persist_name ? g_strdup(persist_name) : NULL;

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -266,9 +266,9 @@ main_loop_worker_invoke_batch_callbacks(void)
   iv_list_for_each_safe(lh, lh2, &batch_callbacks)
   {
     WorkerBatchCallback *cb = iv_list_entry(lh, WorkerBatchCallback, list);
+    iv_list_del_init(&cb->list);
 
     cb->func(cb->user_data);
-    iv_list_del_init(&cb->list);
   }
 }
 


### PR DESCRIPTION
… was not executed

Otherwise it could cause a use-after-free,
when the file destination closes the logwriter at time reap (possible race condition)

There were some core files at user,
and in these core files shows the symptoms of a use-after-free incident

This correction is based on only a guess.
Anyway in the logqueue-fifo, there was nothing which guarantee,
that the queue won't be freed before the callback is called.

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>