### PR TITLE
F/kv scanner support space separator

### DIFF
--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -389,6 +389,18 @@ assert_string_array_non_fatal(gchar **actual, guint32 actual_length, gchar **exp
 }
 
 gboolean
+expect_not_reached(const gchar *error_message, ...)
+{
+  va_list args;
+
+  va_start(args, error_message);
+  print_failure(error_message, args, "execution was not expected to reach this point");
+  va_end(args);
+
+  return FALSE;
+}
+
+gboolean
 assert_gboolean_non_fatal(gboolean actual, gboolean expected, const gchar *error_message, ...)
 {
   va_list args;

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -74,7 +74,7 @@ gboolean assert_guint32_set_non_fatal(guint32 *actual, guint32 actual_length, gu
 gboolean assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error_message, ...);
 gboolean assert_msg_field_equals_non_fatal(LogMessage *msg, gchar *field_name, gchar *expected_value, gssize expected_value_len, const gchar *error_message, ...);
 gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, gchar *field_name, const gchar *error_message, ...);
-
+gboolean expect_not_reached(const gchar *error_message, ...);
 
 #define assert_guint16(actual, expected, error_message, ...) (assert_guint16_non_fatal(actual, expected, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
 

--- a/modules/kvformat/Makefile.am
+++ b/modules/kvformat/Makefile.am
@@ -7,6 +7,10 @@ modules_kvformat_libkvformat_la_SOURCES=	\
 	modules/kvformat/kv-parser.h		\
 	modules/kvformat/kv-scanner.c		\
 	modules/kvformat/kv-scanner.h		\
+	modules/kvformat/kv-scanner-generic.c \
+	modules/kvformat/kv-scanner-generic.h \
+	modules/kvformat/kv-scanner-simple.c \
+	modules/kvformat/kv-scanner-simple.h \
 	modules/kvformat/linux-audit-scanner.c	\
 	modules/kvformat/linux-audit-scanner.h	\
 	modules/kvformat/kv-parser-grammar.y	\

--- a/modules/kvformat/kv-parser-grammar.ym
+++ b/modules/kvformat/kv-parser-grammar.ym
@@ -51,6 +51,7 @@
 %token KW_LINUX_AUDIT_PARSER
 %token KW_PREFIX
 %token KW_VALUE_SEPARATOR
+%token KW_ALLOW_PAIR_SEPARATOR_OPTION
 
 %type	<ptr> parser_expr_kv
 
@@ -83,12 +84,14 @@ parser_kv_opts
 
 parser_kv_opt
 	: KW_PREFIX '(' string ')'		{ kv_parser_set_prefix(last_parser, $3); free($3); }
+	| KW_ALLOW_PAIR_SEPARATOR_OPTION '(' yesno ')'		{ kv_parser_set_allow_pair_separator_in_value(last_parser, $3); }
 	| KW_VALUE_SEPARATOR '(' string ')'
 	  {
 	    CHECK_ERROR((strlen($3) == 1), @3, "kv-parser() only supports single-character values for value-separator()");
+	    CHECK_ERROR((kv_parser_is_valid_separator_character($3[0])), @3, "kv-parser() unsupported character for value-separator()");
             kv_parser_set_value_separator(last_parser, $3[0]);
             free($3);
-          }
+	  }
 	| parser_opt
 	;
 

--- a/modules/kvformat/kv-parser-grammar.ym
+++ b/modules/kvformat/kv-parser-grammar.ym
@@ -64,13 +64,13 @@ start
 parser_expr_kv
 	: KW_KV_PARSER '('
 	  {
-	    last_parser = *instance = (LogParser *) kv_parser_new(configuration, kv_scanner_new());
+	    last_parser = *instance = (LogParser *) kv_parser_new(configuration);
 	  }
 	  parser_kv_opts
 	  ')'					{ $$ = last_parser; }
 	| KW_LINUX_AUDIT_PARSER '('
 	  {
-	    last_parser = *instance = (LogParser *) kv_parser_new(configuration, linux_audit_scanner_new());
+	    last_parser = *instance = (LogParser *) kv_parser_linux_audit_new(configuration);
 	  }
 	  parser_kv_opts
 	  ')'					{ $$ = last_parser; }

--- a/modules/kvformat/kv-parser-parser.c
+++ b/modules/kvformat/kv-parser-parser.c
@@ -29,10 +29,11 @@ int kv_parser_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
 
 static CfgLexerKeyword kv_parser_keywords[] =
 {
-  { "kv_parser",          KW_KV_PARSER,  },
-  { "linux_audit_parser", KW_LINUX_AUDIT_PARSER,  },
-  { "prefix",             KW_PREFIX,  },
-  { "value_separator",    KW_VALUE_SEPARATOR,  },
+  { "kv_parser",                     KW_KV_PARSER,  },
+  { "linux_audit_parser",            KW_LINUX_AUDIT_PARSER,  },
+  { "prefix",                        KW_PREFIX,  },
+  { "value_separator",               KW_VALUE_SEPARATOR,  },
+  { "allow_pair_separator_in_value", KW_ALLOW_PAIR_SEPARATOR_OPTION, },
   { NULL }
 };
 

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -21,15 +21,28 @@
 
 #include "kv-parser.h"
 #include "kv-scanner.h"
+#include "kv-scanner-simple.h"
+#include "kv-scanner-generic.h"
+#include "linux-audit-scanner.h"
 
 typedef struct _KVParser
 {
   LogParser super;
+  gboolean allow_pair_separator_in_value;
+  gchar value_separator;
   gchar *prefix;
   gsize prefix_len;
   GString *formatted_key;
   KVScanner *kv_scanner;
 } KVParser;
+
+gboolean
+kv_parser_is_valid_separator_character(char c)
+{
+  return (c != ' '  &&
+          c != '\'' &&
+          c != '\"' );
+}
 
 void
 kv_parser_set_prefix(LogParser *p, const gchar *prefix)
@@ -50,11 +63,17 @@ kv_parser_set_prefix(LogParser *p, const gchar *prefix)
 }
 
 void
+kv_parser_set_allow_pair_separator_in_value(LogParser *s, gboolean allow_pair_separator_in_value)
+{
+  KVParser *self = (KVParser *) s;
+  self->allow_pair_separator_in_value = allow_pair_separator_in_value;
+}
+
+void
 kv_parser_set_value_separator(LogParser *s, gchar value_separator)
 {
   KVParser *self = (KVParser *) s;
-
-  kv_scanner_set_value_separator(self->kv_scanner, value_separator);
+  self->value_separator = value_separator;
 }
 
 static const gchar *
@@ -71,15 +90,15 @@ _get_formatted_key(KVParser *self, const gchar *key)
 }
 
 static gboolean
-kv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
-                  gsize input_len)
+_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
+         gsize input_len)
 {
   KVParser *self = (KVParser *) s;
 
   log_msg_make_writable(pmsg, path_options);
   /* FIXME: input length */
   kv_scanner_input(self->kv_scanner, input);
-  while (kv_scanner_scan_next(self->kv_scanner))
+  while (self->kv_scanner->scan_next(self->kv_scanner))
     {
 
       /* FIXME: value length */
@@ -91,20 +110,44 @@ kv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_op
 }
 
 static LogPipe *
-kv_parser_clone(LogPipe *s)
+_set_cloned_fields(LogParser *cloned, KVParser *self)
 {
-  KVParser *self = (KVParser *) s;
-  LogParser *cloned;
+  KVParser *cloned_kvparser = (KVParser *)cloned;
 
-  cloned = kv_parser_new(s->cfg, kv_scanner_clone(self->kv_scanner));
   kv_parser_set_prefix(cloned, self->prefix);
   log_parser_set_template(cloned, log_template_ref(self->super.template));
+  kv_parser_set_allow_pair_separator_in_value(cloned, self->allow_pair_separator_in_value);
+  kv_parser_set_value_separator(cloned, self->value_separator);
+  log_parser_set_template(cloned, log_template_ref(self->super.template));
+
+  if (self->kv_scanner)
+    {
+      cloned_kvparser->kv_scanner = kv_scanner_clone(self->kv_scanner);
+    }
 
   return &cloned->super;
 }
 
+static LogPipe *
+_clone(LogPipe *s)
+{
+  KVParser *self = (KVParser *) s;
+  LogParser *cloned = kv_parser_new(s->cfg);
+
+  return _set_cloned_fields(cloned, self);
+}
+
+static LogPipe *
+_clone_linux_audit(LogPipe *s)
+{
+  KVParser *self = (KVParser *) s;
+  LogParser *cloned = kv_parser_linux_audit_new(s->cfg);
+
+  return _set_cloned_fields(cloned, self);
+}
+
 static void
-kv_parser_free(LogPipe *s)
+_free(LogPipe *s)
 {
   KVParser *self = (KVParser *)s;
 
@@ -115,28 +158,89 @@ kv_parser_free(LogPipe *s)
 }
 
 static gboolean
-kv_parser_process_threaded(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
-                           gsize input_len)
+_process_threaded(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
+                  gsize input_len)
 {
   LogParser *self = (LogParser *)log_pipe_clone(&s->super);
 
-  gboolean ok = kv_parser_process(self, pmsg, path_options, input, input_len);
+  gboolean ok = _process(self, pmsg, path_options, input, input_len);
 
   log_pipe_unref(&self->super);
   return ok;
 }
 
-LogParser *
-kv_parser_new(GlobalConfig *cfg, KVScanner *kv_scanner)
+static gboolean
+_init(LogPipe *s)
+{
+  KVParser *self = (KVParser *)s;
+  g_assert(self->kv_scanner == NULL);
+
+  if (self->allow_pair_separator_in_value)
+    {
+      self->kv_scanner = kv_scanner_generic_new(self->value_separator, NULL);
+    }
+  else
+    {
+      self->kv_scanner = kv_scanner_simple_new(self->value_separator, NULL);
+    }
+
+  return TRUE;
+}
+
+static gboolean
+_init_linux_audit(LogPipe *s)
+{
+  KVParser *self = (KVParser *)s;
+  g_assert(self->kv_scanner == NULL);
+  _init(s);
+  self->kv_scanner = linux_audit_scanner_new(self->kv_scanner);
+  return TRUE;
+}
+
+static gboolean
+_deinit(LogPipe *s)
+{
+  KVParser *self = (KVParser *)s;
+  kv_scanner_free(self->kv_scanner);
+  self->kv_scanner = NULL;
+  return TRUE;
+}
+
+static KVParser *
+_create_common(GlobalConfig *cfg)
 {
   KVParser *self = g_new0(KVParser, 1);
 
   log_parser_init_instance(&self->super, cfg);
-  self->super.super.free_fn = kv_parser_free;
-  self->super.super.clone = kv_parser_clone;
-  self->super.process = kv_parser_process_threaded;
-
-  self->kv_scanner = kv_scanner;
+  self->super.super.deinit = _deinit;
+  self->super.super.free_fn = _free;
+  self->super.process = _process_threaded;
+  self->kv_scanner = NULL;
+  self->value_separator = '=';
+  self->allow_pair_separator_in_value = FALSE;
   self->formatted_key = g_string_sized_new(32);
+
+  return self;
+}
+
+LogParser *
+kv_parser_new(GlobalConfig *cfg)
+{
+  KVParser *self = _create_common(cfg);
+
+  self->super.super.init = _init;
+  self->super.super.clone = _clone;
+
+  return &self->super;
+}
+
+LogParser *
+kv_parser_linux_audit_new(GlobalConfig *cfg)
+{
+  KVParser *self = _create_common(cfg);
+
+  self->super.super.init = _init_linux_audit;
+  self->super.super.clone = _clone_linux_audit;
+
   return &self->super;
 }

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -193,7 +193,8 @@ _init_linux_audit(LogPipe *s)
   KVParser *self = (KVParser *)s;
   g_assert(self->kv_scanner == NULL);
   _init(s);
-  self->kv_scanner = linux_audit_scanner_new(self->kv_scanner);
+  kv_scanner_set_parse_value(self->kv_scanner, parse_linux_audit_style_hexdump);
+
   return TRUE;
 }
 

--- a/modules/kvformat/kv-scanner-generic.c
+++ b/modules/kvformat/kv-scanner-generic.c
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "kv-scanner-generic.h"
+#include "kv-scanner.h"
+
+typedef struct _KVToken KVToken;
+struct _KVToken
+{
+  const gchar *begin;
+  const gchar *end;
+};
+
+typedef struct _KVScannerGeneric KVScannerGeneric;
+struct _KVScannerGeneric
+{
+  KVScanner super;
+  gint state;
+  KVToken next_key;
+  KVToken next_value;
+};
+
+enum
+{
+  KV_INIT = 0,
+  KV_SEPARATOR_AFTER_INIT,
+  KV_IN_VALUE,
+  KV_IN_KEY_OR_VALUE,
+  KV_IN_QUOTE,
+  KV_AFTER_QUOTE,
+  KV_IN_SEPARATOR,
+  KV_KEY_FOUND,
+  KV_EOL
+};
+
+static inline void
+_next_step(KVScannerGeneric *self)
+{
+  self->super.input_pos++;
+}
+
+static inline const gchar *
+_get_current_position(KVScannerGeneric *self)
+{
+  return self->super.input + self->super.input_pos;
+}
+
+static inline const gchar
+_get_current_char(KVScannerGeneric *self)
+{
+  return *(_get_current_position(self));
+}
+
+static inline gboolean
+_set_current_position(KVScannerGeneric *self, const gchar *pos)
+{
+  if (pos < _get_current_position(self))
+    {
+      return FALSE;
+    }
+
+  self->super.input_pos = pos - _get_current_position(self);
+  return TRUE;
+}
+
+static void
+_reset_value(KVScannerGeneric *self)
+{
+  g_string_truncate(self->super.value, 0);
+  self->next_key.begin = NULL;
+  self->next_key.end = NULL;
+  self->next_value.begin = _get_current_position(self);
+  self->next_value.end = _get_current_position(self);
+  self->super.value_was_quoted = FALSE;
+}
+
+static inline void
+_extend_value_with_next_key(KVScannerGeneric *self)
+{
+  if (self->next_key.begin < self->next_key.end)
+    {
+      self->next_value.end = self->next_key.end;
+      self->next_key.begin = self->next_key.end = NULL;
+    }
+}
+
+static inline void
+_start_next_key(KVScannerGeneric *self)
+{
+  self->next_key.begin = self->next_key.end = _get_current_position(self);
+}
+
+static inline void
+_end_next_key(KVScannerGeneric *self)
+{
+  self->next_key.end = _get_current_position(self);
+}
+
+static inline void
+_start_value(KVScannerGeneric *self)
+{
+  self->next_value.begin = self->next_value.end = _get_current_position(self);
+}
+
+static inline void
+_end_value(KVScannerGeneric *self)
+{
+  self->next_value.end = _get_current_position(self);
+}
+
+static inline void
+_init_state(KVScannerGeneric *self, gchar ch)
+{
+  if (ch == '\0')
+    {
+      self->state = KV_EOL;
+    }
+  else if (ch == ' ')
+    {
+      self->state = KV_SEPARATOR_AFTER_INIT;
+    }
+  else if (ch == '\'' || ch == '\"')
+    {
+      _start_value(self);
+      self->super.quote_char = ch;
+      self->state = KV_IN_QUOTE;
+    }
+  else
+    {
+      _start_value(self);
+      self->state = KV_IN_VALUE;
+    }
+}
+
+static inline void
+_separator_after_init_state(KVScannerGeneric *self, gchar ch)
+{
+  if (ch == '\0')
+    {
+      self->state = KV_EOL;
+    }
+  else if (ch == ' ')
+    {
+    }
+  else if (ch == '\'' || ch == '\"')
+    {
+      _start_value(self);
+      self->super.quote_char = ch;
+      self->state = KV_IN_QUOTE;
+    }
+  else if (kv_scanner_is_valid_key_character(ch))
+    {
+      _start_value(self);
+      _start_next_key(self);
+      self->state = KV_IN_KEY_OR_VALUE;
+    }
+  else
+    {
+      _start_value(self);
+      self->state = KV_IN_VALUE;
+    }
+}
+
+static inline void
+_in_value_state(KVScannerGeneric *self, gchar ch)
+{
+  if (ch == '\0')
+    {
+      _end_value(self);
+      self->state = KV_EOL;
+    }
+  else if (ch == ' ')
+    {
+      _end_value(self);
+      self->state = KV_IN_SEPARATOR;
+    }
+}
+
+static inline void
+_in_key_or_value_state(KVScannerGeneric *self, gchar ch)
+{
+  if (ch == '\0')
+    {
+      _end_next_key(self);
+      _extend_value_with_next_key(self);
+      self->state = KV_EOL;
+    }
+  else if (ch == ' ')
+    {
+      _end_next_key(self);
+      self->state = KV_IN_SEPARATOR;
+    }
+  else if (ch == self->super.value_separator)
+    {
+      _end_next_key(self);
+      self->state = KV_KEY_FOUND;
+    }
+  else if (kv_scanner_is_valid_key_character(ch))
+    {
+    }
+  else
+    {
+      _extend_value_with_next_key(self);
+      self->state = KV_IN_VALUE;
+    }
+}
+
+static inline void
+_in_quote_state(KVScannerGeneric *self, gchar ch)
+{
+  if (ch == '\0')
+    {
+      _end_value(self);
+      self->state = KV_EOL;
+    }
+  else if (ch == self->super.quote_char)
+    {
+      _end_value(self);
+      self->state = KV_AFTER_QUOTE;
+    }
+}
+
+static inline void
+_after_quote_state(KVScannerGeneric *self, gchar ch)
+{
+  _end_value(self);
+  if (ch == '\0')
+    {
+      self->state = KV_EOL;
+    }
+  else if (ch == ' ')
+    {
+      self->state = KV_IN_SEPARATOR;
+    }
+  else if (ch == '\'' || ch == '\"')
+    {
+      self->super.quote_char = ch;
+      self->state = KV_IN_QUOTE;
+    }
+  else if (kv_scanner_is_valid_key_character(ch))
+    {
+      _start_next_key(self);
+      self->state = KV_IN_KEY_OR_VALUE;
+    }
+  else
+    {
+      self->state = KV_IN_VALUE;
+    }
+}
+
+static inline void
+_in_separator_state(KVScannerGeneric *self, gchar ch)
+{
+  if (ch == '\0')
+    {
+      _extend_value_with_next_key(self);
+      self->state = KV_EOL;
+    }
+  else if (ch == ' ')
+    {
+    }
+  else if (ch == self->super.value_separator)
+    {
+      self->state = KV_KEY_FOUND;
+    }
+  else if (kv_scanner_is_valid_key_character(ch))
+    {
+      _extend_value_with_next_key(self);
+      _start_next_key(self);
+      self->state = KV_IN_KEY_OR_VALUE;
+    }
+  else
+    {
+      _extend_value_with_next_key(self);
+      self->state = KV_IN_VALUE;
+    }
+}
+
+static inline void
+_produce_value(KVScannerGeneric *self)
+{
+  const gchar *cur;
+
+  if (*self->next_value.begin == self->super.quote_char && *(self->next_value.end - 1) == self->super.quote_char)
+    {
+      self->super.value_was_quoted = TRUE;
+      self->next_value.begin++;
+      self->next_value.end--;
+    }
+
+  for (cur = self->next_value.begin; cur < self->next_value.end; cur++)
+    {
+      g_string_append_c(self->super.value, *cur);
+    }
+}
+
+static inline void
+_extract_value(KVScannerGeneric *self)
+{
+  gchar cur_char;
+
+  _reset_value(self);
+  self->state = KV_INIT;
+
+  do
+    {
+      cur_char = _get_current_char(self);
+      switch (self->state)
+        {
+        case KV_INIT:
+          _init_state(self, cur_char);
+          break;
+        case KV_SEPARATOR_AFTER_INIT:
+          _separator_after_init_state(self, cur_char);
+          break;
+        case KV_IN_VALUE:
+          _in_value_state(self, cur_char);
+          break;
+        case KV_IN_KEY_OR_VALUE:
+          _in_key_or_value_state(self, cur_char);
+          break;
+        case KV_IN_QUOTE:
+          _in_quote_state(self, cur_char);
+          break;
+        case KV_AFTER_QUOTE:
+          _after_quote_state(self, cur_char);
+          break;
+        case KV_IN_SEPARATOR:
+          _in_separator_state(self, cur_char);
+          break;
+        }
+      _next_step(self);
+    }
+  while (self->state != KV_KEY_FOUND &&
+         self->state != KV_EOL);
+
+  _produce_value(self);
+}
+
+static inline gboolean
+_find_first_key(KVScannerGeneric *self)
+{
+  const gchar *separator, *start_of_key, *end_of_key;
+  gint len;
+
+  separator = strchr(self->super.input, self->super.value_separator);
+
+  do
+    {
+      if (!separator)
+        return FALSE;
+
+      end_of_key = separator - 1;
+      while (end_of_key >= self->super.input && *end_of_key == ' ')
+        end_of_key--;
+
+      start_of_key = end_of_key;
+
+      while (start_of_key >= self->super.input && kv_scanner_is_valid_key_character(*start_of_key))
+        start_of_key--;
+
+      len = end_of_key - start_of_key;
+
+      if (len < 1)
+        separator = strchr(separator + 1, self->super.value_separator);
+    }
+  while (len < 1);
+
+  self->next_key.begin = start_of_key + 1;
+  self->next_key.end = end_of_key + 1;
+
+  return _set_current_position(self, separator + 1);
+}
+
+static inline gboolean
+_extract_key(KVScannerGeneric *self)
+{
+
+  if (self->state == KV_EOL || _get_current_char(self) == '\0')
+    {
+      return FALSE;
+    }
+
+  if ((self->next_key.begin == NULL || self->next_key.end == NULL) && !_find_first_key(self))
+    {
+      return FALSE;
+    }
+
+  g_string_assign_len(self->super.key, self->next_key.begin, self->next_key.end - self->next_key.begin);
+
+  return TRUE;
+}
+
+static gboolean
+_scan_next(KVScanner *s)
+{
+  KVScannerGeneric *self = (KVScannerGeneric *)s;
+
+  if (!_extract_key(self))
+    {
+      return FALSE;
+    }
+
+  _extract_value(self);
+  kv_scanner_decode_value(s);
+
+  return TRUE;
+}
+
+static KVScanner *
+_clone(KVScanner *s)
+{
+  return kv_scanner_generic_new(s->value_separator, s->parse_value);
+}
+
+KVScanner *
+kv_scanner_generic_new(gchar value_separator, KVParseValue *parse_value)
+{
+  KVScannerGeneric *self = g_new0(KVScannerGeneric, 1);
+
+  kv_scanner_init(&self->super, value_separator, parse_value);
+  self->super.scan_next = _scan_next;
+  self->super.clone = _clone;
+
+  return &self->super;
+}

--- a/modules/kvformat/kv-scanner-generic.c
+++ b/modules/kvformat/kv-scanner-generic.c
@@ -153,12 +153,12 @@ _init_state(KVScannerGeneric *self, gchar ch)
 static inline void
 _separator_after_init_state(KVScannerGeneric *self, gchar ch)
 {
+  if (ch == ' ')
+    return;
+
   if (ch == '\0')
     {
       self->state = KV_EOL;
-    }
-  else if (ch == ' ')
-    {
     }
   else if (ch == '\'' || ch == '\"')
     {
@@ -197,6 +197,9 @@ _in_value_state(KVScannerGeneric *self, gchar ch)
 static inline void
 _in_key_or_value_state(KVScannerGeneric *self, gchar ch)
 {
+  if (kv_scanner_is_valid_key_character(ch))
+    return ;
+
   if (ch == '\0')
     {
       _end_next_key(self);
@@ -212,9 +215,6 @@ _in_key_or_value_state(KVScannerGeneric *self, gchar ch)
     {
       _end_next_key(self);
       self->state = KV_KEY_FOUND;
-    }
-  else if (kv_scanner_is_valid_key_character(ch))
-    {
     }
   else
     {
@@ -269,13 +269,13 @@ _after_quote_state(KVScannerGeneric *self, gchar ch)
 static inline void
 _in_separator_state(KVScannerGeneric *self, gchar ch)
 {
+  if (ch == ' ')
+    return;
+
   if (ch == '\0')
     {
       _extend_value_with_next_key(self);
       self->state = KV_EOL;
-    }
-  else if (ch == ' ')
-    {
     }
   else if (ch == self->super.value_separator)
     {

--- a/modules/kvformat/kv-scanner-generic.c
+++ b/modules/kvformat/kv-scanner-generic.c
@@ -420,7 +420,7 @@ _scan_next(KVScanner *s)
     }
 
   _extract_value(self);
-  kv_scanner_decode_value(s);
+  kv_scanner_parse_value(s);
 
   return TRUE;
 }

--- a/modules/kvformat/kv-scanner-generic.h
+++ b/modules/kvformat/kv-scanner-generic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Balabit
+ * Copyright (c) 2016 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -17,19 +17,14 @@
  * As an additional exemption you are allowed to compile & link against the
  * OpenSSL libraries as published by the OpenSSL project. See the file
  * COPYING for details.
+ *
  */
+#ifndef KV_SCANNER_GENERIC_H_INCLUDED
+#define KV_SCANNER_GENERIC_H_INCLUDED
 
-#ifndef KVPARSER_H_INCLUDED
-#define KVPARSER_H_INCLUDED
-
-#include "parser/parser-expr.h"
+#include "syslog-ng.h"
 #include "kv-scanner.h"
 
-void kv_parser_set_prefix(LogParser *p, const gchar *prefix);
-void kv_parser_set_allow_pair_separator_in_value(LogParser *p, gboolean allow_pair_separator_in_value);
-void kv_parser_set_value_separator(LogParser *p, gchar value_separator);
-LogParser *kv_parser_new(GlobalConfig *cfg);
-LogParser *kv_parser_linux_audit_new(GlobalConfig *cfg);
-gboolean kv_parser_is_valid_separator_character(gchar c);
+KVScanner* kv_scanner_generic_new(gchar value_separator, KVParseValue *parse_value);
 
 #endif

--- a/modules/kvformat/kv-scanner-simple.c
+++ b/modules/kvformat/kv-scanner-simple.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2016 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "kv-scanner-simple.h"
+#include "utf8utils.h"
+#include "kv-scanner.h"
+
+#include <string.h>
+
+typedef struct _KVScannerSimple KVScannerSimple;
+struct _KVScannerSimple
+{
+  KVScanner super;
+  gint quote_state;
+};
+
+enum
+{
+  KV_QUOTE_INITIAL = 0,
+  KV_QUOTE_STRING,
+  KV_QUOTE_BACKSLASH,
+  KV_QUOTE_FINISH
+};
+
+static gboolean
+_extract_key(KVScannerSimple *self)
+{
+  const gchar *input_ptr = &self->super.input[self->super.input_pos];
+  const gchar *start_of_key;
+  const gchar *separator;
+  gsize len;
+
+  separator = strchr(input_ptr, self->super.value_separator);
+  do
+    {
+      if (!separator)
+        return FALSE;
+      start_of_key = separator;
+      while (start_of_key > input_ptr && kv_scanner_is_valid_key_character(*(start_of_key - 1)))
+        start_of_key--;
+      len = separator - start_of_key;
+      if (len < 1)
+        separator = strchr(separator + 1, self->super.value_separator);
+    }
+  while (len < 1);
+
+  g_string_assign_len(self->super.key, start_of_key, len);
+  self->super.input_pos = separator - self->super.input + 1;
+  return TRUE;
+}
+
+static void
+_decode_backslash_escape(KVScannerSimple *self, gchar ch)
+{
+  gchar control;
+  switch (ch)
+    {
+    case 'b':
+      control = '\b';
+      break;
+    case 'f':
+      control = '\f';
+      break;
+    case 'n':
+      control = '\n';
+      break;
+    case 'r':
+      control = '\r';
+      break;
+    case 't':
+      control = '\t';
+      break;
+    case '\\':
+      control = '\\';
+      break;
+    default:
+      if (self->super.quote_char != ch)
+        {
+          g_string_append_c(self->super.value, '\\');
+        }
+      control = ch;
+      break;
+    }
+  g_string_append_c(self->super.value, control);
+}
+
+static gboolean
+_is_delimiter(const gchar *cur)
+{
+  return (*cur == ' ') || (strncmp(cur, ", ", 2) == 0);
+}
+
+static void
+_extract_value(KVScannerSimple *self)
+{
+  const gchar *cur;
+
+  g_string_truncate(self->super.value, 0);
+  self->super.value_was_quoted = FALSE;
+  cur = &self->super.input[self->super.input_pos];
+
+  self->quote_state = KV_QUOTE_INITIAL;
+  while (*cur && self->quote_state != KV_QUOTE_FINISH)
+    {
+      switch (self->quote_state)
+        {
+        case KV_QUOTE_INITIAL:
+          if (_is_delimiter(cur))
+            {
+              self->quote_state = KV_QUOTE_FINISH;
+            }
+          else if (*cur == '\"' || *cur == '\'')
+            {
+              self->quote_state = KV_QUOTE_STRING;
+              self->super.quote_char = *cur;
+              if (self->super.value->len == 0)
+                self->super.value_was_quoted = TRUE;
+            }
+          else
+            {
+              g_string_append_c(self->super.value, *cur);
+            }
+          break;
+        case KV_QUOTE_STRING:
+          if (*cur == self->super.quote_char)
+            self->quote_state = KV_QUOTE_INITIAL;
+          else if (*cur == '\\')
+            self->quote_state = KV_QUOTE_BACKSLASH;
+          else
+            g_string_append_c(self->super.value, *cur);
+          break;
+        case KV_QUOTE_BACKSLASH:
+          _decode_backslash_escape(self, *cur);
+          self->quote_state = KV_QUOTE_STRING;
+          break;
+        }
+      cur++;
+    }
+  self->super.input_pos = cur - self->super.input;
+}
+
+static gboolean
+_scan_next(KVScanner *s)
+{
+  KVScannerSimple *self = (KVScannerSimple *)s;
+
+  if (!_extract_key(self))
+    {
+      return FALSE;
+    }
+
+  _extract_value(self);
+  kv_scanner_decode_value(s);
+
+  return TRUE;
+}
+
+static KVScanner *
+_clone(KVScanner *s)
+{
+  return kv_scanner_simple_new(s->value_separator, s->parse_value);
+}
+
+KVScanner *
+kv_scanner_simple_new(gchar value_separator, KVParseValue *parse_value)
+{
+  KVScannerSimple *self = g_new0(KVScannerSimple, 1);
+
+  kv_scanner_init(&self->super, value_separator, parse_value);
+  self->super.scan_next = _scan_next;
+  self->super.clone = _clone;
+
+  return &self->super;
+}

--- a/modules/kvformat/kv-scanner-simple.c
+++ b/modules/kvformat/kv-scanner-simple.c
@@ -168,7 +168,7 @@ _scan_next(KVScanner *s)
     }
 
   _extract_value(self);
-  kv_scanner_decode_value(s);
+  kv_scanner_parse_value(s);
 
   return TRUE;
 }

--- a/modules/kvformat/kv-scanner-simple.h
+++ b/modules/kvformat/kv-scanner-simple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Balabit
+ * Copyright (c) 2016 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -17,19 +17,14 @@
  * As an additional exemption you are allowed to compile & link against the
  * OpenSSL libraries as published by the OpenSSL project. See the file
  * COPYING for details.
+ *
  */
+#ifndef KV_SCANNER_SIMPLE_H_INCLUDED
+#define KV_SCANNER_SIMPLE_H_INCLUDED
 
-#ifndef KVPARSER_H_INCLUDED
-#define KVPARSER_H_INCLUDED
-
-#include "parser/parser-expr.h"
+#include "syslog-ng.h"
 #include "kv-scanner.h"
 
-void kv_parser_set_prefix(LogParser *p, const gchar *prefix);
-void kv_parser_set_allow_pair_separator_in_value(LogParser *p, gboolean allow_pair_separator_in_value);
-void kv_parser_set_value_separator(LogParser *p, gchar value_separator);
-LogParser *kv_parser_new(GlobalConfig *cfg);
-LogParser *kv_parser_linux_audit_new(GlobalConfig *cfg);
-gboolean kv_parser_is_valid_separator_character(gchar c);
+KVScanner* kv_scanner_simple_new(gchar value_separator, KVParseValue *parse_value);
 
 #endif

--- a/modules/kvformat/kv-scanner.c
+++ b/modules/kvformat/kv-scanner.c
@@ -24,7 +24,6 @@
 void
 kv_scanner_init(KVScanner *self, gchar value_separator, KVParseValue *parse_value)
 {
-  memset(self, 0, sizeof(*self));
   self->key = g_string_sized_new(32);
   self->value = g_string_sized_new(64);
   self->decoded_value = g_string_sized_new(64);

--- a/modules/kvformat/kv-scanner.c
+++ b/modules/kvformat/kv-scanner.c
@@ -20,246 +20,25 @@
  *
  */
 #include "kv-scanner.h"
-#include "str-utils.h"
-#include "utf8utils.h"
-
-#include <string.h>
-
-enum
-{
-  KV_QUOTE_INITIAL = 0,
-  KV_QUOTE_STRING,
-  KV_QUOTE_BACKSLASH,
-  KV_QUOTE_FINISH
-};
 
 void
-kv_scanner_set_value_separator(KVScanner *self, gchar value_separator)
-{
-  self->value_separator = value_separator;
-}
-
-void
-kv_scanner_input(KVScanner *self, const gchar *input)
-{
-  self->input = input;
-  self->input_len = strlen(input);
-  self->input_pos = 0;
-}
-
-static gboolean
-_kv_scanner_skip_space(KVScanner *self)
-{
-  while (self->input[self->input_pos] == ' ')
-    self->input_pos++;
-  return TRUE;
-}
-
-static gboolean
-_is_valid_key_character(int c)
-{
-  return (c >= 'a' && c <= 'z') ||
-         (c >= 'A' && c <= 'Z') ||
-         (c >= '0' && c <= '9') ||
-         (c == '_') ||
-         (c == '-');
-}
-
-static gboolean
-_kv_scanner_extract_key(KVScanner *self)
-{
-  const gchar *input_ptr = &self->input[self->input_pos];
-  const gchar *start_of_key;
-  const gchar *separator;
-  gsize len;
-
-  separator = strchr(input_ptr, self->value_separator);
-  do
-    {
-      if (!separator)
-        return FALSE;
-      start_of_key = separator;
-      while (start_of_key > input_ptr && _is_valid_key_character(*(start_of_key - 1)))
-        start_of_key--;
-      len = separator - start_of_key;
-      if (len < 1)
-        separator = strchr(separator + 1, self->value_separator);
-    }
-  while (len < 1);
-
-  g_string_assign_len(self->key, start_of_key, len);
-  self->input_pos = separator - self->input + 1;
-  return TRUE;
-}
-
-static void
-_decode_backslash_escape(KVScanner *self, gchar ch)
-{
-  gchar control;
-  switch (ch)
-    {
-    case 'b':
-      control = '\b';
-      break;
-    case 'f':
-      control = '\f';
-      break;
-    case 'n':
-      control = '\n';
-      break;
-    case 'r':
-      control = '\r';
-      break;
-    case 't':
-      control = '\t';
-      break;
-    case '\\':
-      control = '\\';
-      break;
-    default:
-      if (self->quote_char != ch)
-        g_string_append_c(self->value, '\\');
-      control = ch;
-      break;
-    }
-  g_string_append_c(self->value, control);
-}
-
-static gboolean
-_is_delimiter(const gchar *cur)
-{
-  return (*cur == ' ') || (strncmp(cur, ", ", 2) == 0);
-}
-
-static gboolean
-_kv_scanner_extract_value(KVScanner *self)
-{
-  const gchar *cur;
-
-  g_string_truncate(self->value, 0);
-  self->value_was_quoted = FALSE;
-  cur = &self->input[self->input_pos];
-
-  self->quote_state = KV_QUOTE_INITIAL;
-  while (*cur && self->quote_state != KV_QUOTE_FINISH)
-    {
-      switch (self->quote_state)
-        {
-        case KV_QUOTE_INITIAL:
-          if (_is_delimiter(cur))
-            {
-              self->quote_state = KV_QUOTE_FINISH;
-            }
-          else if (*cur == '\"' || *cur == '\'')
-            {
-              self->quote_state = KV_QUOTE_STRING;
-              self->quote_char = *cur;
-              if (self->value->len == 0)
-                self->value_was_quoted = TRUE;
-            }
-          else
-            {
-              g_string_append_c(self->value, *cur);
-            }
-          break;
-        case KV_QUOTE_STRING:
-          if (*cur == self->quote_char)
-            self->quote_state = KV_QUOTE_INITIAL;
-          else if (*cur == '\\')
-            self->quote_state = KV_QUOTE_BACKSLASH;
-          else
-            g_string_append_c(self->value, *cur);
-          break;
-        case KV_QUOTE_BACKSLASH:
-          _decode_backslash_escape(self, *cur);
-          self->quote_state = KV_QUOTE_STRING;
-          break;
-        }
-      cur++;
-    }
-  self->input_pos = cur - self->input;
-  return TRUE;
-}
-
-static gboolean
-_kv_scanner_decode_value(KVScanner *self)
-{
-  if (self->parse_value)
-    {
-      g_string_truncate(self->decoded_value, 0);
-      if (self->parse_value(self))
-        g_string_assign_len(self->value, self->decoded_value->str, self->decoded_value->len);
-    }
-  return TRUE;
-}
-
-gboolean
-kv_scanner_scan_next(KVScanner *self)
-{
-  _kv_scanner_skip_space(self);
-  if (!_kv_scanner_extract_key(self) ||
-      !_kv_scanner_extract_value(self) ||
-      !_kv_scanner_decode_value(self))
-    return FALSE;
-
-  return TRUE;
-}
-
-const gchar *
-kv_scanner_get_current_key(KVScanner *self)
-{
-  return self->key->str;
-}
-
-const gchar *
-kv_scanner_get_current_value(KVScanner *self)
-{
-  return self->value->str;
-}
-
-void
-kv_scanner_free_method(KVScanner *self)
-{
-  g_string_free(self->key, TRUE);
-  g_string_free(self->value, TRUE);
-  g_string_free(self->decoded_value, TRUE);
-}
-
-/* NOTE: this is a very limited clone operation that doesn't allow
- * descendant types (e.g.  linux-audit scanner to have their own state */
-KVScanner *
-kv_scanner_clone(KVScanner *self)
-{
-  KVScanner *cloned = kv_scanner_new();
-  cloned->parse_value = self->parse_value;
-  cloned->value_separator = self->value_separator;
-  return cloned;
-}
-
-void
-kv_scanner_init(KVScanner *self)
+kv_scanner_init(KVScanner *self, gchar value_separator, KVParseValue *parse_value)
 {
   memset(self, 0, sizeof(*self));
   self->key = g_string_sized_new(32);
   self->value = g_string_sized_new(64);
   self->decoded_value = g_string_sized_new(64);
-  self->free_fn = kv_scanner_free_method;
-  self->value_separator = '=';
-}
-
-KVScanner *
-kv_scanner_new(void)
-{
-  KVScanner *self = g_new0(KVScanner, 1);
-
-  kv_scanner_init(self);
-  return self;
+  self->value_separator = value_separator;
+  self->parse_value = parse_value;
 }
 
 void
 kv_scanner_free(KVScanner *self)
 {
-  if (self->free_fn)
-    self->free_fn(self);
+  if (!self)
+    return;
+  g_string_free(self->key, TRUE);
+  g_string_free(self->value, TRUE);
+  g_string_free(self->decoded_value, TRUE);
   g_free(self);
 }

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -84,7 +84,7 @@ kv_scanner_is_valid_key_character(gchar c)
 }
 
 static inline void
-kv_scanner_decode_value(KVScanner *self)
+kv_scanner_parse_value(KVScanner *self)
 {
   if (self->parse_value)
     {
@@ -92,6 +92,12 @@ kv_scanner_decode_value(KVScanner *self)
       if (self->parse_value(self))
         g_string_assign_len(self->value, self->decoded_value->str, self->decoded_value->len);
     }
+}
+
+static inline void
+kv_scanner_set_parse_value(KVScanner *self, KVParseValue *parse_value)
+{
+  self->parse_value = parse_value;
 }
 
 #endif

--- a/modules/kvformat/kv-scanner.h
+++ b/modules/kvformat/kv-scanner.h
@@ -23,35 +23,75 @@
 #define KV_SCANNER_H_INCLUDED
 
 #include "syslog-ng.h"
+#include "str-utils.h"
+
 
 typedef struct _KVScanner KVScanner;
+
+typedef gboolean KVParseValue(KVScanner *);
+
 struct _KVScanner
 {
   const gchar *input;
   gsize input_pos;
-  gsize input_len;
   GString *key;
   GString *value;
   GString *decoded_value;
   gboolean value_was_quoted;
   gchar value_separator;
   gchar quote_char;
-  gint quote_state;
-  gint next_quote_state;
-  gboolean (*parse_value)(KVScanner *self);
-  void (*free_fn)(KVScanner *self);
+  KVParseValue *parse_value;
+  gboolean (*scan_next)(KVScanner *self);
+  KVScanner* (*clone)(KVScanner *self);
 };
 
-void kv_scanner_set_value_separator(KVScanner *self, gchar value_separator);
-void kv_scanner_input(KVScanner *self, const gchar *input);
-gboolean kv_scanner_scan_next(KVScanner *self);
-const gchar *kv_scanner_get_current_key(KVScanner *self);
-const gchar *kv_scanner_get_current_value(KVScanner *self);
-KVScanner *kv_scanner_clone(KVScanner *self);
-void kv_scanner_free_method(KVScanner *self);
-void kv_scanner_init(KVScanner *self);
-
-KVScanner *kv_scanner_new(void);
+void kv_scanner_init(KVScanner *self, gchar value_separator, KVParseValue *parse_value);
 void kv_scanner_free(KVScanner *self);
+
+static inline void
+kv_scanner_input(KVScanner *self, const gchar *input)
+{
+  self->input = input;
+  self->input_pos = 0;
+}
+
+static inline KVScanner *
+kv_scanner_clone(KVScanner *self)
+{
+  return self->clone(self);
+}
+
+static inline const gchar *
+kv_scanner_get_current_key(KVScanner *self)
+{
+  return self->key->str;
+}
+
+static inline const gchar *
+kv_scanner_get_current_value(KVScanner *self)
+{
+  return self->value->str;
+}
+
+static inline gboolean
+kv_scanner_is_valid_key_character(gchar c)
+{
+  return (c >= 'a' && c <= 'z') ||
+         (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') ||
+         (c == '_') ||
+         (c == '-');
+}
+
+static inline void
+kv_scanner_decode_value(KVScanner *self)
+{
+  if (self->parse_value)
+    {
+      g_string_truncate(self->decoded_value, 0);
+      if (self->parse_value(self))
+        g_string_assign_len(self->value, self->decoded_value->str, self->decoded_value->len);
+    }
+}
 
 #endif

--- a/modules/kvformat/linux-audit-scanner.c
+++ b/modules/kvformat/linux-audit-scanner.c
@@ -114,8 +114,8 @@ _is_field_hex_encoded(const gchar *field)
   return FALSE;
 }
 
-static gboolean
-_parse_linux_audit_style_hexdump(KVScanner *self)
+gboolean
+parse_linux_audit_style_hexdump(KVScanner *self)
 {
   if (!self->value_was_quoted &&
       (self->value->len % 2) == 0 &&
@@ -133,10 +133,3 @@ _parse_linux_audit_style_hexdump(KVScanner *self)
   return FALSE;
 }
 
-KVScanner *
-linux_audit_scanner_new(KVScanner *base)
-{
-  KVScanner *self = base;
-  self->parse_value = _parse_linux_audit_style_hexdump;
-  return self;
-}

--- a/modules/kvformat/linux-audit-scanner.c
+++ b/modules/kvformat/linux-audit-scanner.c
@@ -134,9 +134,9 @@ _parse_linux_audit_style_hexdump(KVScanner *self)
 }
 
 KVScanner *
-linux_audit_scanner_new(void)
+linux_audit_scanner_new(KVScanner *base)
 {
-  KVScanner *self = kv_scanner_new();
+  KVScanner *self = base;
   self->parse_value = _parse_linux_audit_style_hexdump;
   return self;
 }

--- a/modules/kvformat/linux-audit-scanner.h
+++ b/modules/kvformat/linux-audit-scanner.h
@@ -24,6 +24,6 @@
 
 #include "kv-scanner.h"
 
-KVScanner *linux_audit_scanner_new(void);
+KVScanner *linux_audit_scanner_new(KVScanner* base);
 
 #endif

--- a/modules/kvformat/linux-audit-scanner.h
+++ b/modules/kvformat/linux-audit-scanner.h
@@ -24,6 +24,7 @@
 
 #include "kv-scanner.h"
 
-KVScanner *linux_audit_scanner_new(KVScanner* base);
+gboolean
+parse_linux_audit_style_hexdump(KVScanner *self);
 
 #endif

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -27,14 +27,17 @@
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      kv_parser = kv_parser_new(NULL, kv_scanner_new());        \
+      kv_parser =                                               \
+        kv_parser_new(NULL);        \
+      log_pipe_init((LogPipe*)kv_parser);                 \
     }                                                           \
   while (0)
 
 #define kv_parser_testcase_end()                           \
   do                                                            \
     {                                                           \
-      log_pipe_unref(&kv_parser->super);                      \
+      log_pipe_deinit((LogPipe*)kv_parser);                     \
+      log_pipe_unref(&kv_parser->super);                  \
       testcase_end();                                           \
     }                                                           \
   while (0)

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -18,16 +18,19 @@
  * OpenSSL libraries as published by the OpenSSL project. See the file
  * COPYING for details.
  */
-#include "kv-scanner.h"
+#include "kv-scanner-generic.h"
+#include "kv-scanner-simple.h"
 #include "testutils.h"
 
-static gboolean
+static void
 _assert_no_more_tokens(KVScanner *scanner)
 {
-  gboolean ok = kv_scanner_scan_next(scanner);
+  GString *msg;
+  gboolean ok = scanner->scan_next(scanner);
+
   if (ok)
     {
-      GString *msg = g_string_new("kv_scanner is expected to return no more key-value pairs ");
+      msg = g_string_new("kv_scanner is expected to return no more key-value pairs ");
       do
         {
           const gchar *key = kv_scanner_get_current_key(scanner);
@@ -38,11 +41,10 @@ _assert_no_more_tokens(KVScanner *scanner)
             value = "";
           g_string_append_printf(msg, "[%s/%s]", key, value);
         }
-      while (kv_scanner_scan_next(scanner));
-      expect_false(ok, msg->str);
+      while (scanner->scan_next(scanner));
+      expect_not_reached(msg->str);
       g_string_free(msg, TRUE);
     }
-  return !ok;
 }
 
 static gboolean
@@ -62,11 +64,11 @@ _assert_current_value_is(KVScanner *scanner, const gchar *expected_value)
 }
 
 static gboolean
-_compare_key_value(KVScanner *scanner, const gchar *key, const gchar *value, gboolean *expect_more)
+_compare_key_value(KVScanner *scanner, const gchar *key, const gchar *value)
 {
   g_assert(value);
 
-  gboolean ok = kv_scanner_scan_next(scanner);
+  gboolean ok = scanner->scan_next(scanner);
   if (ok)
     {
       _assert_current_key_is(scanner, key);
@@ -75,7 +77,6 @@ _compare_key_value(KVScanner *scanner, const gchar *key, const gchar *value, gbo
     }
   else
     {
-      *expect_more = FALSE;
       expect_true(ok, "kv_scanner is expected to return TRUE for scan_next(), "
                   "first unconsumed pair: [%s/%s]",
                   key, value);
@@ -85,31 +86,6 @@ _compare_key_value(KVScanner *scanner, const gchar *key, const gchar *value, gbo
 
 typedef const gchar *const VAElement;
 
-static void
-_scan_kv_pairs_scanner(KVScanner *scanner, const gchar *input, VAElement args[])
-{
-  g_assert(input);
-  kv_scanner_input(scanner, input);
-  gboolean expect_more = TRUE;
-  const gchar *key = *(args++);
-  while (key)
-    {
-      const gchar *value = *(args++);
-      if (!value || !_compare_key_value(scanner, key, value, &expect_more))
-        break;
-      key = *(args++);
-    }
-  if (expect_more)
-    _assert_no_more_tokens(scanner);
-}
-
-static void
-_scan_kv_pairs_implicit(const gchar *input, VAElement args[])
-{
-  KVScanner *scanner = kv_scanner_new();
-  _scan_kv_pairs_scanner(scanner, input, args);
-  kv_scanner_free(scanner);
-}
 
 typedef struct _KVQElement
 {
@@ -131,200 +107,110 @@ typedef struct _KVQContainer
   }
 
 static void
-_scan_kv_pairs_quoted(const gchar *input, KVQContainer args)
+_scan_kv_pairs_quoted(KVScanner *scanner, const gchar *input, KVQContainer args)
 {
-  KVScanner *scanner = kv_scanner_new();
-
   g_assert(input);
   kv_scanner_input(scanner, input);
-  gboolean expect_more = TRUE;
   for (gsize i = 0; i < args.n; i++)
     {
-      if (!_compare_key_value(scanner, args.arg[i].key, args.arg[i].value, &expect_more))
+      if (!_compare_key_value(scanner, args.arg[i].key, args.arg[i].value))
         break;
       expect_gboolean(scanner->value_was_quoted, args.arg[i].quoted,
                       "mismatch in value_was_quoted for [%s/%s]",
                       args.arg[i].key, args.arg[i].value);
     }
-  if (expect_more)
-    _assert_no_more_tokens(scanner);
+  _assert_no_more_tokens(scanner);
   kv_scanner_free(scanner);
 }
 
-#define TEST_KV_SCAN(TEST_KV_SCAN_input, ...) \
-  do { \
-    testcase_begin("TEST_KV_SCAN(%s, %s)", #TEST_KV_SCAN_input, #__VA_ARGS__); \
-    _scan_kv_pairs_implicit(TEST_KV_SCAN_input, (VAElement[]){ __VA_ARGS__,  NULL }); \
-    testcase_end(); \
-  } while (0)
-
-#define TEST_KV_SCAN0(TEST_KV_SCAN_input, ...) \
-  do { \
-    testcase_begin("TEST_KV_SCAN(%s, %s)", #TEST_KV_SCAN_input, #__VA_ARGS__); \
-    _scan_kv_pairs_implicit(TEST_KV_SCAN_input, (VAElement[]){ NULL }); \
-    testcase_end(); \
-  } while (0)
-
-#define TEST_KV_SCANNER(TEST_KV_SCAN_scanner, TEST_KV_SCAN_input, ...) \
-  do { \
-    testcase_begin("TEST_KV_SCANNER(%s, %s)", #TEST_KV_SCAN_input, #__VA_ARGS__); \
-    _scan_kv_pairs_scanner(TEST_KV_SCAN_scanner, TEST_KV_SCAN_input, \
-      (VAElement[]){ __VA_ARGS__,  NULL }); \
-    testcase_end(); \
-  } while (0)
-
-#define TEST_KV_SCAN_Q(TEST_KV_SCAN_input, ...) \
+#define TEST_KV_SCAN_Q(SCANNER_input, TEST_KV_SCAN_input, ...) \
   do { \
     testcase_begin("TEST_KV_SCAN_Q(%s, %s)", #TEST_KV_SCAN_input, #__VA_ARGS__); \
-    _scan_kv_pairs_quoted(TEST_KV_SCAN_input, VARARG_STRUCT(KVQContainer, KVQElement, __VA_ARGS__)); \
+    _scan_kv_pairs_quoted(SCANNER_input, TEST_KV_SCAN_input, VARARG_STRUCT(KVQContainer, KVQElement, __VA_ARGS__)); \
     testcase_end(); \
   } while (0)
 
-static void
-_test_incomplete_string_returns_no_pairs(void)
+typedef struct _ScannerConfig
 {
-  TEST_KV_SCAN0("");
-  TEST_KV_SCAN0("f");
-  TEST_KV_SCAN0("fo");
-  TEST_KV_SCAN0("foo");
+  gchar kv_separator;
+  gboolean allow_pair_separator_in_value;
+} ScannerConfig;
+
+typedef struct _KV
+{
+  gchar *key;
+  gchar *value;
+} KV;
+
+typedef struct Testcase_t
+{
+  gint line;
+  const gchar *function;
+  ScannerConfig config[5];
+  gchar *input;
+  KV expected[25];
+} Testcase;
+
+KVScanner *
+create_kv_scanner(const ScannerConfig config)
+{
+  return (config.allow_pair_separator_in_value ?
+          kv_scanner_generic_new(config.kv_separator, NULL) :
+          kv_scanner_simple_new(config.kv_separator, NULL));
 }
 
 static void
-_test_name_equals_value_returns_a_pair(void)
+_scan_kv_pairs_scanner(KVScanner *scanner, const gchar *input, const KV kvs[])
 {
-  TEST_KV_SCAN("foo=", "foo", "");
-  TEST_KV_SCAN("foo=b", "foo", "b");
-  TEST_KV_SCAN("foo=bar", "foo", "bar");
-  TEST_KV_SCAN("foo=barbar", "foo", "barbar");
+  g_assert(input);
+  kv_scanner_input(scanner, input);
+
+  while (kvs->key)
+    {
+      if (!kvs->value || !_compare_key_value(scanner, kvs->key, kvs->value))
+        break;
+      kvs++;
+    }
+  _assert_no_more_tokens(scanner);
+  kv_scanner_free(scanner);
 }
 
 static void
-_test_stray_words_are_ignored(void)
+_test_key_buffer_underrun(void)
 {
-  TEST_KV_SCAN("lorem ipsum foo=bar", "foo", "bar");
-  TEST_KV_SCAN("lorem ipsum/dolor @sitamen foo=bar", "foo", "bar");
-  TEST_KV_SCAN("lorem ipsum/dolor = foo=bar\"", "foo", "bar");
-  TEST_KV_SCAN("foo=bar lorem ipsum key=value some more values", "foo", "bar", "key", "value");
-  TEST_KV_SCAN("*k=v", "k", "v");
-  TEST_KV_SCAN("x *k=v", "k", "v");
+  const gchar *buffer = "ab=v";
+  const gchar *input = buffer + 2;
+
+  KV expect_nothing[] =
+  {
+    {}
+  };
+
+  _scan_kv_pairs_scanner(create_kv_scanner((ScannerConfig)
+  {'=', FALSE
+  }), input, expect_nothing);
 }
 
 static void
-_test_with_multiple_key_values_return_multiple_pairs(void)
+_test_quotation_is_stored_in_the_was_quoted_value_member(void)
 {
-  TEST_KV_SCAN("key1=value1 key2=value2 key3=value3 ",
-               "key1", "value1", "key2", "value2", "key3", "value3");
+  ScannerConfig config = {'=', FALSE};
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo=\"bar\"", {"foo", "bar", TRUE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo='bar'", {"foo", "bar", TRUE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo=bar", {"foo", "bar", FALSE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo='bar", {"foo", "bar", TRUE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo='bar' k=v", {"foo", "bar", TRUE}, {"k", "v", FALSE});
 }
 
 static void
-_test_spaces_between_values_are_ignored(void)
+_test_quotation_is_stored_in_the_was_quoted_value_member_with_space_separator_option(void)
 {
-  TEST_KV_SCAN("key1=value1    key2=value2     key3=value3 ",
-               "key1", "value1", "key2", "value2", "key3", "value3");
-}
-
-static void
-_test_with_comma_separated_values(void)
-{
-  TEST_KV_SCAN("key1=value1, key2=value2, key3=value3",
-               "key1", "value1", "key2", "value2", "key3", "value3");
-}
-
-static void
-_test_with_comma_separated_values_and_multiple_spaces(void)
-{
-  TEST_KV_SCAN("key1=value1,   key2=value2  ,    key3=value3",
-               "key1", "value1",
-               "key2", "value2",
-               "key3", "value3");
-}
-
-static void
-_test_with_comma_separated_values_without_space(void)
-{
-  TEST_KV_SCAN("key1=value1,key2=value2,key3=value3",
-               "key1", "value1,key2=value2,key3=value3");
-}
-
-static void
-_test_tab_separated_values(void)
-{
-  TEST_KV_SCAN("key1=value1\tkey2=value2 key3=value3",
-               "key1", "value1\tkey2=value2",
-               "key3", "value3");
-  TEST_KV_SCAN("key1=value1,\tkey2=value2 key3=value3",
-               "key1", "value1,\tkey2=value2",
-               "key3", "value3");
-  TEST_KV_SCAN("key1=value1\t key2=value2 key3=value3",
-               "key1", "value1\t",
-               "key2", "value2",
-               "key3", "value3");
-  TEST_KV_SCAN("k=\t",
-               "k", "\t");
-  TEST_KV_SCAN("k=,\t",
-               "k", ",\t");
-}
-
-static void
-_test_quoted_values_are_unquoted_like_c_strings(void)
-{
-  TEST_KV_SCAN("foo=\"bar\"", "foo", "bar");
-
-  TEST_KV_SCAN("key1=\"value1\", key2=\"value2\"", "key1", "value1", "key2", "value2");
-
-  /* embedded quote */
-  TEST_KV_SCAN("key1=\"\\\"value1\"", "key1", "\"value1");
-
-  /* control sequences */
-  TEST_KV_SCAN("key1=\"\\b \\f \\n \\r \\t \\\\\"",
-               "key1", "\b \f \n \r \t \\");
-
-  /* unknown backslash escape is left as is */
-  TEST_KV_SCAN("key1=\"\\p\"",
-               "key1", "\\p");
-
-  TEST_KV_SCAN("key1='value1', key2='value2'",
-               "key1", "value1",
-               "key2", "value2");
-
-  /* embedded quote */
-  TEST_KV_SCAN("key1='\\'value1'", "key1", "'value1");
-
-  /* control sequences */
-  TEST_KV_SCAN("key1='\\b \\f \\n \\r \\t \\\\'",
-               "key1", "\b \f \n \r \t \\");
-
-  /* unknown backslash escape is left as is */
-  TEST_KV_SCAN("key1='\\p'", "key1", "\\p");
-
-  TEST_KV_SCAN("key1=\\b\\f\\n\\r\\t\\\\",
-               "key1", "\\b\\f\\n\\r\\t\\\\");
-  TEST_KV_SCAN("key1=\b\f\n\r\\",
-               "key1", "\b\f\n\r\\");
-}
-
-static void
-_test_keys_without_values(void)
-{
-  TEST_KV_SCAN("key1 key2=value2, key3, key4=value4",
-               "key2", "value2",
-               "key4", "value4");
-
-  TEST_KV_SCAN("key1= key2=value2, key3=, key4=value4 key5= , key6=value6",
-               "key1", "",
-               "key2", "value2",
-               "key3", "",
-               "key4", "value4",
-               "key5", "",
-               "key6", "value6");
-}
-
-static void
-_test_quoted_values_with_special_characters(void)
-{
-  TEST_KV_SCAN("key1=\"value foo, foo2 =@,\\\"\" key2='value foo,  a='",
-               "key1", "value foo, foo2 =@,\"",
-               "key2", "value foo,  a=");
+  ScannerConfig config = {'=', TRUE};
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo=\"bar\"", {"foo", "bar", TRUE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo='bar'", {"foo", "bar", TRUE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo=bar", {"foo", "bar", FALSE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo='bar", {"foo", "'bar", FALSE});
+  TEST_KV_SCAN_Q(create_kv_scanner(config), "foo='bar' k=v", {"foo", "bar", TRUE}, {"k", "v", FALSE});
 }
 
 static gboolean
@@ -341,189 +227,1020 @@ _parse_value_by_incrementing_all_bytes(KVScanner *self)
 static void
 _test_transforms_values_if_parse_value_is_set(void)
 {
-  KVScanner *scanner = kv_scanner_new();
+  KVScanner *scanner = create_kv_scanner((ScannerConfig)
+  {'=', FALSE
+  });
   scanner->parse_value = _parse_value_by_incrementing_all_bytes;
-  TEST_KV_SCANNER(scanner, "foo=\"bar\"", "foo", "cbs");
-  kv_scanner_free(scanner);
+
+  _scan_kv_pairs_scanner(scanner, "foo=\"bar\"", (KV[])
+  { {"foo", "cbs"}, {}
+  });
 }
 
 static void
-_test_quotation_is_stored_in_the_was_quoted_value_member(void)
+_test_transforms_values_if_parse_value_is_set_with_space_separator_option(void)
 {
-  TEST_KV_SCAN_Q("foo=\"bar\"", {"foo", "bar", TRUE});
-  TEST_KV_SCAN_Q("foo='bar'", {"foo", "bar", TRUE});
-  TEST_KV_SCAN_Q("foo=bar", {"foo", "bar", FALSE});
-  TEST_KV_SCAN_Q("foo='bar' k=v",
-  {"foo", "bar", TRUE},
-  {"k", "v", FALSE});
-}
+  KVScanner *scanner = create_kv_scanner((ScannerConfig)
+  {'=', TRUE
+  });
+  scanner->parse_value = _parse_value_by_incrementing_all_bytes;
 
-static void
-_test_value_separator_with_whitespaces_around(void)
-{
-  KVScanner *scanner = kv_scanner_new();
-  kv_scanner_set_value_separator(scanner, ':');
-
-  TEST_KV_SCANNER(scanner, "key1: value1 key2 : value2 key3 :value3 ",
-                  "key1", "");
-
-  kv_scanner_free(scanner);
-}
-
-static void
-_test_value_separator_is_used_to_separate_key_from_value(void)
-{
-  KVScanner *scanner = kv_scanner_new();
-  kv_scanner_set_value_separator(scanner, ':');
-
-  TEST_KV_SCANNER(scanner, "key1:value1 key2:value2 key3:value3 ",
-                  "key1", "value1",
-                  "key2", "value2",
-                  "key3", "value3");
-
-  kv_scanner_free(scanner);
+  _scan_kv_pairs_scanner(scanner, "foo=\"bar\"", (KV[])
+  { {"foo", "cbs"}, {}
+  });
 }
 
 static void
 _test_value_separator_clone(void)
 {
-  KVScanner *scanner = kv_scanner_new();
-  kv_scanner_set_value_separator(scanner, ':');
-  KVScanner *cloned_scanner = kv_scanner_clone(scanner);
+  KVScanner *scanner = kv_scanner_simple_new(':', NULL);
+  KVScanner *cloned_scanner = scanner->clone(scanner);
   kv_scanner_free(scanner);
 
-  TEST_KV_SCANNER(cloned_scanner, "key1:value1 key2:value2 key3:value3 ",
-                  "key1", "value1",
-                  "key2", "value2",
-                  "key3", "value3");
-  kv_scanner_free(cloned_scanner);
+  _scan_kv_pairs_scanner(
+    cloned_scanner,
+    "key1:value1 key2:value2 key3:value3 ",
+    (KV[])
+  { {"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}, {}
+  }
+  );
 }
 
 static void
-_test_invalid_encoding(void)
+_test_parse_value_clone(void)
 {
-  TEST_KV_SCAN("k=\xc3", "k", "\xc3");
-  TEST_KV_SCAN("k=\xc3v", "k", "\xc3v");
-  TEST_KV_SCAN("k=\xff", "k", "\xff");
-  TEST_KV_SCAN("k=\xffv", "k", "\xffv");
-  TEST_KV_SCAN("k=\"\xc3", "k", "\xc3");
-  TEST_KV_SCAN("k=\"\xc3v", "k", "\xc3v");
-  TEST_KV_SCAN("k=\"\xff", "k", "\xff");
-  TEST_KV_SCAN("k=\"\xffv", "k", "\xffv");
-}
-
-static void
-_test_separator_in_key(void)
-{
-  KVScanner *scanner = kv_scanner_new();
-  kv_scanner_set_value_separator(scanner, '-');
-
-  TEST_KV_SCANNER(scanner, "k-v", "k", "v");
-  TEST_KV_SCANNER(scanner, "k--v", "k", "-v");
-  TEST_KV_SCANNER(scanner, "---", "-", "-");
-
+  KVScanner *scanner = kv_scanner_simple_new('=', _parse_value_by_incrementing_all_bytes);
+  KVScanner *cloned_scanner = scanner->clone(scanner);
   kv_scanner_free(scanner);
+
+  _scan_kv_pairs_scanner(cloned_scanner, "foo=\"hal\"", (KV[])
+  { {"foo", "ibm"}, {}
+  }
+                        );
+}
+
+#define DEFAULT_CONFIG {.kv_separator='=', .allow_pair_separator_in_value=FALSE}
+#define SPACE_HANDLING_CONFIG {.kv_separator='=', .allow_pair_separator_in_value=TRUE}
+
+#define TC_HEAD .line=__LINE__, .function=__FUNCTION__
+
+static const Testcase *
+_provide_common_cases(void)
+{
+  static const Testcase common_cases[] =
+  {
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "foo=bar",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k-j=v",
+      { {"k-j", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "0=v",
+      { {"0", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "_=v",
+      { {"_", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "Z=v",
+      { {"Z", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k==",
+      { {"k", "="}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k===",
+      { {"k", "=="}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k===a",
+      { {"k", "==a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k===a=b",
+      { {"k", "==a=b"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " ==k=",
+      { {"k", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " = =k=",
+      { {"k", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " =k=",
+      { {"k", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " =k=v",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " ==k=v",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=\xc3",
+      { {"k", "\xc3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=\xc3v",
+      { {"k", "\xc3v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=\xff",
+      { {"k", "\xff"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=\xffv",
+      { {"k", "\xffv"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "foo=",
+      { {"foo", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "foo=b",
+      { {"foo", "b"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "lorem ipsum foo=bar",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "lorem ipsum/dolor @sitamen foo=bar",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "*k=v",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "x *k=v",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=v1 k2=v2 k3=v3",
+      { {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k= a=b c=d",
+      { {"k", ""}, {"a", "b"}, {"c", "d"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=v arg= code=27",
+      { {"k", "v"}, {"arg", ""}, {"code", "27"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=a=b c=d",
+      { {"k", "a=b"}, {"c", "d"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=v1    k2=v2     k3=v3 ",
+      { {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=v1,k2=v2,k3=v3",
+      { {"k1", "v1,k2=v2,k3=v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=\\",
+      { {"k", "\\"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=v1\tk2=v2 k3=v3",
+      { {"k1", "v1\tk2=v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=v1,\tk2=v2 k3=v3",
+      { {"k1", "v1,\tk2=v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=v1\t k2=v2 k3=v3",
+      { {"k1", "v1\t"}, {"k2", "v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=\t",
+      { {"k", "\t"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k=,\t",
+      { {"k", ",\t"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "foo=\"bar\"",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=\\b\\f\\n\\r\\t\\\\",
+      { {"k1", "\\b\\f\\n\\r\\t\\\\"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k1=\b\f\n\r\\",
+      { {"k1", "\b\f\n\r\\"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "=v",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "k*=v",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "=",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "==",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "===",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " =",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " ==",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " ===",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      " = =",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      ":=",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "á=v",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "f",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "fo",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "foo",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      ", k=v",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      ",k=v",
+      { {"k", "v"}, {} }
+    },
+
+    {}
+  };
+
+  return common_cases;
+}
+
+static const Testcase *
+_provide_cases_without_allow_pair_separator_in_value(void)
+{
+  static const Testcase cases_without_allow_pair_separator_in_value[] =
+  {
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=\"a",
+      { {"k", "a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=\"\\",
+      { {"k", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k='a",
+      { {"k", "a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k='\\",
+      { {"k", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      " =k=v=w",
+      { {"k", "v=w"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=\"\xc3v",
+      { {"k", "\xc3v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=\"\xff",
+      { {"k", "\xff"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=\"\xffv",
+      { {"k", "\xffv"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "lorem ipsum/dolor = foo=bar",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=\"v1\", k2=\"v2\"",
+      { {"k1", "v1"}, {"k2", "v2"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=\"\\\"v1\"",
+      { {"k1", "\"v1"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=\"\\b \\f \\n \\r \\t \\\\\"",
+      { {"k1", "\b \f \n \r \t \\"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=\"\\p\"",
+      { {"k1", "\\p"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1='\\'v1'",
+      { {"k1", "'v1"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1='\\b \\f \\n \\r \\t \\\\'",
+      { {"k1", "\b \f \n \r \t \\"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1='\\p'",
+      { {"k1", "\\p"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=\"v foo, foo2 =@,\\\"\" k2='v foo,  a='",
+      { {"k1", "v foo, foo2 =@,\""}, {"k2", "v foo,  a="}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=v1, k2=v2, k3=v3",
+      { {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "foo=bar lorem ipsum key=value some more values",
+      { {"foo", "bar"}, {"key", "value"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1=v1,   k2=v2  ,    k3=v3",
+      { {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1 k2=v2, k3, k4=v4",
+      { {"k2", "v2"}, {"k4", "v4"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1= k2=v2, k3=, k4=v4 k5= , k6=v6",
+      { {"k1", ""}, {"k2", "v2"}, {"k3", ""}, {"k4", "v4"}, {"k5", ""}, {"k6", "v6"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1= v1 k2 = v2 k3 =v3 ",
+      { {"k1", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k1='v1', k2='v2'",
+      { {"k1", "v1"}, {"k2", "v2"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=v,",
+      { {"k", "v,"}, {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, {} },
+      "k=v, ",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { {':', FALSE}, {} },
+      "k1:v1 k2:v2 k3:v3 ",
+      { {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}, {} }
+    },
+    {
+      TC_HEAD,
+      { {':', FALSE}, {} },
+      "k1: v1 k2 : v2 k3 :v3 ",
+      { {"k1", ""}, {} }
+    },
+    {
+      TC_HEAD,
+      { {'-', FALSE}, {} },
+      "k-v",
+      { {"k", "v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { {'-', FALSE}, {} },
+      "k--v",
+      { {"k", "-v"}, {} }
+    },
+    {
+      TC_HEAD,
+      { {'-', FALSE}, {} },
+      "---",
+      { {"-", "-"}, {} }
+    },
+
+    {}
+  };
+
+  return cases_without_allow_pair_separator_in_value;
+}
+
+static const Testcase *
+_provide_cases_with_allow_pair_separator_in_value(void)
+{
+  static const Testcase cases_with_allow_pair_separator_in_value[] =
+  {
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo =bar",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo =bar",
+      { {"foo", "bar"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=bar ggg",
+      { {"foo", "bar ggg"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=bar ggg baz=ez",
+      { {"foo", "bar ggg"}, {"baz", "ez"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      " foo =bar ggg baz=ez",
+      { {"foo", "bar ggg"}, {"baz", "ez"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo =bar ggg baz =ez",
+      { {"foo", "bar ggg"}, {"baz", "ez"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo =bar ggg baz   =ez",
+      { {"foo", "bar ggg"}, {"baz", "ez"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo =  bar ggg baz   =   ez",
+      { {"foo", "bar ggg"}, {"baz", "ez"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "k===  a",
+      { {"k", "==  a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "a b c=d",
+      { {"c", "d"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      " k= b",
+      { {"k", "b"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=a \"bar baz\" ",
+      { {"foo", "a \"bar baz\""}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=a \"bar baz",
+      { {"foo", "a \"bar baz"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=a \"bar baz c=d",
+      { {"foo", "a \"bar baz"}, {"c", "d"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=a \"bar baz\"=f c=d a",
+      { {"foo", "a \"bar baz\"=f"}, {"c", "d a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=\\\"bar baz\\\"",
+      { {"foo", "\\\"bar baz\\\""}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=\"bar\" baz c=d",
+      { {"foo", "\"bar\" baz"}, {"c", "d"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=bar\"",
+      { {"foo", "bar\""}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "k===a",
+      { {"k", "==a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "k===  a",
+      { {"k", "==  a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "k===a=b",
+      { {"k", "==a=b"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "a==b=",
+      { {"a", "=b="}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "a=,=b=a",
+      { {"a", ",=b=a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "a= =a",
+      { {"a", "=a"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo=\"bar baz\"",
+      { {"foo", "bar baz"}, {} }
+    },
+    {
+      TC_HEAD,
+      { SPACE_HANDLING_CONFIG, {} },
+      "foo='bar",
+      { {"foo", "'bar"}, {} }
+    },
+
+    {}
+  };
+
+  return cases_with_allow_pair_separator_in_value;
+}
+
+static const Testcase *
+_provide_cases_for_performance_test_nothing_to_parse(void)
+{
+  static const Testcase cases_for_performance_test_nothing_to_parse[] =
+  {
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "Reducing the compressed framebuffer size. This may lead to less power savings than a non-reduced-size. \
+Try to increase stolen memory size if available in BIOS.",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "interrupt took too long (3136 > 3127), lowering kernel.perf_event_max_sample_rate to 63750",
+      { {} }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "Linux version 4.6.3-040603-generic (kernel@gomeisa) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-4ubuntu1) ) \
+#201606241434 SMP Fri Jun 24 18:36:33 UTC 2016",
+      { {} }
+    },
+
+    {}
+  };
+
+  return cases_for_performance_test_nothing_to_parse;
+}
+
+static const Testcase *
+_provide_cases_for_performance_test_parse_long_msg(void)
+{
+  static const Testcase cases_for_performance_test_parse_long_msg[] =
+  {
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "PF: filter/forward DROP \
+      IN=15dd205a6ac8b0c80ab3bcdcc5649c9c830074cdbdc094ff1d79f20f17c56843 \
+      OUT=980816f36b77e58d342de41f85854376d10cf9bf33aa1934e129ffd77ddc833d \
+      SRC=cc8177fc0c8681d3d5d2a42bc1ed86990f773589592fa3100c23fae445f8a260 \
+      DST=5fee25396500fc798e10b4dcb0b3fb315618ff11843be59978c0d5b41cd9f12c \
+      LEN=71ee45a3c0db9a9865f7313dd3372cf60dca6479d46261f3542eb9346e4a04d6 \
+      TOS=c4dd67368286d02d62bdaa7a775b7594765d5210c9ad20cc3c24148d493353d7 \
+      PREC=c4dd67368286d02d62bdaa7a775b7594765d5210c9ad20cc3c24148d493353d7 \
+      TTL=da4ea2a5506f2693eae190d9360a1f31793c98a1adade51d93533a6f520ace1c \
+      ID=242a9377518dd1afaf021b2d0bfe6484e3fe48a878152f76dec99a396160022c \
+      PROTO=dc4030f9688d6e67dfc4c5f8f7afcbdbf5c30de866d8a3c6e1dd038768ab91c3 \
+      SPT=1e7996c7b0181429bba237ac2799ee5edc31aca2d5d90c39a48f9e9a3d4078bd \
+      DPT=ca902d4a8acbdea132ada81a004081f51c5c9279d409cee414de5a39a139fab6 \
+      LEN=c2356069e9d1e79ca924378153cfbbfb4d4416b1f99d41a2940bfdb66c5319db",
+      { {"IN", "15dd205a6ac8b0c80ab3bcdcc5649c9c830074cdbdc094ff1d79f20f17c56843"},
+        {"OUT", "980816f36b77e58d342de41f85854376d10cf9bf33aa1934e129ffd77ddc833d"},
+        {"SRC", "cc8177fc0c8681d3d5d2a42bc1ed86990f773589592fa3100c23fae445f8a260"},
+        {"DST", "5fee25396500fc798e10b4dcb0b3fb315618ff11843be59978c0d5b41cd9f12c"},
+        {"LEN", "71ee45a3c0db9a9865f7313dd3372cf60dca6479d46261f3542eb9346e4a04d6"},
+        {"TOS", "c4dd67368286d02d62bdaa7a775b7594765d5210c9ad20cc3c24148d493353d7"},
+        {"PREC", "c4dd67368286d02d62bdaa7a775b7594765d5210c9ad20cc3c24148d493353d7"},
+        {"TTL", "da4ea2a5506f2693eae190d9360a1f31793c98a1adade51d93533a6f520ace1c"},
+        {"ID", "242a9377518dd1afaf021b2d0bfe6484e3fe48a878152f76dec99a396160022c"},
+        {"PROTO", "dc4030f9688d6e67dfc4c5f8f7afcbdbf5c30de866d8a3c6e1dd038768ab91c3"},
+        {"SPT", "1e7996c7b0181429bba237ac2799ee5edc31aca2d5d90c39a48f9e9a3d4078bd"},
+        {"DPT", "ca902d4a8acbdea132ada81a004081f51c5c9279d409cee414de5a39a139fab6"},
+        {"LEN", "c2356069e9d1e79ca924378153cfbbfb4d4416b1f99d41a2940bfdb66c5319db"},
+        {}
+      }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "fw=108.53.156.38 pri=6 c=262144 m=98 msg=\"Connection Opened\" f=2 sess=\"None\" \
+      n=16351474 src=10.0.5.200:57719:X0:MOGWAI dst=71.250.0.14:53:X1 dstMac=f8:c0:01:73:c7:c1 proto=udp/dns sent=66",
+      { {"fw", "108.53.156.38"},
+        {"pri", "6"},
+        {"c", "262144"},
+        {"m", "98"},
+        {"msg", "Connection Opened"},
+        {"f", "2"},
+        {"sess", "None"},
+        {"n", "16351474"},
+        {"src", "10.0.5.200:57719:X0:MOGWAI"},
+        {"dst", "71.250.0.14:53:X1"},
+        {"dstMac", "f8:c0:01:73:c7:c1"},
+        {"proto", "udp/dns"},
+        {"sent", "66"},
+        {}
+      }
+    },
+    {
+      TC_HEAD,
+      { DEFAULT_CONFIG, SPACE_HANDLING_CONFIG, {} },
+      "sn=C0EAE484E43E time=\"2016-07-08 13:42:58\" fw=132.237.143.192 pri=5 c=4 m=16 msg=\"Web site access allowed\" \
+      app=11 sess=\"Auto\" n=5086 usr=\"DEMO\\primarystudent\" src=10.2.3.64:50682:X2-V3023 dst=157.55.240.220:443:X1 \
+      srcMac=00:50:56:8e:55:8e dstMac=c0:ea:e4:84:e4:40 proto=tcp/https dstname=sls.update.microsoft.com arg= code=27 \
+      Category=\"Information Technology/Computers\" fw_action=\"process\"",
+      { {"sn", "C0EAE484E43E"},
+        {"time", "2016-07-08 13:42:58"},
+        {"fw", "132.237.143.192"},
+        {"pri", "5"},
+        {"c", "4"},
+        {"m", "16"},
+        {"msg", "Web site access allowed"},
+        {"app", "11"},
+        {"sess", "Auto"},
+        {"n", "5086"},
+        {"usr", "DEMO\\primarystudent"},
+        {"src", "10.2.3.64:50682:X2-V3023"},
+        {"dst", "157.55.240.220:443:X1"},
+        {"srcMac", "00:50:56:8e:55:8e"},
+        {"dstMac", "c0:ea:e4:84:e4:40"},
+        {"proto", "tcp/https"},
+        {"dstname", "sls.update.microsoft.com"},
+        {"arg", ""},
+        {"code", "27"},
+        {"Category", "Information Technology/Computers"},
+        {"fw_action", "process"},
+        {}
+      }
+    },
+
+    {}
+  };
+  return cases_for_performance_test_parse_long_msg;
+}
+
+static GString *
+_expected_to_string(const KV *kvs)
+{
+  GString *result = g_string_new("");
+  gboolean first = TRUE;
+  while (kvs->key)
+    {
+      if (!first)
+        {
+          g_string_append_c(result, ' ');
+        }
+      first = FALSE;
+      g_string_append_printf(result, "%s=%s", kvs->key, kvs->value);
+      kvs++;
+    }
+
+  return result;
 }
 
 static void
-_test_empty_keys(void)
+_run_testcase(const Testcase tc)
 {
-  TEST_KV_SCAN0("=v");
-  TEST_KV_SCAN0("k*=v");
-  TEST_KV_SCAN0("=");
-  TEST_KV_SCAN0("==");
-  TEST_KV_SCAN0("===");
-  TEST_KV_SCAN0(" =");
-  TEST_KV_SCAN0(" ==");
-  TEST_KV_SCAN0(" ===");
-  TEST_KV_SCAN0(" = =");
-  TEST_KV_SCAN(" ==k=", "k", "");
-  TEST_KV_SCAN(" = =k=", "k", "");
-  TEST_KV_SCAN(" =k=", "k", "");
-  TEST_KV_SCAN(" =k=v", "k", "v");
-  TEST_KV_SCAN(" ==k=v", "k", "v");
-  TEST_KV_SCAN(" =k=v=w", "k", "v=w");
+  GString *pretty_expected;
+  const ScannerConfig *cfg = tc.config;
+  while (cfg->kv_separator != 0)
+    {
+      pretty_expected = _expected_to_string(tc.expected);
+      testcase_begin("line:(%d), function:(%s), input:(%s), expected:(%s), separator(%c), separator_in_values(%d)",
+                     tc.line,
+                     tc.function,
+                     tc.input,
+                     pretty_expected->str,
+                     cfg->kv_separator,
+                     cfg->allow_pair_separator_in_value);
+      _scan_kv_pairs_scanner(create_kv_scanner(*cfg), tc.input, tc.expected);
+      testcase_end();
+      g_string_free(pretty_expected, TRUE);
+      cfg++;
+    }
 }
 
 static void
-_test_unclosed_quotes(void)
+_run_testcases(const Testcase *cases)
 {
-  TEST_KV_SCAN("k=\"a", "k", "a");
-  TEST_KV_SCAN("k=\\", "k", "\\");
-  TEST_KV_SCAN("k=\"\\", "k", "");
-
-  TEST_KV_SCAN("k='a", "k", "a");
-  TEST_KV_SCAN("k='\\", "k", "");
+  const Testcase *tc = cases;
+  while (tc->input)
+    {
+      _run_testcase(*tc);
+      tc++;
+    }
 }
 
-static void
-_test_comma_separator(void)
-{
-  TEST_KV_SCAN(", k=v", "k", "v");
-  TEST_KV_SCAN(",k=v", "k", "v");
-  TEST_KV_SCAN("k=v,", "k", "v,");
-  TEST_KV_SCAN("k=v, ", "k", "v");
-}
+#define ITERATION_NUMBER 10000
 
 static void
-_test_multiple_separators(void)
+_test_performance(const Testcase *tcs, gchar *title)
 {
-  TEST_KV_SCAN("k==", "k", "=");
-  TEST_KV_SCAN("k===", "k", "==");
-}
+  GString *pretty_expected;
+  const ScannerConfig *cfg = NULL;
+  gint cfg_index = 0;
+  const Testcase *tc;
+  gint iteration_index = 0;
 
-static void
-_test_key_charset(void)
-{
-  TEST_KV_SCAN("k-j=v", "k-j", "v");
-  TEST_KV_SCAN("0=v", "0", "v");
-  TEST_KV_SCAN("_=v", "_", "v");
-  TEST_KV_SCAN0(":=v");
-  TEST_KV_SCAN("Z=v", "Z", "v");
-  TEST_KV_SCAN0("á=v");
-}
+  if (title)
+    {
+      printf("Performance test: %s\n", title);
+    }
 
-static void
-_test_key_buffer_underrun(void)
-{
-  const gchar *buffer = "ab=v";
-  const gchar *input = buffer + 2;
-  TEST_KV_SCAN0(input);
-}
+  for (cfg_index = 0; tcs->config[cfg_index].kv_separator != 0; cfg_index++)
+    {
 
-static void
-test_kv_scanner(void)
-{
-  _test_empty_keys();
-  _test_incomplete_string_returns_no_pairs();
-  _test_stray_words_are_ignored();
-  _test_name_equals_value_returns_a_pair();
-  _test_with_multiple_key_values_return_multiple_pairs();
-  _test_spaces_between_values_are_ignored();
-  _test_with_comma_separated_values();
-  _test_with_comma_separated_values_and_multiple_spaces();
-  _test_with_comma_separated_values_without_space();
-  _test_tab_separated_values();
-  _test_quoted_values_are_unquoted_like_c_strings();
-  _test_keys_without_values();
-  _test_quoted_values_with_special_characters();
-  _test_transforms_values_if_parse_value_is_set();
-  _test_quotation_is_stored_in_the_was_quoted_value_member();
-  _test_value_separator_is_used_to_separate_key_from_value();
-  _test_value_separator_clone();
-  _test_value_separator_with_whitespaces_around();
-  _test_invalid_encoding();
-  _test_separator_in_key();
-  _test_unclosed_quotes();
-  _test_comma_separator();
-  _test_multiple_separators();
-  _test_key_charset();
-  _test_key_buffer_underrun();
+      start_stopwatch();
+
+      for (iteration_index = 0; iteration_index < ITERATION_NUMBER; iteration_index++)
+        {
+          for (tc = tcs; tc->input; tc++)
+            {
+              cfg = &tc->config[cfg_index];
+
+              pretty_expected = _expected_to_string(tc->expected);
+              testcase_begin("input:(%s), expected:(%s), separator(%c), separator_in_values(%d)",
+                             tc->input, pretty_expected->str, cfg->kv_separator, cfg->allow_pair_separator_in_value);
+              _scan_kv_pairs_scanner(create_kv_scanner(*cfg), tc->input, tc->expected);
+              testcase_end();
+              g_string_free(pretty_expected, TRUE);
+            }
+        }
+
+      if (cfg != NULL)
+        {
+          stop_stopwatch_and_display_result(1, "Is pair-separator allowed in values: %s KV-separator: '%c' ",
+                                            cfg->allow_pair_separator_in_value?"YES":"NO ",
+                                            cfg->kv_separator);
+        }
+    }
 }
 
 int main(int argc, char *argv[])
 {
-  test_kv_scanner();
+  _test_quotation_is_stored_in_the_was_quoted_value_member();
+  _test_quotation_is_stored_in_the_was_quoted_value_member_with_space_separator_option();
+  _test_key_buffer_underrun();
+  _test_transforms_values_if_parse_value_is_set();
+  _test_transforms_values_if_parse_value_is_set_with_space_separator_option();
+  _test_value_separator_clone();
+  _test_parse_value_clone();
+  _run_testcases(_provide_cases_without_allow_pair_separator_in_value());
+  _run_testcases(_provide_common_cases());
+  _run_testcases(_provide_cases_with_allow_pair_separator_in_value());
+  if (0)
+    {
+      _test_performance(_provide_common_cases(), "Common test cases");
+      _test_performance(_provide_cases_for_performance_test_nothing_to_parse(), "Nothing to parse in the message");
+      _test_performance(_provide_cases_for_performance_test_parse_long_msg(), "Parse long strings");
+    }
   if (testutils_deinit())
     return 0;
   else

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -18,6 +18,7 @@
  * OpenSSL libraries as published by the OpenSSL project. See the file
  * COPYING for details.
  */
+#include "kv-scanner-simple.h"
 #include "linux-audit-scanner.h"
 #include "testutils.h"
 
@@ -25,7 +26,9 @@
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      kv_scanner = linux_audit_scanner_new();                   \
+      kv_scanner =                                              \
+        linux_audit_scanner_new(                                \
+          kv_scanner_simple_new('=', NULL));       \
     }                                                           \
   while (0)
 
@@ -49,13 +52,13 @@ KVScanner *kv_scanner;
 static void
 assert_no_more_tokens(void)
 {
-  assert_false(kv_scanner_scan_next(kv_scanner), "kv_scanner is expected to return no more key-value pairs");
+  assert_false(kv_scanner->scan_next(kv_scanner), "kv_scanner is expected to return no more key-value pairs");
 }
 
 static void
 scan_next_token(void)
 {
-  assert_true(kv_scanner_scan_next(kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
+  assert_true(kv_scanner->scan_next(kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
 }
 
 static void

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -26,9 +26,8 @@
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      kv_scanner =                                              \
-        linux_audit_scanner_new(                                \
-          kv_scanner_simple_new('=', NULL));       \
+      kv_scanner = kv_scanner_simple_new('=', NULL);            \
+      kv_scanner_set_parse_value(kv_scanner, parse_linux_audit_style_hexdump); \
     }                                                           \
   while (0)
 


### PR DESCRIPTION
    modules/kvformat: support allow-pair-separator-in-values option
    
    We can parse multiple words as values with spaces between them.
    Also handles the case when values are between quotes.
    Leading and trailing spaces will be trimmed from values and keys as well.
    You can put spaces around the separator character.
    
    input:[k=a b c=d]       output:   [k]:[a b]    ; [c]:[d]
    input:[k=a b ,    c=d]  output:   [k]:[a b ,]  ; [c]:[d]
    input:[foo = bar ggg]   output: [foo]:[bar ggg]
    input:[foo = "bar ggg"] output: [foo]:[bar ggg]
    input:[foo = "a=b"]     output: [foo]:[a=b]
    input:[a= b=c]          output:   [a]:[]       ; [b]:[c]
    input:[a=b=c d=e]       output:   [a]:[b=c]    ; [d]:[e]