### PR TITLE
affile: guard against double-free errors

### DIFF
--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -28,7 +28,6 @@
 #include <errno.h>
 #include <sys/uio.h>
 #include <unistd.h>
-#include <pthread.h>
 
 typedef struct _LogProtoFileWriter
 {
@@ -40,11 +39,9 @@ typedef struct _LogProtoFileWriter
   gint fd;
   gint sum_len;
   gboolean fsync;
+  GMutex mutex_write;
   struct iovec buffer[0];
 } LogProtoFileWriter;
-
-pthread_mutex_t mutex_write;
-unsigned short int write_mutex_init = 1;
 
 /*
  * log_proto_file_writer_flush:
@@ -82,12 +79,6 @@ log_proto_file_writer_flush(LogProtoClient *s)
           g_free(self->partial);
           self->partial = NULL;
         }
-    }
-
-  if(write_mutex_init)
-    {
-      write_mutex_init = 0;
-      pthread_mutex_init(&mutex_write, NULL);
     }
 
   /* we might be called from log_writer_deinit() without having a buffer at all */
@@ -132,14 +123,14 @@ log_proto_file_writer_flush(LogProtoClient *s)
     }
 
   /* free the previous message strings (the remaning part has been copied to the partial buffer) */
-  if (pthread_mutex_trylock(&mutex_write) == 0) /* guard against double-free from another thread */
+  if (g_mutex_trylock(&self->mutex_write)) /* guard against double-free from another thread */
     {
       for (i = 0; i < self->buf_count; ++i)
         g_free(self->buffer[i].iov_base);
       self->buf_count = 0;
       self->sum_len = 0;
 
-      pthread_mutex_unlock(&mutex_write);
+      g_mutex_unlock(&self->mutex_write);
     }
   else /* other thread is doing the free, log a message and continue */
     msg_warning("Multiple threads detected in log_proto_file_writer_flush", NULL);
@@ -243,6 +234,7 @@ log_proto_file_writer_new(LogTransport *transport, const LogProtoClientOptions *
   self->fd = transport->fd;
   self->buf_size = flush_lines;
   self->fsync = fsync_;
+  g_mutex_init(&self->mutex_write);
   self->super.prepare = log_proto_file_writer_prepare;
   self->super.post = log_proto_file_writer_post;
   self->super.flush = log_proto_file_writer_flush;


### PR DESCRIPTION
In certain conditions (many SIGHUP signals), multiple threads
enter the log_proto_file_writer_flush function and generate double-free
errors while deallocating self->buffer[i].iov_base elemets.

A mutex was added (called "mutex_write") that allows only one thread
into the critical region that deallocates the variables, while all
the other threads skip over that region and log a warning message.

Signed-off-by: Adrian Stratulat <adrian.stratulat@enea.com>
Signed-off-by: Dilimot Mihai <mihai.dilimot@enea.com>