### PR TITLE
Add support for IP_FREEBIND

### DIFF
--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -139,6 +139,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_IP_TTL
 %token KW_SO_BROADCAST
 %token KW_IP_TOS
+%token KW_IP_FREEBIND
 %token KW_SO_SNDBUF
 %token KW_SO_RCVBUF
 %token KW_SO_KEEPALIVE
@@ -730,6 +731,7 @@ inet_socket_option
 	: socket_option
 	| KW_IP_TTL '(' LL_NUMBER ')'               { ((SocketOptionsInet *) last_sock_options)->ip_ttl = $3; }
 	| KW_IP_TOS '(' LL_NUMBER ')'               { ((SocketOptionsInet *) last_sock_options)->ip_tos = $3; }
+	| KW_IP_FREEBIND '(' yesno ')'              { ((SocketOptionsInet *) last_sock_options)->ip_freebind = $3; }
 	| KW_TCP_KEEPALIVE_TIME '(' LL_NUMBER ')'   { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_time = $3; }
 	| KW_TCP_KEEPALIVE_INTVL '(' LL_NUMBER ')'  { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_intvl = $3; }
 	| KW_TCP_KEEPALIVE_PROBES '(' LL_NUMBER ')' { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_probes = $3; }

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -61,6 +61,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "destport",           KW_DESTPORT },
   { "ip_ttl",             KW_IP_TTL },
   { "ip_tos",             KW_IP_TOS },
+  { "ip_freebind",        KW_IP_FREEBIND },
   { "so_broadcast",       KW_SO_BROADCAST },
   { "so_rcvbuf",          KW_SO_RCVBUF },
   { "so_sndbuf",          KW_SO_SNDBUF },

--- a/modules/afsocket/socket-options-inet.c
+++ b/modules/afsocket/socket-options-inet.c
@@ -44,6 +44,7 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
 {
   SocketOptionsInet *self = (SocketOptionsInet *) s;
   gint off = 0;
+  gint on = 1;
 
   if (!socket_options_setup_socket_method(s, fd, addr, dir))
     return FALSE;
@@ -107,6 +108,15 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
       if (self->ip_tos && (dir & AFSOCKET_DIR_SEND))
         setsockopt(fd, SOL_IP, IP_TOS, &self->ip_tos, sizeof(self->ip_tos));
 
+      if (self->ip_freebind && (dir & AFSOCKET_DIR_RECV))
+        {
+#ifdef IP_FREEBIND
+          setsockopt(sock, SOL_IP, IP_FREEBIND, &on, sizeof(on));
+#else
+          msg_error("ip-freebind() is set but no IP_FREEBIND setsockopt on this platform");
+          return FALSE;
+#endif
+        }
       break;
     }
 #if SYSLOG_NG_ENABLE_IPV6
@@ -134,6 +144,16 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
         {
           if (self->ip_ttl && (dir & AFSOCKET_DIR_SEND))
             setsockopt(fd, SOL_IPV6, IPV6_UNICAST_HOPS, &self->ip_ttl, sizeof(self->ip_ttl));
+        }
+      
+      if (self->ip_freebind && (dir & AFSOCKET_DIR_RECV))
+        {
+#ifdef IP_FREEBIND
+          setsockopt(sock, SOL_IPV6, IP_FREEBIND, &on, sizeof(on));
+#else
+          msg_error("ip-freebind() is set but no IP_FREEBIND setsockopt on this platform");
+          return FALSE;
+#endif
         }
       break;
     }

--- a/modules/afsocket/socket-options-inet.h
+++ b/modules/afsocket/socket-options-inet.h
@@ -31,6 +31,7 @@ typedef struct _SocketOptionsInet
   /* user settings */
   gint ip_ttl;
   gint ip_tos;
+  gboolean ip_freebind;
   gint tcp_keepalive_time;
   gint tcp_keepalive_intvl;
   gint tcp_keepalive_probes;

--- a/modules/afsocket/transport-mapper.c
+++ b/modules/afsocket/transport-mapper.c
@@ -68,6 +68,9 @@ transport_mapper_open_socket(TransportMapper *self,
   g_fd_set_nonblock(sock, TRUE);
   g_fd_set_cloexec(sock, TRUE);
 
+  if (!socket_options_setup_socket(socket_options, sock, bind_addr, dir))
+    goto error_close;
+
   if (!transport_mapper_privileged_bind(sock, bind_addr))
     {
       gchar buf[256];
@@ -77,9 +80,6 @@ transport_mapper_open_socket(TransportMapper *self,
                 evt_tag_errno(EVT_TAG_OSERROR, errno));
       goto error_close;
     }
-
-  if (!socket_options_setup_socket(socket_options, sock, bind_addr, dir))
-    goto error_close;
 
   *fd = sock;
   return TRUE;


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/1298

Adds support for binding to non-local addresses on network sources via a new configuration entry:
   source x { network(ip(10.0.0.2) port(1999) ip-freebind(yes)); };

Signed-off-by: Jason Hensley <jhensley@subfx.net>