### PR TITLE
java-modules: report location information only when 'loglevel <= DEBUG'

### DIFF
--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -38,7 +38,6 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
         if (logger.getAppender(SyslogNgInternalLogger.NAME) == null) {
             logger.removeAllAppenders();
             logger.addAppender(new SyslogNgInternalLogger());
-            logger.setLevel(Level.DEBUG);
         }
     }
 
@@ -58,15 +57,24 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
 
     @Override
     protected void append(LoggingEvent event) {
-        StringBuilder formatedMessage = new StringBuilder();
-        formatedMessage.append(event.getLocationInformation().getClassName());
-        formatedMessage.append(".");
-        formatedMessage.append(event.getLocationInformation().getMethodName());
-        formatedMessage.append(":");
-        formatedMessage.append(event.getLocationInformation().getLineNumber());
-        formatedMessage.append(" - ");
-        formatedMessage.append(event.getMessage().toString());
-        String message = formatedMessage.toString();
+
+        String message = null;
+        String internalMessageBody = event.getMessage().toString();
+
+        if (event.getLevel().isGreaterOrEqual(Level.INFO)) {
+            message = internalMessageBody;
+        }
+        else {
+            StringBuilder formatedMessage = new StringBuilder();
+            formatedMessage.append(event.getLocationInformation().getClassName());
+            formatedMessage.append(".");
+            formatedMessage.append(event.getLocationInformation().getMethodName());
+            formatedMessage.append(":");
+            formatedMessage.append(event.getLocationInformation().getLineNumber());
+            formatedMessage.append(" - ");
+            formatedMessage.append(internalMessageBody);
+            message = formatedMessage.toString();
+        }
 
         switch(event.getLevel().toInt()) {
         case Level.INFO_INT:


### PR DESCRIPTION
Requesting location information (class name, method name, line number) is a slow operation, this should be displayed only in DEBUG (and TRACE) mode.