### PR TITLE
logproto: fix possible reading loop in case of multi-line file source

### DIFF
--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -169,8 +169,13 @@ log_proto_server_options_init(LogProtoServerOptions *options, GlobalConfig *cfg)
     {
       if (options->encoding)
         {
-          /* maximum number of bytes needed to represent an utf8 character is 6 */
-          options->max_buffer_size = 6 * options->max_msg_size;
+          /* Based on the implementation of LogProtoTextServer, the buffer is yielded as
+             a complete message when max_msg_size is reached and there is no EOM in the buffer.
+             In worst case, the buffer contains max_msg_size - 1 bytes before the next fetch,
+             which can be 6 times max_msg_size due to the utf8 conversion.
+             And additional space is required because of the possible leftover bytes.
+          */
+          options->max_buffer_size = 8 * options->max_msg_size;
         }
       else
         options->max_buffer_size = options->max_msg_size;

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -398,7 +398,18 @@ log_proto_text_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar 
   else
     {
       if (!log_proto_text_server_extract(self, state, buffer_start, buffer_bytes, eol, msg, msg_len))
-        goto exit;
+        {
+          if (buffer_bytes == state->buffer_size)
+            {
+              log_proto_text_server_yield_whole_buffer_as_message(self, state, buffer_start, buffer_bytes, msg, msg_len);
+              goto success;
+            }
+          else
+            {
+              log_proto_text_server_split_buffer(self, state, buffer_start, buffer_bytes);
+              goto exit;
+            }
+        }
     }
 
 success:

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -117,6 +117,17 @@ log_proto_text_server_prepare(LogProtoServer *s, GIOCondition *cond)
   return avail;
 }
 
+static void
+log_proto_test_server_maybe_realloc_reverse_buffer(LogProtoTextServer *self, gsize buffer_length)
+{
+  if (self->reverse_buffer_len >= buffer_length)
+    return;
+
+  /* we free and malloc, since we never need the data still in reverse buffer */
+  g_free(self->reverse_buffer);
+  self->reverse_buffer_len = buffer_length;
+  self->reverse_buffer = g_malloc(buffer_length);
+}
 
 /*
  * returns the number of bytes that represent the UTF8 encoding buffer
@@ -153,13 +164,9 @@ log_proto_text_server_get_raw_size_of_buffer(LogProtoTextServer *self, const guc
   if (self->convert_scale)
     return g_utf8_strlen((gchar *) buffer, buffer_len) * self->convert_scale;
 
-  if (self->reverse_buffer_len < buffer_len * 6)
-    {
-      /* we free and malloc, since we never need the data still in reverse buffer */
-      g_free(self->reverse_buffer);
-      self->reverse_buffer_len = buffer_len * 6;
-      self->reverse_buffer = g_malloc(buffer_len * 6);
-    }
+
+  /* Multiplied by 6, because 1 character can be maximum 6 bytes in UTF-8 encoding */
+  log_proto_test_server_maybe_realloc_reverse_buffer(self, buffer_len * 6);
 
   avail_out = self->reverse_buffer_len;
   out = self->reverse_buffer;
@@ -368,7 +375,6 @@ log_proto_text_server_message_size_too_large(LogProtoTextServer *self, gsize buf
 {
   return buffer_bytes >= self->super.super.options->max_msg_size;
 }
-
 
 /**
  * log_proto_text_server_fetch_from_buffer:


### PR DESCRIPTION
Using multi-line file sources, EOL is not equivalent with EOM therefore two additional cases should be handled:

- the buffer should be split when log_proto_text_server_extract() can not extract the message from the current buffer.
- if the buffer is full with a single message, the buffer should be yielded as a complete message



Previously, the meaning of the log-msg-size() option was not clearly defined when encoding was set.

In multi-line mode, the buffer size increased without limit to the maximum size due to our conversion mechanism.

This PR also defines the meaning of the log-msg-size() option if conversion is enabled:

If the size of incoming message is greater than log-msg-size() (in the internal UTF-8 representation), it will be splitted.

Fixes #1318