### PR TITLE
afsocket: make listen-backlog configurable

### DIFF
--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -145,6 +145,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_TCP_KEEPALIVE_TIME
 %token KW_TCP_KEEPALIVE_PROBES
 %token KW_TCP_KEEPALIVE_INTVL
+%token KW_LISTEN_BACKLOG
 %token KW_SPOOF_SOURCE
 
 %token KW_KEEP_ALIVE
@@ -358,6 +359,7 @@ source_afinet_tcp_option
 source_afsocket_stream_params
 	: KW_KEEP_ALIVE '(' yesno ')'		{ afsocket_sd_set_keep_alive(last_driver, $3); }
 	| KW_MAX_CONNECTIONS '(' LL_NUMBER ')'	{ afsocket_sd_set_max_connections(last_driver, $3); }
+	| KW_LISTEN_BACKLOG '(' LL_NUMBER ')'	{ afsocket_sd_set_listen_backlog(last_driver, $3); }
 	;
 
 source_afsyslog

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -74,6 +74,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "transport",          KW_TRANSPORT },
   { "ip_protocol",        KW_IP_PROTOCOL },
   { "max_connections",    KW_MAX_CONNECTIONS },
+  { "listen_backlog",     KW_LISTEN_BACKLOG },
   { "keep_alive",         KW_KEEP_ALIVE },
   { "systemd_syslog",     KW_SYSTEMD_SYSLOG  },
   { NULL }

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -253,6 +253,14 @@ afsocket_sd_set_max_connections(LogDriver *s, gint max_connections)
   self->max_connections = max_connections;
 }
 
+void
+afsocket_sd_set_listen_backlog(LogDriver *s, gint listen_backlog)
+{
+  AFSocketSourceDriver *self = (AFSocketSourceDriver *) s;
+
+  self->listen_backlog = listen_backlog;
+}
+
 static const gchar *
 afsocket_sd_format_name(const LogPipe *s)
 {

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -73,6 +73,7 @@ struct _AFSocketSourceDriver
 
 void afsocket_sd_set_keep_alive(LogDriver *self, gint enable);
 void afsocket_sd_set_max_connections(LogDriver *self, gint max_connections);
+void afsocket_sd_set_listen_backlog(LogDriver *self, gint listen_backlog);
 
 static inline gboolean
 afsocket_sd_acquire_socket(AFSocketSourceDriver *s, gint *fd)

--- a/tests/functional/test_input_drivers.py
+++ b/tests/functional/test_input_drivers.py
@@ -30,12 +30,12 @@ config = """@version: 3.8
 options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
 
 source s_int { internal(); };
-source s_unix { unix-stream("log-stream" flags(expect-hostname)); unix-dgram("log-dgram" flags(expect-hostname));  };
-source s_inet { tcp(port(%(port_number)d)); udp(port(%(port_number)d) so_rcvbuf(131072)); };
+source s_unix { unix-stream("log-stream" flags(expect-hostname) listen-backlog(64)); unix-dgram("log-dgram" flags(expect-hostname));  };
+source s_inet { tcp(port(%(port_number)d) listen-backlog(64)); udp(port(%(port_number)d) so_rcvbuf(131072)); };
 source s_inetssl { tcp(port(%(ssl_port_number)d) tls(peer-verify(none) cert-file("%(src_dir)s/ssl.crt") key-file("%(src_dir)s/ssl.key"))); };
 source s_pipe { pipe("log-pipe" flags(expect-hostname)); pipe("log-padded-pipe" pad_size(2048) flags(expect-hostname)); };
 source s_file { file("log-file"); };
-source s_network { network(transport(udp) port(%(port_number_network)s)); network(transport(tcp) port(%(port_number_network)s)); };
+source s_network { network(transport(udp) port(%(port_number_network)s)); network(transport(tcp) listen-backlog(64) port(%(port_number_network)s)); };
 source s_catchall { unix-stream("log-stream-catchall" flags(expect-hostname)); };
 
 source s_syslog { syslog(port(%(port_number_syslog)d) transport("tcp") so_rcvbuf(131072)); syslog(port(%(port_number_syslog)d) transport("udp") so_rcvbuf(131072)); };


### PR DESCRIPTION
This patch introduces listen-backlog() option as one applicable to stream
oriented transports (both unix domain and inet).

Here's a sample configuration:

@version: 3.8

log {
	source { tcp(port(6514) listen-backlog(2048)); };
	destination { file("/dev/stdout"); };
};

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>