### PR TITLE
Minor add-contextual-data fixes

### DIFF
--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -260,19 +260,37 @@ context_info_db_get_selectors(ContextInfoDB *self)
   return g_hash_table_get_keys(self->index);
 }
 
+static void
+_truncate_eol(gchar *line, gsize line_len)
+{
+  if (line_len >= 2 && line[line_len - 2] == '\r' && line[line_len - 1] == '\n')
+    line[line_len - 2] = '\0';
+  else if (line_len >= 1 && line[line_len - 1] == '\n')
+    line[line_len - 1] = '\0';
+}
+
+static gboolean
+_get_line_without_eol(gchar **line_buf, gsize *line_buf_len, FILE *fp)
+{
+  gssize n;
+  if ((n = getline(line_buf, line_buf_len, fp)) == -1)
+    return FALSE;
+
+  _truncate_eol(*line_buf, n);
+
+  return TRUE;
+}
+
 gboolean
 context_info_db_import(ContextInfoDB *self, FILE *fp,
                        ContextualDataRecordScanner *scanner)
 {
-  ssize_t n;
   size_t line_buf_len;
   gchar *line_buf = NULL;
   const ContextualDataRecord *next_record;
 
-  while ((n = getline(&line_buf, &line_buf_len, fp)) != -1)
+  while (_get_line_without_eol(&line_buf, &line_buf_len, fp))
     {
-      if (line_buf[n - 1] == '\n')
-        line_buf[n - 1] = '\0';
       next_record = contextual_data_record_scanner_get_next(scanner, line_buf);
       if (!next_record)
         {

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.c
@@ -105,7 +105,7 @@ csv_contextual_data_record_scanner_new()
   csv_scanner_options_set_columns(&self->options,
                                   string_array_to_list(column_array));
   csv_scanner_options_set_flags(&self->options, CSV_SCANNER_STRIP_WHITESPACE | CSV_SCANNER_DROP_INVALID);
-  csv_scanner_options_set_dialect(&self->options, CSV_SCANNER_ESCAPE_NONE);
+  csv_scanner_options_set_dialect(&self->options, CSV_SCANNER_ESCAPE_DOUBLE_CHAR);
   csv_scanner_state_init(&self->scanner, &self->options);
   self->super.scanner = &self->scanner;
   self->super.get_next = get_next_record;

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -190,6 +190,28 @@ _assert_context_info_db_contains_name_value_pairs_by_selector(ContextInfoDB *
     }
 }
 
+static void
+_assert_import_csv_with_single_selector(gchar *csv_content, gchar *selector_to_check,
+                                        TestNVPair *expected_nvpairs, gsize expected_nvpairs_size)
+{
+  FILE *fp = fmemopen(csv_content, strlen(csv_content) + 1, "r");
+  ContextInfoDB *db = context_info_db_new();
+  ContextualDataRecordScanner *scanner =
+    create_contextual_data_record_scanner_by_type("csv");
+
+  cr_assert(context_info_db_import(db, fp, scanner),
+            "Failed to import valid CSV file.");
+  fclose(fp);
+
+  _assert_context_info_db_contains_name_value_pairs_by_selector(db,
+      selector_to_check,
+      expected_nvpairs,
+      expected_nvpairs_size);
+
+  context_info_db_free(db);
+  contextual_data_record_scanner_free(scanner);
+}
+
 Test(add_contextual_data, test_inserted_nv_pairs)
 {
   ContextInfoDB *context_info_db = context_info_db_new();
@@ -256,6 +278,20 @@ Test(add_contextual_data, test_import_with_valid_csv)
 
   context_info_db_free(db);
   contextual_data_record_scanner_free(scanner);
+}
+
+Test(add_contextual_data, test_import_with_valid_csv_crlf)
+{
+  gchar csv_content[] = "selector1,name1,value1\r\n"
+                        "selector1,name1.1,value1.1";
+
+  TestNVPair expected_nvpairs[] =
+  {
+    {.name = "name1",.value = "value1"},
+    {.name = "name1.1",.value = "value1.1"},
+  };
+
+  _assert_import_csv_with_single_selector(csv_content, "selector1", expected_nvpairs, ARRAY_SIZE(expected_nvpairs));
 }
 
 Test(add_contextual_data, test_import_with_invalid_csv_content)

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 static void
 _count_records(gpointer arg, const ContextualDataRecord *record)
@@ -194,7 +195,7 @@ Test(add_contextual_data, test_inserted_nv_pairs)
   ContextInfoDB *context_info_db = context_info_db_new();
   _fill_context_info_db(context_info_db, "selector", "name", "value", 1, 3);
 
-  TestNVPair expected_nvpairs[3] =
+  TestNVPair expected_nvpairs[] =
   {
     {.name = "name-0.0",.value = "value-0.0"},
     {.name = "name-0.1",.value = "value-0.1"},
@@ -202,7 +203,7 @@ Test(add_contextual_data, test_inserted_nv_pairs)
   };
 
   _assert_context_info_db_contains_name_value_pairs_by_selector
-  (context_info_db, "selector-0", expected_nvpairs, 3);
+  (context_info_db, "selector-0", expected_nvpairs, ARRAY_SIZE(expected_nvpairs));
   context_info_db_unref(context_info_db);
 }
 
@@ -224,18 +225,18 @@ Test(add_contextual_data, test_import_with_valid_csv)
             "The context_info_db_is_indexed reports False after successful import&load operations.");
   fclose(fp);
 
-  TestNVPair expected_nvpairs_selector1[2] =
+  TestNVPair expected_nvpairs_selector1[] =
   {
     {.name = "name1",.value = "value1"},
     {.name = "name1.1",.value = "value1.1"},
   };
 
-  TestNVPair expected_nvpairs_selector2[1] =
+  TestNVPair expected_nvpairs_selector2[] =
   {
     {.name = "name2",.value = "value2"},
   };
 
-  TestNVPair expected_nvpairs_selector3[1] =
+  TestNVPair expected_nvpairs_selector3[] =
   {
     {.name = "name3",.value = "value3"},
   };
@@ -243,15 +244,15 @@ Test(add_contextual_data, test_import_with_valid_csv)
   _assert_context_info_db_contains_name_value_pairs_by_selector(db,
       "selector1",
       expected_nvpairs_selector1,
-      2);
+      ARRAY_SIZE(expected_nvpairs_selector1));
   _assert_context_info_db_contains_name_value_pairs_by_selector(db,
       "selector2",
       expected_nvpairs_selector2,
-      1);
+      ARRAY_SIZE(expected_nvpairs_selector2));
   _assert_context_info_db_contains_name_value_pairs_by_selector(db,
       "selector3",
       expected_nvpairs_selector3,
-      1);
+      ARRAY_SIZE(expected_nvpairs_selector3));
 
   context_info_db_free(db);
   contextual_data_record_scanner_free(scanner);

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -280,7 +280,8 @@ Test(add_contextual_data, test_import_with_valid_csv)
   contextual_data_record_scanner_free(scanner);
 }
 
-Test(add_contextual_data, test_import_with_valid_csv_crlf)
+Test(add_contextual_data, test_import_from_csv_with_crlf_line_ending,
+     .description = "RFC 4180: Each record should be located on a separate line, delimited by a line break (CRLF).")
 {
   gchar csv_content[] = "selector1,name1,value1\r\n"
                         "selector1,name1.1,value1.1";
@@ -289,6 +290,20 @@ Test(add_contextual_data, test_import_with_valid_csv_crlf)
   {
     {.name = "name1",.value = "value1"},
     {.name = "name1.1",.value = "value1.1"},
+  };
+
+  _assert_import_csv_with_single_selector(csv_content, "selector1", expected_nvpairs, ARRAY_SIZE(expected_nvpairs));
+}
+
+Test(add_contextual_data, test_import_from_csv_with_escaped_double_quote,
+     .description = "RFC 4180: If double-quotes are used to enclose fields, then a double-quote appearing inside a "
+                    "field must be escaped by preceding it with another double quote.")
+{
+  gchar csv_content[] = "selector1,name1,\"c\"\"cc\"";
+
+  TestNVPair expected_nvpairs[] =
+  {
+    {.name = "name1",.value = "c\"cc"},
   };
 
   _assert_import_csv_with_single_selector(csv_content, "selector1", expected_nvpairs, ARRAY_SIZE(expected_nvpairs));


### PR DESCRIPTION
This PR
- adds CRLF line ending support to add-contextual-data
- sets the dialect of `CSVScanner` to [escape-double-char](https://www.balabit.com/sites/default/files/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html-single/index.html#reference-parsers-csv) in `ContextualDataRecordScanner` (as recorded in [RFC 4180](https://www.ietf.org/rfc/rfc4180.txt))

Fixes #1179 (Issue 1 and 3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/balabit/syslog-ng/1184)
<!-- Reviewable:end -->
