### PR TITLE
afsocket: add SOL_TCP alias to fix compilation on BSD systems

### DIFF
--- a/modules/afsocket/socket-options-inet.c
+++ b/modules/afsocket/socket-options-inet.c
@@ -35,6 +35,10 @@
 #define SOL_IPV6 IPPROTO_IPV6
 #endif
 
+#ifndef SOL_TCP
+#define SOL_TCP IPPROTO_TCP
+#endif
+
 static gboolean
 socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFSocketDirection dir)
 {


### PR DESCRIPTION
This is the continuation of #1214.

On BSD-like platforms, `IPPROTO_TCP` should be used instead of `SOL_TCP`.

Related to #1249