### PR TITLE
tlscontext: use getter function to access X509 verify param

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -872,8 +872,10 @@ if test -n "$OPENSSL_LIBS" -a "$linking_mode" != "dynamic"; then
 	LIBS=$old_LIBS
 fi
 
-AC_CHECK_FUNC(SSL_CTX_get0_param, AC_DEFINE(HAVE_SSL_CTX_GET0_PARAM, 1, [SSL_CTX_get0_param is present]))
-
+AC_CHECK_DECLS([SSL_CTX_get0_param],[], [], [[#include <openssl/ssl.h>]])
+AC_CHECK_DECLS([X509_STORE_CTX_get0_cert],[], [], [[#include <openssl/ssl.h>]])
+AC_CHECK_DECLS([X509_get_extension_flags], [], [], [[#include <openssl/x509v3.h>]])
+AC_CHECK_DECLS([EVP_MD_CTX_reset], [], [], [[#include <openssl/evp.h>]])
 
 dnl
 dnl Right now, openssl is never linked statically as it is only used by the

--- a/configure.ac
+++ b/configure.ac
@@ -872,6 +872,8 @@ if test -n "$OPENSSL_LIBS" -a "$linking_mode" != "dynamic"; then
 	LIBS=$old_LIBS
 fi
 
+AC_CHECK_FUNC(SSL_CTX_get0_param, AC_DEFINE(HAVE_SSL_CTX_GET0_PARAM, 1, [SSL_CTX_get0_param is present]))
+
 
 dnl
 dnl Right now, openssl is never linked statically as it is only used by the

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -7,6 +7,7 @@ set(COMPAT_HEADERS
     compat/socket.h
     compat/string.h
     compat/time.h
+    compat/openssl_support.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES
@@ -17,4 +18,5 @@ set(COMPAT_SOURCES
     compat/strcasestr.c
     compat/strtok_r.c
     compat/time.c
+    compat/openssl_support.c
     PARENT_SCOPE)

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -8,7 +8,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/pio.h		\
 	lib/compat/socket.h		\
 	lib/compat/string.h		\
-	lib/compat/time.h
+	lib/compat/time.h		\
+	lib/compat/openssl_support.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\
@@ -17,6 +18,7 @@ compat_sources			= 	\
 	lib/compat/pio.c		\
 	lib/compat/strcasestr.c		\
 	lib/compat/strtok_r.c		\
-	lib/compat/time.c
+	lib/compat/time.c		\
+	lib/compat/openssl_support.c
 
 include lib/compat/tests/Makefile.am

--- a/lib/compat/openssl_support.c
+++ b/lib/compat/openssl_support.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "compat/openssl_support.h"
+
+#if !SYSLOG_NG_HAVE_DECL_SSL_CTX_GET0_PARAM
+X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx)
+{
+  return ctx->param;
+}
+#endif
+
+#if !SYSLOG_NG_HAVE_DECL_X509_STORE_CTX_GET0_CERT
+X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *ctx)
+{
+  return ctx->cert;
+}
+#endif
+
+#if !SYSLOG_NG_HAVE_DECL_X509_GET_EXTENSION_FLAGS
+uint32_t X509_get_extension_flags(X509 *x)
+{
+  return x->ex_flags;
+}
+#endif
+

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef OPENSSL_SUPPORT_H_INCLUDED
+#define OPENSSL_SUPPORT_H_INCLUDED
+
+#include "compat/compat.h"
+#include <openssl/ssl.h>
+
+#if !SYSLOG_NG_HAVE_DECL_SSL_CTX_GET0_PARAM
+X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx);
+#endif
+
+#if !SYSLOG_NG_HAVE_DECL_X509_STORE_CTX_GET0_CERT
+X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *ctx);
+#endif
+
+#if !SYSLOG_NG_HAVE_DECL_X509_GET_EXTENSION_FLAGS
+#include <stdint.h>
+uint32_t X509_get_extension_flags(X509 *x);
+#endif
+
+#if SYSLOG_NG_HAVE_DECL_EVP_MD_CTX_RESET
+#include <openssl/evp.h>
+#define EVP_MD_CTX_cleanup EVP_MD_CTX_reset
+#define DECLARE_EVP_MD_CTX(md_ctx) EVP_MD_CTX md_ctx
+#else
+#define DECLARE_EVP_MD_CTX(md_ctx) EVP_MD_CTX _##md_ctx; EVP_MD_CTX * md_ctx = & _##md_ctx
+#endif
+
+#endif
+

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -24,6 +24,7 @@
 #include "tlscontext.h"
 #include "str-utils.h"
 #include "messages.h"
+#include "compat/openssl_support.h"
 
 #include <arpa/inet.h>
 #include <unistd.h>
@@ -31,13 +32,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
-
-#ifndef SYSLOG_NG_HAVE_SSL_CTX_GET0_PARAM
-X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx)
-{
-  return ctx->param;
-}
-#endif
+#include <syslog-ng-config.h>
 
 gboolean
 tls_get_x509_digest(X509 *x, GString *hash_string)
@@ -152,10 +147,11 @@ tls_session_verify(TLSSession *self, int ok, X509_STORE_CTX *ctx)
       return 0;
     }
 
-  if (ok && ctx_error_depth != 0 && (ctx->current_cert->ex_flags & EXFLAG_CA) == 0)
+  X509 *current_cert = X509_STORE_CTX_get_current_cert(ctx);
+  if (ok && ctx_error_depth != 0 && (X509_get_extension_flags(current_cert) & EXFLAG_CA) == 0)
     {
       msg_notice("Invalid certificate found in chain, basicConstraints.ca is unset in non-leaf certificate");
-      ctx->error = X509_V_ERR_INVALID_CA;
+      X509_STORE_CTX_set_error(ctx, X509_V_ERR_INVALID_CA);
       return 0;
     }
 
@@ -163,17 +159,17 @@ tls_session_verify(TLSSession *self, int ok, X509_STORE_CTX *ctx)
   if (ok && ctx_error_depth == 0 && !tls_session_verify_dn(ctx))
     {
       msg_notice("Certificate valid, but DN constraints were not met, rejecting");
-      ctx->error = X509_V_ERR_CERT_UNTRUSTED;
+      X509_STORE_CTX_set_error(ctx, X509_V_ERR_CERT_UNTRUSTED);
       return 0;
     }
   /* if the crl_dir is set in the configuration file but the directory is empty ignore this error */
-  if (!ok && ctx->error == X509_V_ERR_UNABLE_TO_GET_CRL)
+  if (!ok && X509_STORE_CTX_get_error(ctx) == X509_V_ERR_UNABLE_TO_GET_CRL)
     {
       msg_notice("CRL directory is set but no CRLs found");
       return 1;
     }
 
-  if (!ok && ctx->error == X509_V_ERR_INVALID_PURPOSE)
+  if (!ok && X509_STORE_CTX_get_error(ctx) == X509_V_ERR_INVALID_PURPOSE)
     {
       msg_warning("Certificate valid, but purpose is invalid");
       return 1;
@@ -193,7 +189,8 @@ tls_session_verify_callback(int ok, X509_STORE_CTX *ctx)
    */
   if (X509_STORE_CTX_get_current_cert(ctx) == NULL)
     {
-      switch (ctx->error)
+      int ctx_error = X509_STORE_CTX_get_error(ctx);
+      switch (ctx_error)
         {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
           /* NOTE: Because we set the CHECK_POLICY_FLAG if the
@@ -205,7 +202,7 @@ tls_session_verify_callback(int ok, X509_STORE_CTX *ctx)
           break;
         default:
           msg_notice("Error occured during certificate validation",
-                     evt_tag_int("error", ctx->error));
+                     evt_tag_int("error", X509_STORE_CTX_get_error(ctx)));
           break;
         }
     }

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -32,6 +32,13 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
+#ifndef SYSLOG_NG_HAVE_SSL_CTX_GET0_PARAM
+X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx)
+{
+  return ctx->param;
+}
+#endif
+
 gboolean
 tls_get_x509_digest(X509 *x, GString *hash_string)
 {
@@ -338,7 +345,7 @@ tls_context_setup_session(TLSContext *self)
       if (self->crl_dir)
         verify_flags |= X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL;
 
-      X509_VERIFY_PARAM_set_flags(self->ssl_ctx->param, verify_flags);
+      X509_VERIFY_PARAM_set_flags(SSL_CTX_get0_param(self->ssl_ctx), verify_flags);
 
       switch (self->verify_mode)
         {

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -26,6 +26,7 @@
 #include "socket-options-inet.h"
 #include "messages.h"
 #include "gprocess.h"
+#include "compat/openssl_support.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -97,10 +98,13 @@ afinet_dd_verify_callback(gint ok, X509_STORE_CTX *ctx, gpointer user_data)
   AFInetDestDriver *self G_GNUC_UNUSED = (AFInetDestDriver *) user_data;
   TransportMapperInet *transport_mapper_inet = (TransportMapperInet *) self->super.transport_mapper;
 
-  if (ok && ctx->current_cert == ctx->cert && self->hostname
+  X509 *current_cert = X509_STORE_CTX_get_current_cert(ctx);
+  X509 *cert = X509_STORE_CTX_get0_cert(ctx);
+
+  if (ok && current_cert == cert && self->hostname
       && (transport_mapper_inet->tls_context->verify_mode & TVM_TRUSTED))
     {
-      ok = tls_verify_certificate_name(ctx->cert, self->hostname);
+      ok = tls_verify_certificate_name(cert, self->hostname);
     }
 
   return ok;

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -27,6 +27,7 @@
 #include "uuid.h"
 #include "str-format.h"
 #include "plugin-types.h"
+#include "compat/openssl_support.h"
 #include <openssl/evp.h>
 
 static void
@@ -100,9 +101,30 @@ tf_hash_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
       return FALSE;
     }
   state->md = md;
-  if ((state->length == 0) || (state->length > md->md_size * 2))
-    state->length = md->md_size * 2;
+  gint md_size = EVP_MD_size(md);
+  if ((state->length == 0) || (state->length > md_size * 2))
+    state->length = md_size * 2;
   return TRUE;
+}
+
+static guint
+_hash(const EVP_MD *md, GString **argv, gint argc, guchar *hash, guint hash_size)
+{
+  gint i;
+  guint md_len;
+  DECLARE_EVP_MD_CTX(mdctx);
+  EVP_MD_CTX_init(mdctx);
+  EVP_DigestInit_ex(mdctx, md, NULL);
+
+  for (i = 0; i < argc; i++)
+    {
+      EVP_DigestUpdate(mdctx, argv[i]->str, argv[i]->len);
+    }
+
+  EVP_DigestFinal_ex(mdctx, hash, &md_len);
+  EVP_MD_CTX_cleanup(mdctx);
+
+  return md_len;
 }
 
 static void
@@ -111,25 +133,12 @@ tf_hash_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs 
   TFHashState *state = (TFHashState *) s;
   GString **argv;
   gint argc;
-  gint i;
-  EVP_MD_CTX mdctx;
   guchar hash[EVP_MAX_MD_SIZE];
   gchar hash_str[EVP_MAX_MD_SIZE * 2 + 1];
   guint md_len;
-
   argv = (GString **) args->bufs->pdata;
   argc = args->bufs->len;
-
-  EVP_MD_CTX_init(&mdctx);
-  EVP_DigestInit_ex(&mdctx, state->md, NULL);
-
-  for (i = 0; i < argc; i++)
-    {
-      EVP_DigestUpdate(&mdctx, argv[i]->str, argv[i]->len);
-    }
-  EVP_DigestFinal_ex(&mdctx, hash, &md_len);
-  EVP_MD_CTX_cleanup(&mdctx);
-
+  md_len = _hash(state->md, argv, argc, hash, sizeof(hash));
   // we fetch the entire hash in a hex format otherwise we cannot truncate at
   // odd character numbers
   format_hex_string(hash, md_len, hash_str, sizeof(hash_str));

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -42,6 +42,7 @@
 #include "pathutils.h"
 #include "resolved-configurable-paths.h"
 #include "crypto.h"
+#include "compat/openssl_support.h"
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
ssl_ctx_st structure is a non-exported interface (ssl/ssl_locl.h)

Fixes: #1234

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>

I did not test the PR.

@czanik: could you test it?