### PR TITLE
add-contextual-data: add ordered list of selector to selector::init

### DIFF
--- a/modules/add-contextual-data/add-contextual-data-selector.h
+++ b/modules/add-contextual-data/add-contextual-data-selector.h
@@ -32,7 +32,7 @@ struct _AddContextualDataSelector{
   gchar *(*resolve)(AddContextualDataSelector *self, LogMessage *msg);
   void (*free)(AddContextualDataSelector *self);
   AddContextualDataSelector*(*clone)(AddContextualDataSelector *self, GlobalConfig *cfg);
-  gboolean (*init)(AddContextualDataSelector *self);
+  gboolean (*init)(AddContextualDataSelector *self, GList *ordered_selectors);
 };
 
 static inline gchar*
@@ -56,11 +56,11 @@ add_contextual_data_selector_free(AddContextualDataSelector *self)
 }
 
 static inline gboolean
-add_contextual_data_selector_init(AddContextualDataSelector *self)
+add_contextual_data_selector_init(AddContextualDataSelector *self, GList *ordered_selectors)
 {
   if (self && self->init)
     {
-      return self->init(self);
+      return self->init(self, ordered_selectors);
     }
 
   return FALSE;

--- a/modules/add-contextual-data/add-contextual-data-template-selector.c
+++ b/modules/add-contextual-data/add-contextual-data-template-selector.c
@@ -61,7 +61,7 @@ _replace_template(LogTemplate **old_template, LogTemplate *new_template)
 }
 
 static gboolean
-_init(AddContextualDataSelector *s)
+_init(AddContextualDataSelector *s, GList *ordered_selectors)
 {
   AddContextualDataTemplateSelector *self = (AddContextualDataTemplateSelector *)s;
   return _compile_selector_template(self);

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -269,7 +269,7 @@ _first_init(AddContextualData *self)
       return FALSE;
     }
 
-  if (!add_contextual_data_selector_init(self->selector))
+  if (!add_contextual_data_selector_init(self->selector, context_info_db_ordered_selectors(self->context_info_db)))
     return FALSE;
 
   return TRUE;

--- a/modules/add-contextual-data/tests/test_selector.c
+++ b/modules/add-contextual-data/tests/test_selector.c
@@ -56,7 +56,7 @@ _create_template_selector(const gchar *template_string)
 {
   GlobalConfig *cfg = cfg_new(VERSION_VALUE);
   AddContextualDataSelector *selector = add_contextual_data_template_selector_new(cfg, template_string);
-  add_contextual_data_selector_init(selector);
+  add_contextual_data_selector_init(selector, NULL);
 
   return selector;
 }


### PR DESCRIPTION
Evaluation order of selectors are defined by user in the ContextInfoDB file.
It is possible to implement such selector where this ordering is needed.

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>