### PR TITLE
Utf8 encoding tests

### DIFF
--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -102,6 +102,8 @@ _strchr_optimized_for_single_char_haystack(const char *str, int c)
 {
   if (str[0] == c)
     return (char *) str;
+  else if (str[0] == '\0')
+    return NULL;
   if (str[1] == '\0')
     {
       if (c != '\0')

--- a/lib/tests/test_str-utils.c
+++ b/lib/tests/test_str-utils.c
@@ -53,6 +53,7 @@ int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
   assert_strchr_is_null("", 'x');
+  assert_strchr_is_null("\0x", 'x');
   assert_strchr_is_null("a", 'x');
   assert_strchr_is_null("abc", 'x');
 

--- a/lib/tests/test_utf8utils.c
+++ b/lib/tests/test_utf8utils.c
@@ -28,18 +28,33 @@
 
 
 void
+assert_escaped_binary_with_unsafe_chars_with_len(const gchar *str, gssize str_len, const gchar *expected_escaped_str,
+    const gchar *unsafe_chars)
+{
+  GString *escaped_str = g_string_sized_new(64);
+
+  append_unsafe_utf8_as_escaped_binary(escaped_str, str, str_len, unsafe_chars);
+
+  assert_string(escaped_str->str, expected_escaped_str, "Escaped UTF-8 string is not expected");
+  g_string_free(escaped_str, TRUE);
+}
+
+void
 assert_escaped_binary_with_unsafe_chars(const gchar *str, const gchar *expected_escaped_str, const gchar *unsafe_chars)
 {
-  gchar *escaped_str = convert_unsafe_utf8_to_escaped_binary(str, -1, unsafe_chars);
-
-  assert_string(escaped_str, expected_escaped_str, "Escaped UTF-8 string is not expected");
-  g_free(escaped_str);
+  assert_escaped_binary_with_unsafe_chars_with_len(str, -1, expected_escaped_str, unsafe_chars);
 }
 
 void
 assert_escaped_binary(const gchar *str, const gchar *expected_escaped_str)
 {
   assert_escaped_binary_with_unsafe_chars(str, expected_escaped_str, NULL);
+}
+
+void
+assert_escaped_binary_with_len(const gchar *str, gssize str_len, const gchar *expected_escaped_str)
+{
+  assert_escaped_binary_with_unsafe_chars_with_len(str, str_len, expected_escaped_str, NULL);
 }
 
 void
@@ -70,6 +85,9 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   assert_escaped_binary("\x7", "\\x07");
   assert_escaped_binary("\xad", "\\xad");
   assert_escaped_binary("Á\xadÉ", "Á\\xadÉ");
+  assert_escaped_binary("\xc3\x00\xc1""", "\\xc3");
+  assert_escaped_binary_with_len("\xc3""\xa1 non zero terminated", 1, "\\xc3");
+  assert_escaped_binary_with_len("\xc3""\xa1 non zero terminated", 2, "á");
 
   assert_escaped_binary_with_unsafe_chars("\"text\"", "\\\"text\\\"", "\"");
   assert_escaped_binary_with_unsafe_chars("\"text\"", "\\\"te\\xt\\\"", "\"x");

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -100,6 +100,32 @@ _append_escaped_utf8_character(GString *escaped_output, const gchar **raw,
   return *raw - char_ptr;
 }
 
+
+static void
+_append_unsafe_utf8_as_escaped_with_specific_length(GString *escaped_output, const gchar *raw,
+    gsize raw_len,
+    const gchar *unsafe_chars,
+    const gchar *control_format,
+    const gchar *invalid_format)
+{
+  const gchar *raw_end = raw + raw_len;
+
+  while (raw < raw_end)
+    _append_escaped_utf8_character(escaped_output, &raw, raw_end - raw, unsafe_chars,
+                                   control_format, invalid_format);
+}
+
+static void
+_append_unsafe_utf8_as_escaped_nul_terminated(GString *escaped_output, const gchar *raw,
+    const gchar *unsafe_chars,
+    const gchar *control_format,
+    const gchar *invalid_format)
+{
+  _append_unsafe_utf8_as_escaped_with_specific_length(escaped_output, raw, strlen(raw), unsafe_chars, control_format,
+      invalid_format);
+}
+
+
 /**
  * @see _append_escaped_utf8_character()
  */
@@ -110,13 +136,10 @@ _append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
                                const gchar *invalid_format)
 {
   if (raw_len < 0)
-    while (*raw)
-      _append_escaped_utf8_character(escaped_output, &raw, -1, unsafe_chars,
-                                     control_format, invalid_format);
+    _append_unsafe_utf8_as_escaped_nul_terminated(escaped_output, raw, unsafe_chars, control_format, invalid_format);
   else
-    while (raw_len)
-      raw_len -= _append_escaped_utf8_character(escaped_output, &raw, raw_len, unsafe_chars,
-                 control_format, invalid_format);
+    _append_unsafe_utf8_as_escaped_with_specific_length(escaped_output, raw, raw_len, unsafe_chars, control_format,
+        invalid_format);
 }
 
 /**


### PR DESCRIPTION
This branch adds new testcases in utf8 encoding, as an issue was reported on this functionality.

The new testcases didn't reveal a bug, and it turned out to be a non-issue, but nevertheless this improves test coverage and also improves the production code somewhat.

This also includes a fix into our optimized strchr() implementation.