### PR TITLE
astylerc: allow continuation lines to start until column 60

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -9,6 +9,7 @@
 
 # max line lenght is 120 chars
 --max-code-length=120
+--max-instatement-indent=60
 
 # pointer is aligned to the name of the variable
 --align-pointer=name

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -495,8 +495,8 @@ cfg_lexer_include_file_add(CfgLexer *self, const gchar *fn)
   level->include_type = CFGI_FILE;
 
   level->file.files = g_slist_insert_sorted(level->file.files,
-                      strdup(fn),
-                      (GCompareFunc) strcmp);
+                                            strdup(fn),
+                                            (GCompareFunc) strcmp);
 
   msg_debug("Adding include file",
             evt_tag_str("filename", fn),
@@ -615,7 +615,7 @@ cfg_lexer_include_file(CfgLexer *self, const gchar *filename_)
 
 gboolean
 cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self, const gchar *name, const gchar *buffer,
-    gsize length)
+                                                       gsize length)
 {
   CfgIncludeLevel *level;
   gchar *lexer_buffer;

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -440,7 +440,7 @@ cfg_tree_add_all_sources(gpointer key, gpointer value, gpointer user_data)
 
   /* prepend a source reference */
   referring_rule->children = log_expr_node_append_tail(log_expr_node_new_source_reference(rule->name, NULL),
-                             referring_rule->children);
+                                                       referring_rule->children);
 }
 
 static gboolean

--- a/lib/compat/tests/test_strtok_r.c
+++ b/lib/compat/tests/test_strtok_r.c
@@ -58,9 +58,9 @@ typedef char *(STRTOK_R_FUN)(char *str, const char *delim, char **saveptr);
 
 void
 assert_if_tokenizer_concatenated_result_not_match(STRTOK_R_FUN tokenizer,
-    const char *delim,
-    const char *input,
-    const char *expected)
+                                                  const char *delim,
+                                                  const char *input,
+                                                  const char *expected)
 {
   gchar *token;
   gchar *saveptr;
@@ -94,40 +94,40 @@ void
 test_strtok_with_literals(STRTOK_R_FUN tokenizer_func)
 {
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, ".",
-      "token1.token2",
-      "token1token2");
+                                                    "token1.token2",
+                                                    "token1token2");
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, ".",
-      ".token",
-      "token");
+                                                    ".token",
+                                                    "token");
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, ".",
-      "token.",
-      "token");
+                                                    "token.",
+                                                    "token");
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, ".",
-      ".",
-      NULL);
+                                                    ".",
+                                                    NULL);
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, "...",
-      ".",
-      NULL);
+                                                    ".",
+                                                    NULL);
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, "... ",
-      "      ",
-      NULL);
+                                                    "      ",
+                                                    NULL);
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, "..*,;-",
-      ";-*token1...*****token2**,;;;.",
-      "token1token2");
+                                                    ";-*token1...*****token2**,;;;.",
+                                                    "token1token2");
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, "..*,;- ",
-      ";-*token1...*****token2**,;;;.token3",
-      "token1token2token3");
+                                                    ";-*token1...*****token2**,;;;.token3",
+                                                    "token1token2token3");
 
   assert_if_tokenizer_concatenated_result_not_match(tokenizer_func, "..*,;- ",
-      ";-*token1...*****token2**,;;;.token3 ",
-      "token1token2token3");
+                                                    ";-*token1...*****token2**,;;;.token3 ",
+                                                    "token1token2token3");
 }
 
 int

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -298,7 +298,7 @@ sockaddr_to_dnscache_key(GSockAddr *saddr)
 
 static const gchar *
 resolve_sockaddr_to_inet_or_inet6_hostname(gsize *result_len, GSockAddr *saddr,
-    const HostResolveOptions *host_resolve_options)
+                                           const HostResolveOptions *host_resolve_options)
 {
   const gchar *hname;
   gsize hname_len;

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1148,7 +1148,7 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
   /* reference the original message */
   self->original = log_msg_ref(msg);
   self->ack_and_ref_and_abort_and_suspended = LOGMSG_REFCACHE_REF_TO_VALUE(1) + LOGMSG_REFCACHE_ACK_TO_VALUE(
-        0) + LOGMSG_REFCACHE_ABORT_TO_VALUE(0);
+                                                0) + LOGMSG_REFCACHE_ABORT_TO_VALUE(0);
   self->cur_node = 0;
   self->protect_cnt = 0;
 
@@ -1323,7 +1323,7 @@ _ack_and_ref_and_abort_and_suspend_to_acktype(gint value)
 /* Function to update the combined ACK (with the abort flag) and REF counter. */
 static inline gint
 log_msg_update_ack_and_ref_and_abort_and_suspended(LogMessage *self, gint add_ref, gint add_ack, gint add_abort,
-    gint add_suspend)
+                                                   gint add_suspend)
 {
   gint old_value, new_value;
   do
@@ -1519,11 +1519,11 @@ log_msg_refcache_start_producer(LogMessage *self)
   /* we don't need to be thread-safe here, as a producer has just created this message and no parallel access is yet possible */
 
   self->ack_and_ref_and_abort_and_suspended = (self->ack_and_ref_and_abort_and_suspended & ~LOGMSG_REFCACHE_REF_MASK) +
-      LOGMSG_REFCACHE_REF_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_REF(self->ack_and_ref_and_abort_and_suspended) +
-                                    LOGMSG_REFCACHE_BIAS));
+                                              LOGMSG_REFCACHE_REF_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_REF(self->ack_and_ref_and_abort_and_suspended) +
+                                                  LOGMSG_REFCACHE_BIAS));
   self->ack_and_ref_and_abort_and_suspended = (self->ack_and_ref_and_abort_and_suspended & ~LOGMSG_REFCACHE_ACK_MASK) +
-      LOGMSG_REFCACHE_ACK_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_ACK(self->ack_and_ref_and_abort_and_suspended) +
-                                    LOGMSG_REFCACHE_BIAS));
+                                              LOGMSG_REFCACHE_ACK_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_ACK(self->ack_and_ref_and_abort_and_suspended) +
+                                                  LOGMSG_REFCACHE_BIAS));
 
   logmsg_cached_refs = -LOGMSG_REFCACHE_BIAS;
   logmsg_cached_acks = -LOGMSG_REFCACHE_BIAS;

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -75,7 +75,7 @@ _construct_merged_message(const gchar *name, const gchar *value)
 
 static void
 assert_log_msg_clear_clears_all_properties(LogMessage *message, NVHandle nv_handle,
-    NVHandle sd_handle, const gchar *tag_name)
+                                           NVHandle sd_handle, const gchar *tag_name)
 {
   log_msg_clear(message);
 
@@ -175,9 +175,9 @@ Test(log_message, test_log_message_can_be_cleared)
   log_message_test_params_clone_message(params);
 
   assert_log_msg_clear_clears_all_properties(params->message, params->nv_handle,
-      params->sd_handle, params->tag_name);
+                                             params->sd_handle, params->tag_name);
   assert_log_msg_clear_clears_all_properties(params->cloned_message, params->nv_handle,
-      params->sd_handle, params->tag_name);
+                                             params->sd_handle, params->tag_name);
 
   log_message_test_params_free(params);
 }

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -549,14 +549,14 @@ log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond)
 
 static gint
 log_proto_buffered_server_read_data_method(LogProtoBufferedServer *self, guchar *buf, gsize len,
-    LogTransportAuxData *aux)
+                                           LogTransportAuxData *aux)
 {
   return log_transport_read(self->super.transport, buf, len, aux);
 }
 
 static gboolean
 log_proto_buffered_server_fetch_from_buffer(LogProtoBufferedServer *self, const guchar **msg, gsize *msg_len,
-    LogTransportAuxData *aux)
+                                            LogTransportAuxData *aux)
 {
   gsize buffer_bytes;
   const guchar *buffer_start;

--- a/lib/logproto/logproto-dgram-server.c
+++ b/lib/logproto/logproto-dgram-server.c
@@ -34,7 +34,7 @@ struct _LogProtoDGramServer
 
 static gboolean
 log_proto_dgram_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar *buffer_start, gsize buffer_bytes,
-    const guchar **msg, gsize *msg_len)
+                                         const guchar **msg, gsize *msg_len)
 {
   LogProtoBufferedServerState *state = log_proto_buffered_server_get_state(s);
 

--- a/lib/logproto/logproto-indented-multiline-server.c
+++ b/lib/logproto/logproto-indented-multiline-server.c
@@ -32,9 +32,9 @@ log_proto_indented_multiline_is_continuation(guchar first_char)
 
 static gint
 log_proto_indented_multiline_accumulate_line(LogProtoTextServer *s,
-    const guchar *msg,
-    gsize msg_len,
-    gssize consumed_len)
+                                             const guchar *msg,
+                                             gsize msg_len,
+                                             gssize consumed_len)
 {
 
   /* NOTES:
@@ -74,8 +74,8 @@ log_proto_indented_multiline_accumulate_line(LogProtoTextServer *s,
 
 void
 log_proto_indented_multiline_server_init(LogProtoIMultiLineServer *self,
-    LogTransport *transport,
-    const LogProtoServerOptions *options)
+                                         LogTransport *transport,
+                                         const LogProtoServerOptions *options)
 {
   log_proto_text_server_init(&self->super, transport, options);
   self->super.accumulate_line = log_proto_indented_multiline_accumulate_line;

--- a/lib/logproto/logproto-record-server.c
+++ b/lib/logproto/logproto-record-server.c
@@ -85,7 +85,7 @@ log_proto_record_server_init(LogProtoRecordServer *self, LogTransport *transport
 
 static gboolean
 log_proto_binary_record_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar *buffer_start,
-    gsize buffer_bytes, const guchar **msg, gsize *msg_len)
+                                                 gsize buffer_bytes, const guchar **msg, gsize *msg_len)
 {
   LogProtoBufferedServerState *state = log_proto_buffered_server_get_state(s);
 
@@ -109,7 +109,7 @@ log_proto_binary_record_server_new(LogTransport *transport, const LogProtoServer
 
 static gboolean
 log_proto_padded_record_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar *buffer_start,
-    gsize buffer_bytes, const guchar **msg, gsize *msg_len)
+                                                 gsize buffer_bytes, const guchar **msg, gsize *msg_len)
 {
   LogProtoBufferedServerState *state = log_proto_buffered_server_get_state(s);
   const guchar *eol;

--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -118,7 +118,7 @@ _regexp_matches(MultiLineRegexp *re, const guchar *str, gsize len)
 
 gint
 log_proto_prefix_garbage_multiline_get_offset_of_garbage(LogProtoREMultiLineServer *self, const guchar *line,
-    gsize line_len)
+                                                         gsize line_len)
 {
   gint match[3];
   if (_find_regexp(self->garbage, line, line_len, match, 1) < 0)
@@ -128,7 +128,7 @@ log_proto_prefix_garbage_multiline_get_offset_of_garbage(LogProtoREMultiLineServ
 
 gint
 log_proto_prefix_suffix_multiline_get_offset_of_garbage(LogProtoREMultiLineServer *self, const guchar *line,
-    gsize line_len)
+                                                        gsize line_len)
 {
   gint match[3];
   if (_find_regexp(self->garbage, line, line_len, match, 1) < 0)
@@ -168,9 +168,9 @@ _accumulate_continuation_line(LogProtoREMultiLineServer *self,
 
 static gint
 log_proto_regexp_multiline_accumulate_line(LogProtoTextServer *s,
-    const guchar *msg,
-    gsize msg_len,
-    gssize consumed_len)
+                                           const guchar *msg,
+                                           gsize msg_len,
+                                           gssize consumed_len)
 {
   LogProtoREMultiLineServer *self = (LogProtoREMultiLineServer *) s;
   gboolean initial_line;
@@ -221,9 +221,9 @@ log_proto_regexp_multiline_server_init(LogProtoREMultiLineServer *self,
 
 LogProtoServer *
 log_proto_prefix_garbage_multiline_server_new(LogTransport *transport,
-    const LogProtoServerOptions *options,
-    MultiLineRegexp *prefix,
-    MultiLineRegexp *garbage)
+                                              const LogProtoServerOptions *options,
+                                              MultiLineRegexp *prefix,
+                                              MultiLineRegexp *garbage)
 {
   LogProtoREMultiLineServer *self = g_new0(LogProtoREMultiLineServer, 1);
 
@@ -234,9 +234,9 @@ log_proto_prefix_garbage_multiline_server_new(LogTransport *transport,
 
 LogProtoServer *
 log_proto_prefix_suffix_multiline_server_new(LogTransport *transport,
-    const LogProtoServerOptions *options,
-    MultiLineRegexp *prefix,
-    MultiLineRegexp *suffix)
+                                             const LogProtoServerOptions *options,
+                                             MultiLineRegexp *prefix,
+                                             MultiLineRegexp *suffix)
 {
   LogProtoREMultiLineServer *self = g_new0(LogProtoREMultiLineServer, 1);
 

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -191,7 +191,7 @@ log_proto_text_server_get_raw_size_of_buffer(LogProtoTextServer *self, const guc
 
 static gint
 log_proto_text_server_accumulate_line_method(LogProtoTextServer *self, const guchar *msg, gsize msg_len,
-    gssize consumed_len)
+                                             gssize consumed_len)
 {
   return LPT_CONSUME_LINE | LPT_EXTRACTED;
 }
@@ -338,7 +338,7 @@ log_proto_text_server_remove_trailing_newline(const guchar **msg, gsize *msg_len
 
 static inline void
 log_proto_text_server_yield_whole_buffer_as_message(LogProtoTextServer *self, LogProtoBufferedServerState *state,
-    const guchar *buffer_start, gsize buffer_bytes, const guchar **msg, gsize *msg_len)
+                                                    const guchar *buffer_start, gsize buffer_bytes, const guchar **msg, gsize *msg_len)
 {
   /* no EOL, our buffer is full, no way to move forward, return
    * everything we have in our buffer. */

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -302,13 +302,13 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       stats_lock();
 
       stats_register_and_increment_dynamic_counter(2, SCS_HOST | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST, NULL),
-          msg->timestamps[LM_TS_RECVD].tv_sec);
+                                                   msg->timestamps[LM_TS_RECVD].tv_sec);
       if (stats_check_level(3))
         {
           stats_register_and_increment_dynamic_counter(3, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM,
-              NULL), msg->timestamps[LM_TS_RECVD].tv_sec);
+                                                       NULL), msg->timestamps[LM_TS_RECVD].tv_sec);
           stats_register_and_increment_dynamic_counter(3, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM,
-              NULL), msg->timestamps[LM_TS_RECVD].tv_sec);
+                                                       NULL), msg->timestamps[LM_TS_RECVD].tv_sec);
         }
 
       stats_unlock();

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -352,7 +352,7 @@ log_threaded_dest_driver_start(LogPipe *s)
                          self->dropped_messages);
 
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
-                                  log_threaded_dest_driver_format_seqnum_for_persist(self)));
+                                                           log_threaded_dest_driver_format_seqnum_for_persist(self)));
   if (!self->seq_num)
     init_sequence_number(&self->seq_num);
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1106,7 +1106,7 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
   if (self->line_buffer->len)
     {
       LogProtoStatus status = log_proto_client_post(self->proto, (guchar *)self->line_buffer->str, self->line_buffer->len,
-                              &consumed);
+                                                    &consumed);
 
       if (consumed)
         log_writer_realloc_line_buffer(self);

--- a/lib/persistable-state-presenter.c
+++ b/lib/persistable-state-presenter.c
@@ -41,7 +41,7 @@ persistable_state_presenter_get_constructor_by_prefix(const gchar *prefix)
 
 void
 persistable_state_presenter_register_constructor(const gchar *prefix,
-    PersistableStatePresenterConstructFunc handler)
+                                                 PersistableStatePresenterConstructFunc handler)
 {
   if (!persist_state_storage)
     {

--- a/lib/rcptid.c
+++ b/lib/rcptid.c
@@ -87,7 +87,7 @@ rcptid_create_new_entry(void)
   RcptidState *data;
 
   rcptid_service.persist_handle = persist_state_alloc_entry(rcptid_service.persist_state, "next.rcptid",
-                                  sizeof(RcptidState));
+                                                            sizeof(RcptidState));
   if (!rcptid_service.persist_handle)
     {
       msg_error("Error allocating RCPTID structure in persist-state");

--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -66,7 +66,7 @@ csv_scanner_options_set_string_delimiters(CSVScannerOptions *options, GList *str
 
 void
 csv_scanner_options_set_quotes_start_and_end(CSVScannerOptions *options, const gchar *quotes_start,
-    const gchar *quotes_end)
+                                             const gchar *quotes_end)
 {
   g_free(options->quotes_start);
   g_free(options->quotes_end);
@@ -251,8 +251,8 @@ _parse_string_delimiters_at_current_position(CSVScanner *self)
     return FALSE;
 
   if (_match_string_delimiters_at_current_position(self->src,
-      self->options->string_delimiters,
-      &delim_len))
+                                                   self->options->string_delimiters,
+                                                   &delim_len))
     {
       self->src += delim_len;
       return TRUE;

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -42,7 +42,7 @@ static const gchar *_counter_type[SC_TYPE_MAX+1] =
 
 
 typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
-    gpointer user_data);
+                                          gpointer user_data);
 
 static void
 _foreach_live_counters(StatsCluster *sc, StatsClusterCounterCb counter_cb, gpointer user_data)
@@ -73,7 +73,7 @@ _append_counter_without_value(StatsCluster *sc, StatsCounterItem *ctr, const gch
 
 static gboolean
 _append_counter_with_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
-    gpointer user_data)
+                                                 gpointer user_data)
 {
   gpointer *args = (gpointer *) user_data;
   GString *result = (GString *) args[0];
@@ -88,7 +88,7 @@ _append_counter_with_value_when_name_is_matching(StatsCluster *sc, StatsCounterI
 
 static gboolean
 _append_counter_without_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
-    gpointer user_data)
+                                                    gpointer user_data)
 {
   gpointer *args = (gpointer *) user_data;
   GString *result = (GString *) args[0];

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -135,7 +135,7 @@ stats_register_dynamic_counter(gint stats_level, gint component, const gchar *id
  */
 void
 stats_register_and_increment_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance,
-    time_t timestamp)
+                                             time_t timestamp)
 {
   StatsCounterItem *counter, *stamp;
   StatsCluster *handle;

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -73,13 +73,13 @@ test_stats_cluster_equal_if_component_id_and_instance_are_the_same(void)
                                        stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance"));
 
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance1"),
-      stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance2"));
+                                           stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance2"));
 
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id1", "instance"),
-      stats_cluster_new(SCS_SOURCE | SCS_FILE, "id2", "instance"));
+                                           stats_cluster_new(SCS_SOURCE | SCS_FILE, "id2", "instance"));
 
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
-      stats_cluster_new(SCS_DESTINATION | SCS_FILE, "id", "instance"));
+                                           stats_cluster_new(SCS_DESTINATION | SCS_FILE, "id", "instance"));
 }
 
 typedef struct _ValidateCountersState

--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -94,7 +94,7 @@ log_template_prepare_function_call(LogTemplateCompiler *self, Plugin *p, LogTemp
 
 static gboolean
 log_template_lookup_and_setup_function_call(LogTemplateCompiler *self, LogTemplateElem *e, gint argc, gchar *argv[],
-    GError **error)
+                                            GError **error)
 {
   Plugin *p;
 
@@ -367,8 +367,8 @@ log_template_compiler_process_template_function(LogTemplateCompiler *self, GErro
   if (!log_template_compiler_process_arg_list(self, strv))
     {
       log_template_compiler_fill_compile_error(error,
-          "Invalid template function reference, missing function name or inbalanced '('",
-          self->cursor - self->template->template);
+                                               "Invalid template function reference, missing function name or inbalanced '('",
+                                               self->cursor - self->template->template);
       goto error;
     }
   self->cursor++;

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -261,7 +261,7 @@ test_compat(void)
   reset_grabbed_messages();
   assert_template_format("$MSG", "syslog-ng[23323]:árvíztűrőtükörfúrógép");
   gchar *expected_msg_macros_changed = g_strdup_printf("the meaning of the $MSG/$MESSAGE macros has changed from %s",
-                                       VERSION_3_0);
+                                                       VERSION_3_0);
   assert_grabbed_messages_contain(expected_msg_macros_changed, NULL);
   stop_grabbing_messages();
   g_free(expected_msg_default_value_changed);

--- a/lib/tests/test_utf8utils.c
+++ b/lib/tests/test_utf8utils.c
@@ -29,7 +29,7 @@
 
 void
 assert_escaped_binary_with_unsafe_chars_with_len(const gchar *str, gssize str_len, const gchar *expected_escaped_str,
-    const gchar *unsafe_chars)
+                                                 const gchar *unsafe_chars)
 {
   GString *escaped_str = g_string_sized_new(64);
 

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -103,10 +103,10 @@ _append_escaped_utf8_character(GString *escaped_output, const gchar **raw,
 
 static void
 _append_unsafe_utf8_as_escaped_with_specific_length(GString *escaped_output, const gchar *raw,
-    gsize raw_len,
-    const gchar *unsafe_chars,
-    const gchar *control_format,
-    const gchar *invalid_format)
+                                                    gsize raw_len,
+                                                    const gchar *unsafe_chars,
+                                                    const gchar *control_format,
+                                                    const gchar *invalid_format)
 {
   const gchar *raw_end = raw + raw_len;
 
@@ -117,12 +117,12 @@ _append_unsafe_utf8_as_escaped_with_specific_length(GString *escaped_output, con
 
 static void
 _append_unsafe_utf8_as_escaped_nul_terminated(GString *escaped_output, const gchar *raw,
-    const gchar *unsafe_chars,
-    const gchar *control_format,
-    const gchar *invalid_format)
+                                              const gchar *unsafe_chars,
+                                              const gchar *control_format,
+                                              const gchar *invalid_format)
 {
   _append_unsafe_utf8_as_escaped_with_specific_length(escaped_output, raw, strlen(raw), unsafe_chars, control_format,
-      invalid_format);
+                                                      invalid_format);
 }
 
 
@@ -139,7 +139,7 @@ _append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
     _append_unsafe_utf8_as_escaped_nul_terminated(escaped_output, raw, unsafe_chars, control_format, invalid_format);
   else
     _append_unsafe_utf8_as_escaped_with_specific_length(escaped_output, raw, raw_len, unsafe_chars, control_format,
-        invalid_format);
+                                                        invalid_format);
 }
 
 /**

--- a/libtest/template_lib.c
+++ b/libtest/template_lib.c
@@ -151,7 +151,7 @@ assert_template_format_msg(const gchar *template, const gchar *expected,
 
 void
 assert_template_format_with_escaping_msg(const gchar *template, gboolean escaping,
-    const gchar *expected, LogMessage *msg)
+                                         const gchar *expected, LogMessage *msg)
 {
   LogTemplate *templ = compile_template(template, escaping);
   if (!templ)
@@ -194,7 +194,7 @@ assert_template_format_with_context(const gchar *template, const gchar *expected
 
 void
 assert_template_format_with_context_msgs(const gchar *template, const gchar *expected,
-    LogMessage **msgs, gint num_messages)
+                                         LogMessage **msgs, gint num_messages)
 {
   LogTemplate *templ = compile_template(template, FALSE);
   if (!templ)

--- a/modules/add-contextual-data/add-contextual-data-template-selector.c
+++ b/modules/add-contextual-data/add-contextual-data-template-selector.c
@@ -92,7 +92,7 @@ _clone(AddContextualDataSelector *s, GlobalConfig *cfg)
 {
   AddContextualDataTemplateSelector *self = (AddContextualDataTemplateSelector *)s;
   AddContextualDataTemplateSelector *cloned = (AddContextualDataTemplateSelector *)
-      add_contextual_data_template_selector_new(cfg, self->selector_template_string);
+                                              add_contextual_data_template_selector_new(cfg, self->selector_template_string);
   _replace_template(&cloned->selector_template, self->selector_template);
 
   return &cloned->super;

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -145,7 +145,7 @@ _clone(LogPipe *s)
   add_contextual_data_set_prefix(&cloned->super, self->prefix);
   add_contextual_data_set_filename(&cloned->super, self->filename);
   add_contextual_data_set_database_default_selector(&cloned->super,
-      self->default_selector);
+                                                    self->default_selector);
   self->selector = add_contextual_data_selector_clone(self->selector, s->cfg);
 
   return &cloned->super.super;

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -34,7 +34,7 @@ contextual_data_record_scanner_free(ContextualDataRecordScanner *self)
 
 void
 contextual_data_record_scanner_set_name_prefix(ContextualDataRecordScanner *
-    self, const gchar *prefix)
+                                               self, const gchar *prefix)
 {
   self->name_prefix = prefix;
 }

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.c
@@ -27,7 +27,7 @@
 
 static gchar *
 _csv_scanner_dup_current_value_with_prefix(CSVScanner *line_scanner,
-    const gchar *prefix)
+                                           const gchar *prefix)
 {
   return g_strdup_printf("%s%s", prefix ? prefix : "",
                          csv_scanner_get_current_value(line_scanner));

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -255,10 +255,10 @@ affile_sd_construct_proto(AFFileSourceDriver *self, gint fd)
           return log_proto_indented_multiline_server_new(transport, proto_options);
         case MLM_PREFIX_GARBAGE:
           return log_proto_prefix_garbage_multiline_server_new(transport, proto_options, self->multi_line_prefix,
-                 self->multi_line_garbage);
+                                                               self->multi_line_garbage);
         case MLM_PREFIX_SUFFIX:
           return log_proto_prefix_suffix_multiline_server_new(transport, proto_options, self->multi_line_prefix,
-                 self->multi_line_garbage);
+                                                              self->multi_line_garbage);
         default:
           return log_proto_text_server_new(transport, proto_options);
         }

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -220,7 +220,7 @@ log_proto_file_writer_new(LogTransport *transport, const LogProtoClientOptions *
 
   /* allocate the structure with the proper number of items at the end */
   LogProtoFileWriter *self = (LogProtoFileWriter *)g_malloc0(sizeof(LogProtoFileWriter) + sizeof(
-                               struct iovec)*flush_lines);
+      struct iovec)*flush_lines);
 
   log_proto_client_init(&self->super, transport, options);
   self->fd = transport->fd;

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -185,7 +185,7 @@ _connect(MongoDBDestDriver *self, gboolean reconnect)
   bson_error_t error;
   const mongoc_read_prefs_t *read_prefs = mongoc_collection_get_read_prefs(self->coll_obj);
   gboolean ok = mongoc_client_get_server_status(self->client, (mongoc_read_prefs_t *)read_prefs,
-                status, &error);
+                                                status, &error);
   bson_destroy(status);
   if (!ok)
     {

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -385,7 +385,7 @@ afprogram_dd_reopen(AFProgramDestDriver *self)
     return FALSE;
 
   log_writer_reopen(self->writer, log_proto_text_client_new(log_transport_pipe_new(fd),
-                    &self->writer_options.proto_options.super));
+                                                            &self->writer_options.proto_options.super));
   return TRUE;
 }
 

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -255,7 +255,7 @@ _smtp_message_add_recipient_header(smtp_message_t self, AFSMTPRecipient *rcpt, A
 
 static void
 _smtp_message_add_recipient_from_template(smtp_message_t self, AFSMTPDriver *driver, LogTemplate *template,
-    LogMessage *msg)
+                                          LogMessage *msg)
 {
   log_template_format(template, msg, &driver->template_options, LTZ_SEND,
                       driver->super.seq_num, NULL, driver->str);

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -362,7 +362,7 @@ afinet_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
    * spoofed packets are also going through the LogWriter queue */
 
   if (self->spoof_source && self->lnet_ctx && msg->saddr && (msg->saddr->sa.sa_family == AF_INET
-      || msg->saddr->sa.sa_family == AF_INET6) && log_writer_opened(self->super.writer))
+                                                             || msg->saddr->sa.sa_family == AF_INET6) && log_writer_opened(self->super.writer))
     {
       gboolean success = FALSE;
 

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -94,7 +94,7 @@ afsocket_sc_init(LogPipe *s)
         return FALSE;
 
       proto = log_proto_server_factory_construct(self->owner->proto_factory, transport,
-              &self->owner->reader_options.proto_options.super);
+                                                 &self->owner->reader_options.proto_options.super);
       self->reader = log_reader_new(s->cfg);
       log_reader_reopen(self->reader, proto, poll_fd_events_new(self->sock));
       log_reader_set_peer_addr(self->reader, self->peer_addr);

--- a/modules/afsocket/systemd-syslog-source.c
+++ b/modules/afsocket/systemd-syslog-source.c
@@ -203,14 +203,14 @@ AFSocketSourceDriver *
 create_and_set_unix_dgram_or_systemd_syslog_source(gchar *filename, GlobalConfig *cfg)
 {
   return create_and_set_unix_socket_or_systemd_syslog_source(filename,
-         cfg,
-         ST_DGRAM);
+                                                             cfg,
+                                                             ST_DGRAM);
 }
 
 AFSocketSourceDriver *
 create_and_set_unix_stream_or_systemd_syslog_source(gchar *filename, GlobalConfig *cfg)
 {
   return create_and_set_unix_socket_or_systemd_syslog_source(filename,
-         cfg,
-         ST_STREAM);
+                                                             cfg,
+                                                             ST_STREAM);
 }

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1195,7 +1195,7 @@ afsql_dd_init(LogPipe *s)
     init_sequence_number(&self->seq_num);
 
   self->queue = log_dest_driver_acquire_queue(&self->super,
-                afsql_dd_format_persist_name((const LogPipe *)self));
+                                              afsql_dd_format_persist_name((const LogPipe *)self));
   if (self->queue == NULL)
     {
       return FALSE;

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -186,7 +186,7 @@ afstreams_sd_init(LogPipe *s)
       g_fd_set_nonblock(fd, TRUE);
       self->reader = log_reader_new(cfg);
       log_reader_reopen(self->reader, log_proto_dgram_server_new(log_transport_streams_new(fd),
-                        &self->reader_options.proto_options.super), poll_fd_events_new(fd));
+                                                                 &self->reader_options.proto_options.super), poll_fd_events_new(fd));
       log_reader_set_options(self->reader,
                              s,
                              &self->reader_options,

--- a/modules/date/strptime-tz.c
+++ b/modules/date/strptime-tz.c
@@ -676,7 +676,7 @@ recurse:
         {
           /* calculate day of year (ordinal date) */
           tm->tm_yday =  start_of_month[isleap_sum(tm->tm_year,
-                                        TM_YEAR_BASE)][tm->tm_mon] + (tm->tm_mday - 1);
+                                                   TM_YEAR_BASE)][tm->tm_mon] + (tm->tm_mday - 1);
           state |= S_YDAY;
         }
       else if (day_offset != -1)

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -181,7 +181,7 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   LogDBParser *self = (LogDBParser *) s;
 
   if (G_UNLIKELY(!self->db_file_reloading && (self->db_file_last_check == 0
-                 || self->db_file_last_check < (*pmsg)->timestamps[LM_TS_RECVD].tv_sec - 5)))
+                                              || self->db_file_last_check < (*pmsg)->timestamps[LM_TS_RECVD].tv_sec - 5)))
     {
       /* first check if we need to reload without doing a lock, then grab
        * the lock, recheck the condition to rule out parallel database

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -130,7 +130,7 @@ grouping_by_set_time(GroupingBy *self, const LogStamp *ls)
             evt_tag_long("utc", timer_wheel_get_time(self->timer_wheel)),
             evt_tag_str("location",
                         log_expr_node_format_location(self->super.super.super.expr_node,
-                            buf, sizeof(buf))));
+                                                      buf, sizeof(buf))));
 
 }
 
@@ -162,7 +162,7 @@ _grouping_by_timer_tick(GroupingBy *self)
                 evt_tag_long("utc", timer_wheel_get_time(self->timer_wheel)),
                 evt_tag_str("location",
                             log_expr_node_format_location(self->super.super.super.expr_node,
-                                buf, sizeof(buf))));
+                                                          buf, sizeof(buf))));
       /* update last_tick, take the fraction of the seconds not calculated into this update into account */
 
       self->last_tick = now;
@@ -223,7 +223,7 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
                 evt_tag_str("key", context->key.session_id),
                 evt_tag_str("location",
                             log_expr_node_format_location(self->super.super.super.expr_node,
-                                buf, sizeof(buf))));
+                                                          buf, sizeof(buf))));
     }
 }
 
@@ -239,7 +239,7 @@ grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
             evt_tag_str("context-id", context->key.session_id),
             evt_tag_str("location",
                         log_expr_node_format_location(self->super.super.super.expr_node,
-                            buf, sizeof(buf))));
+                                                      buf, sizeof(buf))));
   grouping_by_emit_synthetic(self, context);
   g_hash_table_remove(self->correllation->state, &context->key);
 
@@ -284,7 +284,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
                     evt_tag_int("expiration", timer_wheel_get_time(self->timer_wheel) + self->timeout),
                     evt_tag_str("location",
                                 log_expr_node_format_location(self->super.super.super.expr_node,
-                                    buf, sizeof(buf))));
+                                                              buf, sizeof(buf))));
           context = correllation_context_new(&key);
           g_hash_table_insert(self->correllation->state, &context->key, context);
           g_string_steal(buffer);
@@ -298,7 +298,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
                     evt_tag_int("num_messages", context->messages->len),
                     evt_tag_str("location",
                                 log_expr_node_format_location(self->super.super.super.expr_node,
-                                    buf, sizeof(buf))));
+                                                              buf, sizeof(buf))));
         }
 
       g_ptr_array_add(context->messages, log_msg_ref(msg));
@@ -312,7 +312,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
                       evt_tag_int("num_messages", context->messages->len),
                       evt_tag_str("location",
                                   log_expr_node_format_location(self->super.super.super.expr_node,
-                                      buf, sizeof(buf))));
+                                                                buf, sizeof(buf))));
           /* close down state */
           if (context->timer)
             timer_wheel_del_timer(self->timer_wheel, context->timer);

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -314,8 +314,8 @@ pdb_execute_action_create_context(PDBAction *self, PatternDB *db, PDBRule *rule,
   g_ptr_array_add(new_context->super.messages, context_msg);
 
   new_context->super.timer = timer_wheel_add_timer(db->timer_wheel, rule->context.timeout, pattern_db_expire_entry,
-                             correllation_context_ref(&new_context->super),
-                             (GDestroyNotify) correllation_context_unref);
+                                                   correllation_context_ref(&new_context->super),
+                                                   (GDestroyNotify) correllation_context_unref);
   new_context->rule = pdb_rule_ref(rule);
 }
 
@@ -694,8 +694,8 @@ _pattern_db_process_matching_rule(PatternDB *self, PDBRule *rule, LogMessage *ms
       else
         {
           context->super.timer = timer_wheel_add_timer(self->timer_wheel, rule->context.timeout, pattern_db_expire_entry,
-                                 correllation_context_ref(&context->super),
-                                 (GDestroyNotify) correllation_context_unref);
+                                                       correllation_context_ref(&context->super),
+                                                       (GDestroyNotify) correllation_context_unref);
         }
       if (context->rule != rule)
         {
@@ -808,7 +808,7 @@ static void
 _init_state(PatternDB *self)
 {
   self->rate_limits = g_hash_table_new_full(correllation_key_hash, correllation_key_equal, NULL,
-                      (GDestroyNotify) pdb_rate_limit_free);
+                                            (GDestroyNotify) pdb_rate_limit_free);
   correllation_state_init_instance(&self->correllation);
   self->timer_wheel = timer_wheel_new();
   timer_wheel_set_associated_data(self->timer_wheel, self, NULL);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -155,8 +155,8 @@ _pop_state(PDBLoader *state)
 
 static gboolean
 _pop_state_for_closing_tag_with_alternatives(PDBLoader *state, const gchar *element_name,
-    const gchar *expected_element, const gchar *alternatives,
-    GError **error)
+                                             const gchar *expected_element, const gchar *alternatives,
+                                             GError **error)
 {
   if (strcmp(element_name, expected_element) != 0)
     {
@@ -607,7 +607,7 @@ _pdbl_rule_end(PDBLoader *state, const gchar *element_name, GError **error)
       /* valid, but we don't do anything */
     }
   else if (_pop_state_for_closing_tag_with_alternatives(state, element_name, "rule",
-           "</patterns>, </description>, </tags>, </urls>, </values>", error) == 0)
+                                                        "</patterns>, </description>, </tags>, </urls>, </values>", error) == 0)
     {
       if (state->current_rule)
         {

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -695,7 +695,7 @@ pdbtool_test_find_conflicts(PatternDB *patterndb, LogMessage *msg)
       gint matching_ids_len;
 
       matching_ids = r_find_all_applicable_nodes(program_rules->rules, (guint8 *) message, strlen(message),
-          (RNodeGetValueFunc) pdb_rule_get_name);
+                                                 (RNodeGetValueFunc) pdb_rule_get_name);
       matching_ids_len = g_strv_length(matching_ids);
 
       if (matching_ids_len > 1)

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -86,7 +86,7 @@ synthetic_message_add_tag(SyntheticMessage *self, const gchar *text)
 
 gboolean
 synthetic_message_add_value_template_string(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name,
-    const gchar *value, GError **error)
+                                            const gchar *value, GError **error)
 {
   LogTemplate *value_template;
   gboolean result = FALSE;

--- a/modules/dbparser/tests/test_parsers.c
+++ b/modules/dbparser/tests/test_parsers.c
@@ -76,7 +76,7 @@ _invoke_parser(gboolean (*parser)(guint8 *str, gint *len, const gchar *param, gp
 
 static void
 assert_parser_success(gboolean (*parser)(guint8 *str, gint *len, const gchar *param, gpointer state,
-                      RParserMatch *match), const gchar *str, gpointer param, gpointer state, const gchar *expected_string)
+                                         RParserMatch *match), const gchar *str, gpointer param, gpointer state, const gchar *expected_string)
 {
   gchar *result_string = NULL;
   gboolean result;
@@ -89,7 +89,7 @@ assert_parser_success(gboolean (*parser)(guint8 *str, gint *len, const gchar *pa
 
 static void
 assert_parser_failure(gboolean (*parser)(guint8 *str, gint *len, const gchar *param, gpointer state,
-                      RParserMatch *match), const gchar *str, gpointer param, gpointer state)
+                                         RParserMatch *match), const gchar *str, gpointer param, gpointer state)
 {
   gboolean result;
 

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -174,7 +174,7 @@ _feed_message_to_correllation_state(const gchar *program, const gchar *message, 
 
 static void
 assert_msg_with_program_matches_and_nvpair_equals(const gchar *program, const gchar *message,
-    const gchar *name, const gchar *expected_value)
+                                                  const gchar *name, const gchar *expected_value)
 {
   LogMessage *msg;
   gboolean result;
@@ -263,7 +263,7 @@ assert_msg_matches_and_no_such_output_message(const gchar *pattern, gint ndx)
 
 void
 assert_msg_matches_and_output_message_nvpair_equals(const gchar *pattern, gint ndx, const gchar *name,
-    const gchar *value)
+                                                    const gchar *value)
 {
   assert_msg_matches_and_output_message_nvpair_equals_with_timeout(pattern, 0, ndx, name, value);
 }
@@ -279,7 +279,7 @@ assert_output_message_has_tag(gint ndx, const gchar *tag, gboolean set)
 
 void
 assert_msg_matches_and_output_message_has_tag_with_timeout(const gchar *pattern, gint timeout, gint ndx,
-    const gchar *tag, gboolean set)
+                                                           const gchar *tag, gboolean set)
 {
   LogMessage *msg;
 
@@ -630,10 +630,10 @@ test_correllation_rule_with_action_on_match(void)
   assert_msg_matches_and_has_tag("correllated-message-with-action-on-match", ".classifier.violation", TRUE);
 
   assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-action-on-match", 1, "MESSAGE",
-      "generated-message-on-match");
+                                                      "generated-message-on-match");
   assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-action-on-match", 1, "context-id", "999");
   assert_msg_matches_and_output_message_has_tag("correllated-message-with-action-on-match", 1, "correllated-msg-tag",
-      TRUE);
+                                                TRUE);
 }
 
 static void
@@ -653,7 +653,7 @@ test_correllation_rule_with_action_condition(void)
   assert_msg_matches_and_has_tag("correllated-message-with-action-condition", ".classifier.violation", TRUE);
 
   assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-action-condition", 1, "MESSAGE",
-      "generated-message-on-condition");
+                                                      "generated-message-on-condition");
 }
 
 static void
@@ -671,7 +671,7 @@ test_correllation_rule_with_rate_limited_action(void)
    * [5] GENERATED (as rate limit was met again due to advance time */
 
   assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-rate-limited-action", 1, "MESSAGE",
-      "generated-message-rate-limit");
+                                                      "generated-message-rate-limit");
   _dont_reset_patterndb_state_for_the_next_call();
   assert_msg_matches_and_no_such_output_message("correllated-message-with-rate-limited-action", 3);
   _dont_reset_patterndb_state_for_the_next_call();
@@ -679,7 +679,7 @@ test_correllation_rule_with_rate_limited_action(void)
   _dont_reset_patterndb_state_for_the_next_call();
   _advance_time(120);
   assert_msg_matches_and_output_message_nvpair_equals("correllated-message-with-rate-limited-action", 5, "MESSAGE",
-      "generated-message-rate-limit");
+                                                      "generated-message-rate-limit");
 }
 
 static void
@@ -689,7 +689,7 @@ test_simple_rule_with_action_on_match(void)
   assert_msg_matches_and_has_tag("simple-message-with-action-on-match", ".classifier.violation", TRUE);
 
   assert_msg_matches_and_output_message_nvpair_equals("simple-message-with-action-on-match", 1, "MESSAGE",
-      "generated-message-on-match");
+                                                      "generated-message-on-match");
   assert_msg_matches_and_output_message_has_tag("simple-message-with-action-on-match", 1, "simple-msg-tag", TRUE);
 }
 
@@ -708,7 +708,7 @@ test_simple_rule_with_rate_limited_action(void)
    * [5] GENERATED (as rate limit was met again due to advance time */
 
   assert_msg_matches_and_output_message_nvpair_equals("simple-message-with-rate-limited-action", 1, "MESSAGE",
-      "generated-message-rate-limit");
+                                                      "generated-message-rate-limit");
   _dont_reset_patterndb_state_for_the_next_call();
   assert_msg_matches_and_no_such_output_message("simple-message-with-rate-limited-action", 3);
   _dont_reset_patterndb_state_for_the_next_call();
@@ -716,7 +716,7 @@ test_simple_rule_with_rate_limited_action(void)
   _dont_reset_patterndb_state_for_the_next_call();
   _advance_time(120);
   assert_msg_matches_and_output_message_nvpair_equals("simple-message-with-rate-limited-action", 5, "MESSAGE",
-      "generated-message-rate-limit");
+                                                      "generated-message-rate-limit");
 }
 
 
@@ -727,7 +727,7 @@ test_simple_rule_with_action_condition(void)
   assert_msg_matches_and_has_tag("simple-message-with-action-condition", ".classifier.violation", TRUE);
 
   assert_msg_matches_and_output_message_nvpair_equals("simple-message-with-action-condition", 1, "MESSAGE",
-      "generated-message-on-condition");
+                                                      "generated-message-on-condition");
 }
 
 static void
@@ -897,7 +897,7 @@ test_patterndb_message_property_inheritance_enabled()
   _load_pattern_db_from_string(pdb_inheritance_enabled_skeleton);
 
   assert_msg_matches_and_output_message_nvpair_equals("pattern-with-inheritance-enabled", 1, "MESSAGE",
-      "pattern-with-inheritance-enabled");
+                                                      "pattern-with-inheritance-enabled");
   assert_msg_matches_and_output_message_has_tag("pattern-with-inheritance-enabled", 1, "basetag1", TRUE);
   assert_msg_matches_and_output_message_has_tag("pattern-with-inheritance-enabled", 1, "basetag2", TRUE);
   assert_msg_matches_and_output_message_has_tag("pattern-with-inheritance-enabled", 1, "actiontag", TRUE);

--- a/modules/dbparser/tests/test_patternize.c
+++ b/modules/dbparser/tests/test_patternize.c
@@ -259,7 +259,7 @@ test_clusters_find(gpointer key, gpointer value, gpointer user_data)
     {
 
       line = g_strdup((gchar *) log_msg_get_value((LogMessage *) g_ptr_array_index(data->logs, data->lines[i]), LM_V_MESSAGE,
-                      &msglen));
+                                                  &msglen));
 
       find_data = g_new(clusterfind2Data, 1);
       find_data->search_line = line;

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -363,7 +363,7 @@ void
 test_rewind_backlog()
 {
   LogQueueDiskReliable *dq = _init_diskq_for_test(QDISK_RESERVED_SPACE + mark_message_serialized_size * 10,
-                             mark_message_serialized_size * 5);
+                                                  mark_message_serialized_size * 5);
   gint64 old_read_pos;
 
   _prepare_rewind_backlog_test(dq, &old_read_pos);

--- a/modules/java/native/java-class-loader.c
+++ b/modules/java/native/java-class-loader.c
@@ -77,7 +77,7 @@ class_loader_new(JNIEnv *java_env)
     }
 
   self->mi_init_current_thread = CALL_JAVA_FUNCTION(java_env, GetMethodID, self->syslogng_class_loader,
-                                 "initCurrentThread", "()V");
+                                                    "initCurrentThread", "()V");
   if (!self->mi_init_current_thread)
     {
       msg_error("Can't find method in class",

--- a/modules/java/proxies/java-destination-proxy.c
+++ b/modules/java/proxies/java-destination-proxy.c
@@ -96,9 +96,9 @@ __load_destination_object(JavaDestinationProxy *self, const gchar *class_name, c
     }
 
   self->dest_impl.mi_send = CALL_JAVA_FUNCTION(java_env, GetMethodID, self->loaded_class, "sendProxy",
-      "(Ljava/lang/String;)Z");
+                                               "(Ljava/lang/String;)Z");
   self->dest_impl.mi_send_msg = CALL_JAVA_FUNCTION(java_env, GetMethodID, self->loaded_class, "sendProxy",
-      "(Lorg/syslog_ng/LogMessage;)Z");
+                                                   "(Lorg/syslog_ng/LogMessage;)Z");
 
   if (!self->dest_impl.mi_send_msg && !self->dest_impl.mi_send)
     {
@@ -141,7 +141,7 @@ __load_destination_object(JavaDestinationProxy *self, const gchar *class_name, c
     }
 
   self->dest_impl.dest_object = CALL_JAVA_FUNCTION(java_env, NewObject, self->loaded_class,
-      self->dest_impl.mi_constructor, handle);
+                                                   self->dest_impl.mi_constructor, handle);
   if (!self->dest_impl.dest_object)
     {
       msg_error("Can't create object",
@@ -289,7 +289,7 @@ __get_name_by_uniq_options(JavaDestinationProxy *self)
   jstring java_string;
 
   java_string = (jstring) CALL_JAVA_FUNCTION(env, CallObjectMethod, self->dest_impl.dest_object,
-      self->dest_impl.mi_get_name_by_uniq_options);
+                                             self->dest_impl.mi_get_name_by_uniq_options);
   if (!java_string)
     {
       msg_error("Can't get name by unique options");

--- a/modules/java/proxies/java-template-proxy.c
+++ b/modules/java/proxies/java-template-proxy.c
@@ -38,7 +38,7 @@ Java_org_syslog_1ng_LogTemplate_create_1new_1template_1instance(JNIEnv *env, job
 
 JNIEXPORT jboolean
 JNICALL Java_org_syslog_1ng_LogTemplate_compile(JNIEnv *env, jobject obj, jlong template_handle,
-    jstring template_string)
+                                                jstring template_string)
 {
   LogTemplate *template = (LogTemplate *)template_handle;
   GError *error = NULL;

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -46,8 +46,8 @@ assert_log_kmsg_value(LogMessage *message, const gchar *key,
                       const gchar *expected_value)
 {
   const gchar *actual_value = log_msg_get_value(message,
-                              log_msg_get_value_handle(key),
-                              NULL);
+                                                log_msg_get_value_handle(key),
+                                                NULL);
   assert_string(actual_value, expected_value, NULL);
 }
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -235,7 +235,7 @@ _py_invoke_void_method_by_name(PythonDestDriver *self, PyObject *instance, const
 
 static gboolean
 _py_invoke_bool_method_by_name_with_args(PythonDestDriver *self, PyObject *instance, const gchar *method_name,
-    PyObject *args)
+                                         PyObject *args)
 {
   gboolean result = FALSE;
   PyObject *method = _py_get_method(self, instance, method_name);

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -356,7 +356,7 @@ riemann_worker_init(LogPipe *s)
   if (self->event.batch_size_max <= 0)
     self->event.batch_size_max = 1;
   self->event.list = (riemann_event_t **)malloc (sizeof (riemann_event_t *) *
-                     self->event.batch_size_max);
+                                                 self->event.batch_size_max);
 
   msg_verbose("Initializing Riemann destination",
               evt_tag_str("driver", self->super.super.super.id),
@@ -587,7 +587,7 @@ riemann_worker_batch_flush(RiemannDestDriver *self)
    */
   self->event.n = 0;
   self->event.list = (riemann_event_t **)malloc (sizeof (riemann_event_t *) *
-                     self->event.batch_size_max);
+                                                 self->event.batch_size_max);
   g_static_mutex_unlock(&self->event.lock);
 
   if (r != 0)

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -1013,7 +1013,7 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
 
       /* A kernel message? Use 'kernel' as the program name. */
       if ((self->flags & LF_INTERNAL) == 0 && ((self->pri & LOG_FACMASK) == LOG_KERN &&
-          (self->flags & LF_LOCAL) != 0))
+                                               (self->flags & LF_LOCAL) != 0))
         {
           log_msg_set_value(self, LM_V_PROGRAM, "kernel", 6);
         }

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -246,7 +246,7 @@ _set_message_timestamp(JournalReader *self, LogMessage *msg)
   msg->timestamps[LM_TS_STAMP].tv_sec = ts / 1000000;
   msg->timestamps[LM_TS_STAMP].tv_usec = ts % 1000000;
   msg->timestamps[LM_TS_STAMP].zone_offset = time_zone_info_get_offset(self->options->recv_time_zone_info,
-      msg->timestamps[LM_TS_STAMP].tv_sec);
+                                             msg->timestamps[LM_TS_STAMP].tv_sec);
   if (msg->timestamps[LM_TS_STAMP].zone_offset == -1)
     {
       msg->timestamps[LM_TS_STAMP].zone_offset = get_local_timezone_ofs(msg->timestamps[LM_TS_STAMP].tv_sec);
@@ -292,7 +292,7 @@ _load_state(JournalReader *self)
 
   self->persist_state = cfg->state;
   self->persist_handle = persist_state_lookup_entry(self->persist_state, self->persist_name, &state_size,
-                         &persist_version);
+                                                    &persist_version);
   return !!(self->persist_handle);
 }
 


### PR DESCRIPTION
This is one of the things that I fail to properly do with our style-checks. I agree that very long lines should
not "continue", but I would permit lines that start up to the 60. character, indented by spaces. I think because of the long identifiers we have, this is a pretty common case.

The patch contains both the patch to astylerc and the resulting indentations.

I would love to hear your opinions. Merging this may need some thought, as it would probably generate conflicts with the rest of the pull requests, but those should be pretty easy to resolve.

Anyway, would be great to know your thoughts @kvch and @lbudai, whether 

1) you agree
2) when you think this could be merged


This patch adds --max-instatement-indent=60 to astylerc, as we are permitting
120 long lines and it makes sense to increase this as well.

This causes a number of reindents in the code, effectively reverting
part of the changes that were made when astyle was implemented. A lot
of our identifiers are pretty long due to the naming
convention.
