### PR TITLE
list-scanner-test: add enable criterion condition

### DIFF
--- a/lib/scanner/list-scanner/tests/Makefile.am
+++ b/lib/scanner/list-scanner/tests/Makefile.am
@@ -1,3 +1,4 @@
+if ENABLE_CRITERION
 lib_scanner_list_scanner_tests_TESTS		= \
 	lib/scanner/list-scanner/tests/test_list_scanner
 
@@ -7,3 +8,4 @@ check_PROGRAMS		+= ${lib_scanner_list_scanner_tests_TESTS}
 lib_scanner_list_scanner_tests_test_list_scanner_CFLAGS	= $(TEST_CFLAGS)
 lib_scanner_list_scanner_tests_test_list_scanner_LDADD	=	\
 	$(TEST_LDADD)
+endif


### PR DESCRIPTION
Run Criterion tests only when Criterion is installed on the system.

Signed-off-by: Noémi Ványi <sitbackandwait@gmail.com>