### PR TITLE
F/syslog parser fixes

### DIFF
--- a/lib/logstamp.c
+++ b/lib/logstamp.c
@@ -144,3 +144,11 @@ log_stamp_eq(const LogStamp *a, const LogStamp *b)
          a->tv_usec == b->tv_usec &&
          a->zone_offset == b->zone_offset;
 }
+
+void
+log_stamp_unset(LogStamp *stamp)
+{
+  stamp->tv_sec = -1;
+  stamp->tv_usec = -1;
+  stamp->zone_offset = -1;
+}

--- a/lib/logstamp.h
+++ b/lib/logstamp.h
@@ -45,6 +45,6 @@ typedef struct _LogStamp
 void log_stamp_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
 void log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
 gboolean log_stamp_eq(const LogStamp *a, const LogStamp *b);
-
+void log_stamp_unset(LogStamp *stamp);
 
 #endif

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -82,6 +82,18 @@ msg_format_options_init(MsgFormatOptions *options, GlobalConfig *cfg)
 }
 
 void
+msg_format_options_copy(MsgFormatOptions *options, MsgFormatOptions *source)
+{
+  g_assert(!options->initialized);
+
+  options->format = g_strdup(source->format);
+  options->flags = source->flags;
+  options->default_pri = source->default_pri;
+  options->recv_time_zone = g_strdup(source->recv_time_zone);
+  options->sdata_param_value_max = source->sdata_param_value_max;
+}
+
+void
 msg_format_options_destroy(MsgFormatOptions *options)
 {
   if (options->format)

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -82,7 +82,7 @@ msg_format_options_init(MsgFormatOptions *options, GlobalConfig *cfg)
 }
 
 void
-msg_format_options_copy(MsgFormatOptions *options, MsgFormatOptions *source)
+msg_format_options_copy(MsgFormatOptions *options, const MsgFormatOptions *source)
 {
   g_assert(!options->initialized);
 

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -85,7 +85,7 @@ struct _MsgFormatHandler
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);
 void msg_format_options_destroy(MsgFormatOptions *parse_options);
-void msg_format_options_copy(MsgFormatOptions *options, MsgFormatOptions *source);
+void msg_format_options_copy(MsgFormatOptions *options, const MsgFormatOptions *source);
 
 gboolean msg_format_options_process_flag(MsgFormatOptions *options, gchar *flag);
 

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -85,6 +85,7 @@ struct _MsgFormatHandler
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);
 void msg_format_options_destroy(MsgFormatOptions *parse_options);
+void msg_format_options_copy(MsgFormatOptions *options, MsgFormatOptions *source);
 
 gboolean msg_format_options_process_flag(MsgFormatOptions *options, gchar *flag);
 

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -32,6 +32,9 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   LogMessage *msg;
 
   msg = log_msg_make_writable(pmsg, path_options);
+
+  msg->timestamps[LM_TS_STAMP].tv_sec = -1;
+  msg->timestamps[LM_TS_STAMP].zone_offset = -1;
   syslog_format_handler(&self->parse_options, (guchar *) input, strlen(input), msg);
   return TRUE;
 }

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -32,9 +32,8 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   LogMessage *msg;
 
   msg = log_msg_make_writable(pmsg, path_options);
+  log_stamp_unset(&msg->timestamps[LM_TS_STAMP]);
 
-  msg->timestamps[LM_TS_STAMP].tv_sec = -1;
-  msg->timestamps[LM_TS_STAMP].zone_offset = -1;
   syslog_format_handler(&self->parse_options, (guchar *) input, strlen(input), msg);
   return TRUE;
 }

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -36,6 +36,15 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   return TRUE;
 }
 
+static gboolean
+syslog_parser_init(LogPipe *s)
+{
+  SyslogParser *self = (SyslogParser *) s;
+
+  msg_format_options_init(&self->parse_options, log_pipe_get_config(s));
+  return log_parser_init_method(s);
+}
+
 static LogPipe *
 syslog_parser_clone(LogPipe *s)
 {
@@ -44,7 +53,17 @@ syslog_parser_clone(LogPipe *s)
 
   cloned = (SyslogParser *) syslog_parser_new(s->cfg);
   cloned->super.template = log_template_ref(self->super.template);
+  msg_format_options_copy(&cloned->parse_options, &self->parse_options);
   return &cloned->super.super;
+}
+
+static void
+syslog_parser_free(LogPipe *s)
+{
+  SyslogParser *self = (SyslogParser *) s;
+
+  msg_format_options_destroy(&self->parse_options);
+  log_parser_free_method(s);
 }
 
 /*
@@ -56,7 +75,10 @@ syslog_parser_new(GlobalConfig *cfg)
   SyslogParser *self = g_new0(SyslogParser, 1);
 
   log_parser_init_instance(&self->super, cfg);
+  self->super.super.free_fn = syslog_parser_free;
   self->super.super.clone = syslog_parser_clone;
+  self->super.super.init = syslog_parser_init;
   self->super.process = syslog_parser_process;
+  msg_format_options_defaults(&self->parse_options);
   return &self->super;
 }


### PR DESCRIPTION
This branch contains two pretty important fixes to syslog-parser():

1) all structured data elements were parsed as the empty string (due to an error in MsgFormatOptions initialization)

2) partial timestamps were not always parsed properly

Please merge!