### PR TITLE
Fix pcre jit leak

### DIFF
--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -8,6 +8,7 @@ set(COMPAT_HEADERS
     compat/string.h
     compat/time.h
     compat/openssl_support.h
+    compat/pcre.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -9,7 +9,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/socket.h		\
 	lib/compat/string.h		\
 	lib/compat/time.h		\
-	lib/compat/openssl_support.h
+	lib/compat/openssl_support.h	\
+	lib/compat/pcre.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/pcre.h
+++ b/lib/compat/pcre.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef COMPAT_PCRE_H_INCLUDED
+#define COMPAT_PCRE_H_INCLUDED
+
+#include "compat/compat.h"
+#include <pcre.h>
+
+#ifndef PCRE_CONFIG_JIT
+#define pcre_free_study pcre_free
+#endif
+
+#endif /* COMPAT_PCRE_H_INCLUDED */

--- a/lib/compat/pcre.h
+++ b/lib/compat/pcre.h
@@ -32,4 +32,12 @@
 #define pcre_free_study pcre_free
 #endif
 
+#ifndef PCRE_STUDY_JIT_COMPILE
+#define PCRE_STUDY_JIT_COMPILE 0
+#endif
+
+#ifndef PCRE_NEWLINE_ANYCRLF
+#define PCRE_NEWLINE_ANYCRLF 0
+#endif
+
 #endif /* COMPAT_PCRE_H_INCLUDED */

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -481,19 +481,18 @@ log_matcher_pcre_re_compile(LogMatcher *s, const gchar *re, GError **error)
   const gchar *errptr;
   gint erroffset;
   gint flags = 0;
-  gint optflags = 0;
 
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
   if (self->super.flags & LMF_ICASE)
     flags |= PCRE_CASELESS;
-#ifdef PCRE_NEWLINE_ANYCRLF
+
   if (self->super.flags & LMF_NEWLINE)
-    flags |= PCRE_NEWLINE_ANYCRLF;
-#else
-  if (self->super.flags & LMF_NEWLINE)
-    msg_warning("syslog-ng was compiled against an old PCRE which doesn't support the 'newline' flag");
-#endif
+    {
+      if (!PCRE_NEWLINE_ANYCRLF)
+        msg_warning("syslog-ng was compiled against an old PCRE which doesn't support the 'newline' flag");
+      flags |= PCRE_NEWLINE_ANYCRLF;
+    }
   if (self->super.flags & LMF_UTF8)
     {
       gint support;
@@ -525,12 +524,8 @@ log_matcher_pcre_re_compile(LogMatcher *s, const gchar *re, GError **error)
       return FALSE;
     }
 
-#ifdef PCRE_STUDY_JIT_COMPILE
-  optflags = PCRE_STUDY_JIT_COMPILE;
-#endif
-
   /* optimize regexp */
-  self->extra = pcre_study(self->pattern, optflags, &errptr);
+  self->extra = pcre_study(self->pattern, PCRE_STUDY_JIT_COMPILE, &errptr);
   if (errptr != NULL)
     {
       g_set_error(error, LOG_TEMPLATE_ERROR, 0, "Error while optimizing regular expression, error=%s", errptr);

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -27,8 +27,7 @@
 #include "cfg.h"
 #include "str-utils.h"
 #include "compat/string.h"
-
-#include <pcre.h>
+#include "compat/pcre.h"
 
 static void
 log_matcher_init(LogMatcher *self, const LogMatcherOptions *options)
@@ -778,7 +777,7 @@ static void
 log_matcher_pcre_re_free(LogMatcher *s)
 {
   LogMatcherPcreRe *self = (LogMatcherPcreRe *) s;
-  pcre_free(self->extra);
+  pcre_free_study(self->extra);
   pcre_free(self->pattern);
 }
 

--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -81,7 +81,7 @@ multi_line_regexp_free(MultiLineRegexp *self)
       if (self->pattern)
         pcre_free(self->pattern);
       if (self->extra)
-        pcre_free(self->extra);
+        pcre_free_study(self->extra);
       g_free(self);
     }
 }

--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -23,9 +23,9 @@
 
 #include "logproto-regexp-multiline-server.h"
 #include "messages.h"
+#include "compat/pcre.h"
 
 #include <string.h>
-#include <pcre.h>
 
 struct _MultiLineRegexp
 {


### PR DESCRIPTION
This branch builds on PR #1345 by @juhaszviktor so it works on older PCRE releases as well. It removes ifdef trickery by introducing a compat/pcre.h file.
