### PR TITLE
F/decouple configuration

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -209,7 +209,7 @@ cfg_init(GlobalConfig *cfg)
 
   dns_caching_update_options(&cfg->dns_cache_options);
   hostname_reinit(cfg->custom_domain);
-  host_resolve_options_init(&cfg->host_resolve_options, cfg);
+  host_resolve_options_init_globals(&cfg->host_resolve_options);
   log_template_options_init(&cfg->template_options, cfg);
   if (!cfg_init_modules(cfg))
     return FALSE;

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -316,11 +316,7 @@ cfg_new(gint version)
   self->template_options.frac_digits = 0;
   self->template_options.on_error = ON_ERROR_DROP_MESSAGE;
 
-  host_resolve_options_defaults(&self->host_resolve_options);
-  self->host_resolve_options.use_fqdn = FALSE;
-  self->host_resolve_options.use_dns = TRUE;
-  self->host_resolve_options.use_dns_cache = TRUE;
-  self->host_resolve_options.normalize_hostnames = FALSE;
+  host_resolve_options_global_defaults(&self->host_resolve_options);
 
   self->recv_time_zone = NULL;
   self->keep_timestamp = TRUE;

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -205,7 +205,7 @@ cfg_init(GlobalConfig *cfg)
     return FALSE;
 
   stats_reinit(&cfg->stats_options);
-  log_tags_reinit_stats(cfg);
+  log_tags_reinit_stats();
 
   dns_caching_update_options(&cfg->dns_cache_options);
   hostname_reinit(cfg->custom_domain);

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -74,7 +74,7 @@ gboolean
 filter_re_compile_pattern(FilterRE *self, GlobalConfig *cfg, gchar *re, GError **error)
 {
   log_matcher_options_init(&self->matcher_options, cfg);
-  self->matcher = log_matcher_new(&self->matcher_options);
+  self->matcher = log_matcher_new(cfg, &self->matcher_options);
   return log_matcher_compile(self->matcher, re, error);
 }
 

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -377,6 +377,15 @@ host_resolve_options_defaults(HostResolveOptions *options)
 }
 
 void
+host_resolve_options_global_defaults(HostResolveOptions *options)
+{
+  options->use_fqdn = FALSE;
+  options->use_dns = TRUE;
+  options->use_dns_cache = TRUE;
+  options->normalize_hostnames = FALSE;
+}
+
+void
 host_resolve_options_init(HostResolveOptions *options, GlobalConfig *cfg)
 {
   if (options->use_dns == -1)

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -385,17 +385,29 @@ host_resolve_options_global_defaults(HostResolveOptions *options)
   options->normalize_hostnames = FALSE;
 }
 
+static void
+_init_options(HostResolveOptions *options)
+{
+}
+
 void
-host_resolve_options_init(HostResolveOptions *options, GlobalConfig *cfg)
+host_resolve_options_init_globals(HostResolveOptions *options)
+{
+  _init_options(options);
+}
+
+void
+host_resolve_options_init(HostResolveOptions *options, HostResolveOptions *global_options)
 {
   if (options->use_dns == -1)
-    options->use_dns = cfg->host_resolve_options.use_dns;
+    options->use_dns = global_options->use_dns;
   if (options->use_fqdn == -1)
-    options->use_fqdn = cfg->host_resolve_options.use_fqdn;
+    options->use_fqdn = global_options->use_fqdn;
   if (options->use_dns_cache == -1)
-    options->use_dns_cache = cfg->host_resolve_options.use_dns_cache;
+    options->use_dns_cache = global_options->use_dns_cache;
   if (options->normalize_hostnames == -1)
-    options->normalize_hostnames = cfg->host_resolve_options.normalize_hostnames;
+    options->normalize_hostnames = global_options->normalize_hostnames;
+  _init_options(options);
 }
 
 void

--- a/lib/host-resolve.h
+++ b/lib/host-resolve.h
@@ -40,6 +40,7 @@ gboolean resolve_hostname_to_sockaddr(GSockAddr **addr, gint family, const gchar
 const gchar *resolve_hostname_to_hostname(gsize *result_len, const gchar *hostname, HostResolveOptions *options);
 
 void host_resolve_options_defaults(HostResolveOptions *options);
+void host_resolve_options_global_defaults(HostResolveOptions *options);
 void host_resolve_options_init(HostResolveOptions *options, GlobalConfig *cfg);
 void host_resolve_options_destroy(HostResolveOptions *options);
 

--- a/lib/host-resolve.h
+++ b/lib/host-resolve.h
@@ -41,7 +41,8 @@ const gchar *resolve_hostname_to_hostname(gsize *result_len, const gchar *hostna
 
 void host_resolve_options_defaults(HostResolveOptions *options);
 void host_resolve_options_global_defaults(HostResolveOptions *options);
-void host_resolve_options_init(HostResolveOptions *options, GlobalConfig *cfg);
+void host_resolve_options_init_globals(HostResolveOptions *options);
+void host_resolve_options_init(HostResolveOptions *options, HostResolveOptions *global_options);
 void host_resolve_options_destroy(HostResolveOptions *options);
 
 #endif

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -212,7 +212,7 @@ log_matcher_posix_re_free(LogMatcher *s)
 }
 
 LogMatcher *
-log_matcher_posix_re_new(const LogMatcherOptions *options)
+log_matcher_posix_re_new(GlobalConfig *cfg, const LogMatcherOptions *options)
 {
   LogMatcherPosixRe *self = g_new0(LogMatcherPosixRe, 1);
 
@@ -222,7 +222,7 @@ log_matcher_posix_re_new(const LogMatcherOptions *options)
   self->super.replace = log_matcher_posix_re_replace;
   self->super.free_fn = log_matcher_posix_re_free;
 
-  if (configuration && cfg_is_config_version_older(configuration, 0x0300))
+  if (cfg_is_config_version_older(cfg, 0x0300))
     {
       msg_warning_once("WARNING: filters do not store matches in macros by default from " VERSION_3_0
                        ", please update your configuration by using an explicit 'store-matches' flag to achieve that");
@@ -382,7 +382,7 @@ log_matcher_string_free(LogMatcher *s)
 }
 
 LogMatcher *
-log_matcher_string_new(const LogMatcherOptions *options)
+log_matcher_string_new(GlobalConfig *cfg, const LogMatcherOptions *options)
 {
   LogMatcherString *self = g_new0(LogMatcherString, 1);
 
@@ -450,7 +450,7 @@ log_matcher_glob_free(LogMatcher *s)
 }
 
 LogMatcher *
-log_matcher_glob_new(const LogMatcherOptions *options)
+log_matcher_glob_new(GlobalConfig *cfg, const LogMatcherOptions *options)
 {
   LogMatcherGlob *self = g_new0(LogMatcherGlob, 1);
 
@@ -783,7 +783,7 @@ log_matcher_pcre_re_free(LogMatcher *s)
 }
 
 LogMatcher *
-log_matcher_pcre_re_new(const LogMatcherOptions *options)
+log_matcher_pcre_re_new(GlobalConfig *cfg, const LogMatcherOptions *options)
 {
   LogMatcherPcreRe *self = g_new0(LogMatcherPcreRe, 1);
 
@@ -793,7 +793,7 @@ log_matcher_pcre_re_new(const LogMatcherOptions *options)
   self->super.replace = log_matcher_pcre_re_replace;
   self->super.free_fn = log_matcher_pcre_re_free;
 
-  if (configuration && cfg_is_config_version_older(configuration, 0x0300))
+  if (cfg_is_config_version_older(cfg, 0x0300))
     {
       msg_warning_once("WARNING: filters do not store matches in macros by default from " VERSION_3_0
                        ", please update your configuration by using an explicit 'store-matches' flag to achieve that");
@@ -804,7 +804,7 @@ log_matcher_pcre_re_new(const LogMatcherOptions *options)
   return &self->super;
 }
 
-typedef LogMatcher *(*LogMatcherConstructFunc)(const LogMatcherOptions *options);
+typedef LogMatcher *(*LogMatcherConstructFunc)(GlobalConfig *cfg, const LogMatcherOptions *options);
 
 struct
 {
@@ -833,12 +833,12 @@ log_matcher_lookup_construct(const gchar *type)
 }
 
 LogMatcher *
-log_matcher_new(const LogMatcherOptions *options)
+log_matcher_new(GlobalConfig *cfg, const LogMatcherOptions *options)
 {
   LogMatcherConstructFunc construct;
 
   construct = log_matcher_lookup_construct(options->type);
-  return construct(options);
+  return construct(cfg, options);
 }
 
 LogMatcher *

--- a/lib/logmatcher.h
+++ b/lib/logmatcher.h
@@ -104,12 +104,12 @@ log_matcher_is_replace_supported(LogMatcher *s)
   return s->replace != NULL;
 }
 
-LogMatcher *log_matcher_posix_re_new(const LogMatcherOptions *options);
-LogMatcher *log_matcher_pcre_re_new(const LogMatcherOptions *options);
-LogMatcher *log_matcher_string_new(const LogMatcherOptions *options);
-LogMatcher *log_matcher_glob_new(const LogMatcherOptions *options);
+LogMatcher *log_matcher_posix_re_new(GlobalConfig *cfg, const LogMatcherOptions *options);
+LogMatcher *log_matcher_pcre_re_new(GlobalConfig *cfg, const LogMatcherOptions *options);
+LogMatcher *log_matcher_string_new(GlobalConfig *cfg, const LogMatcherOptions *options);
+LogMatcher *log_matcher_glob_new(GlobalConfig *cfg, const LogMatcherOptions *options);
 
-LogMatcher *log_matcher_new(const LogMatcherOptions *options);
+LogMatcher *log_matcher_new(GlobalConfig *cfg, const LogMatcherOptions *options);
 LogMatcher *log_matcher_ref(LogMatcher *s);
 void log_matcher_unref(LogMatcher *s);
 

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -164,7 +164,7 @@ log_tags_dec_counter(LogTagId id)
  * get handled by this function.
  */
 void
-log_tags_reinit_stats(GlobalConfig *cfg)
+log_tags_reinit_stats(void)
 {
   gint id;
 

--- a/lib/logmsg/tags.h
+++ b/lib/logmsg/tags.h
@@ -44,7 +44,7 @@ typedef guint16 LogTagId;
 LogTagId log_tags_get_by_name(const gchar *name);
 const gchar *log_tags_get_by_id(LogTagId id);
 
-void log_tags_reinit_stats(GlobalConfig *cfg);
+void log_tags_reinit_stats(void);
 void log_tags_global_init(void);
 void log_tags_global_deinit(void);
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -427,7 +427,7 @@ log_source_options_init(LogSourceOptions *options, GlobalConfig *cfg, const gcha
   source_group_name = g_strdup_printf(".source.%s", group_name);
   options->source_group_tag = log_tags_get_by_name(source_group_name);
   g_free(source_group_name);
-  host_resolve_options_init(&options->host_resolve_options, cfg);
+  host_resolve_options_init(&options->host_resolve_options, &cfg->host_resolve_options);
 }
 
 void

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1605,7 +1605,7 @@ log_writer_options_init(LogWriterOptions *options, GlobalConfig *cfg, guint32 op
     return;
 
   log_template_options_init(&options->template_options, cfg);
-  host_resolve_options_init(&options->host_resolve_options, cfg);
+  host_resolve_options_init(&options->host_resolve_options, &cfg->host_resolve_options);
   log_proto_client_options_init(&options->proto_options.super, cfg);
   options->options |= option_flags;
 

--- a/lib/rewrite/rewrite-subst.c
+++ b/lib/rewrite/rewrite-subst.c
@@ -74,7 +74,7 @@ log_rewrite_subst_compile_pattern(LogRewrite *s, const gchar *regexp, GError **e
   GlobalConfig *cfg = log_pipe_get_config(&s->super);
 
   log_matcher_options_init(&self->matcher_options, cfg);
-  self->matcher = log_matcher_new(&self->matcher_options);
+  self->matcher = log_matcher_new(cfg, &self->matcher_options);
 
   if (!log_matcher_is_replace_supported(self->matcher))
     {

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -79,19 +79,9 @@
  * methods.
  */
 
-StatsOptions *stats_options;
-
-gboolean
-stats_check_level(gint level)
-{
-  if (stats_options)
-    return (stats_options->level >= level);
-  else
-    return level == 0;
-}
 
 static gboolean
-stats_cluster_is_expired(StatsCluster *sc, time_t now)
+stats_cluster_is_expired(StatsOptions *options, StatsCluster *sc, time_t now)
 {
   time_t tstamp;
 
@@ -110,7 +100,7 @@ stats_cluster_is_expired(StatsCluster *sc, time_t now)
     return FALSE;
 
   tstamp = sc->counters[SC_TYPE_STAMP].value;
-  return (tstamp <= now - stats_options->lifetime);
+  return (tstamp <= now - options->lifetime);
 }
 
 typedef struct _StatsTimerState
@@ -119,6 +109,7 @@ typedef struct _StatsTimerState
   time_t oldest_counter;
   gint dropped_counters;
   EVTREC *stats_event;
+  StatsOptions *options;
 } StatsTimerState;
 
 static gboolean
@@ -126,7 +117,7 @@ stats_prune_counter(StatsCluster *sc, StatsTimerState *st)
 {
   gboolean expired;
 
-  expired = stats_cluster_is_expired(sc, st->now.tv_sec);
+  expired = stats_cluster_is_expired(st->options, sc, st->now.tv_sec);
   if (expired)
     {
       time_t tstamp = sc->counters[SC_TYPE_STAMP].value;
@@ -148,14 +139,15 @@ stats_format_and_prune_cluster(StatsCluster *sc, gpointer user_data)
 }
 
 void
-stats_publish_and_prune_counters(void)
+stats_publish_and_prune_counters(StatsOptions *options)
 {
   StatsTimerState st;
-  gboolean publish = (stats_options->log_freq > 0);
+  gboolean publish = (options->log_freq > 0);
 
   st.oldest_counter = 0;
   st.dropped_counters = 0;
   st.stats_event = NULL;
+  st.options = options;
   cached_g_current_time(&st.now);
 
   if (publish)
@@ -178,9 +170,13 @@ stats_publish_and_prune_counters(void)
 
 
 static void
-stats_timer_rearm(struct iv_timer *timer)
+stats_timer_rearm(StatsOptions *options, struct iv_timer *timer)
 {
-  gint freq = GPOINTER_TO_INT(timer->cookie);
+  gint freq;
+
+  freq = options->log_freq;
+  if (!freq)
+    freq = options->lifetime <= 1 ? 1 : options->lifetime / 2;
   if (freq > 0)
     {
       /* arm the timer */
@@ -192,11 +188,11 @@ stats_timer_rearm(struct iv_timer *timer)
 }
 
 static void
-stats_timer_init(struct iv_timer *timer, void (*handler)(void *), gint freq)
+stats_timer_init(struct iv_timer *timer, void (*handler)(void *), StatsOptions *options)
 {
   IV_TIMER_INIT(timer);
   timer->handler = handler;
-  timer->cookie = GINT_TO_POINTER(freq);
+  timer->cookie = options;
 }
 
 static void
@@ -210,34 +206,31 @@ stats_timer_kill(struct iv_timer *timer)
 
 static struct iv_timer stats_timer;
 
-
 static void
 stats_timer_elapsed(gpointer st)
 {
-  stats_publish_and_prune_counters();
-  stats_timer_rearm(&stats_timer);
+  StatsOptions *options = (StatsOptions *) st;
+
+  stats_publish_and_prune_counters(options);
+  stats_timer_rearm(options, &stats_timer);
 }
 
 void
-stats_timer_reinit(void)
+stats_timer_reinit(StatsOptions *options)
 {
-  gint freq;
-
-  freq = stats_options->log_freq;
-  if (!freq)
-    freq = stats_options->lifetime <= 1 ? 1 : stats_options->lifetime / 2;
-
   stats_timer_kill(&stats_timer);
-  stats_timer_init(&stats_timer, stats_timer_elapsed, freq);
-  stats_timer_rearm(&stats_timer);
+  stats_timer_init(&stats_timer, stats_timer_elapsed, options);
+  stats_timer_rearm(options, &stats_timer);
 }
+
+static StatsOptions *stats_options;
 
 void
 stats_reinit(StatsOptions *options)
 {
   stats_options = options;
   stats_syslog_reinit();
-  stats_timer_reinit();
+  stats_timer_reinit(options);
 }
 
 void
@@ -258,4 +251,13 @@ stats_options_defaults(StatsOptions *options)
   options->level = 0;
   options->log_freq = 600;
   options->lifetime = 600;
+}
+
+gboolean
+stats_check_level(gint level)
+{
+  if (stats_options)
+    return (stats_options->level >= level);
+  else
+    return level == 0;
 }

--- a/lib/tests/test_host_resolve.c
+++ b/lib/tests/test_host_resolve.c
@@ -44,7 +44,7 @@
       testcase_begin("%s(%s)", func, args);                       \
       dns_caching_thread_init();          \
       host_resolve_options_defaults(&host_resolve_options);   \
-      host_resolve_options_init(&host_resolve_options, configuration);  \
+      host_resolve_options_init(&host_resolve_options, &configuration->host_resolve_options);  \
       hostname_reinit(NULL);            \
     }                                                             \
   while (0)

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -57,14 +57,14 @@ _create_log_message(const gchar *log)
 }
 
 static LogMatcher *
-_construct_matcher(gint matcher_flags, LogMatcher *(*construct)(const LogMatcherOptions *options))
+_construct_matcher(gint matcher_flags, LogMatcher *(*construct)(GlobalConfig *cfg, const LogMatcherOptions *options))
 {
   LogMatcherOptions matcher_options;
 
   log_matcher_options_defaults(&matcher_options);
   matcher_options.flags = matcher_flags;
 
-  return construct(&matcher_options);
+  return construct(configuration, &matcher_options);
 }
 
 


### PR DESCRIPTION
These are relatively straightforward patches to decrease coupling between the GlobalConfig class and various subsystems in syslog-ng.

Instead of relying on GlobalConfig to store global settings for these subsystem, a separate *Options struct is introduced which is then embedded within GlobalConfig. and call sites are changed to pass this embedded struct instead of the entire configuration object.

I do have a series of more introsive patches that make the plugin related code a lot more straightforward, but those patches are a long way before they can be integrated, hence I submit these separately.