### PR TITLE
groupunset: there is set/unset rewrite rules, but the groupset had no…

### DIFF
--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -64,6 +64,7 @@ LogRewrite *last_rewrite;
 %token KW_SET_TAG
 %token KW_CLEAR_TAG
 %token KW_GROUP_SET
+%token KW_GROUP_UNSET
 %token KW_SET
 %token KW_UNSET
 %token KW_SUBST
@@ -126,7 +127,10 @@ rewrite_expr
             log_template_unref($3);
             }
         rewrite_groupset_opts ')' { $$ = last_rewrite; }
-
+        | KW_GROUP_UNSET '('
+        {
+            last_rewrite = log_rewrite_groupunset_new(configuration);
+        } rewrite_groupset_opts ')' { $$ = last_rewrite; }
         | LL_IDENTIFIER
           {
             Plugin *p;

--- a/lib/rewrite/rewrite-expr-parser.c
+++ b/lib/rewrite/rewrite-expr-parser.c
@@ -39,6 +39,7 @@ static CfgLexerKeyword rewrite_expr_keywords[] =
 
   { "condition",          KW_CONDITION },
   { "groupset",           KW_GROUP_SET },
+  { "groupunset",         KW_GROUP_UNSET },
   { "value",              KW_VALUE },
   { "values",             KW_VALUES },
 

--- a/lib/rewrite/rewrite-groupset.h
+++ b/lib/rewrite/rewrite-groupset.h
@@ -29,7 +29,9 @@ typedef struct _LogRewriteGroupSet {
   LogRewrite super;
   ValuePairs *query;
   LogTemplate *replacement;
+  VPForeachFunc vp_func;
 } LogRewriteGroupSet;
 
 LogRewrite *log_rewrite_groupset_new(LogTemplate *template, GlobalConfig *cfg);
+LogRewrite *log_rewrite_groupunset_new(GlobalConfig *cfg);
 void log_rewrite_groupset_add_fields(LogRewrite *rewrite, GList *fields);

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -309,6 +309,18 @@ test_unset_field_disappears(void)
   rewrite_teardown(msg);
 }
 
+static void
+test_groupunset_field_disappears(void)
+{
+  LogRewrite *test_rewrite = create_rewrite_rule("groupunset(values('field?'));");
+  LogMessage *msg = create_message_with_fields("field1", "oldvalue", "field2", "oldvalue2", "PROGRAM", "foobar", NULL);
+  invoke_rewrite_rule(test_rewrite, msg);
+  assert_msg_field_unset(msg, "field1", ASSERTION_ERROR("field1 should be unset"));
+  assert_msg_field_unset(msg, "field2", ASSERTION_ERROR("field2 should be unset"));
+  assert_msg_field_equals(msg, "PROGRAM", "foobar", -1, ASSERTION_ERROR("field1 should be unset"));
+  rewrite_teardown(msg);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -339,5 +351,6 @@ main(int argc, char **argv)
   test_set_field_exist_and_group_set_when_condition_matches();
   test_set_field_cloned();
   test_unset_field_disappears();
+  test_groupunset_field_disappears();
   stop_grabbing_messages();
 }


### PR DESCRIPTION
… pair.

This patch implements the groupunset rewrite rule.
Previously you can unset a batch of values using the groupset with empty value
But, the empty value handling is introduced, this method does not work anymore.

So we need a rewrite rule which can do this job.

That is what this patch does.

usage example:
``` 
groupunset(values(".SDATA.*"));
```
Signed-off-by: Viktor Juhasz <viktor.juhasz@balabit.com>