### PR TITLE
Fix automatic libcap detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1314,6 +1314,8 @@ if test "x$enable_linux_caps" = "xyes" -o "x$enable_linux_caps" = "xauto"; then
         if test "x$enable_linux_caps" = "xyes" -a "x$has_linux_caps" = "xno"; then
            AC_MSG_ERROR([Cannot enable Linux capability support.])
         fi
+
+        enable_linux_caps="$has_linux_caps"
 fi
 
 if test "x$enable_mongodb" = "xauto"; then


### PR DESCRIPTION
If the enable-linux-caps flag is not specified explicitly (`enable_linux_caps="auto"`), the corresponding `ENABLE_...` macro in syslog-ng-config.h will be set to a constant FALSE value.

This PR fixes this issue by setting the value of `enable_linux_caps` after calling `AC_CHECK_LIB`.

Fixes #1207