### PR TITLE
getent: add getent module

### DIFF
--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -34,6 +34,7 @@ include modules/native/Makefile.am
 include modules/cef/Makefile.am
 include modules/diskq/Makefile.am
 include modules/add-contextual-data/Makefile.am
+include modules/getent/Makefile.am
 
 SYSLOG_NG_CORE_JAR=$(top_builddir)/modules/java/syslog-ng-core/libs/syslog-ng-core.jar
 
@@ -45,7 +46,7 @@ SYSLOG_NG_MODULES	=	\
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
 	mod-python mod-java mod-java-modules mod-kvformat mod-date \
-	mod-native mod-cef mod-add-contextual-data mod-diskq
+	mod-native mod-cef mod-add-contextual-data mod-diskq mod-getent
 
 
 modules modules/: ${SYSLOG_NG_MODULES}
@@ -60,6 +61,6 @@ modules_test_subdirs	=	\
 	modules_cryptofuncs modules_geoip modules_afstomp \
 	modules_graphite modules_riemann modules_python \
 	modules_systemd_journal modules_kvformat modules_date \
-	modules_cef modules_diskq modules-add-contextual-data
+	modules_cef modules_diskq modules-add-contextual-data modules_getent
 
 .PHONY: modules modules/

--- a/modules/getent/Makefile.am
+++ b/modules/getent/Makefile.am
@@ -17,6 +17,8 @@ modules_getent_libtfgetent_la_LIBADD	= \
   $(MODULE_DEPS_LIBS)
 modules_getent_libtfgetent_la_LDFLAGS	= \
   $(MODULE_LDFLAGS)
+modules_getent_libtfgetent_la_DEPENDENCIES = \
+  $(MODULE_DEPS_LIBS)
 
 modules/getent mod-getent: modules/getent/libtfgetent.la
 

--- a/modules/getent/Makefile.am
+++ b/modules/getent/Makefile.am
@@ -1,0 +1,23 @@
+module_LTLIBRARIES			+= \
+  modules/getent/libtfgetent.la
+
+modules_getent_libtfgetent_la_SOURCES	= \
+  modules/getent/tfgetent.c
+
+EXTRA_DIST				+=\
+  modules/getent/getent-protocols.c	  \
+  modules/getent/getent-services.c	  \
+  modules/getent/getent-group.c	  \
+  modules/getent/getent-passwd.c
+
+modules_getent_libtfgetent_la_CPPFLAGS	= \
+  $(AM_CPPFLAGS)			  \
+  -I$(top_srcdir)/modules/getent
+modules_getent_libtfgetent_la_LIBADD	= \
+  $(MODULE_DEPS_LIBS)
+modules_getent_libtfgetent_la_LDFLAGS	= \
+  $(MODULE_LDFLAGS)
+
+modules/getent mod-getent: modules/getent/libtfgetent.la
+
+.PHONY: modules/getent mod-getent

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -20,7 +20,8 @@
  * COPYING for details.
  */
 
-static formatter_map_t group_field_map[] = {
+static formatter_map_t group_field_map[] =
+{
   { "name", _getent_format_string, offsetof(struct group, gr_name) },
   { "gid", _getent_format_uid_gid, offsetof(struct group, gr_gid) },
   { "members", _getent_format_array, offsetof(struct group, gr_mem) },

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+static formatter_map_t group_field_map[] = {
+  { "name", _getent_format_string, offsetof(struct group, gr_name) },
+  { "gid", _getent_format_uid_gid, offsetof(struct group, gr_gid) },
+  { "members", _getent_format_array, offsetof(struct group, gr_mem) },
+  { NULL, NULL, 0 }
+};
+
+static gboolean
+tf_getent_group(gchar *key, gchar *member_name, GString *result)
+{
+  struct group grp;
+  struct group *res;
+  char *buf;
+  long bufsize;
+  int s;
+  glong d;
+  gboolean is_num, r;
+
+  bufsize = 16384;
+
+  buf = g_malloc(bufsize);
+
+  if ((is_num = parse_number(key, &d)) == TRUE)
+    s = getgrgid_r((gid_t)d, &grp, buf, bufsize, &res);
+  else
+    s = getgrnam_r(key, &grp, buf, bufsize, &res);
+
+  if (res == NULL && s != 0)
+    {
+      msg_error("$(getent group) failed",
+                evt_tag_str("key", key),
+                evt_tag_errno("errno", errno),
+                NULL);
+      g_free(buf);
+      return FALSE;
+    }
+
+  if (member_name == NULL)
+    {
+      if (is_num)
+        member_name = "name";
+      else
+        member_name = "gid";
+    }
+
+  if (res == NULL)
+    {
+      g_free(buf);
+      return FALSE;
+    }
+
+  s = _find_formatter(group_field_map, member_name);
+
+  if (s == -1)
+    {
+      msg_error("$(getent group): unknown member",
+                evt_tag_str("key", key),
+                evt_tag_str("member", member_name),
+                NULL);
+      g_free(buf);
+      return FALSE;
+    }
+
+  r = group_field_map[s].format(member_name,
+                                ((uint8_t *)res) + group_field_map[s].offset,
+                                result);
+  g_free(buf);
+  return r;
+}

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+static formatter_map_t passwd_field_map[] = {
+  { "name", _getent_format_string, offsetof(struct passwd, pw_name) },
+  { "uid", _getent_format_uid_gid, offsetof(struct passwd, pw_uid) },
+  { "gid", _getent_format_uid_gid, offsetof(struct passwd, pw_gid) },
+  { "gecos", _getent_format_string, offsetof(struct passwd, pw_gecos) },
+  { "dir", _getent_format_string, offsetof(struct passwd, pw_dir) },
+  { "shell", _getent_format_string, offsetof(struct passwd, pw_shell) },
+  { NULL, NULL, 0 }
+};
+
+static gboolean
+tf_getent_passwd(gchar *key, gchar *member_name, GString *result)
+{
+  struct passwd pwd;
+  struct passwd *res;
+  char *buf;
+  long bufsize;
+  int s;
+  glong d;
+  gboolean is_num, r;
+
+  bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+  if (bufsize == -1)
+    bufsize = 16384;
+
+  buf = g_malloc(bufsize);
+
+  if ((is_num = parse_number(key, &d)) == TRUE)
+    s = getpwuid_r((uid_t)d, &pwd, buf, bufsize, &res);
+  else
+    s = getpwnam_r(key, &pwd, buf, bufsize, &res);
+
+  if (res == NULL && s != 0)
+    {
+      msg_error("$(getent passwd) failed",
+                evt_tag_str("key", key),
+                evt_tag_errno("errno", errno),
+                NULL);
+      g_free(buf);
+      return FALSE;
+    }
+
+  if (member_name == NULL)
+    {
+      if (is_num)
+        member_name = "name";
+      else
+        member_name = "uid";
+    }
+
+  if (res == NULL)
+    {
+      g_free(buf);
+      return FALSE;
+    }
+
+  s = _find_formatter(passwd_field_map, member_name);
+
+  if (s == -1)
+    {
+      msg_error("$(getent passwd): unknown member",
+                evt_tag_str("key", key),
+                evt_tag_str("member", member_name),
+                NULL);
+      g_free(buf);
+      return FALSE;
+    }
+
+  r = passwd_field_map[s].format(member_name,
+                                 ((uint8_t *)res) + passwd_field_map[s].offset,
+                                 result);
+  g_free(buf);
+  return r;
+}

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -20,7 +20,8 @@
  * COPYING for details.
  */
 
-static formatter_map_t passwd_field_map[] = {
+static formatter_map_t passwd_field_map[] =
+{
   { "name", _getent_format_string, offsetof(struct passwd, pw_name) },
   { "uid", _getent_format_uid_gid, offsetof(struct passwd, pw_uid) },
   { "gid", _getent_format_uid_gid, offsetof(struct passwd, pw_gid) },

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/getent/getent-protocols.c
+++ b/modules/getent/getent-protocols.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+static gboolean
+tf_getent_protocols(gchar *key, gchar *member_name, GString *result)
+{
+  struct protoent proto, *res;
+  glong d;
+  gboolean is_num;
+  char buf[4096];
+
+  if ((is_num = parse_number(key, &d)) == TRUE)
+    getprotobynumber_r((int) d, &proto, buf, sizeof(buf), &res);
+  else
+    getprotobyname_r(key, &proto, buf, sizeof(buf), &res);
+
+  if (res == NULL)
+    return TRUE;
+
+  if (is_num)
+    g_string_append(result, res->p_name);
+  else
+    g_string_append_printf(result, "%i", htons(res->p_proto));
+
+  return TRUE;
+}

--- a/modules/getent/getent-protocols.c
+++ b/modules/getent/getent-protocols.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/getent/getent-services.c
+++ b/modules/getent/getent-services.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+static gboolean
+tf_getent_services(gchar *key, gchar *member_name, GString *result)
+{
+  struct servent serv, *res;
+  glong d;
+  gboolean is_num;
+  char buf[4096];
+
+  if ((is_num = parse_number(key, &d)) == TRUE)
+    getservbyport_r((int)ntohs(d), NULL, &serv, buf, sizeof(buf), &res);
+  else
+    getservbyname_r(key, NULL, &serv, buf, sizeof(buf), &res);
+
+  if (res == NULL)
+    return TRUE;
+
+  if (is_num)
+    g_string_append(result, res->s_name);
+  else
+    g_string_append_printf(result, "%i", htons(res->s_port));
+
+  return TRUE;
+}

--- a/modules/getent/getent-services.c
+++ b/modules/getent/getent-services.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Balabit
  * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "syslog-ng.h"
+#include "logmsg/logmsg.h"
+#include "plugin.h"
+#include "plugin-types.h"
+#include "cfg.h"
+#include "parse-number.h"
+#include "template/simple-function.h"
+
+#include <grp.h>
+#include <pwd.h>
+#include <netdb.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stddef.h>
+
+
+typedef gboolean (*lookup_method)(gchar *key, gchar *member_name, GString *result);
+typedef gboolean (*format_member)(gchar *member_name, gpointer member, GString *result);
+
+typedef struct
+{
+  gchar *member_name;
+  format_member format;
+  size_t offset;
+} formatter_map_t;
+
+static gboolean
+_getent_format_array(gchar *member_name, gpointer member, GString *result)
+{
+  int i = 0;
+  char *o = *(char **)member;
+  char *p = *(char **)o;
+  char *sep = "";
+
+  do
+    {
+      g_string_append(result, sep);
+      g_string_append(result, p);
+      sep = ",";
+      p = *((char **)o + ++i);
+    }
+  while (p != NULL && p != '\0');
+
+  return TRUE;
+}
+
+static gboolean
+_getent_format_string(gchar *member_name, gpointer member, GString *result)
+{
+  char *value = *(char **)member;
+
+  g_string_append(result, value);
+  return TRUE;
+}
+
+static gboolean
+_getent_format_uid_gid(gchar *member_name, gpointer member, GString *result)
+{
+  if (strcmp(member_name, "uid") == 0)
+    {
+      uid_t u = *(uid_t *)member;
+
+      g_string_append_printf(result, "%" G_GUINT64_FORMAT, (guint64)u);
+    }
+  else
+    {
+      gid_t g = *(gid_t *)member;
+
+      g_string_append_printf(result, "%" G_GUINT64_FORMAT, (guint64)g);
+    }
+
+  return TRUE;
+}
+
+static int
+_find_formatter(formatter_map_t *map, gchar *member_name)
+{
+  gint i = 0;
+
+  while (map[i].member_name != NULL)
+    {
+      if (strcmp(map[i].member_name, member_name) == 0)
+        return i;
+      i++;
+    }
+
+  return -1;
+}
+
+#include "getent-protocols.c"
+#include "getent-services.c"
+#include "getent-group.c"
+#include "getent-passwd.c"
+
+static struct
+{
+  gchar *entity;
+  lookup_method lookup;
+} tf_getent_lookup_map[] =  {
+  { "group", tf_getent_group },
+  { "passwd", tf_getent_passwd },
+  { "services", tf_getent_services },
+  { "protocols", tf_getent_protocols },
+  { NULL, NULL }
+};
+
+static lookup_method
+tf_getent_find_lookup_method(gchar *entity)
+{
+  gint i = 0;
+
+  while (tf_getent_lookup_map[i].entity != NULL)
+    {
+      if (strcmp(tf_getent_lookup_map[i].entity, entity) == 0)
+        return tf_getent_lookup_map[i].lookup;
+      i++;
+    }
+  return NULL;
+}
+
+static gboolean
+tf_getent(LogMessage *msg, gint argc, GString *argv[], GString *result)
+{
+  lookup_method lookup;
+
+  if (argc != 2 && argc != 3)
+    {
+      msg_error("$(getent) takes either two or three arguments",
+                evt_tag_int("argc", argc),
+                NULL);
+      return FALSE;
+    }
+
+  lookup = tf_getent_find_lookup_method(argv[0]->str);
+  if (!lookup)
+    {
+      msg_error("Unsupported $(getent) NSS service",
+                evt_tag_str("service", argv[0]->str),
+                NULL);
+      return FALSE;
+    }
+
+  return lookup(argv[1]->str, (argc == 2) ? NULL : argv[2]->str, result);
+}
+TEMPLATE_FUNCTION_SIMPLE(tf_getent);
+
+static Plugin getent_plugins[] =
+{
+  TEMPLATE_FUNCTION_PLUGIN(tf_getent, "getent"),
+};
+
+gboolean
+getent_plugin_module_init(GlobalConfig *cfg, CfgArgs *args)
+{
+  plugin_register(cfg, getent_plugins, G_N_ELEMENTS(getent_plugins));
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "getent-plugin",
+  .version = SYSLOG_NG_VERSION,
+  .description = "The getent module provides getent template functions for syslog-ng.",
+  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .plugins = getent_plugins,
+  .plugins_len = G_N_ELEMENTS(getent_plugins),
+};

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -119,7 +119,8 @@ static struct
 {
   gchar *entity;
   lookup_method lookup;
-} tf_getent_lookup_map[] =  {
+} tf_getent_lookup_map[] =
+{
   { "group", tf_getent_group },
   { "passwd", tf_getent_passwd },
   { "services", tf_getent_services },

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -53,7 +53,7 @@ dev-utils/plugin_skeleton_creator/create_plugin.sh
 tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
-modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|system-source|[^/]*$)
+modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|[^/]*$)
 modules/add-contextual-data
 scl
 scripts


### PR DESCRIPTION
This module adds $(getent) that allows one to look up various NSS based
databases, such as passwd, services or protocols.

A few examples:

  $(getent passwd $UID)
  $(getent passwd $UID gecos)

Supported databases and members:
  - passwd: name, uid, gid, gecos, dir, shell
  - group: name, gid, members
  - services: none
  - protocols: none

Original implementation was created by:
Gergely Nagy <algernon@madhouse-project.org>
Fabien Wernli <cpan@faxm0dem.org

Their original signed-off-by is reproduced here for clarity, their patches
were ported as a single commit by Balazs Scheidler <balazs.scheidler@balabit.com>.

Signed-off-by: Gergely Nagy <algernon@madhouse-project.org>
Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>

@faxm0dem Please, send a signed-off-by on this branch in order to get it integrated. Thanks.

