### PR TITLE
autogen.sh: temporarily disable shm counters in mongo-c-driver

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -66,7 +66,7 @@ autogen_submodules()
 
 		CONFIGURE_OPTS="--disable-shared --enable-static --with-pic"
 		# kludge needed by make distcheck in mongo-c-driver
-		CONFIGURE_OPTS="$CONFIGURE_OPTS --enable-man-pages"
+		CONFIGURE_OPTS="$CONFIGURE_OPTS --enable-man-pages --disable-shm-counters"
 
 		sed -e "s/@__CONFIGURE_OPTS__@/${CONFIGURE_OPTS}/g" ${origdir}/sub-configure.sh >configure.gnu
 		cd "$origdir"


### PR DESCRIPTION
This is a temporary quick workaround to help testing, do not merge yet.

* TODO: extract mongo-c-driver kludges to a separate function
* TODO: introduce configure option to reenable shm counters with warnings