### PR TITLE
Named parser cannot be referenced multiple times

### DIFF
--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -146,7 +146,7 @@ _clone(LogPipe *s)
   add_contextual_data_set_filename(&cloned->super, self->filename);
   add_contextual_data_set_database_default_selector(&cloned->super,
                                                     self->default_selector);
-  self->selector = add_contextual_data_selector_clone(self->selector, s->cfg);
+  cloned->selector = add_contextual_data_selector_clone(self->selector, s->cfg);
 
   return &cloned->super.super;
 }


### PR DESCRIPTION
The syslog-ng cannot start (with message `Error initializing message pipeline;`) if a named parser is referenced multiple times.

## Version of syslog-ng

```
syslog-ng 3.9.1
Installer-Version: 3.9.1
Revision: 
Module-Directory: /home/matefarkas/install/syslog-ng/lib/syslog-ng
Module-Path: /home/matefarkas/install/syslog-ng/lib/syslog-ng
Available-Modules: afmongodb,affile,sdjournal,confgen,cryptofuncs,syslogformat,pseudofile,afsocket,afamqp,basicfuncs,afuser,linux-kmsg-format,tfgetent,afprog,kvformat,mod-python,date,graphite,disk-buffer,csvparser,dbparser,add-contextual-data,cef,afstomp,system-source,json-plugin
Enable-Debug: on
Enable-GProf: off
Enable-Memtrace: off
Enable-IPv6: on
Enable-Spoof-Source: off
Enable-TCP-Wrapper: off
Enable-Linux-Caps: off
```

## Steps to reproduce

1. `touch etc/hosts.csv`
2. Edit `syslog-ng.conf`
3. Try to start syslog-ng

## Configuration

```
@version: 3.9
parser p_contextual {
    add_contextual_data( database("hosts.csv") selector("${HOST}") );
};
log {
    source{ internal(); };
    parser(p_contextual);
    #parser(p_contextual); # Enable this line and syslog-ng won't start
    destination { file("/dev/null"); };
};
```

It also fails if the parser is referenced by 2 absolutely different log path.
