### PR TITLE
new syslog-ng-ctl command: query

### DIFF
--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -25,6 +25,7 @@
 #include "control/control-main.h"
 #include "mainloop.h"
 #include "messages.h"
+#include "stats/stats-query-commands.h"
 
 static GList *command_list = NULL;
 
@@ -111,6 +112,7 @@ ControlCommand default_commands[] =
   { "LOG", NULL, control_connection_message_log },
   { "STOP", NULL, control_connection_stop_process },
   { "RELOAD", NULL, control_connection_reload },
+  { "QUERY", NULL, process_query_command },
   { NULL, NULL, NULL },
 };
 

--- a/lib/stats/CMakeLists.txt
+++ b/lib/stats/CMakeLists.txt
@@ -7,6 +7,8 @@ set(STATS_HEADERS
     stats/stats-log.h
     stats/stats-registry.h
     stats/stats-syslog.h
+    stats/stats-query.h
+    stats/stats-query-commands.h
     PARENT_SCOPE)
 
 set(STATS_SOURCES
@@ -18,4 +20,6 @@ set(STATS_SOURCES
     stats/stats-log.c
     stats/stats-registry.c
     stats/stats-syslog.c
+    stats/stats-query.c
+    stats/stats-query-commands.c
     PARENT_SCOPE)

--- a/lib/stats/Makefile.am
+++ b/lib/stats/Makefile.am
@@ -8,7 +8,9 @@ statsinclude_HEADERS = \
 	lib/stats/stats-csv.h			\
 	lib/stats/stats-log.h			\
 	lib/stats/stats-registry.h		\
-	lib/stats/stats-syslog.h
+	lib/stats/stats-syslog.h		\
+	lib/stats/stats-query.h			\
+	lib/stats/stats-query-commands.h
 
 stats_sources = \
 	lib/stats/stats.c			\
@@ -18,6 +20,8 @@ stats_sources = \
 	lib/stats/stats-csv.c			\
 	lib/stats/stats-log.c			\
 	lib/stats/stats-registry.c		\
-	lib/stats/stats-syslog.c
+	lib/stats/stats-syslog.c		\
+	lib/stats/stats-query.c			\
+	lib/stats/stats-query-commands.c
 
 include lib/stats/tests/Makefile.am

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -164,6 +164,12 @@ stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **
   *counter = NULL;
 }
 
+gboolean
+stats_cluster_is_alive(StatsCluster *self, gint type)
+{
+  return ((1<<type) & self->live_mask);
+}
+
 StatsCluster *
 stats_cluster_new(gint component, const gchar *id, const gchar *instance)
 {

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -39,18 +39,18 @@ stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, 
     }
 }
 
+static const gchar *tag_names[SC_TYPE_MAX] =
+{
+  /* [SC_TYPE_DROPPED]   = */ "dropped",
+  /* [SC_TYPE_PROCESSED] = */ "processed",
+  /* [SC_TYPE_STORED]   = */  "stored",
+  /* [SC_TYPE_SUPPRESSED] = */ "suppressed",
+  /* [SC_TYPE_STAMP] = */ "stamp",
+};
+
 const gchar *
 stats_cluster_get_type_name(gint type)
 {
-  static const gchar *tag_names[SC_TYPE_MAX] =
-  {
-    /* [SC_TYPE_DROPPED]   = */ "dropped",
-    /* [SC_TYPE_PROCESSED] = */ "processed",
-    /* [SC_TYPE_STORED]   = */  "stored",
-    /* [SC_TYPE_SUPPRESSED] = */ "suppressed",
-    /* [SC_TYPE_STAMP] = */ "stamp",
-  };
-
   return tag_names[type];
 }
 
@@ -164,6 +164,27 @@ stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **
   *counter = NULL;
 }
 
+static gchar *
+_stats_build_query_key(StatsCluster *self)
+{
+  GString *key = g_string_new("");
+  gchar buffer[64] = {0};
+  const gchar *component_name = stats_cluster_get_component_name(self, buffer, sizeof(buffer));
+
+  g_string_append(key, component_name);
+
+  if (self->id && self->id[0])
+    {
+      g_string_append_printf(key, ".%s", self->id);
+    }
+  if (self->instance && self->instance[0])
+    {
+      g_string_append_printf(key, ".%s", self->instance);
+    }
+
+  return g_string_free(key, FALSE);
+}
+
 gboolean
 stats_cluster_is_alive(StatsCluster *self, gint type)
 {
@@ -179,6 +200,7 @@ stats_cluster_new(gint component, const gchar *id, const gchar *instance)
   self->id = g_strdup(id ? : "");
   self->instance = g_strdup(instance ? : "");
   self->use_count = 0;
+  self->query_key = _stats_build_query_key(self);
   return self;
 }
 
@@ -187,5 +209,6 @@ stats_cluster_free(StatsCluster *self)
 {
   g_free(self->id);
   g_free(self->instance);
+  g_free(self->query_key);
   g_free(self);
 }

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2002-2017 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
@@ -28,7 +28,6 @@
 
 typedef enum
 {
-  SC_TYPE_MIN,
   SC_TYPE_DROPPED=0, /* number of messages dropped */
   SC_TYPE_PROCESSED, /* number of messages processed */
   SC_TYPE_STORED,    /* number of messages on disk */
@@ -103,11 +102,13 @@ typedef struct _StatsCluster
   gchar *instance;
   guint16 live_mask;
   guint16 dynamic:1;
+  gchar *query_key;
 } StatsCluster;
 
 typedef void (*StatsForeachCounterFunc)(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data);
 
 const gchar *stats_cluster_get_type_name(gint type);
+gint stats_cluster_get_type_by_name(const gchar *name);
 const gchar *stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len);
 
 void stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, gpointer user_data);

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -117,6 +117,7 @@ guint stats_cluster_hash(const StatsCluster *self);
 
 StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
+gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
 StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance);
 void stats_cluster_free(StatsCluster *self);

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats-query-commands.h"
+#include "stats/stats-query.h"
+#include "messages.h"
+
+typedef enum _QueryCommand
+{
+  QUERY_GET = 0,
+  QUERY_GET_SUM,
+  QUERY_LIST,
+  QUERY_CMD_MAX
+} QueryCommand;
+
+typedef GString *(*query_cmd)(const gchar *filter_expr);
+
+static GString *
+_query_get(const gchar *filter_expr)
+{
+  return stats_query_get(filter_expr);
+}
+
+static GString *
+_query_list(const gchar *filter_expr)
+{
+  return stats_query_list(filter_expr);
+}
+
+static GString *
+_query_get_sum(const gchar *filter_expr)
+{
+  return stats_query_get_sum(filter_expr);
+}
+
+static QueryCommand
+_command_str_to_id(const gchar *cmd)
+{
+  if (g_str_equal(cmd, "GET_SUM"))
+    return QUERY_GET_SUM;
+
+  if (g_str_equal(cmd, "GET"))
+    return QUERY_GET;
+
+  if (g_str_equal(cmd, "LIST"))
+    return QUERY_LIST;
+
+  msg_error("Unknown query command", evt_tag_str("command", cmd));
+
+  return QUERY_CMD_MAX;
+}
+
+static query_cmd QUERY_CMDS[] =
+{
+  _query_get,
+  _query_get_sum,
+  _query_list
+};
+
+static GString *
+_dispatch_query(gint cmd_id, const gchar *filter_expr)
+{
+  if (cmd_id < QUERY_GET || cmd_id >= QUERY_CMD_MAX)
+    {
+      msg_error("Invalid query command",
+                evt_tag_int("cmd_id", cmd_id),
+                evt_tag_str("query", filter_expr));
+      return g_string_new("");
+    }
+
+  return QUERY_CMDS[cmd_id](filter_expr);
+}
+
+GString *
+process_query_command(GString *command, gpointer user_data)
+{
+  GString *result;
+  gchar **cmds = g_strsplit(command->str, " ", 3);
+
+  g_assert(g_str_equal(cmds[0], "QUERY"));
+
+  result = _dispatch_query(_command_str_to_id(cmds[1]), cmds[2]);
+
+  g_strfreev(cmds);
+  return result;
+}
+

--- a/lib/stats/stats-query-commands.h
+++ b/lib/stats/stats-query-commands.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STATS_QUERY_COMMANDS_H_INCLUDED
+#define STATS_QUERY_COMMANDS_H_INCLUDED
+
+#include "syslog-ng.h"
+
+GString* process_query_command(GString *cmd, gpointer user_data);
+
+#endif

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats-cluster.h"
+#include "stats-query.h"
+#include "stats-registry.h"
+#include "stats.h"
+#include "messages.h"
+
+#include <string.h>
+#include <stdio.h>
+
+static const gchar *_counter_type[SC_TYPE_MAX+1] =
+{
+  "dropped",
+  "processed",
+  "stored",
+  "suppressed",
+  "stamp",
+  "MAX"
+};
+
+
+typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
+    gpointer user_data);
+
+static void
+_foreach_live_counters(StatsCluster *sc, StatsClusterCounterCb counter_cb, gpointer user_data)
+{
+  for (gint i = 0; i < SC_TYPE_MAX; i++)
+    {
+      if (stats_cluster_is_alive(sc, i))
+        if (!counter_cb(sc, &sc->counters[i], _counter_type[i], user_data))
+          break;
+    }
+}
+
+static gboolean
+_append_counter_with_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+{
+  GString *str = (GString *)user_data;
+  g_string_append_printf(str, "%s.%s: %d\n", sc->query_key, ctr_name ? ctr_name : "", ctr->value);
+  return TRUE;
+}
+
+static gboolean
+_append_counter_without_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+{
+  GString *str = (GString *)user_data;
+  g_string_append_printf(str, "%s.%s\n", sc->query_key, ctr_name ? ctr_name : "");
+  return TRUE;
+}
+
+static gboolean
+_append_counter_with_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
+    gpointer user_data)
+{
+  gpointer *args = (gpointer *) user_data;
+  GString *result = (GString *) args[0];
+  const gchar *requested_ctr_name = (const gchar *) args[1];
+  if (ctr_name && !strcmp(requested_ctr_name, ctr_name))
+    {
+      _append_counter_with_value(sc, ctr, ctr_name, (gpointer) result);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_append_counter_without_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
+    gpointer user_data)
+{
+  gpointer *args = (gpointer *) user_data;
+  GString *result = (GString *) args[0];
+  const gchar *requested_ctr_name = (const gchar *) args[1];
+  if (ctr_name && !strcmp(requested_ctr_name, ctr_name))
+    {
+      _append_counter_without_value(sc, ctr, ctr_name, (gpointer) result);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_add_counter_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+{
+  if (ctr_name && g_str_equal(ctr_name, _counter_type[SC_TYPE_STAMP]))
+    return TRUE;
+
+  gint *sum = (gint *) user_data;
+  *sum += ctr->value;
+  return TRUE;
+}
+
+static gboolean
+_add_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+{
+  gpointer *args = (gpointer *) user_data;
+  gint *sum = (gint *) args[0];
+  const gchar *requested_ctr_name = (const gchar *) args[1];
+
+  if (ctr_name && g_str_equal(ctr_name, _counter_type[SC_TYPE_STAMP]))
+    return FALSE;
+
+  if (ctr_name && !strcmp(requested_ctr_name, ctr_name))
+    {
+      *sum += ctr->value;
+      return FALSE;
+    }
+  return TRUE;
+}
+
+void
+_split_expr(const gchar *expr, gchar **key, gchar **ctr)
+{
+  const gchar *last_delim_pos = strrchr(expr, '.');
+  size_t expr_len = strlen(expr);
+  if (last_delim_pos)
+    {
+      size_t key_len = last_delim_pos - expr ;
+      *key = g_strndup(expr, key_len);
+      *ctr = g_strndup(expr + key_len + 1, expr_len - key_len - 1);
+    }
+  else
+    {
+      *key = g_strdup(expr);
+      *ctr = g_strdup("*");
+    }
+}
+
+static gboolean
+_find_key_by_pattern(gpointer key, gpointer value, gpointer user_data)
+{
+  StatsCluster *sc = (StatsCluster *)key;
+  GPatternSpec *pattern = (GPatternSpec *)user_data;
+
+  return g_pattern_match_string(pattern, sc->query_key);
+}
+
+static gboolean
+_query_counter_hash(gchar *key_str, gchar *ctr_str, StatsClusterCounterCb wildcard_match_cb,
+                    StatsClusterCounterCb match_cb, gpointer result)
+{
+  GHashTable *counter_hash = stats_registry_get_counter_hash();
+  GPatternSpec *pattern = g_pattern_spec_new(key_str);
+  StatsCluster *sc = NULL;
+  gboolean found_match = FALSE;
+  gpointer key, value;
+  GHashTableIter iter;
+
+  g_hash_table_iter_init (&iter, counter_hash);
+
+  gboolean single_match = strchr(key_str, '*') ? FALSE : TRUE;
+  while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+      if (_find_key_by_pattern(key, value, (gpointer)pattern))
+        {
+          sc = (StatsCluster *)key;
+          if (ctr_str[0] == '*')
+            {
+              _foreach_live_counters(sc, wildcard_match_cb, result);
+            }
+          else
+            {
+              gpointer args[] = {result, (gpointer) ctr_str};
+              _foreach_live_counters(sc, match_cb, (gpointer) args);
+            }
+          found_match = TRUE;
+          if (single_match)
+            break;
+        }
+    }
+  g_pattern_spec_free(pattern);
+  return found_match;
+}
+
+GString *
+stats_query_get(const gchar *expr)
+{
+  GString *result = g_string_new("");
+  if (!expr)
+    return result;
+
+  gchar *key_str = NULL;
+  gchar *ctr_str = NULL;
+
+  _split_expr(expr, &key_str, &ctr_str);
+  _query_counter_hash(key_str, ctr_str, _append_counter_with_value, _append_counter_with_value_when_name_is_matching,
+                      (gpointer) result);
+
+  g_free(key_str);
+  g_free(ctr_str);
+
+  return result;
+}
+
+GString *
+stats_query_get_sum(const gchar *expr)
+{
+  gboolean found_match;
+  gchar *key_str = NULL;
+  gchar *ctr_str = NULL;
+  gint sum = 0;
+  GString *result = g_string_new("");
+
+  if (!expr)
+    {
+      key_str = g_strdup("*");
+      ctr_str = g_strdup("*");
+    }
+  else
+    {
+      _split_expr(expr, &key_str, &ctr_str);
+    }
+
+  found_match = _query_counter_hash(key_str, ctr_str, _add_counter_value, _add_value_when_name_is_matching,
+                                    (gpointer) &sum);
+
+  g_free(key_str);
+  g_free(ctr_str);
+
+  if (found_match)
+    g_string_append_printf(result, "%d\n", sum);
+
+  return result;
+}
+
+GString *
+stats_query_list(const gchar *expr)
+{
+  gchar *key_str = NULL;
+  gchar *ctr_str = NULL;
+  GString *result = g_string_new("");
+
+  if (!expr)
+    {
+      key_str = g_strdup("*");
+      ctr_str = g_strdup("*");
+    }
+  else
+    {
+      _split_expr(expr, &key_str, &ctr_str);
+    }
+
+  _query_counter_hash(key_str, ctr_str, _append_counter_without_value,
+                      _append_counter_without_value_when_name_is_matching, (gpointer) result);
+
+  g_free(key_str);
+  g_free(ctr_str);
+
+  return result;
+}

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STATS_QUERY_H_INCLUDED
+#define STATS_QUERY_H_INCLUDED
+
+#include "syslog-ng.h"
+
+GString* stats_query_list(const gchar *expr);
+GString* stats_query_get(const gchar *expr);
+GString* stats_query_get_sum(const gchar *expr);
+
+#endif
+

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -22,7 +22,6 @@
  *
  */
 #include "stats/stats-registry.h"
-
 #include <string.h>
 
 static GHashTable *counter_hash;
@@ -282,3 +281,10 @@ stats_registry_deinit(void)
   counter_hash = NULL;
   g_static_mutex_free(&stats_mutex);
 }
+
+GHashTable *
+stats_registry_get_counter_hash(void)
+{
+  return counter_hash;
+}
+

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -47,4 +47,6 @@ void stats_foreach_cluster_remove(StatsForeachClusterRemoveFunc func, gpointer u
 void stats_registry_init(void);
 void stats_registry_deinit(void);
 
+GHashTable* stats_registry_get_counter_hash(void);
+
 #endif

--- a/lib/stats/tests/Makefile.am
+++ b/lib/stats/tests/Makefile.am
@@ -8,3 +8,15 @@ lib_stats_tests_test_stats_cluster_CFLAGS	= $(TEST_CFLAGS) \
 lib_stats_tests_test_stats_cluster_LDADD	= $(TEST_LDADD)
 lib_stats_tests_test_stats_cluster_SOURCES	= 		\
 	lib/stats/tests/test_stats_cluster.c
+
+if ENABLE_CRITERION
+stats_test_extra_modules			= \
+	$(PREOPEN_SYSLOGFORMAT)
+
+lib_stats_tests_TESTS		+= \
+	lib/stats/tests/test_stats_query
+
+lib_stats_tests_test_stats_query_CFLAGS	= $(TEST_CFLAGS)
+lib_stats_tests_test_stats_query_LDADD	= \
+	$(TEST_LDADD) $(stats_test_extra_modules)
+endif

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#include "apphook.h"
+#include "stats/stats-query-commands.h"
+#include "stats/stats-cluster.h"
+#include "stats/stats-counter.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-query.h"
+#include "syslog-ng.h"
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+
+typedef struct _CounterHashContent
+{
+  const gint component;
+  const gchar *id;
+  const gchar *instance;
+  const gint type;
+} CounterHashContent;
+
+typedef struct _QueryTestCase
+{
+  const gchar *pattern;
+  const gchar *expected;
+} QueryTestCase;
+
+
+static void
+_initialize_counter_hash()
+{
+  size_t i, n;
+  const CounterHashContent counters[] =
+  {
+    {SCS_GLOBAL, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
+    {SCS_CENTER, "guba.polo", "frozen", SC_TYPE_SUPPRESSED},
+    {SCS_TCP | SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_STORED},
+    {SCS_FILE | SCS_SOURCE, "guba", "processed", SC_TYPE_PROCESSED},
+    {SCS_PIPE | SCS_SOURCE, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
+    {SCS_TCP | SCS_DESTINATION, "guba.labda", "received", SC_TYPE_DROPPED},
+  };
+
+  stats_init();
+  stats_lock();
+
+  n = sizeof(counters) / sizeof(counters[0]);
+  for (i = 0; i < n; i++)
+    {
+      StatsCounterItem *item = NULL;
+      stats_register_counter(0, counters[i].component, counters[i].id, counters[i].instance, counters[i].type, &item);
+    }
+
+  stats_unlock();
+}
+
+TestSuite(cluster_query_key, .init = app_startup, .fini = app_shutdown);
+
+Test(cluster_query_key, test_global_key)
+{
+  const gchar *expected_key = "dst.file.d_file.instance";
+  StatsCluster *sc = stats_cluster_new(SCS_DESTINATION|SCS_FILE, "d_file", "instance");
+  cr_assert_str_eq(sc->query_key, expected_key,
+                   "generated query key(%s) does not match to the expected key(%s)",
+                   sc->query_key, expected_key);
+}
+
+ParameterizedTestParameters(stats_query, test_stats_query_list)
+{
+  static QueryTestCase test_cases[] =
+  {
+    {
+      NULL, "global.guba.gumi.diszno.frozen.suppressed\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed\n"
+      "center.guba.polo.frozen.suppressed\n"
+      "src.tcp.guba.frizbi.left.stored\n"
+      "dst.tcp.guba.labda.received.dropped\n"
+      "src.file.guba.processed.processed\n"
+    },
+    {
+      "*.*", "global.guba.gumi.diszno.frozen.suppressed\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed\n"
+      "center.guba.polo.frozen.suppressed\n"
+      "src.tcp.guba.frizbi.left.stored\n"
+      "dst.tcp.guba.labda.received.dropped\n"
+      "src.file.guba.processed.processed\n"
+    },
+    {"center.*.*", "center.guba.polo.frozen.suppressed\n"},
+    {"cent*", "center.guba.polo.frozen.suppressed\n"},
+    {"src.pipe.guba.gumi.diszno.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed\n"},
+    {"src.pipe.guba.gumi.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed\n"},
+    {"src.pipe.guba.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed\n"},
+    {"src.pipe.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed\n"},
+    {
+      "*.tcp.guba.*.*", "src.tcp.guba.frizbi.left.stored\n"
+      "dst.tcp.guba.labda.received.dropped\n"
+    },
+    {
+      "*.guba.*i.*.*", "global.guba.gumi.diszno.frozen.suppressed\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed\n"
+      "src.tcp.guba.frizbi.left.stored\n"
+    },
+    {
+      "*.guba.gum?.*.*", "global.guba.gumi.diszno.frozen.suppressed\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed\n"
+    },
+    {
+      "src.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed\n"
+      "src.tcp.guba.frizbi.left.stored\n"
+      "src.file.guba.processed.processed\n"
+    },
+    {"dst.*.*", "dst.tcp.guba.labda.received.dropped\n"},
+    {"dst.*.*.*", "dst.tcp.guba.labda.received.dropped\n"},
+    {"dst.*.*.*.*", "dst.tcp.guba.labda.received.dropped\n"},
+    {"src.java.*.*", ""},
+    {"src.ja*.*.*", ""},
+  };
+
+  return cr_make_param_array(QueryTestCase, test_cases, sizeof(test_cases) / sizeof(test_cases[0]));
+}
+
+ParameterizedTest(QueryTestCase *test_cases, stats_query, test_stats_query_list)
+{
+  GString *result = NULL;
+
+  _initialize_counter_hash();
+
+  result = stats_query_list(test_cases->pattern);
+  cr_assert_str_eq(result->str, test_cases->expected,
+                   "Pattern: '%s'; expected key: '%s';, got: '%s';", test_cases->pattern, test_cases->expected, result->str);
+}
+
+ParameterizedTestParameters(stats_query, test_stats_query_get)
+{
+  static QueryTestCase test_cases[] =
+  {
+    {
+      "*.*", "global.guba.gumi.diszno.frozen.suppressed: 0\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"
+      "center.guba.polo.frozen.suppressed: 0\n"
+      "src.tcp.guba.frizbi.left.stored: 0\n"
+      "dst.tcp.guba.labda.received.dropped: 0\n"
+      "src.file.guba.processed.processed: 0\n"
+    },
+    {"center.*.*", "center.guba.polo.frozen.suppressed: 0\n"},
+    {"cent*", "center.guba.polo.frozen.suppressed: 0\n"},
+    {"src.pipe.guba.gumi.diszno.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"},
+    {"src.pipe.guba.gumi.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"},
+    {"src.pipe.guba.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"},
+    {"src.pipe.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"},
+    {
+      "*.tcp.guba.*.*", "src.tcp.guba.frizbi.left.stored: 0\n"
+      "dst.tcp.guba.labda.received.dropped: 0\n"
+    },
+    {
+      "*.guba.*i.*.*", "global.guba.gumi.diszno.frozen.suppressed: 0\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"
+      "src.tcp.guba.frizbi.left.stored: 0\n"
+    },
+    {
+      "*.guba.gum?.*.*", "global.guba.gumi.diszno.frozen.suppressed: 0\n"
+      "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"
+    },
+    {
+      "src.*.*", "src.pipe.guba.gumi.diszno.frozen.suppressed: 0\n"
+      "src.tcp.guba.frizbi.left.stored: 0\n"
+      "src.file.guba.processed.processed: 0\n"
+    },
+    {"dst.*.*", "dst.tcp.guba.labda.received.dropped: 0\n"},
+    {"dst.*.*.*", "dst.tcp.guba.labda.received.dropped: 0\n"},
+    {"dst.*.*.*.*", "dst.tcp.guba.labda.received.dropped: 0\n"},
+    {"src.java.*.*", ""},
+    {"src.ja*.*.*", ""},
+  };
+
+  return cr_make_param_array(QueryTestCase, test_cases, sizeof(test_cases) / sizeof(test_cases[0]));
+}
+
+ParameterizedTest(QueryTestCase *test_cases, stats_query, test_stats_query_get)
+{
+  GString *result = NULL;
+
+  _initialize_counter_hash();
+
+  result = stats_query_get(test_cases->pattern);
+  cr_assert_str_eq(result->str, test_cases->expected,
+                   "Pattern: '%s'; expected key and value: '%s';, got: '%s';", test_cases->pattern, test_cases->expected, result->str);
+}
+
+ParameterizedTestParameters(stats_query, test_stats_query_get_sum)
+{
+  static QueryTestCase test_cases[] =
+  {
+    {"*.*", "0\n"},
+    {"center.*.*", "0\n"},
+    {"cent*", "0\n"},
+    {"src.pipe.guba.gumi.diszno.*.*", "0\n"},
+    {"src.pipe.guba.gumi.*.*", "0\n"},
+    {"src.pipe.guba.*.*", "0\n"},
+    {"src.pipe.*.*", "0\n"},
+    {"*.tcp.guba.*.*", "0\n"},
+    {"*.guba.*i.*.*", "0\n"},
+    {"*.guba.gum?.*.*", "0\n"},
+    {"src.*.*", "0\n"},
+    {"dst.*.*", "0\n"},
+    {"dst.*.*.*", "0\n"},
+    {"dst.*.*.*.*", "0\n"},
+    {"src.java.*.*", ""},
+    {"src.ja*.*.*", ""},
+  };
+
+  return cr_make_param_array(QueryTestCase, test_cases, sizeof(test_cases) / sizeof(test_cases[0]));
+}
+
+ParameterizedTest(QueryTestCase *test_cases, stats_query, test_stats_query_get_sum)
+{
+  GString *result = NULL;
+
+  _initialize_counter_hash();
+
+  result = stats_query_get_sum(test_cases->pattern);
+  cr_assert_str_eq(result->str, test_cases->expected,
+                   "Pattern: '%s'; expected number: '%s';, got: '%s';", test_cases->pattern, test_cases->expected, result->str);
+}

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2002-2017 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
@@ -205,7 +205,7 @@ static struct
   gint (*main)(gint argc, gchar *argv[], const gchar *mode);
 } modes[] =
 {
-  { "stats", stats_options, "Query/reset syslog-ng statistics", slng_stats },
+  { "stats", stats_options, "Get syslog-ng statistics in CSV format", slng_stats },
   { "verbose", verbose_options, "Enable/query verbose messages", slng_verbose },
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose },
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose },

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -64,7 +64,33 @@ slng_run_command(const gchar *command)
   return control_client_read_reply(control_client);
 }
 
+static gint
+_dispatch_command(const gchar *cmd)
+{
+  gchar *dispatchable_command = g_strdup_printf("%s\n", cmd);
+  GString *rsp = slng_run_command(dispatchable_command);
+
+  if (rsp == NULL)
+    return 1;
+
+  printf("%s\n", rsp->str);
+
+  g_string_free(rsp, TRUE);
+  g_free(dispatchable_command);
+
+  return 0;
+}
+
 static gchar *verbose_set = NULL;
+
+static GOptionEntry verbose_options[] =
+{
+  {
+    "set", 's', 0, G_OPTION_ARG_STRING, &verbose_set,
+    "enable/disable messages", "<on|off|0|1>"
+  },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
 
 static gint
 slng_verbose(int argc, char *argv[], const gchar *mode)
@@ -103,65 +129,147 @@ static GOptionEntry stats_options[] =
   { NULL,    0,   0, G_OPTION_ARG_NONE, NULL,                        NULL,             NULL }
 };
 
-static GOptionEntry verbose_options[] =
-{
-  {
-    "set", 's', 0, G_OPTION_ARG_STRING, &verbose_set,
-    "enable/disable messages", "<on|off|0|1>"
-  },
-  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
-};
-
-
 static const gchar *
 _stats_command_builder()
 {
-  return stats_options_reset_is_set ? "RESET_STATS\n" : "STATS\n";
+  return stats_options_reset_is_set ? "RESET_STATS" : "STATS";
 }
 
 static gint
 slng_stats(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = slng_run_command(_stats_command_builder());
-
-  if (rsp == NULL)
-    return 1;
-
-  printf("%s\n", rsp->str);
-
-  g_string_free(rsp, TRUE);
-
-  return 0;
+  return _dispatch_command(_stats_command_builder());
 }
 
 static gint
 slng_stop(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = slng_run_command("STOP\n");
-
-  if (rsp == NULL)
-    return 1;
-
-  printf("%s\n", rsp->str);
-
-  g_string_free(rsp, TRUE);
-
-  return 0;
+  return _dispatch_command("STOP");
 }
 
 static gint
 slng_reload(int argc, char *argv[], const gchar *mode)
 {
-  GString *rsp = slng_run_command("RELOAD\n");
+  return _dispatch_command("RELOAD");
+}
 
-  if (rsp == NULL)
+const static gint QUERY_COMMAND = 0;
+static gboolean query_is_get_sum = FALSE;
+static gchar **raw_query_params = NULL;
+
+static GOptionEntry query_options[] =
+{
+  { "sum", 0, 0, G_OPTION_ARG_NONE, &query_is_get_sum, "aggregate sum", NULL },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &raw_query_params, NULL, NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+enum
+{
+  QUERY_CMD_LIST,
+  QUERY_CMD_GET,
+  QUERY_CMD_GET_SUM
+};
+
+const static gchar *QUERY_COMMANDS[] = {"LIST", "GET", "GET_SUM"};
+
+static gint
+_get_query_cmd(gchar *cmd)
+{
+  if (g_str_equal(cmd, "list"))
+    {
+      if (query_is_get_sum)
+        return -1;
+      return QUERY_CMD_LIST;
+    }
+
+  if (g_str_equal(cmd, "get"))
+    {
+      if (query_is_get_sum)
+        return QUERY_CMD_GET_SUM;
+      return QUERY_CMD_GET;
+    }
+
+  return -1;
+}
+
+static gboolean
+_is_query_params_empty()
+{
+  return raw_query_params == NULL;
+}
+
+static gchar *
+_shift_query_command_out_of_params()
+{
+  if (raw_query_params[QUERY_COMMAND] != NULL)
+    return *(raw_query_params++);
+  return *raw_query_params;
+}
+
+static gboolean
+_validate_get_params(gint query_cmd)
+{
+  if(query_cmd == QUERY_CMD_GET || query_cmd == QUERY_CMD_GET_SUM)
+    if (*raw_query_params == NULL)
+      {
+        fprintf(stderr, "error: need a path argument\n");
+        return TRUE;
+      }
+  return FALSE;
+}
+
+static gchar *
+_get_query_command_string(gint query_cmd)
+{
+  gchar *query_params_to_pass, *command_to_dispatch;
+  query_params_to_pass = g_strjoinv(" ", raw_query_params);
+  if (query_params_to_pass)
+    {
+      command_to_dispatch = g_strdup_printf("QUERY %s %s", QUERY_COMMANDS[query_cmd], query_params_to_pass);
+    }
+  else
+    {
+      command_to_dispatch = g_strdup_printf("QUERY %s", QUERY_COMMANDS[query_cmd]);
+    }
+  g_free(query_params_to_pass);
+
+  return command_to_dispatch;
+}
+
+static gchar *
+_get_dispatchable_query_command()
+{
+  gint query_cmd;
+
+  if (_is_query_params_empty())
+    return NULL;
+
+  query_cmd = _get_query_cmd(raw_query_params[QUERY_COMMAND]);
+  if (query_cmd < 0)
+    return NULL;
+
+  *raw_query_params = _shift_query_command_out_of_params();
+  if(_validate_get_params(query_cmd))
+    return NULL;
+
+  return _get_query_command_string(query_cmd);
+}
+
+static gint
+slng_query(int argc, char *argv[], const gchar *mode)
+{
+  gint result;
+
+  gchar *cmd = _get_dispatchable_query_command();
+  if (cmd == NULL)
     return 1;
 
-  printf("%s\n", rsp->str);
+  result = _dispatch_command(cmd);
 
-  g_string_free(rsp, TRUE);
+  g_free(cmd);
 
-  return 0;
+  return result;
 }
 
 static GOptionEntry no_options[] =
@@ -211,6 +319,7 @@ static struct
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose },
   { "stop", no_options, "Stop syslog-ng process", slng_stop },
   { "reload", no_options, "Reload syslog-ng", slng_reload },
+  { "query", query_options, "Query syslog-ng statistics. Possible commands: list, get, get --sum", slng_query },
   { NULL, NULL },
 };
 


### PR DESCRIPTION
Previously, the only possiblity to get statistics of syslog-ng was using `stats` command of `syslog-ng-ctl`. It is limited as it return all of the counters in CSV format. From now on, it is possible to filter, so only desired metrics are shown using the new `query` command. The new format of each counter and its value is `<counter-id>: <value>`.

## Commands
`list` - List all counters with matching name
`get` - Get the value of selected counter
`get --sum` - Get the aggregated value of selected counters

## Usage

### List all counters
```
$ syslog-ng-ctl query list
center.received.processed
src.internal.s_local#0.processed
src.internal.s_local#0.stamp
center.queued.processed
global.payload_reallocs.processed
global.sdata_updates.processed
destination.d_local.processed
global.msg_clones.processed
source.s_local.processed
```

### List selected counters
```
$ syslog-ng-ctl query list "global.*.*"
global.payload_reallocs.processed
global.sdata_updates.processed
global.msg_clones.processed
```

```
$ syslog-ng-ctl query list "glob?l*"
global.payload_reallocs.processed
global.sdata_updates.processed
global.msg_clones.processed
```

### Retrieve values of selected counters
```
$ syslog-ng-ctl query get "global.*.*"
global.payload_reallocs.processed: 0
global.sdata_updates.processed: 0
global.msg_clones.processed: 0
```

### Retrieve aggregated values of selected counters
```
$ syslog-ng-ctl query get --sum "global.*.*"
0
```