### PR TITLE
Fixed the path of the configuration file

### DIFF
--- a/doc/man/pdbtool.1.xml
+++ b/doc/man/pdbtool.1.xml
@@ -305,7 +305,7 @@
         <filename moreinfo="none">/opt/syslog-ng/bin/pdbtool</filename>
       </para>
       <para>
-        <filename moreinfo="none">/opt/syslog-ng/etc/syslog-ng/syslog-ng.conf</filename>
+        <filename moreinfo="none">/opt/syslog-ng/etc/syslog-ng.conf</filename>
       </para>
     </refsect1>
     <refsect1>


### PR DESCRIPTION
Another small typo fix, in this case in the pdbtool man page.

