### PR TITLE
Add unit tests for BSD format year calculation

### DIFF
--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -106,11 +106,17 @@ lib_tests_test_userdb_LDADD	= \
 if ENABLE_CRITERION
 
 lib_tests_TESTS		+= \
-	lib/tests/test_cache
+	lib/tests/test_cache		\
+	lib/tests/test_timeutils
 
 lib_tests_test_cache_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_cache_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_timeutils_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_timeutils_LDADD	=	\
 	$(TEST_LDADD)
 
 endif

--- a/lib/tests/test_timeutils.c
+++ b/lib/tests/test_timeutils.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include <criterion/theories.h>
+#include <time.h>
+
+#include "timeutils.h"
+
+TheoryDataPoints(msgparse, test_year_calculation_for_bsd_format_regular_months) =
+{
+  DataPoints(int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+  DataPoints(int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+};
+
+Theory((int lhs, int rhs), msgparse, test_year_calculation_for_bsd_format_regular_months)
+{
+  /* For regular months, the year will be the actual year, independently of the current month. */
+  cr_assume(lhs != 11 || rhs != 0);
+  cr_assume(lhs != 0 || rhs != 11);
+
+  struct tm *tm;
+  time_t t;
+
+  time(&t);
+  tm = localtime(&t);
+  tm->tm_mon = rhs;
+  cr_assert_eq(tm->tm_year, determine_year_for_month(lhs, tm));
+}
+
+Test(msgparse, test_bsd_year_calculation_near_to_end_of_the_year)
+{
+  struct tm *tm;
+  time_t t;
+
+  time(&t);
+  tm = localtime(&t);
+
+  /* Current month is January, the given month is December => last year */
+  tm->tm_mon = 0;
+  cr_assert_eq(tm->tm_year - 1, determine_year_for_month(11, tm));
+
+  /* Current month is December, the given month is January => next year */
+  tm->tm_mon = 11;
+  cr_assert_eq(tm->tm_year + 1, determine_year_for_month(0, tm));
+}


### PR DESCRIPTION
There were no unit tests for it, and we got some complaints about this heuristic. Now it is clear that it is intended to work this way. It can be changed later, just the reference tests must be updated.

See e0548d870a0fb4d85379814240e8f8f746a764b4 and 7e280cafb450125d26affdbde2610d05c0951bd8, and #818.