### PR TITLE
Added "shield" client mode for elastic v1: This is required to be com…

### DIFF
--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchOptions.java
@@ -49,7 +49,8 @@ public class ElasticSearchOptions {
 	public static String FLUSH_LIMIT_DEFAULT = "5000";
 	public static String CLIENT_MODE_TRANSPORT = "transport";
 	public static String CLIENT_MODE_NODE = "node";
-	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE));
+	public static String CLIENT_MODE_SHIELD = "shield";
+	public static HashSet<String> CLIENT_MODES  = new HashSet<String>(Arrays.asList(CLIENT_MODE_TRANSPORT, CLIENT_MODE_NODE, CLIENT_MODE_SHIELD));
 
 	public static String CLIENT_MODE_DEFAULT = CLIENT_MODE_TRANSPORT;
 	public static String CONCURRENT_REQUESTS_DEFAULT = "1";

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClientFactory.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/client/ESClientFactory.java
@@ -28,7 +28,7 @@ import org.syslog_ng.elasticsearch.ElasticSearchOptions;
 public class ESClientFactory {
 	public static ESClient getESClient(ElasticSearchOptions options) throws UnknownESClientModeException {
 		String client_type = options.getClientMode();
-		if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_TRANSPORT)) {
+		if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_TRANSPORT)|| client_type.equals(ElasticSearchOptions.CLIENT_MODE_SHIELD)) {
 			return new ESTransportClient(options);
 		}
 		else if (client_type.equals(ElasticSearchOptions.CLIENT_MODE_NODE)) {


### PR DESCRIPTION
…patible with elastic v2

In case of elastic v2, if someone wants to use shield, the client mode must be "shield".
However, elastic v1 only uses "transport" for shield and gave error for "shield" mode in the config.
The different config option was confusing if someone wanted to use both elastic v1 and v2 or just switched from v1 to v2 or vice versa.

This patch fixes it, from now, if someone wants to use shield mode, he can give "shield" as client mode for both elastic v1 and v2.

Signed-off-by: Zoltan Pallagi <pzoleex@gmail.com>