### PR TITLE
java: make it possible to pass numbers to generic options

### DIFF
--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -89,7 +89,7 @@ java_dest_custom_options
   ;
 
 java_dest_custom_option
-  : LL_STRING LL_STRING { java_dd_set_option(last_driver, $1, $2); free($1); free($2); }
+  : string string_or_number { java_dd_set_option(last_driver, $1, $2); free($1); free($2); }
 
 /* INCLUDE_RULES */
 


### PR DESCRIPTION
Earlier, values passed by the option() config option could only be
strings, this change would allow specifying LL_NUMBER tokens as well.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>