### PR TITLE
[WIP] Enable warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,34 @@ AM_CFLAGS += \
 	-Wold-style-definition \
 	-Wsuggest-attribute=const \
 	-Wsuggest-attribute=pure
+
+# To satisfy travis
+AM_CFLAGS +=\
+	-Wno-error=deprecated-declarations \
+	-Wno-error=aggregate-return \
+	-Wno-error=bad-function-cast \
+	-Wno-error=cast-qual \
+	-Wno-error=conversion \
+	-Wno-error=double-promotion \
+	-Wno-error=float-equal \
+	-Wno-error=format-nonliteral \
+	-Wno-error=inline \
+	-Wno-error=missing-declarations \
+	-Wno-error=missing-format-attribute \
+	-Wno-error=missing-prototypes \
+	-Wno-error=pointer-arith \
+	-Wno-error=pointer-sign \
+	-Wno-error=redundant-decls \
+	-Wno-error=sign-compare \
+	-Wno-error=sign-conversion \
+	-Wno-error=strict-overflow \
+	-Wno-error=suggest-attribute=const \
+	-Wno-error=suggest-attribute=noreturn \
+	-Wno-error=suggest-attribute=pure \
+	-Wno-error=switch-default \
+	-Wno-error=type-limits \
+	-Wno-error=undef \
+	-Wno-error=write-strings
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest $(AM_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,32 @@ AM_CFLAGS += \
 	-Wcast-align \
 	-Wdeprecated \
 	-Wdeprecated-declarations \
-	-Woverflow
+	-Woverflow \
+	-Winline \
+	-Waggregate-return \
+	-Wbad-function-cast \
+	-Wcast-qual \
+	-Wconversion \
+	-Wdouble-promotion \
+	-Wfloat-equal \
+	-Wmissing-field-initializers \
+	-Wmissing-prototypes \
+	-Wpointer-arith \
+	-Wpointer-sign \
+	-Wredundant-decls \
+	-Wsign-conversion \
+	-Wformat=2 \
+	-Wsuggest-attribute=noreturn \
+	-Wswitch-default \
+	-Wundef \
+	-Wmissing-declarations \
+	-Woverride-init \
+	-Wmissing-format-attribute \
+	-Wignored-qualifiers \
+	-Winline \
+	-Wold-style-definition \
+	-Wsuggest-attribute=const \
+	-Wsuggest-attribute=pure
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest $(AM_CFLAGS)


### PR DESCRIPTION
(edited)
Trivia:
--enable-extra-warnings is **not** a gcc/clang compiler/linker option. It is a syslog-ng configure option (like any --disable-[some-module] options). It is already part of syslog-ng, marked as recommended to be used, and its purpose was to enable three specific kind of warnings during build.

The ultimate goal is of course that there would not be any kind of warnings: to add -Wall compile option, which is part of this patch. The problem is a lot of warnings appear this way (tens of megabytes of log), which is not practical to handle. So we need to reduce the appearing warnings to a manageable size by whitelisting warnings, and the whitelist would be later reduced in other patches.

In short, this patchset replaces the backlisting method on warnings to whitelisting method, and try to enforce the current whitelisting with travis.
(/edited)

This branch rebases #1128 against current master and refines options somewhat and CLAGS as well.

Major changes against #1128:
 * use g_path_basename() instead of a const basename() implementation
 * it sets the default CFLAGS even if --enable-extra-warnings is not defined, e.g -Wshadow is always defined
 * all warning related CFLAGS are set in the Makefile and not in configure.ac

I am not yet sure if travis should run with --enable-extra-warnings, it bloats the build log. My feeling is that we should merge this without the travis part (e.g. build without the extra warnings even in travis). But I am open to ideas.

It would be great if we could merge this at this time, so we don't need to rebase it again in 6 months time :)
