### PR TITLE
README: rm drone.io as it is no longer maintined by syslog devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/balabit/syslog-ng?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
 [![Build Status](https://travis-ci.org/balabit/syslog-ng.svg?branch=master)](https://travis-ci.org/balabit/syslog-ng)
-[![Build Status](https://drone.io/github.com/balabit/syslog-ng/status.png)](https://drone.io/github.com/balabit/syslog-ng/latest)
 
 syslog-ng
 =========


### PR DESCRIPTION
Remove build status on drone.io, because the building is no longer maintaned.