### PR TITLE
fix silent drop of messages in http bulk mode

### DIFF
--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -76,7 +76,11 @@ public class ESHttpClient implements ESClient {
 
 	@Override
 	public void close() {
-		messageProcessor.flush();
+		try {
+			messageProcessor.flush();
+		} catch (IOException e) {
+			logger.error(e.getMessage());
+		}
 	}
 
 	@Override

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
@@ -26,6 +26,7 @@ package org.syslog_ng.elasticsearch_v2.messageprocessor.http;
 
 import io.searchbox.core.Bulk;
 import io.searchbox.core.Index;
+import io.searchbox.client.JestResult;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.http.ESHttpClient;
 
@@ -48,25 +49,35 @@ public class HttpBulkMessageProcessor extends  HttpMessageProcessor {
 	}
 
 	@Override
-	public void flush() {
+	public void flush() throws IOException {
+		JestResult jestResult = null;
 		logger.debug("Flushing messages for ES destination [mode=http]");
 		Bulk bulkActions = bulk.build();
 		try {
-			client.getClient().execute(bulkActions);
+			jestResult = client.getClient().execute(bulkActions);
 		}
 		catch (IOException e)
 		{
 			logger.error(e.getMessage());
 		}
-		bulk = new Bulk.Builder();
-		messageCounter = 0;
+		if (! jestResult.isSucceeded()) {
+			throw new IOException(jestResult.getErrorMessage());
+		} else {
+			bulk = new Bulk.Builder();
+			messageCounter = 0;
+		}
 	}
 
 	@Override
 	public boolean send(Index index) {
 		if (messageCounter >= flushLimit)
 		{
-			flush();
+			try {
+				flush();
+			} catch (IOException e) {
+				logger.error(e.getMessage());
+				return false;
+			}
 		}
 		bulk = bulk.addAction(index);
 		messageCounter++;

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
@@ -30,6 +30,7 @@ import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.http.ESHttpClient;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessor;
+import java.io.IOException;
 
 public abstract class HttpMessageProcessor implements ESMessageProcessor {
 	protected ElasticSearchOptions options;
@@ -45,7 +46,7 @@ public abstract class HttpMessageProcessor implements ESMessageProcessor {
 	public void init() {
 	}
 
-	public void flush() {
+	public void flush() throws IOException {
 
 	}
 


### PR DESCRIPTION
elastic-v2 with `flush-limit(N)` and `N>1` *e.g.* bulk mode would not notice when bulk failed *e.g.* for 40x status codes (for instance 403 Unauthorized).

