### PR TITLE
F/uppercase month names in rfc3164

### DIFF
--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -349,27 +349,27 @@ scan_day_abbrev(const gchar **buf, gint *left, gint *wday)
   switch (**buf)
     {
     case 'S':
-      if (memcmp(*buf, "Sun", 3) == 0)
+      if (strncasecmp(*buf, "Sun", 3) == 0)
         *wday = 0;
-      else if (memcmp(*buf, "Sat", 3) == 0)
+      else if (strncasecmp(*buf, "Sat", 3) == 0)
         *wday = 6;
       break;
     case 'M':
-      if (memcmp(*buf, "Mon", 3) == 0)
+      if (strncasecmp(*buf, "Mon", 3) == 0)
         *wday = 1;
       break;
     case 'T':
-      if (memcmp(*buf, "Tue", 3) == 0)
+      if (strncasecmp(*buf, "Tue", 3) == 0)
         *wday = 2;
-      else if (memcmp(*buf, "Thu", 3) == 0)
+      else if (strncasecmp(*buf, "Thu", 3) == 0)
         *wday = 4;
       break;
     case 'W':
-      if (memcmp(*buf, "Wed", 3) == 0)
+      if (strncasecmp(*buf, "Wed", 3) == 0)
         *wday = 3;
       break;
     case 'F':
-      if (memcmp(*buf, "Fri", 3) == 0)
+      if (strncasecmp(*buf, "Fri", 3) == 0)
         *wday = 5;
       break;
     default:
@@ -392,43 +392,43 @@ scan_month_abbrev(const gchar **buf, gint *left, gint *mon)
   switch (**buf)
     {
     case 'J':
-      if (memcmp(*buf, "Jan", 3) == 0)
+      if (strncasecmp(*buf, "Jan", 3) == 0)
         *mon = 0;
-      else if (memcmp(*buf, "Jun", 3) == 0)
+      else if (strncasecmp(*buf, "Jun", 3) == 0)
         *mon = 5;
-      else if (memcmp(*buf, "Jul", 3) == 0)
+      else if (strncasecmp(*buf, "Jul", 3) == 0)
         *mon = 6;
       break;
     case 'F':
-      if (memcmp(*buf, "Feb", 3) == 0)
+      if (strncasecmp(*buf, "Feb", 3) == 0)
         *mon = 1;
       break;
     case 'M':
-      if (memcmp(*buf, "Mar", 3) == 0)
+      if (strncasecmp(*buf, "Mar", 3) == 0)
         *mon = 2;
-      else if (memcmp(*buf, "May", 3) == 0)
+      else if (strncasecmp(*buf, "May", 3) == 0)
         *mon = 4;
       break;
     case 'A':
-      if (memcmp(*buf, "Apr", 3) == 0)
+      if (strncasecmp(*buf, "Apr", 3) == 0)
         *mon = 3;
-      else if (memcmp(*buf, "Aug", 3) == 0)
+      else if (strncasecmp(*buf, "Aug", 3) == 0)
         *mon = 7;
       break;
     case 'S':
-      if (memcmp(*buf, "Sep", 3) == 0)
+      if (strncasecmp(*buf, "Sep", 3) == 0)
         *mon = 8;
       break;
     case 'O':
-      if (memcmp(*buf, "Oct", 3) == 0)
+      if (strncasecmp(*buf, "Oct", 3) == 0)
         *mon = 9;
       break;
     case 'N':
-      if (memcmp(*buf, "Nov",3 ) == 0)
+      if (strncasecmp(*buf, "Nov", 3) == 0)
         *mon = 10;
       break;
     case 'D':
-      if (memcmp(*buf, "Dec", 3) == 0)
+      if (strncasecmp(*buf, "Dec", 3) == 0)
         *mon = 11;
       break;
     default:

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -557,6 +557,17 @@ Test(msgparse, test_timestamp_others)
       "Teardown TCP connection 1688438 for bloomberg-net:1.2.3.4/8294 to inside:5.6.7.8/3639 duration 0:07:01 bytes 16975 TCP FINs",
       NULL, NULL, NULL, ignore_sdata_pairs
     },
+
+    /* Dell switch */
+    {
+      "<190>NOV 22 00:00:33 192.168.33.8-1 CMDLOGGER[165319912]: cmd_logger_api.c(83) 13518 %% CLI:192.168.32.100:root:User  logged in", LP_EXPECT_HOSTNAME, NULL,
+      190,
+      _get_bsd_year_utc(10) + 28166433, 0, 3600,
+      "192.168.33.8-1",
+      "CMDLOGGER",
+      "cmd_logger_api.c(83) 13518 %% CLI:192.168.32.100:root:User  logged in",
+      NULL, NULL, NULL, ignore_sdata_pairs
+    },
     {NULL}
   };
 


### PR DESCRIPTION
Fixes the issue reported on the mailing list. Low level testcases should be improved, I only added an
end-to-end testcase, which partially tests this functionality.

The change itself is to use strncasecmp() instead of memcmp(), that should not be a lot slower, but will handle month abbreviations with any case.
