### PR TITLE
F/syslog parse date speed up

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -619,6 +619,10 @@ log_reader_options_init(LogReaderOptions *options, GlobalConfig *cfg, const gcha
     {
       options->parse_options.flags |= LP_CHECK_HOSTNAME;
     }
+  if (!options->super.keep_timestamp)
+    {
+      options->parse_options.flags |= LP_NO_PARSE_DATE;
+    }
   if (options->parse_options.default_pri == 0xFFFF)
     {
       if (options->flags & LR_KERNEL)

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -53,6 +53,8 @@ enum
   LP_EXPECT_HOSTNAME = 0x0100,
   /* message is locally generated and should be marked with LF_LOCAL */
   LP_LOCAL = 0x0200,
+  /* for the date part of a message, only skip it, don't fully parse - recommended for keep_timestamp(no) */
+  LP_NO_PARSE_DATE = 0x0400,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -421,13 +421,11 @@ __get_normalized_time(LogStamp const timestamp, gint const normalized_hour, gint
 
 /* FIXME: this function should really be exploded to a lot of smaller functions... (Bazsi) */
 static gboolean
-log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint parse_flags, glong assume_timezone)
+log_msg_parse_date_unnormalized(LogMessage *self, const guchar **data, gint *length, guint parse_flags, struct tm *tm)
 {
   const guchar *src = *data;
   gint left = *length;
   GTimeVal now;
-  struct tm tm;
-  gint unnormalized_hour;
 
   cached_g_current_time(&now);
 
@@ -437,13 +435,15 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
        * unsynced, '.' if it is known to be synced */
       if (G_UNLIKELY(src[0] == '*'))
         {
-          log_msg_set_value(self, is_synced, "0", 1);
+          if (!(parse_flags & LP_NO_PARSE_DATE))
+            log_msg_set_value(self, is_synced, "0", 1);
           src++;
           left--;
         }
       else if (G_UNLIKELY(src[0] == '.'))
         {
-          log_msg_set_value(self, is_synced, "1", 1);
+          if (!(parse_flags & LP_NO_PARSE_DATE))
+            log_msg_set_value(self, is_synced, "1", 1);
           src++;
           left--;
         }
@@ -451,14 +451,13 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
   /* If the next chars look like a date, then read them as a date. */
   if (__is_iso_stamp((const gchar *)src, left))
     {
-      if (!__parse_iso_stamp(&now, self, &tm, &src, &left))
+      if (!__parse_iso_stamp(&now, self, tm, &src, &left))
         goto error;
-      tm.tm_isdst = -1;
     }
   else if ((parse_flags & LP_SYSLOG_PROTOCOL) == 0)
     {
       glong usec = 0;
-      if (!__parse_bsd_timestamp(&src, &left, &now, &tm, &usec))
+      if (!__parse_bsd_timestamp(&src, &left, &now, tm, &usec))
         goto error;
       self->timestamps[LM_TS_STAMP].tv_usec = usec;
     }
@@ -476,11 +475,6 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
         return FALSE;
     }
 
-  unnormalized_hour = tm.tm_hour;
-  self->timestamps[LM_TS_STAMP].tv_sec = cached_mktime(&tm);
-  __set_zone_offset(&(self->timestamps[LM_TS_STAMP]), assume_timezone);
-  self->timestamps[LM_TS_STAMP].tv_sec = __get_normalized_time(self->timestamps[LM_TS_STAMP], tm.tm_hour,
-                                         unnormalized_hour);
 
   *data = src;
   *length = left;
@@ -490,6 +484,38 @@ error:
 
   self->timestamps[LM_TS_STAMP] = self->timestamps[LM_TS_RECVD];
   return FALSE;
+}
+
+static void
+_normalize_time(LogStamp *stamp, struct tm *tm, glong assume_timezone)
+{
+  tm->tm_isdst = -1;
+  gint unnormalized_hour = tm->tm_hour;
+  stamp->tv_sec = cached_mktime(tm);
+  __set_zone_offset(stamp, assume_timezone);
+  stamp->tv_sec = __get_normalized_time(*stamp, tm->tm_hour, unnormalized_hour);
+}
+
+static gboolean
+log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint parse_flags, glong assume_timezone)
+{
+  struct tm tm;
+  if (!log_msg_parse_date_unnormalized(self, data, length, parse_flags, &tm))
+    return FALSE;
+
+  LogStamp *stamp = &self->timestamps[LM_TS_STAMP];
+  if (parse_flags & LP_NO_PARSE_DATE)
+    {
+      *stamp = (const LogStamp) {};
+      stamp->tv_sec = -1;
+      stamp->zone_offset = -1;
+    }
+  else
+    {
+      _normalize_time(stamp, &tm, assume_timezone);
+    }
+
+  return TRUE;
 }
 
 static gboolean


### PR DESCRIPTION
Resolve some of the bottlenecks when processing syslog source, 2-3x speedup.

Some more bottlenecks remain to be investigated, but the implemented parts (existing commits) can already be reviewed.