### PR TITLE
logproto: do not enable position tracking by default

### DIFF
--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -428,7 +428,6 @@ log_proto_buffered_server_restart_with_state(LogProtoServer *s, PersistState *pe
   gpointer new_state = NULL;
   gboolean success;
 
-  self->pos_tracking = TRUE;
   self->persist_state = persist_state;
   old_state_handle = persist_state_lookup_entry(persist_state, persist_name, &old_state_size, &persist_version);
   if (!old_state_handle)
@@ -887,4 +886,5 @@ log_proto_buffered_server_init(LogProtoBufferedServer *self, LogTransport *trans
   else
     self->convert = (GIConv) -1;
   self->stream_based = TRUE;
+  self->pos_tracking = options->position_tracking_enabled;
 }

--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -152,6 +152,7 @@ log_proto_server_options_defaults(LogProtoServerOptions *options)
   options->max_msg_size = -1;
   options->init_buffer_size = -1;
   options->max_buffer_size = -1;
+  options->position_tracking_enabled = FALSE;
 }
 
 void

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -44,6 +44,7 @@ struct _LogProtoServerOptions
   gint max_msg_size;
   gint max_buffer_size;
   gint init_buffer_size;
+  gboolean position_tracking_enabled;
 };
 
 typedef union LogProtoServerOptionsStorage

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -434,7 +434,6 @@ log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, co
   self->super.stream_based = TRUE;
   self->reverse_convert = (GIConv) -1;
   self->consumed_len = -1;
-  self->super.pos_tracking = TRUE;
 }
 
 LogProtoServer *

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -233,17 +233,22 @@ affile_sd_construct_proto(AFFileSourceDriver *self, gint fd)
   format_handler = self->reader_options.parse_options.format_handler;
   if ((format_handler && format_handler->construct_proto))
     {
+      proto_options->position_tracking_enabled = TRUE;
       return format_handler->construct_proto(&self->reader_options.parse_options, transport, proto_options);
     }
 
   if (self->pad_size)
-    return log_proto_padded_record_server_new(transport, proto_options, self->pad_size);
+    {
+      proto_options->position_tracking_enabled = TRUE;
+      return log_proto_padded_record_server_new(transport, proto_options, self->pad_size);
+    }
   else if (affile_is_linux_proc_kmsg(self->filename->str))
     return log_proto_linux_proc_kmsg_reader_new(transport, proto_options);
   else if (affile_is_linux_dev_kmsg(self->filename->str))
     return log_proto_dgram_server_new(transport, proto_options);
   else
     {
+      proto_options->position_tracking_enabled = TRUE;
       switch (self->multi_line_mode)
         {
         case MLM_INDENTED:


### PR DESCRIPTION
There was a performance issue around TCP source.
As it came out LateAckTracker was used instead of EarlyAckTracker.
The reason was that position tracking was enabled by default for the
LogProto type that is used for TCP source.

Signed-off-by: Laszlo Budai <Laszlo.Budai@balabit.com>