### PR TITLE
afsocket: tcp: Include missing setsockopt header

### DIFF
--- a/modules/afsocket/socket-options-inet.c
+++ b/modules/afsocket/socket-options-inet.c
@@ -25,6 +25,7 @@
 #include "messages.h"
 
 #include <string.h>
+#include <netinet/tcp.h>
 
 #ifndef SOL_IP
 #define SOL_IP IPPROTO_IP


### PR DESCRIPTION
The #ifdef macros disable the TCP_KEEPIDLE, TCP_KEEPCNT, TCP_KEEPINTVL
set socket options as the header file that defines them is not included.

Include the necessary header file to enable the options.

Signed-off-by: Kyle Manna <kyle@kylemanna.com>