### PR TITLE
F/searchguard

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -105,6 +105,7 @@ EXTRA_DIST += \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESTransportShieldClient.java \
+	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESTransportSearchGuardClient.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java \
 	modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java \

--- a/modules/java-modules/elastic-v2/build.gradle
+++ b/modules/java-modules/elastic-v2/build.gradle
@@ -8,6 +8,7 @@ configurations {
 dependencies {
     compile 'org.elasticsearch:elasticsearch:2.4.0'
     compile 'org.elasticsearch.plugin:shield:2.4.0'
+    compile 'com.floragunn:search-guard-ssl:2.4.0.16'
     compile 'io.searchbox:jest:2.0.2'
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.13'
     compile name: 'syslog-ng-common'

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -54,10 +54,11 @@ public class ElasticSearchOptions {
 	public static String CLIENT_MODE_TRANSPORT = "transport";
 	public static String CLIENT_MODE_NODE = "node";
 	public static String CLIENT_MODE_SHIELD = "shield";
+	public static String CLIENT_MODE_SEARCHGUARD = "searchguard";
 	public static String CLIENT_MODE_HTTP = "http";
 	public static String SKIP_CLUSTER_HEALTH_CHECK = "skip_cluster_health_check";
 	public static String SKIP_CLUSTER_HEALTH_CHECK_DEFAULT = "false";
-	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE, CLIENT_MODE_SHIELD, CLIENT_MODE_HTTP));
+	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE, CLIENT_MODE_SHIELD, CLIENT_MODE_HTTP, CLIENT_MODE_SEARCHGUARD));
 	public static final HashMap<String, Integer> DEFAULT_PORTS_BY_MODE = new HashMap<String, Integer>() {
 		{
 			this.put(CLIENT_MODE_HTTP, 9200);

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClientFactory.java
@@ -27,6 +27,7 @@ import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.esnative.ESNodeClient;
 import org.syslog_ng.elasticsearch_v2.client.esnative.ESTransportClient;
 import org.syslog_ng.elasticsearch_v2.client.esnative.ESTransportShieldClient;
+import org.syslog_ng.elasticsearch_v2.client.esnative.ESTransportSearchGuardClient;
 import org.syslog_ng.elasticsearch_v2.client.http.ESHttpClient;
 
 public class ESClientFactory {
@@ -43,6 +44,9 @@ public class ESClientFactory {
         }
 		else if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_HTTP)) {
 			return new ESHttpClient(options);
+		}
+		else if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_SEARCHGUARD)) {
+			return new ESTransportSearchGuardClient(options);
 		}
 		throw new UnknownESClientModeException(client_type);
 	}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESTransportSearchGuardClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESTransportSearchGuardClient.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ * Copyright (c) 2016 Zoltan Pallagi <zoltan.pallagi@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+package org.syslog_ng.elasticsearch_v2.client.esnative;
+
+import java.util.ArrayList;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.plugins.Plugin;
+import com.floragunn.searchguard.ssl.SearchGuardSSLPlugin;
+import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
+import org.syslog_ng.elasticsearch_v2.client.esnative.ESTransportClient;
+
+public class ESTransportSearchGuardClient extends ESTransportClient {
+
+	public ESTransportSearchGuardClient(ElasticSearchOptions options) {
+		super(options);
+	}
+	
+	@Override
+    public Client createClient() {
+	    ArrayList<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();    
+        plugins.add(SearchGuardSSLPlugin.class);
+
+        super.createClient(plugins);
+        return transportClient;
+    }
+}


### PR DESCRIPTION
WIP: implements an additional `client-mode(searchguard)`

this was tested against searchguard 2.4.0.6 and searchguard-ssl 2.4.0.16

```
destination d_elastic {
  elasticsearch2(
    client-lib-dir("/usr/share/elasticsearch/lib/*.jar:/tmp/all-sg-jars/")
    resource("/etc/syslog-ng/elasticsearch/elasticsearch.yml")
    client-mode("searchguard")
    port("9300")
    concurrent_requests("1")
    flush_limit("1")
    index("syslog-$YEAR.$MONTH")
    type("syslog")
    skip-cluster-health-check("yes")
    template("$(format-json -s all-nv-pairs -x __* -x tmp.* -x SOURCE -x PROGRAM -x MESSAGE -x PID -x HOST_FROM -x HOST -x LEGACY_MSGHDR -p uniqid=$UNIQID --rekey timestamp --add-prefix @ --rekey .classifier.* --add-prefix pdb --rekey .SDATA.auto.* --shift 12 --rekey .SDATA.* --shift 7 --rekey .* --shift 1)")
  );
};
```

``` yaml

---
cluster:
  name: elasticsearch
node:
  client: true
  name: syslog_ng
path:
  data: /tmp
  home: /tmp
http:
  enabled: false
searchguard:
  ssl:
    transport:
      enabled: true
      keystore_filepath: "/etc/syslog-ng/elasticsearch/node-1-keystore.jks"
      keystore_password: changeit
      truststore_filepath: "/etc/syslog-ng/elasticsearch/truststore.jks"
      truststore_password: changeit
      enforce_hostname_verification: false
    http:
      enabled: false
  audit:
    type: internal_elasticsearch
  authcz:
    admin_dn:
      - CN=sgadmin
      - "CN=node-0.example.com, OU=SSL, L=Test, C=DE"
```

This fixes #1221 
