### PR TITLE
java-modules: remove location information from internal debug logs

### DIFF
--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -58,23 +58,7 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
     @Override
     protected void append(LoggingEvent event) {
 
-        String message = null;
-        String internalMessageBody = event.getMessage().toString();
-
-        if (event.getLevel().isGreaterOrEqual(Level.INFO)) {
-            message = internalMessageBody;
-        }
-        else {
-            StringBuilder formatedMessage = new StringBuilder();
-            formatedMessage.append(event.getLocationInformation().getClassName());
-            formatedMessage.append(".");
-            formatedMessage.append(event.getLocationInformation().getMethodName());
-            formatedMessage.append(":");
-            formatedMessage.append(event.getLocationInformation().getLineNumber());
-            formatedMessage.append(" - ");
-            formatedMessage.append(internalMessageBody);
-            message = formatedMessage.toString();
-        }
+        String message = event.getMessage().toString();
 
         switch(event.getLevel().toInt()) {
         case Level.INFO_INT:


### PR DESCRIPTION
Getting location information (e.g. `org.syslog_ng.hdfs.HdfsDestination.open:83 - Opening hdfs`) is an expensive operation. This caused a 70% performance loss in the HDFS destination.

A "syslog-ng debug-mode" checker should be implemented on the Java side. After this, we can revert this patch if someone finds this kind of location information useful.

Fixes #1229