### PR TITLE
pcre_study: pcre_study_free should be used to free m

### DIFF
--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -81,7 +81,7 @@ multi_line_regexp_free(MultiLineRegexp *self)
       if (self->pattern)
         pcre_free(self->pattern);
       if (self->extra)
-        pcre_free(self->extra);
+        pcre_free_study(self->extra);
       g_free(self);
     }
 }


### PR DESCRIPTION
when memory was allocated with pcre_study.
Otherwise it causes memory leak.

Signed-off-by: Juhász Viktor <juhasz.viktor81@gmail.com>