### PR TITLE
dnscache: fix cache list corruption causing SIGABRT

### DIFF
--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -159,12 +159,12 @@ dns_cache_store(DNSCache *self, gboolean persistent, gint family, void *addr, co
   if (!persistent)
     {
       entry->resolved = cached_g_current_time_sec();
-      iv_list_add(&self->cache_list, &entry->list);
+      iv_list_add(&entry->list, &self->cache_list);
     }
   else
     {
       entry->resolved = 0;
-      iv_list_add(&self->persist_list, &entry->list);
+      iv_list_add(&entry->list, &self->persist_list);
     }
   hash_size = g_hash_table_size(self->cache);
   g_hash_table_replace(self->cache, &entry->key, entry);
@@ -175,7 +175,7 @@ dns_cache_store(DNSCache *self, gboolean persistent, gint family, void *addr, co
   /* persistent elements are not counted */
   if ((gint) (g_hash_table_size(self->cache) - self->persistent_count) > self->options->cache_size)
     {
-      DNSCacheEntry *entry_to_remove = iv_list_entry(&self->cache_list, DNSCacheEntry, list);
+      DNSCacheEntry *entry_to_remove = iv_list_entry(self->cache_list.next, DNSCacheEntry, list);
 
       /* remove oldest element */
       g_hash_table_remove(self->cache, &entry_to_remove->key);

--- a/tests/unit/test_dnscache.c
+++ b/tests/unit/test_dnscache.c
@@ -220,3 +220,21 @@ Test(dnscache, test_run_benchmark)
 
   dns_cache_free(cache);
 }
+
+/* test case to check the LRU expiration functionality */
+Test(dnscache, test_lru_lists)
+{
+  DNSCacheOptions options =
+  {
+    .cache_size = 10,
+    .expire = 600,
+    .expire_failed = 300,
+    .hosts = NULL
+  };
+
+
+  DNSCache *cache = dns_cache_new(&options);
+  gint cache_size = 100;
+  _fill_dns_cache(cache, cache_size);
+  dns_cache_free(cache);
+}


### PR DESCRIPTION
As reported on the mailing list, DNS cache corruption occurs when the dns-cache-size limit is reached.
Kudos for the great report go to Claus Albøge.

This patch fixes a SIGABRT that happens when an element is being
removed from the DNS cache, due to the high number of elements already
present. Both the cache_list and the persist_list lists were incorrectly
handled.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>