### PR TITLE
F/elastic http load balancing

### DIFF
--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -28,6 +28,7 @@ package org.syslog_ng.elasticsearch_v2;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.syslog_ng.LogDestination;
 import org.syslog_ng.options.*;
@@ -147,17 +148,21 @@ public class ElasticSearchOptions {
                 return options.get(SKIP_CLUSTER_HEALTH_CHECK).getValueAsBoolean();
         }
 
-	public String getClusterUrl() {
-		String cluster_url = options.get(CLUSTER_URL).getValue();
-		if (cluster_url.isEmpty()) {
-			StringBuilder url = new StringBuilder();
-			url.append("http://");
-			url.append(getServerList()[0]);
-			url.append(":");
-			url.append(getPort());
-			cluster_url = url.toString();
+	public Set<String> getClusterUrl() {
+		String[] cluster_url = options.get(CLUSTER_URL).getValueAsStringList(" ");
+		if (cluster_url[0].isEmpty()) {
+			String[] server_list = getServerList();
+			cluster_url = new String[server_list.length];
+			for (int i = 0; i < server_list.length; i++) {
+				StringBuilder url = new StringBuilder();
+				url.append("http://");
+				url.append(server_list[i]);
+				url.append(":");
+				url.append(getPort());
+				cluster_url[i] = url.toString();
+			}
 		}
-		return cluster_url;
+		return new HashSet<String>(Arrays.asList(cluster_url));
 	}
 
 

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -148,7 +148,7 @@ public class ElasticSearchOptions {
                 return options.get(SKIP_CLUSTER_HEALTH_CHECK).getValueAsBoolean();
         }
 
-	public Set<String> getClusterUrl() {
+	public Set<String> getClusterUrls() {
 		String[] cluster_url = options.get(CLUSTER_URL).getValueAsStringList(" ");
 		if (cluster_url[0].isEmpty()) {
 			String[] server_list = getServerList();

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -35,6 +35,7 @@ import org.syslog_ng.elasticsearch_v2.client.ESClient;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessorFactory;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.http.HttpMessageProcessor;
+import java.util.Set;
 
 import java.io.IOException;
 
@@ -51,11 +52,11 @@ public class ESHttpClient implements ESClient {
 	}
 
 	private JestClient createClient() {
-		String connectionUrl = options.getClusterUrl();
+		Set<String> connectionUrl = options.getClusterUrl();
 		JestClientFactory clientFactory = new JestClientFactory();
 		clientFactory.setHttpClientConfig(new HttpClientConfig
 				.Builder(connectionUrl)
-				.multiThreaded(false)
+				.multiThreaded(true)
 				.build());
 		return clientFactory.getObject();
 	}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -52,10 +52,10 @@ public class ESHttpClient implements ESClient {
 	}
 
 	private JestClient createClient() {
-		Set<String> connectionUrl = options.getClusterUrl();
+		Set<String> connectionUrls = options.getClusterUrls();
 		JestClientFactory clientFactory = new JestClientFactory();
 		clientFactory.setHttpClientConfig(new HttpClientConfig
-				.Builder(connectionUrl)
+				.Builder(connectionUrls)
 				.multiThreaded(true)
 				.build());
 		return clientFactory.getObject();

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpSingleMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpSingleMessageProcessor.java
@@ -25,6 +25,7 @@
 package org.syslog_ng.elasticsearch_v2.messageprocessor.http;
 
 import io.searchbox.core.Index;
+import io.searchbox.client.JestResult;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.http.ESHttpClient;
 
@@ -39,12 +40,17 @@ public class HttpSingleMessageProcessor extends  HttpMessageProcessor {
 	@Override
 	public boolean send(Index req) {
 		boolean result = true;
+	  JestResult jestResult = null;
 		try {
-			client.getClient().execute(req);
+			jestResult = client.getClient().execute(req);
 		}
 		catch (IOException e)
 		{
 			logger.error(e.getMessage());
+			result = false;
+		}
+		if (! jestResult.isSucceeded()) {
+			logger.error(jestResult.getErrorMessage());
 			result = false;
 		}
 		return result;


### PR DESCRIPTION
This allows to specify multiple cluster URLs so jest will supposedly load-balance across nodes:

```
destination d_elasticsearch {
  elasticsearch2(
    client-lib-dir("/usr/share/elasticsearch/lib/")
    index("syslog-${YEAR}.${MONTH}.${DAY}")
    type("syslog")
    time-zone("UTC")
    client_mode("http")
    cluster_url("http://node01:9200 http://node02:9200")
  );
};
```

If `cluster_url` is omitted, we leverage `server` option to connect to those using url list:

```
destination d_elasticsearch {
  elasticsearch2(
    client-lib-dir("/usr/share/elasticsearch/lib/")
    index("syslog-${YEAR}.${MONTH}.${DAY}")
    type("syslog")
    time-zone("UTC")
    client_mode("http")
    server("node01 node02")
    port(9200)
  );
};
```