### PR TITLE
diskq: fix qoverflow_size setting in nonreliable mode

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -368,7 +368,7 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options)
   self->qout = g_queue_new ();
   self->qoverflow = g_queue_new ();
   self->qout_size = options->qout_size;
-  self->qoverflow_size = options->mem_buf_size;
+  self->qoverflow_size = options->mem_buf_length;
   _set_virtual_functions (&self->super);
   return &self->super.super;
 }


### PR DESCRIPTION
In non-reliable mode, qoverflow_size was set to mem_buf_size instead of
mem_buf_length, which is wrong, as the first is measured in bytes, whereas
the latter is measured in number of elements.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>