### PR TITLE
Avoid openssl 1.1.0 deprecated APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -876,6 +876,7 @@ AC_CHECK_DECLS([SSL_CTX_get0_param],[], [], [[#include <openssl/ssl.h>]])
 AC_CHECK_DECLS([X509_STORE_CTX_get0_cert],[], [], [[#include <openssl/ssl.h>]])
 AC_CHECK_DECLS([X509_get_extension_flags], [], [], [[#include <openssl/x509v3.h>]])
 AC_CHECK_DECLS([EVP_MD_CTX_reset], [], [], [[#include <openssl/evp.h>]])
+AC_CHECK_DECLS([ASN1_STRING_get0_data], [], [], [[#include <openssl/asn1.h>]])
 
 dnl
 dnl Right now, openssl is never linked statically as it is only used by the

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -49,5 +49,9 @@ uint32_t X509_get_extension_flags(X509 *x);
 #define EVP_MD_CTX_destroy(md_ctx) EVP_MD_CTX_cleanup(md_ctx) 
 #endif
 
+#if !SYSLOG_NG_HAVE_DECL_ASN1_STRING_GET0_DATA
+#define ASN1_STRING_get0_data ASN1_STRING_data
+#endif
+
 #endif
 

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -584,7 +584,7 @@ tls_verify_certificate_name(X509 *cert, const gchar *host_name)
               gen_name = sk_GENERAL_NAME_value(alt_names, i);
               if (gen_name->type == GEN_DNS)
                 {
-                  guchar *dnsname = ASN1_STRING_data(gen_name->d.dNSName);
+                  const guchar *dnsname = ASN1_STRING_get0_data(gen_name->d.dNSName);
                   guint dnsname_len = ASN1_STRING_length(gen_name->d.dNSName);
 
                   if (dnsname_len > sizeof(pattern_buf) - 1)


### PR DESCRIPTION
When openssl is built with `--api=1.1 disable-deprecated`, use of deprecated
APIs results in build failure.

- Don't call initialization functions, they are handled internally in openssl
- Replace ASN1_STRING_data with const version ASN1_STRING_get0_data when
  available

X-Gentoo-Bug: 604882
X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=604882

---

This was tested with openssl 1.1.0c on Gentoo. The rabbitmq and mongodb modules
will still fail.