### PR TITLE
F/fix internal msg timestamps

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1118,56 +1118,6 @@ log_msg_merge_context(LogMessage *self, LogMessage **context, gsize context_len)
     }
 }
 
-/**
- * log_msg_new:
- * @msg: message to parse
- * @length: length of @msg
- * @saddr: sender address
- * @flags: parse flags (LP_*)
- *
- * This function allocates, parses and returns a new LogMessage instance.
- **/
-LogMessage *
-log_msg_new(const gchar *msg, gint length,
-            GSockAddr *saddr,
-            MsgFormatOptions *parse_options)
-{
-  LogMessage *self = log_msg_alloc(length == 0 ? 256 : length * 2);
-
-  log_msg_init(self, saddr);
-
-  if (G_LIKELY(parse_options->format_handler))
-    {
-      parse_options->format_handler->parse(parse_options, (guchar *) msg, length, self);
-    }
-  else
-    {
-      log_msg_set_value(self, LM_V_MESSAGE, "Error parsing message, format module is not loaded", -1);
-    }
-  return self;
-}
-
-LogMessage *
-log_msg_new_empty(void)
-{
-  LogMessage *self = log_msg_alloc(256);
-
-  log_msg_init(self, NULL);
-  return self;
-}
-
-LogMessage *
-log_msg_new_local(void)
-{
-  LogMessage *self = log_msg_new_empty();
-
-  self->flags |= LF_LOCAL;
-
-  self->timestamps[LM_TS_STAMP] = self->timestamps[LM_TS_RECVD];
-
-  return self;
-}
-
 static void
 log_msg_clone_ack(LogMessage *msg, AckType ack_type)
 {
@@ -1228,6 +1178,57 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
     self->flags |= LF_STATE_OWN_TAGS;
   return self;
 }
+
+/**
+ * log_msg_new:
+ * @msg: message to parse
+ * @length: length of @msg
+ * @saddr: sender address
+ * @flags: parse flags (LP_*)
+ *
+ * This function allocates, parses and returns a new LogMessage instance.
+ **/
+LogMessage *
+log_msg_new(const gchar *msg, gint length,
+            GSockAddr *saddr,
+            MsgFormatOptions *parse_options)
+{
+  LogMessage *self = log_msg_alloc(length == 0 ? 256 : length * 2);
+
+  log_msg_init(self, saddr);
+
+  if (G_LIKELY(parse_options->format_handler))
+    {
+      parse_options->format_handler->parse(parse_options, (guchar *) msg, length, self);
+    }
+  else
+    {
+      log_msg_set_value(self, LM_V_MESSAGE, "Error parsing message, format module is not loaded", -1);
+    }
+  return self;
+}
+
+LogMessage *
+log_msg_new_empty(void)
+{
+  LogMessage *self = log_msg_alloc(256);
+
+  log_msg_init(self, NULL);
+  return self;
+}
+
+LogMessage *
+log_msg_new_local(void)
+{
+  LogMessage *self = log_msg_new_empty();
+
+  self->flags |= LF_LOCAL;
+
+  self->timestamps[LM_TS_STAMP] = self->timestamps[LM_TS_RECVD];
+
+  return self;
+}
+
 
 /**
  * log_msg_new_internal:

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1016,8 +1016,7 @@ log_msg_init(LogMessage *self, GSockAddr *saddr)
   self->timestamps[LM_TS_RECVD].tv_sec = tv.tv_sec;
   self->timestamps[LM_TS_RECVD].tv_usec = tv.tv_usec;
   self->timestamps[LM_TS_RECVD].zone_offset = get_local_timezone_ofs(self->timestamps[LM_TS_RECVD].tv_sec);
-  self->timestamps[LM_TS_STAMP].tv_sec = -1;
-  self->timestamps[LM_TS_STAMP].zone_offset = -1;
+  self->timestamps[LM_TS_STAMP] = self->timestamps[LM_TS_RECVD];
 
   self->sdata = NULL;
   self->saddr = g_sockaddr_ref(saddr);
@@ -1217,15 +1216,13 @@ log_msg_new_empty(void)
   return self;
 }
 
+/* This function creates a new log message that should be considered local */
 LogMessage *
 log_msg_new_local(void)
 {
   LogMessage *self = log_msg_new_empty();
 
   self->flags |= LF_LOCAL;
-
-  self->timestamps[LM_TS_STAMP] = self->timestamps[LM_TS_RECVD];
-
   return self;
 }
 
@@ -1246,12 +1243,12 @@ log_msg_new_internal(gint prio, const gchar *msg)
   LogMessage *self;
 
   g_snprintf(buf, sizeof(buf), "%d", (int) getpid());
-  self = log_msg_new_empty();
+  self = log_msg_new_local();
   log_msg_set_value(self, LM_V_PROGRAM, "syslog-ng", 9);
   log_msg_set_value(self, LM_V_PID, buf, -1);
   log_msg_set_value(self, LM_V_MESSAGE, msg, -1);
   self->pri = prio;
-  self->flags |= LF_INTERNAL | LF_LOCAL;
+  self->flags |= LF_INTERNAL;
 
   return self;
 }
@@ -1265,11 +1262,11 @@ log_msg_new_internal(gint prio, const gchar *msg)
 LogMessage *
 log_msg_new_mark(void)
 {
-  LogMessage *self = log_msg_new_empty();
+  LogMessage *self = log_msg_new_local();
 
   log_msg_set_value(self, LM_V_MESSAGE, "-- MARK --", 10);
   self->pri = LOG_SYSLOG | LOG_INFO;
-  self->flags |= LF_LOCAL | LF_MARK | LF_INTERNAL;
+  self->flags |= LF_MARK | LF_INTERNAL;
   return self;
 }
 

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -312,10 +312,11 @@ Test(log_message, test_log_msg_get_value_with_time_related_macro)
 
   msg = log_msg_new_empty();
   msg->timestamps[LM_TS_STAMP].tv_sec = 1389783444;
+  msg->timestamps[LM_TS_STAMP].zone_offset = 3600;
 
   handle = log_msg_get_value_handle("ISODATE");
   date_value = log_msg_get_value(msg, handle, &value_len);
-  cr_assert_str_eq(date_value, "2014-01-15T10:57:23-00:00", "ISODATE macro value does not match!");
+  cr_assert_str_eq(date_value, "2014-01-15T11:57:24+01:00", "ISODATE macro value does not match! value=%s", date_value);
 
   log_msg_unref(msg);
 }

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -261,7 +261,7 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
 
   msg_set_context(msg);
 
-  if (msg->timestamps[LM_TS_STAMP].tv_sec == -1 || !self->options->keep_timestamp)
+  if (!self->options->keep_timestamp)
     msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
 
   g_assert(msg->timestamps[LM_TS_STAMP].zone_offset != -1);

--- a/lib/logstamp.c
+++ b/lib/logstamp.c
@@ -144,11 +144,3 @@ log_stamp_eq(const LogStamp *a, const LogStamp *b)
          a->tv_usec == b->tv_usec &&
          a->zone_offset == b->zone_offset;
 }
-
-void
-log_stamp_unset(LogStamp *stamp)
-{
-  stamp->tv_sec = -1;
-  stamp->tv_usec = -1;
-  stamp->zone_offset = -1;
-}

--- a/lib/logstamp.h
+++ b/lib/logstamp.h
@@ -45,6 +45,5 @@ typedef struct _LogStamp
 void log_stamp_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
 void log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
 gboolean log_stamp_eq(const LogStamp *a, const LogStamp *b);
-void log_stamp_unset(LogStamp *stamp);
 
 #endif

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -757,9 +757,6 @@ log_writer_mark_timeout(void *cookie)
 
   log_msg_set_value(msg, LM_V_HOST, hostname, hostname_len);
 
-  /* set the current time in the message stamp */
-  msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
-
   if (!log_writer_is_msg_suppressed(self, msg))
     {
       log_queue_push_tail(self->queue, msg, &path_options);

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -63,7 +63,7 @@ create_message_with_fields(const char *field_name, ...)
   const char *arg;
   LogMessage *msg = log_msg_new_empty();
 
-  msg->timestamps[LM_TS_STAMP].tv_sec = 31536000;
+  msg->timestamps[LM_TS_STAMP].tv_sec = 365 * 24 * 3600;
   arg = field_name;
   va_start(args, field_name);
   while (arg != NULL)

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -62,6 +62,8 @@ create_message_with_fields(const char *field_name, ...)
   va_list args;
   const char *arg;
   LogMessage *msg = log_msg_new_empty();
+
+  msg->timestamps[LM_TS_STAMP].tv_sec = 31536000;
   arg = field_name;
   va_start(args, field_name);
   while (arg != NULL)
@@ -209,7 +211,7 @@ void test_set_field_honors_time_zone()
   LogRewrite *test_rewrite = create_rewrite_rule("set('${ISODATE}' value('UTCDATE') time-zone('Asia/Tokyo'));");
   LogMessage *msg = create_message_with_fields("field1", "a123b", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "UTCDATE", "1970-01-01T08:59:59+09:00", -1,
+  assert_msg_field_equals(msg, "UTCDATE", "1971-01-01T09:00:00+09:00", -1,
                           ASSERTION_ERROR("Couldn't use time-zone option in rewrite-set"));
   rewrite_teardown(msg);
 }

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -146,6 +146,9 @@ _convert_struct_tm_to_logstamp(DateParser *self, time_t now, struct tm *tm, glon
   unnormalized_hour = tm->tm_hour;
   target->tv_sec = cached_mktime(tm);
 
+  /* we can't parse USEC value, as strptime() does not support that */
+  target->tv_usec = 0;
+
   /* SECOND: adjust tv_sec as if we converted it according to our timezone. */
   _adjust_tvsec_to_move_it_into_given_timezone(target, tm->tm_hour, unnormalized_hour);
   return TRUE;

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -32,7 +32,6 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   LogMessage *msg;
 
   msg = log_msg_make_writable(pmsg, path_options);
-  log_stamp_unset(&msg->timestamps[LM_TS_STAMP]);
 
   syslog_format_handler(&self->parse_options, (guchar *) input, strlen(input), msg);
   return TRUE;

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -180,7 +180,9 @@ test_log_messages_can_be_parsed(struct msgparse_params *param)
   if (param->expected_stamp_sec)
     {
       if (param->expected_stamp_sec != 1)
-        cr_assert_eq(parsed_timestamp->tv_sec, param->expected_stamp_sec, "Unexpected timestamp");
+        cr_assert_eq(parsed_timestamp->tv_sec, param->expected_stamp_sec,
+                     "Unexpected timestamp, value=%ld, expected=%ld, msg=%s",
+                     parsed_timestamp->tv_sec, param->expected_stamp_sec, param->msg);
 
       cr_assert_eq(parsed_timestamp->tv_usec, param->expected_stamp_usec, "Unexpected microseconds");
       cr_assert_eq(parsed_timestamp->zone_offset, param->expected_stamp_ofs, "Unexpected timezone offset");


### PR DESCRIPTION
This patch should fix the timestamp issue for suppression messages, reported by 
Scot Needy scotrn@gmail.com on the mailing list.

This revamps how timestamps are initialized/parsed, so the code becomes less coupled.
