### PR TITLE
syslog-ng: make '--preprocess-into' foreground only

### DIFF
--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -115,7 +115,8 @@ static GString *
 control_connection_stop_process(GString *command)
 {
   GString *result = g_string_new("OK Shutdown initiated");
-  main_loop_exit();
+  MainLoop *main_loop = main_loop_get_instance();
+  main_loop_exit(main_loop);
   return result;
 }
 

--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -123,7 +123,8 @@ static GString *
 control_connection_reload(GString *command)
 {
   GString *result = g_string_new("OK Config reload initiated");
-  main_loop_reload_config();
+  MainLoop *main_loop = main_loop_get_instance();
+  main_loop_reload_config(main_loop);
   return result;
 }
 

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -177,7 +177,8 @@ _cmd_drop(Debugger *self, gint argc, gchar *argv[])
 static gboolean
 _cmd_quit(Debugger *self, gint argc, gchar *argv[])
 {
-  main_loop_exit();
+  MainLoop *main_loop = main_loop_get_instance();
+  main_loop_exit(main_loop);
   self->drop_current_message = TRUE;
   return FALSE;
 }

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -473,15 +473,15 @@ main_loop_free_config(void)
 }
 
 void
-main_loop_deinit(void)
+main_loop_deinit(MainLoop *self_static)
 {
   main_loop_free_config();
 
-  if (!main_loop.options->syntax_only)
+  if (!self_static->options->syntax_only)
     control_destroy();
 
-  iv_event_unregister(&main_loop.exit_requested);
-  iv_event_unregister(&main_loop.reload_config_requested);
+  iv_event_unregister(&self_static->exit_requested);
+  iv_event_unregister(&self_static->reload_config_requested);
   main_loop_call_deinit();
   main_loop_io_worker_deinit();
   main_loop_worker_deinit();

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -154,6 +154,12 @@ struct _MainLoop
 
 static MainLoop main_loop;
 
+MainLoop *
+main_loop_get_instance(void)
+{
+  return &main_loop;
+}
+
 /* called when syslog-ng first starts up */
 gboolean
 main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -488,7 +488,7 @@ main_loop_deinit(void)
 }
 
 void
-main_loop_run(void)
+main_loop_run(MainLoop *self_static)
 {
   msg_notice("syslog-ng starting up",
              evt_tag_str("version", SYSLOG_NG_VERSION));
@@ -496,10 +496,10 @@ main_loop_run(void)
   /* main loop */
   service_management_indicate_readiness();
   service_management_clear_status();
-  if (main_loop.options->interactive_mode)
+  if (self_static->options->interactive_mode)
     {
-      plugin_load_module("python", main_loop.current_configuration, NULL);
-      debugger_start(main_loop.current_configuration);
+      plugin_load_module("python", self_static->current_configuration, NULL);
+      debugger_start(self_static->current_configuration);
     }
   iv_main();
   service_management_publish_status("Shutting down...");

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -94,7 +94,7 @@
  * closer to their usage.  The simple reason they are here, is that mainloop
  * needed them and it implements the command line options to parse them.
  * This is far from perfect. (Bazsi) */
-static gchar *preprocess_into = NULL;
+gchar *preprocess_into = NULL;
 gboolean syntax_only = FALSE;
 gboolean interactive_mode = FALSE;
 
@@ -503,7 +503,7 @@ static GOptionEntry main_loop_options[] =
 {
   { "cfgfile",           'f',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.cfgfilename, "Set config file name, default=" PATH_SYSLOG_NG_CONF, "<config>" },
   { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
-  { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &preprocess_into, "Write the preprocessed configuration file to the file specified", "output" },
+  { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &preprocess_into, "Write the preprocessed configuration file to the file specified and quit", "output" },
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &syntax_only, "Only read and parse config file", NULL},
   { "control",           'c',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &interactive_mode, "Enable interactive mode" },

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -97,69 +97,71 @@
 gchar *preprocess_into = NULL;
 gboolean syntax_only = FALSE;
 gboolean interactive_mode = FALSE;
-
-/*
- * This variable is used to detect that syslog-ng is being terminated, in which
- * case ongoing reload operations are aborted.
- *
- * The variable is deeply embedded in various mainloop callbacks to get out
- * of an ongoing reload and start doing the termination instead.  A better
- * solution would be to use a queue for intrusive, worker-stopping
- * operations and serialize such tasks so they won't interfere which each other.
- *
- * This interference is now implemented by conditionals scattered around the code.
- *
- * Example:
- *   * reload is now taking two steps (marked R in the figure below)
- *     1) parse the configuration and request worker threads to be stopped
- *     2) apply the configuration once all threads exited
- *   * termination is also taking two steps
- *     1) send out the shutting down message and start waiting 100msec
- *     2) terminate the mainloop
- *
- * The problem happens when reload and termination happen at around the same
- * time and these steps are interleaved.
- *
- *   Normal operation: RRTT (e.g. reload finishes, then termination)
- *   Problematic case: RTRT (e.g. reload starts, termination starts, config apply, terminate)
- *
- * In the problematic case, two independent operations do similar things to
- * the mainloop, and to prevent misfortune we need to handle this case explicitly.
- *
- * Were the two operations serialized by some kind of queue, the problems
- * would be gone.
- */
-gboolean __main_loop_is_terminating = FALSE;
-
-/* signal handling */
-static struct iv_signal sighup_poll;
-static struct iv_signal sigterm_poll;
-static struct iv_signal sigint_poll;
-static struct iv_signal sigchild_poll;
-
-static struct iv_event exit_requested;
-static struct iv_event reload_config_requested;
-
-
-/* Currently running configuration, should not be used outside the mainloop
- * logic. If anything needs access to the GlobalConfig instance at runtime,
- * it needs to save that during initialization.  If anything needs the
- * config being parsed (e.g.  in the bison generated code), it should
- * consult the value of "configuration", which is NULL after the parsing is
- * finished.
- */
-static GlobalConfig *current_configuration;
 ThreadId main_thread_handle;
 
-/************************************************************************************
- * config load/reload
- ************************************************************************************/
+struct _MainLoop
+{
+  /*
+   * This variable is used to detect that syslog-ng is being terminated, in which
+   * case ongoing reload operations are aborted.
+   *
+   * The variable is deeply embedded in various mainloop callbacks to get out
+   * of an ongoing reload and start doing the termination instead.  A better
+   * solution would be to use a queue for intrusive, worker-stopping
+   * operations and serialize such tasks so they won't interfere which each other.
+   *
+   * This interference is now implemented by conditionals scattered around the code.
+   *
+   * Example:
+   *   * reload is now taking two steps (marked R in the figure below)
+   *     1) parse the configuration and request worker threads to be stopped
+   *     2) apply the configuration once all threads exited
+   *   * termination is also taking two steps
+   *     1) send out the shutting down message and start waiting 100msec
+   *     2) terminate the mainloop
+   *
+   * The problem happens when reload and termination happen at around the same
+   * time and these steps are interleaved.
+   *
+   *   Normal operation: RRTT (e.g. reload finishes, then termination)
+   *   Problematic case: RTRT (e.g. reload starts, termination starts, config apply, terminate)
+   *
+   * In the problematic case, two independent operations do similar things to
+   * the mainloop, and to prevent misfortune we need to handle this case explicitly.
+   *
+   * Were the two operations serialized by some kind of queue, the problems
+   * would be gone.
+   */
+  gboolean __is_terminating;
 
-/* the old configuration that is being reloaded */
-static GlobalConfig *main_loop_old_config;
-/* the pending configuration we wish to switch to */
-static GlobalConfig *main_loop_new_config;
+  /* signal handling */
+  struct iv_signal sighup_poll;
+  struct iv_signal sigterm_poll;
+  struct iv_signal sigint_poll;
+  struct iv_signal sigchild_poll;
 
+  struct iv_event exit_requested;
+  struct iv_event reload_config_requested;
+
+  struct iv_timer exit_timer;
+
+  /* Currently running configuration, should not be used outside the mainloop
+   * logic. If anything needs access to the GlobalConfig instance at runtime,
+   * it needs to save that during initialization.  If anything needs the
+   * config being parsed (e.g.  in the bison generated code), it should
+   * consult the value of "configuration", which is NULL after the parsing is
+   * finished.
+   */
+  GlobalConfig *current_configuration;
+
+  /* the old configuration that is being reloaded */
+  GlobalConfig *old_config;
+  /* the pending configuration we wish to switch to */
+  GlobalConfig *new_config;
+
+};
+
+static MainLoop main_loop;
 
 /* called when syslog-ng first starts up */
 gboolean
@@ -182,39 +184,45 @@ main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
   return success;
 }
 
+static inline gboolean
+main_loop_is_terminating(void)
+{
+  return main_loop.__is_terminating;
+}
+
 /* called to apply the new configuration once all I/O worker threads have finished */
 static void
 main_loop_reload_config_apply(void)
 {
   if (main_loop_is_terminating())
     {
-      if (main_loop_new_config)
+      if (main_loop.new_config)
         {
-          cfg_free(main_loop_new_config);
-          main_loop_new_config = NULL;
+          cfg_free(main_loop.new_config);
+          main_loop.new_config = NULL;
         }
       return;
     }
-  main_loop_old_config->persist = persist_config_new();
-  cfg_deinit(main_loop_old_config);
-  cfg_persist_config_move(main_loop_old_config, main_loop_new_config);
+  main_loop.old_config->persist = persist_config_new();
+  cfg_deinit(main_loop.old_config);
+  cfg_persist_config_move(main_loop.old_config, main_loop.new_config);
 
-  if (cfg_init(main_loop_new_config))
+  if (cfg_init(main_loop.new_config))
     {
       msg_verbose("New configuration initialized");
-      persist_config_free(main_loop_new_config->persist);
-      main_loop_new_config->persist = NULL;
-      cfg_free(main_loop_old_config);
-      current_configuration = main_loop_new_config;
+      persist_config_free(main_loop.new_config->persist);
+      main_loop.new_config->persist = NULL;
+      cfg_free(main_loop.old_config);
+      main_loop.current_configuration = main_loop.new_config;
       service_management_clear_status();
     }
   else
     {
       msg_error("Error initializing new configuration, reverting to old config");
       service_management_publish_status("Error initializing new configuration, using the old config");
-      cfg_persist_config_move(main_loop_new_config, main_loop_old_config);
-      cfg_deinit(main_loop_new_config);
-      if (!cfg_init(main_loop_old_config))
+      cfg_persist_config_move(main_loop.new_config, main_loop.old_config);
+      cfg_deinit(main_loop.new_config);
+      if (!cfg_init(main_loop.old_config))
         {
           /* hmm. hmmm, error reinitializing old configuration, we're hosed.
            * Best is to kill ourselves in the hope that the supervisor
@@ -223,10 +231,10 @@ main_loop_reload_config_apply(void)
           kill(getpid(), SIGQUIT);
           g_assert_not_reached();
         }
-      persist_config_free(main_loop_old_config->persist);
-      main_loop_old_config->persist = NULL;
-      cfg_free(main_loop_new_config);
-      current_configuration = main_loop_old_config;
+      persist_config_free(main_loop.old_config->persist);
+      main_loop.old_config->persist = NULL;
+      cfg_free(main_loop.new_config);
+      main_loop.current_configuration = main_loop.old_config;
       goto finish;
     }
 
@@ -235,8 +243,8 @@ main_loop_reload_config_apply(void)
   msg_notice("Configuration reload request received, reloading configuration");
 
 finish:
-  main_loop_new_config = NULL;
-  main_loop_old_config = NULL;
+  main_loop.new_config = NULL;
+  main_loop.old_config = NULL;
 
   return;
 }
@@ -250,7 +258,7 @@ main_loop_reload_config_initiate(void)
 
   service_management_publish_status("Reloading configuration");
 
-  if (main_loop_new_config)
+  if (main_loop.new_config)
     {
       /* This block is entered only if this function is reentered before
        * main_loop_reload_config_apply() would be called.  In that case we
@@ -258,18 +266,18 @@ main_loop_reload_config_initiate(void)
        * ensure that the contents of the running configuration matches the
        * contents of the file at the time the SIGHUP signal was received.
        */
-      cfg_free(main_loop_new_config);
-      main_loop_new_config = NULL;
+      cfg_free(main_loop.new_config);
+      main_loop.new_config = NULL;
     }
 
-  main_loop_old_config = current_configuration;
+  main_loop.old_config = main_loop.current_configuration;
   app_pre_config_loaded();
-  main_loop_new_config = cfg_new(0);
-  if (!cfg_read_config(main_loop_new_config, resolvedConfigurablePaths.cfgfilename, FALSE, NULL))
+  main_loop.new_config = cfg_new(0);
+  if (!cfg_read_config(main_loop.new_config, resolvedConfigurablePaths.cfgfilename, FALSE, NULL))
     {
-      cfg_free(main_loop_new_config);
-      main_loop_new_config = NULL;
-      main_loop_old_config = NULL;
+      cfg_free(main_loop.new_config);
+      main_loop.new_config = NULL;
+      main_loop.old_config = NULL;
       msg_error("Error parsing configuration",
                 evt_tag_str(EVT_TAG_FILENAME, resolvedConfigurablePaths.cfgfilename));
       service_management_publish_status("Error parsing new configuration, using the old config");
@@ -282,15 +290,13 @@ main_loop_reload_config_initiate(void)
  * syncronized exit
  ************************************************************************************/
 
-static struct iv_timer main_loop_exit_timer;
-
 static void
 main_loop_exit_finish(void)
 {
   /* deinit the current configuration, as at this point we _know_ that no
    * threads are running.  This will unregister ivykis tasks and timers
    * that could fire while the configuration is being destructed */
-  cfg_deinit(current_configuration);
+  cfg_deinit(main_loop.current_configuration);
   iv_quit();
 }
 
@@ -309,13 +315,13 @@ main_loop_exit_initiate(void)
   msg_notice("syslog-ng shutting down",
              evt_tag_str("version", SYSLOG_NG_VERSION));
 
-  IV_TIMER_INIT(&main_loop_exit_timer);
+  IV_TIMER_INIT(&main_loop.exit_timer);
   iv_validate_now();
-  main_loop_exit_timer.expires = iv_now;
-  main_loop_exit_timer.handler = main_loop_exit_timer_elapsed;
-  timespec_add_msec(&main_loop_exit_timer.expires, 100);
-  iv_timer_register(&main_loop_exit_timer);
-  __main_loop_is_terminating = TRUE;
+  main_loop.exit_timer.expires = iv_now;
+  main_loop.exit_timer.handler = main_loop_exit_timer_elapsed;
+  timespec_add_msec(&main_loop.exit_timer.expires, 100);
+  iv_timer_register(&main_loop.exit_timer);
+  main_loop.__is_terminating = TRUE;
 }
 
 
@@ -378,10 +384,10 @@ static void
 setup_signals(void)
 {
   _ignore_signal(SIGPIPE);
-  _register_signal_handler(&sighup_poll, SIGHUP, sig_hup_handler);
-  _register_signal_handler(&sigchild_poll, SIGCHLD, sig_child_handler);
-  _register_signal_handler(&sigterm_poll, SIGTERM, sig_term_handler);
-  _register_signal_handler(&sigint_poll, SIGINT, sig_term_handler);
+  _register_signal_handler(&main_loop.sighup_poll, SIGHUP, sig_hup_handler);
+  _register_signal_handler(&main_loop.sigchild_poll, SIGCHLD, sig_child_handler);
+  _register_signal_handler(&main_loop.sigterm_poll, SIGTERM, sig_term_handler);
+  _register_signal_handler(&main_loop.sigint_poll, SIGINT, sig_term_handler);
 }
 
 /************************************************************************************
@@ -400,21 +406,21 @@ _register_event(struct iv_event *event, void (*handler)(void *))
 static void
 main_loop_init_events(void)
 {
-  _register_event(&exit_requested, (void (*)(void *)) main_loop_exit_initiate);
-  _register_event(&reload_config_requested, (void (*)(void *)) main_loop_reload_config_initiate);
+  _register_event(&main_loop.exit_requested, (void (*)(void *)) main_loop_exit_initiate);
+  _register_event(&main_loop.reload_config_requested, (void (*)(void *)) main_loop_reload_config_initiate);
 }
 
 void
 main_loop_exit(void)
 {
-  iv_event_post(&exit_requested);
+  iv_event_post(&main_loop.exit_requested);
   return;
 }
 
 void
 main_loop_reload_config(void)
 {
-  iv_event_post(&reload_config_requested);
+  iv_event_post(&main_loop.reload_config_requested);
   return;
 }
 
@@ -440,8 +446,10 @@ main_loop_init(void)
 int
 main_loop_read_and_init_config(void)
 {
-  current_configuration = cfg_new(0);
-  if (!cfg_read_config(current_configuration, resolvedConfigurablePaths.cfgfilename, syntax_only, preprocess_into))
+
+  main_loop.current_configuration = cfg_new(0);
+  if (!cfg_read_config(main_loop.current_configuration, resolvedConfigurablePaths.cfgfilename, syntax_only,
+                       preprocess_into))
     {
       return 1;
     }
@@ -451,7 +459,7 @@ main_loop_read_and_init_config(void)
       return 0;
     }
 
-  if (!main_loop_initialize_state(current_configuration, resolvedConfigurablePaths.persist_file))
+  if (!main_loop_initialize_state(main_loop.current_configuration, resolvedConfigurablePaths.persist_file))
     {
       return 2;
     }
@@ -461,8 +469,8 @@ main_loop_read_and_init_config(void)
 static void
 main_loop_free_config(void)
 {
-  cfg_free(current_configuration);
-  current_configuration = NULL;
+  cfg_free(main_loop.current_configuration);
+  main_loop.current_configuration = NULL;
 }
 
 void
@@ -473,8 +481,8 @@ main_loop_deinit(void)
   if (!syntax_only)
     control_destroy();
 
-  iv_event_unregister(&exit_requested);
-  iv_event_unregister(&reload_config_requested);
+  iv_event_unregister(&main_loop.exit_requested);
+  iv_event_unregister(&main_loop.reload_config_requested);
   main_loop_call_deinit();
   main_loop_io_worker_deinit();
   main_loop_worker_deinit();
@@ -491,8 +499,8 @@ main_loop_run(void)
   service_management_clear_status();
   if (interactive_mode)
     {
-      plugin_load_module("python", current_configuration, NULL);
-      debugger_start(current_configuration);
+      plugin_load_module("python", main_loop.current_configuration, NULL);
+      debugger_start(main_loop.current_configuration);
     }
   iv_main();
   service_management_publish_status("Shutting down...");

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -442,12 +442,12 @@ main_loop_init(MainLoop *self_static, MainLoopOptions *options)
  * Returns: exit code to be returned to the calling process, 0 on success.
  */
 int
-main_loop_read_and_init_config(void)
+main_loop_read_and_init_config(MainLoop *self_static)
 {
-  MainLoopOptions *options = main_loop.options;
+  MainLoopOptions *options = self_static->options;
 
-  main_loop.current_configuration = cfg_new(0);
-  if (!cfg_read_config(main_loop.current_configuration, resolvedConfigurablePaths.cfgfilename, options->syntax_only,
+  self_static->current_configuration = cfg_new(0);
+  if (!cfg_read_config(self_static->current_configuration, resolvedConfigurablePaths.cfgfilename, options->syntax_only,
                        options->preprocess_into))
     {
       return 1;
@@ -458,7 +458,7 @@ main_loop_read_and_init_config(void)
       return 0;
     }
 
-  if (!main_loop_initialize_state(main_loop.current_configuration, resolvedConfigurablePaths.persist_file))
+  if (!main_loop_initialize_state(self_static->current_configuration, resolvedConfigurablePaths.persist_file))
     {
       return 2;
     }

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -415,9 +415,9 @@ main_loop_exit(void)
 }
 
 void
-main_loop_reload_config(void)
+main_loop_reload_config(MainLoop *self_static)
 {
-  iv_event_post(&main_loop.reload_config_requested);
+  iv_event_post(&self_static->reload_config_requested);
   return;
 }
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -422,18 +422,18 @@ main_loop_reload_config(void)
 }
 
 void
-main_loop_init(MainLoopOptions *options)
+main_loop_init(MainLoop *self_static, MainLoopOptions *options)
 {
   service_management_publish_status("Starting up...");
 
-  main_loop.options = options;
+  self_static->options = options;
   main_thread_handle = get_thread_id();
   main_loop_worker_init();
   main_loop_io_worker_init();
   main_loop_call_init();
 
   main_loop_init_events();
-  if (!main_loop.options->syntax_only)
+  if (!self_static->options->syntax_only)
     control_init(resolvedConfigurablePaths.ctlfilename);
   setup_signals();
 }

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -408,9 +408,9 @@ main_loop_init_events(void)
 }
 
 void
-main_loop_exit(void)
+main_loop_exit(MainLoop *self_static)
 {
-  iv_event_post(&main_loop.exit_requested);
+  iv_event_post(&self_static->exit_requested);
   return;
 }
 

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -54,7 +54,7 @@ main_loop_is_main_thread(void)
   return threads_equal(main_thread_handle, get_thread_id());
 }
 
-void main_loop_reload_config(void);
+void main_loop_reload_config(MainLoop *self_static);
 void main_loop_exit(void);
 
 int main_loop_read_and_init_config(MainLoop *self_static);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -27,7 +27,7 @@
 #include "syslog-ng.h"
 #include "thread-utils.h"
 
-
+extern gchar *preprocess_into;
 extern gboolean syntax_only;
 extern gboolean __main_loop_is_terminating;
 extern ThreadId main_thread_handle;

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -57,7 +57,7 @@ main_loop_is_main_thread(void)
 void main_loop_reload_config(void);
 void main_loop_exit(void);
 
-int main_loop_read_and_init_config(void);
+int main_loop_read_and_init_config(MainLoop *self_static);
 void main_loop_run(void);
 
 MainLoop *main_loop_get_instance(void);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -58,7 +58,7 @@ void main_loop_reload_config(void);
 void main_loop_exit(void);
 
 int main_loop_read_and_init_config(MainLoop *self_static);
-void main_loop_run(void);
+void main_loop_run(MainLoop *self_static);
 
 MainLoop *main_loop_get_instance(void);
 void main_loop_init(MainLoop *self_static, MainLoopOptions *options);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -62,7 +62,7 @@ void main_loop_run(MainLoop *self_static);
 
 MainLoop *main_loop_get_instance(void);
 void main_loop_init(MainLoop *self_static, MainLoopOptions *options);
-void main_loop_deinit(void);
+void main_loop_deinit(MainLoop *self_static);
 
 void main_loop_add_options(GOptionContext *ctx);
 

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -60,6 +60,7 @@ void main_loop_exit(void);
 int main_loop_read_and_init_config(void);
 void main_loop_run(void);
 
+MainLoop *main_loop_get_instance(void);
 
 void main_loop_init(MainLoopOptions *options);
 void main_loop_deinit(void);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -29,8 +29,13 @@
 
 typedef struct _MainLoop MainLoop;
 
-extern gchar *preprocess_into;
-extern gboolean syntax_only;
+typedef struct _MainLoopOptions
+{
+  gchar *preprocess_into;
+  gboolean syntax_only;
+  gboolean interactive_mode;
+} MainLoopOptions;
+
 extern ThreadId main_thread_handle;
 
 typedef gpointer (*MainLoopTaskFunc)(gpointer user_data);
@@ -55,7 +60,8 @@ void main_loop_exit(void);
 int main_loop_read_and_init_config(void);
 void main_loop_run(void);
 
-void main_loop_init(void);
+
+void main_loop_init(MainLoopOptions *options);
 void main_loop_deinit(void);
 
 void main_loop_add_options(GOptionContext *ctx);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -61,8 +61,7 @@ int main_loop_read_and_init_config(void);
 void main_loop_run(void);
 
 MainLoop *main_loop_get_instance(void);
-
-void main_loop_init(MainLoopOptions *options);
+void main_loop_init(MainLoop *self_static, MainLoopOptions *options);
 void main_loop_deinit(void);
 
 void main_loop_add_options(GOptionContext *ctx);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -55,7 +55,7 @@ main_loop_is_main_thread(void)
 }
 
 void main_loop_reload_config(MainLoop *self_static);
-void main_loop_exit(void);
+void main_loop_exit(MainLoop *self_static);
 
 int main_loop_read_and_init_config(MainLoop *self_static);
 void main_loop_run(MainLoop *self_static);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -27,9 +27,10 @@
 #include "syslog-ng.h"
 #include "thread-utils.h"
 
+typedef struct _MainLoop MainLoop;
+
 extern gchar *preprocess_into;
 extern gboolean syntax_only;
-extern gboolean __main_loop_is_terminating;
 extern ThreadId main_thread_handle;
 
 typedef gpointer (*MainLoopTaskFunc)(gpointer user_data);
@@ -46,12 +47,6 @@ static inline gboolean
 main_loop_is_main_thread(void)
 {
   return threads_equal(main_thread_handle, get_thread_id());
-}
-
-static inline gboolean
-main_loop_is_terminating(void)
-{
-  return __main_loop_is_terminating;
 }
 
 void main_loop_reload_config(void);

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -298,7 +298,7 @@ main(int argc, char *argv[])
   /* from now on internal messages are written to the system log as well */
 
   main_loop_run(main_loop);
-  main_loop_deinit();
+  main_loop_deinit(main_loop);
 
   app_shutdown();
   z_mem_trace_dump();

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -200,6 +200,8 @@ main(int argc, char *argv[])
   GOptionContext *ctx;
   GError *error = NULL;
 
+  MainLoop *main_loop = main_loop_get_instance();
+
   z_mem_trace_init("syslog-ng.trace");
 
   g_process_set_argv_space(argc, (gchar **) argv);
@@ -266,7 +268,7 @@ main(int argc, char *argv[])
    */
   g_process_start();
   app_startup();
-  main_loop_init(&main_loop_options);
+  main_loop_init(main_loop, &main_loop_options);
   rc = main_loop_read_and_init_config();
 
   if (rc)

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -246,7 +246,8 @@ main(int argc, char *argv[])
       log_stderr = TRUE;
     }
 
-  if (syntax_only || debug_flag)
+  gboolean exit_before_main_loop_run = syntax_only || preprocess_into;
+  if (debug_flag || exit_before_main_loop_run)
     {
       g_process_set_mode(G_PM_FOREGROUND);
     }
@@ -267,7 +268,7 @@ main(int argc, char *argv[])
     }
   else
     {
-      if (syntax_only)
+      if (exit_before_main_loop_run)
         g_process_startup_failed(0, TRUE);
       else
         g_process_startup_ok();

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -297,7 +297,7 @@ main(int argc, char *argv[])
 
   /* from now on internal messages are written to the system log as well */
 
-  main_loop_run();
+  main_loop_run(main_loop);
   main_loop_deinit();
 
   app_shutdown();

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -64,6 +64,8 @@ static gboolean display_version = FALSE;
 static gboolean display_module_registry = FALSE;
 static gboolean dummy = FALSE;
 
+static MainLoopOptions main_loop_options;
+
 #ifdef YYDEBUG
 extern int cfg_parser_debug;
 #endif
@@ -77,6 +79,12 @@ static GOptionEntry syslogng_options[] =
 #ifdef YYDEBUG
   { "yydebug",           'y',         0, G_OPTION_ARG_NONE, &cfg_parser_debug, "Enable configuration parser debugging", NULL },
 #endif
+  { "cfgfile",           'f',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.cfgfilename, "Set config file name, default=" PATH_SYSLOG_NG_CONF, "<config>" },
+  { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
+  { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &main_loop_options.preprocess_into, "Write the preprocessed configuration file to the file specified and quit", "output" },
+  { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
+  { "control",           'c',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
+  { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
   { NULL },
 };
 
@@ -246,7 +254,7 @@ main(int argc, char *argv[])
       log_stderr = TRUE;
     }
 
-  gboolean exit_before_main_loop_run = syntax_only || preprocess_into;
+  gboolean exit_before_main_loop_run = main_loop_options.syntax_only || main_loop_options.preprocess_into;
   if (debug_flag || exit_before_main_loop_run)
     {
       g_process_set_mode(G_PM_FOREGROUND);
@@ -258,7 +266,7 @@ main(int argc, char *argv[])
    */
   g_process_start();
   app_startup();
-  main_loop_init();
+  main_loop_init(&main_loop_options);
   rc = main_loop_read_and_init_config();
 
   if (rc)

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -269,7 +269,7 @@ main(int argc, char *argv[])
   g_process_start();
   app_startup();
   main_loop_init(main_loop, &main_loop_options);
-  rc = main_loop_read_and_init_config();
+  rc = main_loop_read_and_init_config(main_loop);
 
   if (rc)
     {


### PR DESCRIPTION
The behaviour of the  `--preprocess-into` option should be the same as `--syntax-only`:

This patch forces `--preprocess-into` to run in foreground mode and shuts
down syslog-ng after calling main_loop_init() (after parsing the config).