### PR TITLE
syslog-ng as a command line tool

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,6 +57,7 @@ set (LIB_HEADERS
     cfg-parser.h
     cfg-tree.h
     children.h
+    cli.h
     crypto.h
     dnscache.h
     driver.h
@@ -143,6 +144,7 @@ set(LIB_SOURCES
     cfg-parser.c
     cfg-tree.c
     children.c
+    cli.c
     dnscache.c
     driver.c
     fdhelpers.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -90,6 +90,7 @@ pkginclude_HEADERS			+= \
 	lib/cfg-parser.h		\
 	lib/cfg-tree.h			\
 	lib/children.h			\
+	lib/cli.h				\
 	lib/crypto.h			\
 	lib/dnscache.h			\
 	lib/driver.h			\
@@ -172,6 +173,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/cfg-parser.c		\
 	lib/cfg-tree.c			\
 	lib/children.c			\
+	lib/cli.c				\
 	lib/dnscache.c			\
 	lib/driver.c			\
 	lib/fdhelpers.c			\

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -65,6 +65,7 @@ struct _GlobalConfig
    * multiple times if the user uses @version multiple times */
   gint parsed_version;
   const gchar *filename;
+  FILE *cfg_file;
   GList *plugins;
   GList *candidate_plugins;
   gboolean autoload_compiled_modules;
@@ -127,13 +128,15 @@ gint cfg_tz_convert_value(gchar *convert);
 gint cfg_ts_format_value(gchar *format);
 
 void cfg_set_version(GlobalConfig *self, gint version);
+void cfg_set_config_file(GlobalConfig *self, FILE *cfg_file);
 void cfg_load_candidate_modules(GlobalConfig *self);
 
 void cfg_set_global_paths(GlobalConfig *self);
 
 GlobalConfig *cfg_new(gint version);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
-gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gboolean syntax_only, gchar *preprocess_into);
+gboolean cfg_open_config(GlobalConfig *cfg, const gchar *fname);
+gboolean cfg_read_config(GlobalConfig *cfg, gboolean syntax_only, gchar *preprocess_into);
 gboolean cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, gchar *preprocess_into);
 void cfg_free(GlobalConfig *self);
 gboolean cfg_init(GlobalConfig *cfg);

--- a/lib/cli.c
+++ b/lib/cli.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2016-2017 Noémi Ványi
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+
+#include "cli.h"
+#include "messages.h"
+#include "uuid.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static const char DELIMITER[] = " ";
+static const char LOG_PATH_TEMPLATE[] = "%s(%s);";
+static const char DRIVER_TEMPLATE[] = "%s %s { %s};\n";
+static const char DRIVER_NAME_TEMPLATE[] = "%s%s";
+static const char CFG_FILE_TEMPLATE[] =
+  "@version: %s\n"
+  "@include scl.conf\n"
+  "source s_stdin { stdin(); };\n"
+  "destination d_stdout { stdout(); };\n"
+  "%s"
+  "log {source(s_stdin);%s destination(d_stdout);};";
+
+
+static gchar *
+_generate_name(gchar *driver_type)
+{
+  gchar driver_uuid[37];
+
+  uuid_gen_random(driver_uuid, sizeof(driver_uuid));
+
+  return g_strdup_printf(DRIVER_NAME_TEMPLATE, driver_type, driver_uuid);
+}
+
+CliParam *
+cli_param_new(gchar *type, gchar *cfg)
+{
+  CliParam *self = g_new0(CliParam, 1);
+  self->type = type;
+  self->cfg = cfg;
+  self->name = _generate_name(type);
+  return self;
+}
+
+static gchar *
+_get_config_of_driver(CliParam *driver)
+{
+  return g_strdup_printf(DRIVER_TEMPLATE, driver->type, driver->name, driver->cfg);
+}
+
+static gchar *
+_get_logpath_of_driver(CliParam *driver)
+{
+  return g_strdup_printf(LOG_PATH_TEMPLATE, driver->type, driver->name);
+}
+
+static gchar *
+_concatenate_strings(GList *elements)
+{
+  GList *element;
+  gchar *concatenated = "";
+
+  for (element = elements; element != NULL; element = element->next)
+    concatenated = g_strconcat(concatenated, " ", element->data, NULL);
+
+  return concatenated;
+}
+
+static gchar *
+_get_config_lines_of_generated_snippets(GList *driver_configs, GList *log_paths)
+{
+  gchar *drivers_line, *log_paths_line;
+
+  drivers_line = _concatenate_strings(driver_configs);
+  log_paths_line = _concatenate_strings(log_paths);
+
+  return g_strdup_printf(CFG_FILE_TEMPLATE, SYSLOG_NG_VERSION, drivers_line, log_paths_line);
+}
+
+void
+cli_param_converter_convert(CliParamConverter *self)
+{
+  GList *current_param;
+  GList *driver_configs = NULL;
+  GList *logpaths = NULL;
+
+  for (current_param = self->params; current_param != NULL; current_param = current_param->next)
+    {
+      CliParam *cli_param = (CliParam *) current_param->data;
+      gchar *driver_config = _get_config_of_driver(cli_param);
+      gchar *driver_logpath = _get_logpath_of_driver(cli_param);
+
+      driver_configs = g_list_append(driver_configs, driver_config);
+      logpaths = g_list_append(logpaths, driver_logpath);
+    }
+  self->generated_config = _get_config_lines_of_generated_snippets(driver_configs, logpaths);
+}
+
+static inline gboolean
+_more_tokens(gchar *token)
+{
+  return (token != NULL);
+}
+
+static inline gboolean
+_is_driver_type_empty(gchar *driver_type)
+{
+  if (driver_type == NULL)
+    return TRUE;
+  return FALSE;
+}
+
+static void
+_parse_driver_data(gchar *token, gchar **driver_type, gchar **driver_config)
+{
+  if (_is_driver_type_empty(*driver_type))
+    *driver_type = token;
+  else
+    *driver_config = g_strconcat(*driver_config, token, NULL);
+}
+
+static inline gboolean
+_is_driver_ending(gchar *token)
+{
+  size_t token_length = strlen(token);
+  return (token[token_length - 1] == ';');
+}
+
+static inline gboolean
+_is_driver_config_empty(gchar *driver_config)
+{
+  if (driver_config[0] == '\0')
+    return TRUE;
+  return FALSE;
+}
+
+static inline gboolean
+_is_driver_data_incomplete(gchar *driver_type, gchar *driver_config)
+{
+  if (_is_driver_type_empty(driver_type) || _is_driver_config_empty(driver_config))
+    return TRUE;
+  return FALSE;
+}
+
+static void
+_add_new_cli_param(CliParamConverter *self, gchar *driver_type, gchar *driver_config)
+{
+  self->params = g_list_append(self->params, cli_param_new(driver_type, g_strdup(driver_config)));
+  driver_type = NULL;
+  driver_config = "";
+}
+
+static gboolean
+_parse_raw_parameter(CliParamConverter *self, gchar *raw_param)
+{
+  gchar *token;
+  gchar *driver_config = "";
+  gchar *driver_type = NULL;
+
+  if (!_is_driver_ending(raw_param))
+    return FALSE;
+
+  token = strtok(raw_param, DELIMITER);
+  while (_more_tokens(token))
+    {
+      _parse_driver_data(token, &driver_type, &driver_config);
+
+      if (_is_driver_ending(token) && _is_driver_data_incomplete(driver_type, driver_config))
+        return FALSE;
+
+      if (_is_driver_ending(token))
+        _add_new_cli_param(self, driver_type, driver_config);
+
+      token = strtok(NULL, DELIMITER);
+    }
+
+  return TRUE;
+}
+
+gboolean
+cli_param_converter_setup(CliParamConverter *self)
+{
+  guint i;
+
+  for (i = 0; self->raw_params[i]; i++)
+    {
+      gchar *raw_param = g_strdup(self->raw_params[i]);
+
+      if (!_parse_raw_parameter(self, raw_param))
+        return FALSE;
+    }
+  return TRUE;
+}
+
+CliParamConverter *
+cli_param_converter_new(gchar **args)
+{
+  CliParamConverter *self = g_new0(CliParamConverter, 1);
+  self->raw_params = args;
+  self->params = NULL;
+  self->generated_config = NULL;
+  return self;
+}

--- a/lib/cli.h
+++ b/lib/cli.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2017 Noémi Ványi
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef CLI_H_INCLUDED
+#define CLI_H_INCLUDED
+
+#include <glib.h>
+
+typedef struct _CliParam
+{
+  gchar *name;
+  gchar *cfg;
+  gchar *type;
+} CliParam;
+
+CliParam *cli_param_new(gchar *type, gchar *cfg);
+
+typedef struct _CliParamConverter
+{
+  gchar **raw_params;
+  GList *params;
+  gchar *generated_config;
+} CliParamConverter;
+
+CliParamConverter *cli_param_converter_new(gchar **params);
+gboolean cli_param_converter_setup(CliParamConverter *self);
+void cli_param_converter_convert(CliParamConverter *self);
+
+#endif

--- a/lib/cli.h
+++ b/lib/cli.h
@@ -28,7 +28,6 @@
 
 typedef struct _CliParam
 {
-  gchar *name;
   gchar *cfg;
   gchar *type;
 } CliParam;
@@ -38,11 +37,12 @@ CliParam *cli_param_new(gchar *type, gchar *cfg);
 typedef struct _CliParamConverter
 {
   gchar **raw_params;
+  gchar *destination_params;
   GList *params;
   gchar *generated_config;
 } CliParamConverter;
 
-CliParamConverter *cli_param_converter_new(gchar **params);
+CliParamConverter *cli_param_converter_new(gchar **params, gchar *destination_params);
 gboolean cli_param_converter_setup(CliParamConverter *self);
 void cli_param_converter_convert(CliParamConverter *self);
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -39,6 +39,7 @@
 #define NC_FILE_EOF    5
 #define NC_FILE_SKIP   6
 #define NC_REOPEN_REQUIRED 7
+#define NC_STDIN_EOF   8
 
 /* indicates that the LogPipe was initialized */
 #define PIF_INITIALIZED       0x0001

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -458,7 +458,7 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
 static int
 _setup_cli_mode(MainLoopOptions *options, GlobalConfig *current_configuration)
 {
-  CliParamConverter *converter = cli_param_converter_new(options->cli_var);
+  CliParamConverter *converter = cli_param_converter_new(options->cli_var, options->cli_destination_options);
 
   if (!cli_param_converter_setup(converter))
     return 2;

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -482,7 +482,7 @@ _prepare_configuration_for_reading(MainLoop *self)
     {
       return _setup_cli_mode(self->options, self->current_configuration);
     }
-  else if (!cfg_open_config(self->current_configuration, resolvedConfigurablePaths.cfgfilename))
+  if (!cfg_open_config(self->current_configuration, resolvedConfigurablePaths.cfgfilename))
     {
       return 1;
     }

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -274,7 +274,8 @@ main_loop_reload_config_initiate(gpointer user_data)
   self->old_config = self->current_configuration;
   app_pre_config_loaded();
   self->new_config = cfg_new(0);
-  if (!cfg_read_config(self->new_config, resolvedConfigurablePaths.cfgfilename, FALSE, NULL))
+  if (!cfg_open_config(self->new_config, resolvedConfigurablePaths.cfgfilename)
+      || !cfg_read_config(self->new_config, FALSE, NULL))
     {
       cfg_free(self->new_config);
       self->new_config = NULL;

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -34,6 +34,8 @@ typedef struct _MainLoopOptions
   gchar *preprocess_into;
   gboolean syntax_only;
   gboolean interactive_mode;
+  gboolean command_line_mode;
+  gchar **cli_var;
 } MainLoopOptions;
 
 extern ThreadId main_thread_handle;

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -35,6 +35,8 @@ typedef struct _MainLoopOptions
   gboolean syntax_only;
   gboolean interactive_mode;
   gboolean command_line_mode;
+
+  gchar *cli_destination_options;
   gchar **cli_var;
 } MainLoopOptions;
 

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -13,7 +13,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_pathutils	\
 	lib/tests/test_utf8utils	\
 	lib/tests/test_userdb		\
-	lib/tests/test_str-utils
+	lib/tests/test_str-utils	\
+	lib/tests/test_cli
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
@@ -93,6 +94,12 @@ lib_tests_test_str_utils_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_str_utils_LDADD	=	\
 	$(TEST_LDADD)
+
+lib_tests_test_cli_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_cli_LDADD	=	\
+	$(TEST_LDADD)
+
 
 CLEANFILES				+= \
 	test_values.persist		   \

--- a/lib/tests/test_cli.c
+++ b/lib/tests/test_cli.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2016-2017 Noémi Ványi
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "cfg.h"
+#include "cli.h"
+
+#include <criterion/criterion.h>
+
+
+Test(cli, test_cli_param_converter_setup)
+{
+  gchar **parser_raw_param;
+
+  parser_raw_param = (char *[])
+  { "parser csvparser()", NULL
+  };
+  CliParamConverter *converter = cli_param_converter_new(parser_raw_param);
+  cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver separator");
+
+  parser_raw_param = (char *[])
+  { "csvparser();", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver type");
+
+  parser_raw_param = (char *[])
+  { "parser;", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver config");
+
+  parser_raw_param = (char *[])
+  { "parser json-parser();", "parser json-parser()", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver separator in 2nd item");
+
+  parser_raw_param = (char *[])
+  { "parser csvparser();", "parser;", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver config in 2nd item");
+
+  parser_raw_param = (char *[])
+  { "parser csvparser();", "csvparser();", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver config in 2nd item");
+
+  parser_raw_param = (char *[])
+  { "parser csvparser();", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert(cli_param_converter_setup(converter), "Valid raw params: csvparser");
+  cr_assert(g_list_length(converter->params) == 1, "1 parsed driver: csvparser");
+
+  parser_raw_param = (char *[])
+  { "parser csvparser(columns(column));", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert(cli_param_converter_setup(converter), "Valid raw params: csvparser");
+  cr_assert(g_list_length(converter->params) == 1, "1 parsed driver: csvparser");
+
+  parser_raw_param = (char *[])
+  { "parser csvparser(columns(column)); parser json-parser();", NULL
+  };
+  converter = cli_param_converter_new(parser_raw_param);
+  cr_assert(cli_param_converter_setup(converter), "Valid raw params: csvparser, json-parser");
+  cr_assert(g_list_length(converter->params) == 2, "2 parsed driver: csvparser, json-parser");
+}
+
+Test(cli, test_cli_initialize_config_with_one_param)
+{
+  GList *params = NULL;
+  CliParam *cli_param = cli_param_new("parser", "csvparser();");
+  cli_param->name = "my-name";
+  params = g_list_append(params, cli_param);
+  CliParamConverter *converter = cli_param_converter_new(NULL);
+  converter->params = params;
+
+  gchar expected_cfg[200];
+  gchar *expected_cfg_template = "@version: %s\n"
+                                 "@include scl.conf\n"
+                                 "source s_stdin { stdin(); };\n"
+                                 "destination d_stdout { stdout(); };\n"
+                                 " parser my-name { csvparser();};\n"
+                                 "log {source(s_stdin); parser(my-name); destination(d_stdout);};";
+  g_snprintf(expected_cfg, sizeof(expected_cfg), expected_cfg_template, SYSLOG_NG_VERSION);
+
+  cli_param_converter_convert(converter);
+  cr_assert_eq(strcmp(converter->generated_config, expected_cfg), 0, "Generated: \n%s\nExpected:\n%s",
+               converter->generated_config,
+               expected_cfg);
+}
+
+Test(cli, test_cli_initialize_config_with_two_params_param)
+{
+  GList *params = NULL;
+  CliParam *cli_param = cli_param_new("parser", "csvparser();");
+  cli_param->name = "my-csvparser-name";
+  params = g_list_append(params, cli_param);
+  cli_param = cli_param_new("parser", "jsonparser();");
+  cli_param->name = "my-jsonparser-name";
+  params = g_list_append(params, cli_param);
+  CliParamConverter *converter = cli_param_converter_new(NULL);
+  converter->params = params;
+
+  gchar expected_cfg[300];
+  gchar *expected_cfg_template = "@version: %s\n"
+                                 "@include scl.conf\n"
+                                 "source s_stdin { stdin(); };\n"
+                                 "destination d_stdout { stdout(); };\n"
+                                 " parser my-csvparser-name { csvparser();};\n"
+                                 " parser my-jsonparser-name { jsonparser();};\n"
+                                 "log {source(s_stdin); parser(my-csvparser-name); parser(my-jsonparser-name); destination(d_stdout);};";
+  g_snprintf(expected_cfg, sizeof(expected_cfg), expected_cfg_template, SYSLOG_NG_VERSION);
+
+  cli_param_converter_convert(converter);
+  cr_assert_eq(strcmp(converter->generated_config, expected_cfg), 0, "Generated: \n%s\nExpected:\n%s",
+               converter->generated_config, expected_cfg);
+}

--- a/lib/tests/test_cli.c
+++ b/lib/tests/test_cli.c
@@ -32,57 +32,57 @@ Test(cli, test_cli_param_converter_setup)
   parser_raw_param = (char *[])
   { "parser csvparser()", NULL
   };
-  CliParamConverter *converter = cli_param_converter_new(parser_raw_param);
+  CliParamConverter *converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver separator");
 
   parser_raw_param = (char *[])
   { "csvparser();", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver type");
 
   parser_raw_param = (char *[])
   { "parser;", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver config");
 
   parser_raw_param = (char *[])
   { "parser json-parser();", "parser json-parser()", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver separator in 2nd item");
 
   parser_raw_param = (char *[])
   { "parser csvparser();", "parser;", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver config in 2nd item");
 
   parser_raw_param = (char *[])
   { "parser csvparser();", "csvparser();", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert_not(cli_param_converter_setup(converter), "Invalid raw params: missing driver config in 2nd item");
 
   parser_raw_param = (char *[])
   { "parser csvparser();", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert(cli_param_converter_setup(converter), "Valid raw params: csvparser");
   cr_assert(g_list_length(converter->params) == 1, "1 parsed driver: csvparser");
 
   parser_raw_param = (char *[])
   { "parser csvparser(columns(column));", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert(cli_param_converter_setup(converter), "Valid raw params: csvparser");
   cr_assert(g_list_length(converter->params) == 1, "1 parsed driver: csvparser");
 
   parser_raw_param = (char *[])
   { "parser csvparser(columns(column)); parser json-parser();", NULL
   };
-  converter = cli_param_converter_new(parser_raw_param);
+  converter = cli_param_converter_new(parser_raw_param, NULL);
   cr_assert(cli_param_converter_setup(converter), "Valid raw params: csvparser, json-parser");
   cr_assert(g_list_length(converter->params) == 2, "2 parsed driver: csvparser, json-parser");
 }
@@ -90,50 +90,57 @@ Test(cli, test_cli_param_converter_setup)
 Test(cli, test_cli_initialize_config_with_one_param)
 {
   GList *params = NULL;
-  CliParam *cli_param = cli_param_new("parser", "csvparser();");
-  cli_param->name = "my-name";
+  CliParam *cli_param = cli_param_new("parser", "csv-parser();");
   params = g_list_append(params, cli_param);
-  CliParamConverter *converter = cli_param_converter_new(NULL);
-  converter->params = params;
-
-  gchar expected_cfg[200];
-  gchar *expected_cfg_template = "@version: %s\n"
-                                 "@include scl.conf\n"
-                                 "source s_stdin { stdin(); };\n"
-                                 "destination d_stdout { stdout(); };\n"
-                                 " parser my-name { csvparser();};\n"
-                                 "log {source(s_stdin); parser(my-name); destination(d_stdout);};";
-  g_snprintf(expected_cfg, sizeof(expected_cfg), expected_cfg_template, SYSLOG_NG_VERSION);
-
-  cli_param_converter_convert(converter);
-  cr_assert_eq(strcmp(converter->generated_config, expected_cfg), 0, "Generated: \n%s\nExpected:\n%s",
-               converter->generated_config,
-               expected_cfg);
-}
-
-Test(cli, test_cli_initialize_config_with_two_params_param)
-{
-  GList *params = NULL;
-  CliParam *cli_param = cli_param_new("parser", "csvparser();");
-  cli_param->name = "my-csvparser-name";
-  params = g_list_append(params, cli_param);
-  cli_param = cli_param_new("parser", "jsonparser();");
-  cli_param->name = "my-jsonparser-name";
-  params = g_list_append(params, cli_param);
-  CliParamConverter *converter = cli_param_converter_new(NULL);
+  CliParamConverter *converter = cli_param_converter_new(NULL, NULL);
   converter->params = params;
 
   gchar expected_cfg[300];
   gchar *expected_cfg_template = "@version: %s\n"
                                  "@include scl.conf\n"
-                                 "source s_stdin { stdin(); };\n"
-                                 "destination d_stdout { stdout(); };\n"
-                                 " parser my-csvparser-name { csvparser();};\n"
-                                 " parser my-jsonparser-name { jsonparser();};\n"
-                                 "log {source(s_stdin); parser(my-csvparser-name); parser(my-jsonparser-name); destination(d_stdout);};";
+                                 "log {\n"
+                                 "    source {\n"
+                                 "        stdin();\n"
+                                 "    };\n"
+                                 "    parser {csv-parser();};\n"
+                                 "     destination {\n"
+                                 "        stdout();\n"
+                                 "    };\n"
+                                 "};";
   g_snprintf(expected_cfg, sizeof(expected_cfg), expected_cfg_template, SYSLOG_NG_VERSION);
 
   cli_param_converter_convert(converter);
-  cr_assert_eq(strcmp(converter->generated_config, expected_cfg), 0, "Generated: \n%s\nExpected:\n%s",
-               converter->generated_config, expected_cfg);
+  cr_assert_str_eq(converter->generated_config, expected_cfg, "Generated: \n%s\nExpected:\n%s",
+                   converter->generated_config,
+                   expected_cfg);
+}
+
+Test(cli, test_cli_initialize_config_with_two_params_param)
+{
+  GList *params = NULL;
+  CliParam *cli_param = cli_param_new("parser", "csv-parser();");
+  params = g_list_append(params, cli_param);
+  cli_param = cli_param_new("parser", "json-parser();");
+  params = g_list_append(params, cli_param);
+  CliParamConverter *converter = cli_param_converter_new(NULL, NULL);
+  converter->params = params;
+
+  gchar expected_cfg[400];
+  gchar *expected_cfg_template = "@version: %s\n"
+                                 "@include scl.conf\n"
+                                 "log {\n"
+                                 "    source {\n"
+                                 "        stdin();\n"
+                                 "    };\n"
+                                 "    parser {csv-parser();};\n"
+                                 " parser {json-parser();};\n"
+                                 "     destination {\n"
+                                 "        stdout();\n"
+                                 "    };\n"
+                                 "};";
+  g_snprintf(expected_cfg, sizeof(expected_cfg), expected_cfg_template, SYSLOG_NG_VERSION);
+
+  cli_param_converter_convert(converter);
+  cr_assert_str_eq(converter->generated_config, expected_cfg, "Generated: \n%s\nExpected:\n%s",
+                   converter->generated_config, expected_cfg);
 }

--- a/lib/transport/transport-file.h
+++ b/lib/transport/transport-file.h
@@ -37,4 +37,13 @@ struct _LogTransportFile
 void log_transport_file_init_instance(LogTransportFile *self, gint fd);
 LogTransport *log_transport_file_new(gint fd);
 
+typedef struct _LogTransportStdin LogTransportStdin;
+struct _LogTransportStdin
+{
+  LogTransport super;
+  LogPipe *control;
+};
+
+LogTransport *log_transport_stdin_new(gint fd, LogPipe *control);
+
 #endif

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -112,6 +112,14 @@ _open_fd(const gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_op
   return fd;
 }
 
+gboolean
+affile_is_linux_dev_stdin(const gchar *filename)
+{
+  if (strcmp(filename, "/dev/stdin") == 0)
+    return TRUE;
+  return FALSE;
+}
+
 static inline void
 _validate_file_type(const gchar *name, FileOpenOptions *open_opts)
 {
@@ -124,7 +132,7 @@ _validate_file_type(const gchar *name, FileOpenOptions *open_opts)
           msg_warning("WARNING: you are using the pipe driver, underlying file is not a FIFO, it should be used by file()",
                       evt_tag_str("filename", name));
         }
-      else if (!open_opts->is_pipe && S_ISFIFO(st.st_mode))
+      else if (!open_opts->is_pipe && S_ISFIFO(st.st_mode) && !affile_is_linux_dev_stdin(name))
         {
           msg_warning("WARNING: you are using the file driver, underlying file is a FIFO, it should be used by pipe()",
                       evt_tag_str("filename", name));

--- a/modules/affile/affile-common.c
+++ b/modules/affile/affile-common.c
@@ -113,7 +113,7 @@ _open_fd(const gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_op
 }
 
 gboolean
-affile_is_linux_dev_stdin(const gchar *filename)
+affile_is_dev_stdin(const gchar *filename)
 {
   if (strcmp(filename, "/dev/stdin") == 0)
     return TRUE;
@@ -132,7 +132,7 @@ _validate_file_type(const gchar *name, FileOpenOptions *open_opts)
           msg_warning("WARNING: you are using the pipe driver, underlying file is not a FIFO, it should be used by file()",
                       evt_tag_str("filename", name));
         }
-      else if (!open_opts->is_pipe && S_ISFIFO(st.st_mode) && !affile_is_linux_dev_stdin(name))
+      else if (!open_opts->is_pipe && S_ISFIFO(st.st_mode) && !affile_is_dev_stdin(name))
         {
           msg_warning("WARNING: you are using the file driver, underlying file is a FIFO, it should be used by pipe()",
                       evt_tag_str("filename", name));

--- a/modules/affile/affile-common.h
+++ b/modules/affile/affile-common.h
@@ -35,5 +35,6 @@ typedef struct _FileOpenOptions
 } FileOpenOptions;
 
 gboolean affile_open_file(gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_opts, gint *fd);
+gboolean affile_is_linux_dev_stdin(const gchar *filename);
 
 #endif

--- a/modules/affile/affile-common.h
+++ b/modules/affile/affile-common.h
@@ -35,6 +35,6 @@ typedef struct _FileOpenOptions
 } FileOpenOptions;
 
 gboolean affile_open_file(gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_opts, gint *fd);
-gboolean affile_is_linux_dev_stdin(const gchar *filename);
+gboolean affile_is_dev_stdin(const gchar *filename);
 
 #endif

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -203,7 +203,7 @@ affile_sd_construct_poll_events(AFFileSourceDriver *self, gint fd)
 static LogTransport *
 affile_sd_construct_transport(AFFileSourceDriver *self, gint fd)
 {
-  if (affile_is_linux_dev_stdin(self->filename->str))
+  if (affile_is_dev_stdin(self->filename->str))
     return log_transport_stdin_new(fd, &self->super.super.super);
   else if (self->file_open_options.is_pipe)
     return log_transport_pipe_new(fd);
@@ -508,7 +508,7 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
   AFFileSourceDriver *self = affile_sd_new_instance(filename, cfg);
 
   self->file_open_options.is_pipe = FALSE;
-  if (affile_is_linux_dev_stdin(filename))
+  if (affile_is_dev_stdin(filename))
     self->file_open_options.open_flags = DEFAULT_SD_OPEN_FLAGS;
   else
     self->file_open_options.open_flags = STDIN_OPEN_FLAGS;

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -13,7 +13,8 @@ SCL_SUBDIRS	= \
 	hdfs		\
 	apache		\
 	loggly		\
-	logmatic
+	logmatic	\
+	cli
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/cli/plugin.conf
+++ b/scl/cli/plugin.conf
@@ -1,0 +1,31 @@
+#############################################################################
+# Copyright (c) 2016 Noémi Ványi
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block source stdin()
+{
+  file("/dev/stdin");
+};
+
+block destination stdout()
+{
+  file("/dev/stdout");
+};

--- a/scl/cli/plugin.conf
+++ b/scl/cli/plugin.conf
@@ -22,10 +22,10 @@
 
 block source stdin()
 {
-  file("/dev/stdin");
+  file("/dev/stdin")
 };
 
 block destination stdout()
 {
-  file("/dev/stdout");
+  file("/dev/stdout" `__VARARGS__`)
 };

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -66,6 +66,7 @@ static gboolean dummy = FALSE;
 
 static MainLoopOptions main_loop_options;
 
+
 #ifdef YYDEBUG
 extern int cfg_parser_debug;
 #endif
@@ -85,6 +86,8 @@ static GOptionEntry syslogng_options[] =
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
   { "control",           'c',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
+  { "cli",               'l',         0, G_OPTION_ARG_NONE, &main_loop_options.command_line_mode, "Run as a command line tool" },
+  { G_OPTION_REMAINING,  0,           0, G_OPTION_ARG_STRING_ARRAY, &main_loop_options.cli_var, NULL, NULL },
   { NULL },
 };
 
@@ -257,7 +260,7 @@ main(int argc, char *argv[])
     }
 
   gboolean exit_before_main_loop_run = main_loop_options.syntax_only || main_loop_options.preprocess_into;
-  if (debug_flag || exit_before_main_loop_run)
+  if (debug_flag || exit_before_main_loop_run || main_loop_options.command_line_mode)
     {
       g_process_set_mode(G_PM_FOREGROUND);
     }

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -87,6 +87,7 @@ static GOptionEntry syslogng_options[] =
   { "control",           'c',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
   { "cli",               'l',         0, G_OPTION_ARG_NONE, &main_loop_options.command_line_mode, "Run as a command line tool" },
+  { "destination",       's',         0, G_OPTION_ARG_STRING, &main_loop_options.cli_destination_options, "Set options of stdout when run in command line mode", "<destination-config>" },
   { G_OPTION_REMAINING,  0,           0, G_OPTION_ARG_STRING_ARRAY, &main_loop_options.cli_var, NULL, NULL },
   { NULL },
 };

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -1,5 +1,6 @@
  ignore
 scl/syslogconf/convert-syslogconf.awk$
+scl/cli/*
 .*/.*\.am$
 .*\.(yml|md|y|l|txt|xml|xsd|log|key|crt|files|in|conf\.example|gradle|mk|supp|sub|guess|list|pc\.cmake)$
 \..*rc$
@@ -29,6 +30,8 @@ doc/man
 (_configs\.sed|\.project|\.cproject|config\.status)$
 stamp-h1$
 tests/functional/test\.conf$
+lib/cli.*
+lib/tests/test_cli.c
 scripts/update-patterndb$
 (contrib|debian)
 doc/ChangeLog\.[0-9]$


### PR DESCRIPTION
This PR contains:
 * configuration file opening and reading refactor
 * SCL wrapper of `/dev/stdin` and `/dev/stdout`
 * stopping `syslog-ng` on EOF from `/dev/stdin`
 * ability to configure drivers via command line

Possible usage:
```
$ echo logs | syslog-ng --cli 'filter facility(4);'
```