### PR TITLE
PythonModule: Handle deletion of _syslogng module

### DIFF
--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -117,7 +117,7 @@ python_fetch_debugger_command(void)
 
       msg_error("Error calling debugger fetch_command",
                 evt_tag_str("function", DEBUGGER_FETCH_COMMAND),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       goto exit;
     }
   if (!PyBytes_Check(ret))

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -162,7 +162,7 @@ _py_invoke_function(PythonDestDriver *self, PyObject *func, PyObject *arg)
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("script", self->class),
                 evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
-                evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf2, sizeof(buf2))));
       return NULL;
     }
   return ret;
@@ -216,7 +216,7 @@ _py_get_method(PythonDestDriver *self, PyObject *o, const gchar *method_name)
       msg_error("Missing Python method in the driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("method", method_name),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return NULL;
     }
   return method;
@@ -304,7 +304,7 @@ _py_init_bindings(PythonDestDriver *self)
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return FALSE;
     }
 
@@ -316,7 +316,7 @@ _py_init_bindings(PythonDestDriver *self)
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return FALSE;
     }
 

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -62,10 +62,13 @@ start
           LL_BLOCK
           { cfg_lexer_pop_context(lexer); }
           {
-	    python_evaluate_global_code(configuration, $4);
+            gboolean result;
+
+	    result = python_evaluate_global_code(configuration, $4);
 	    free($4);
-	    *instance = (void *) 1;
-	    YYACCEPT;
+            CHECK_ERROR(result, @1, "Error processing global python block");
+            *instance = (void *) 1;
+            YYACCEPT;
           }
         ;
 

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -43,7 +43,7 @@ _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
 }
 
 const gchar *
-_py_format_exception_text(gchar *buf, gsize buf_len)
+_py_fetch_and_format_exception_text(gchar *buf, gsize buf_len)
 {
   PyObject *exc, *value, *tb, *str;
 
@@ -109,7 +109,7 @@ _py_do_import(const gchar *modname)
 
       msg_error("Error loading Python module",
                 evt_tag_str("module", modname),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return NULL;
     }
   return modobj;

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -27,7 +27,7 @@
 #include "python-module.h"
 
 const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
-const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
+const gchar *_py_fetch_and_format_exception_text(gchar *buf, gsize buf_len);
 PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
 PyObject *_py_do_import(const gchar *modname);
 PyObject *_py_resolve_qualified_name(const gchar *name);

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -53,7 +53,8 @@ _py_construct_main_module(void)
   PyObject *modules = PyImport_GetModuleDict();
 
   /* make sure the module registry doesn't contain our module */
-  PyDict_DelItemString(modules, "_syslogng");
+  if (PyDict_Contains(modules, PyBytes_FromString("_syslogng")))
+    PyDict_DelItemString(modules, "_syslogng");
 
   /* create a new module */
   module = PyImport_AddModule("_syslogng");

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -53,11 +53,19 @@ _py_construct_main_module(void)
   PyObject *modules = PyImport_GetModuleDict();
 
   /* make sure the module registry doesn't contain our module */
-  if (PyDict_Contains(modules, PyBytes_FromString("_syslogng")))
-    PyDict_DelItemString(modules, "_syslogng");
+  if (PyDict_DelItemString(modules, "_syslogng") < 0)
+    PyErr_Clear();
 
   /* create a new module */
   module = PyImport_AddModule("_syslogng");
+  if (!module)
+    {
+      gchar buf[256];
+
+      msg_error("Error creating syslog-ng main module",
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
+      return NULL;
+    }
 
   /* make sure __builtins__ is there, it is normally automatically done for
    * __main__ and any imported modules */
@@ -123,6 +131,9 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *code)
   PyObject *dict;
 
   module = _py_get_main_module(pc);
+  if (!module)
+    return FALSE;
+
   dict = PyModule_GetDict(module);
   result = PyRun_String(code, Py_file_input, dict, dict);
 
@@ -131,7 +142,7 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *code)
       gchar buf[256];
 
       msg_error("Error evaluating global Python block",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return FALSE;
     }
   Py_XDECREF(result);

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -55,7 +55,7 @@ _py_invoke_template_function(const gchar *function_name, LogMessage *msg, gint a
     {
       msg_error("$(python): Error looking up Python function",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return NULL;
     }
 
@@ -68,7 +68,7 @@ _py_invoke_template_function(const gchar *function_name, LogMessage *msg, gint a
     {
       msg_error("$(python): Error invoking Python function",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", _py_fetch_and_format_exception_text(buf, sizeof(buf))));
       return NULL;
     }
   return ret;


### PR DESCRIPTION
  * We should only delete if the "_syslogng" module
exists
  * Without this patch syslog-ng crashes at start
in the following conditions:
    * OS: Ubuntu 16.04
    * config contains: python{};

Signed-off-by: Andras <andras.mitzki@balabit.com>