### PR TITLE
Validate non negative numbers

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -884,8 +884,8 @@ options_items
 	;
 
 options_item
-	: KW_MARK_FREQ '(' LL_NUMBER ')'		{ configuration->mark_freq = $3; }
-	| KW_FLUSH_LINES '(' LL_NUMBER ')'		{ configuration->flush_lines = $3; }
+	: KW_MARK_FREQ '(' nonnegative_integer ')'		{ configuration->mark_freq = $3; }
+	| KW_FLUSH_LINES '(' positive_integer ')'		{ configuration->flush_lines = $3; }
         | KW_MARK_MODE '(' KW_INTERNAL ')'         { cfg_set_mark_mode(configuration, "internal"); }
         | KW_MARK_MODE '(' string ')'
           {
@@ -893,23 +893,23 @@ options_item
             cfg_set_mark_mode(configuration, $3);
             free($3);
           }
-	| KW_FLUSH_TIMEOUT '(' LL_NUMBER ')'	{ configuration->flush_timeout = $3; }
+	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ configuration->flush_timeout = $3; }
 	| KW_CHAIN_HOSTNAMES '(' yesno ')'	{ configuration->chain_hostnames = $3; }
 	| KW_KEEP_HOSTNAME '(' yesno ')'	{ configuration->keep_hostname = $3; }
 	| KW_CHECK_HOSTNAME '(' yesno ')'	{ configuration->check_hostname = $3; }
 	| KW_BAD_HOSTNAME '(' string ')'	{ cfg_bad_hostname_set(configuration, $3); free($3); }
-	| KW_TIME_REOPEN '(' LL_NUMBER ')'		{ configuration->time_reopen = $3; }
-	| KW_TIME_REAP '(' LL_NUMBER ')'		{ configuration->time_reap = $3; }
-	| KW_TIME_SLEEP '(' LL_NUMBER ')'	{}
-	| KW_SUPPRESS '(' LL_NUMBER ')'		{ configuration->suppress = $3; }
+	| KW_TIME_REOPEN '(' positive_integer ')'		{ configuration->time_reopen = $3; }
+	| KW_TIME_REAP '(' positive_integer ')'		{ configuration->time_reap = $3; }
+	| KW_TIME_SLEEP '(' nonnegative_integer ')'	{}
+	| KW_SUPPRESS '(' nonnegative_integer ')'		{ configuration->suppress = $3; }
 	| KW_THREADED '(' yesno ')'		{ configuration->threaded = $3; }
 	| KW_PASS_UNIX_CREDENTIALS '(' yesno ')' { configuration->pass_unix_credentials = $3; }
 	| KW_USE_RCPTID '(' yesno ')'		{ cfg_set_use_uniqid($3); }
 	| KW_USE_UNIQID '(' yesno ')'		{ cfg_set_use_uniqid($3); }
-	| KW_LOG_FIFO_SIZE '(' LL_NUMBER ')'	{ configuration->log_fifo_size = $3; }
-	| KW_LOG_IW_SIZE '(' LL_NUMBER ')'	{ msg_warning("WARNING: Support for the global log-iw-size() option was removed, please use a per-source log-iw-size()", cfg_lexer_format_location_tag(lexer, &@1)); }
-	| KW_LOG_FETCH_LIMIT '(' LL_NUMBER ')'	{ msg_warning("WARNING: Support for the global log-fetch-limit() option was removed, please use a per-source log-fetch-limit()", cfg_lexer_format_location_tag(lexer, &@1)); }
-	| KW_LOG_MSG_SIZE '(' LL_NUMBER ')'	{ configuration->log_msg_size = $3; }
+	| KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ configuration->log_fifo_size = $3; }
+	| KW_LOG_IW_SIZE '(' positive_integer ')'	{ msg_warning("WARNING: Support for the global log-iw-size() option was removed, please use a per-source log-iw-size()", cfg_lexer_format_location_tag(lexer, &@1)); }
+	| KW_LOG_FETCH_LIMIT '(' positive_integer ')'	{ msg_warning("WARNING: Support for the global log-fetch-limit() option was removed, please use a per-source log-fetch-limit()", cfg_lexer_format_location_tag(lexer, &@1)); }
+	| KW_LOG_MSG_SIZE '(' positive_integer ')'	{ configuration->log_msg_size = $3; }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ configuration->keep_timestamp = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ configuration->create_dirs = $3; }
         | KW_CUSTOM_DOMAIN '(' string ')'       { configuration->custom_domain = g_strdup($3); free($3); }
@@ -924,15 +924,15 @@ options_item
 	;
 
 stat_option
-	: KW_STATS_FREQ '(' LL_NUMBER ')'          { last_stats_options->log_freq = $3; }
-	| KW_STATS_LEVEL '(' LL_NUMBER ')'         { last_stats_options->level = $3; }
-	| KW_STATS_LIFETIME '(' LL_NUMBER ')'      { last_stats_options->lifetime = $3; }
+	: KW_STATS_FREQ '(' nonnegative_integer ')'          { last_stats_options->log_freq = $3; }
+	| KW_STATS_LEVEL '(' nonnegative_integer ')'         { last_stats_options->level = $3; }
+	| KW_STATS_LIFETIME '(' positive_integer ')'      { last_stats_options->lifetime = $3; }
 	;
 
 dns_cache_option
-	: KW_DNS_CACHE_SIZE '(' LL_NUMBER ')'	{ last_dns_cache_options->cache_size = $3; }
-	| KW_DNS_CACHE_EXPIRE '(' LL_NUMBER ')'	{ last_dns_cache_options->expire = $3; }
-	| KW_DNS_CACHE_EXPIRE_FAILED '(' LL_NUMBER ')'
+	: KW_DNS_CACHE_SIZE '(' positive_integer ')'	{ last_dns_cache_options->cache_size = $3; }
+	| KW_DNS_CACHE_EXPIRE '(' positive_integer ')'	{ last_dns_cache_options->expire = $3; }
+	| KW_DNS_CACHE_EXPIRE_FAILED '(' positive_integer ')'
 	                                        { last_dns_cache_options->expire_failed = $3; }
 	| KW_DNS_CACHE_HOSTS '(' string ')'     { last_dns_cache_options->hosts = g_strdup($3); free($3); }
         ;
@@ -1029,7 +1029,7 @@ parser_opt
 /* LogSource related options */
 source_option
         /* NOTE: plugins need to set "last_source_options" in order to incorporate this rule in their grammar */
-	: KW_LOG_IW_SIZE '(' LL_NUMBER ')'	{ last_source_options->init_window_size = $3; }
+	: KW_LOG_IW_SIZE '(' positive_integer ')'	{ last_source_options->init_window_size = $3; }
 	| KW_CHAIN_HOSTNAMES '(' yesno ')'	{ last_source_options->chain_hostnames = $3; }
 	| KW_KEEP_HOSTNAME '(' yesno ')'	{ last_source_options->keep_hostname = $3; }
 	| KW_PROGRAM_OVERRIDE '(' string ')'	{ last_source_options->program_override = g_strdup($3); free($3); }
@@ -1049,7 +1049,7 @@ source_proto_option
                         "unknown encoding %s", $3);
             free($3);
           }
-	| KW_LOG_MSG_SIZE '(' LL_NUMBER ')'	{ last_proto_server_options->max_msg_size = $3; }
+	| KW_LOG_MSG_SIZE '(' positive_integer ')'	{ last_proto_server_options->max_msg_size = $3; }
         ;
 
 source_reader_options
@@ -1086,7 +1086,7 @@ source_reader_option
 
 	: KW_CHECK_HOSTNAME '(' yesno ')'	{ last_reader_options->check_hostname = $3; }
 	| KW_FLAGS '(' source_reader_option_flags ')'
-	| KW_LOG_FETCH_LIMIT '(' LL_NUMBER ')'	{ last_reader_options->fetch_limit = $3; }
+	| KW_LOG_FETCH_LIMIT '(' positive_integer ')'	{ last_reader_options->fetch_limit = $3; }
         | KW_FORMAT '(' string ')'              { last_reader_options->parse_options.format = g_strdup($3); free($3); }
         | { last_source_options = &last_reader_options->super; } source_option
         | { last_proto_server_options = &last_reader_options->proto_options.super; } source_proto_option
@@ -1104,7 +1104,7 @@ driver_option
     ;
 
 threaded_dest_driver_option
-	: KW_RETRIES '(' LL_NUMBER ')'
+	: KW_RETRIES '(' positive_integer ')'
         {
           log_threaded_dest_driver_set_max_retries(last_driver, $3);
         }
@@ -1112,8 +1112,8 @@ threaded_dest_driver_option
 dest_driver_option
         /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
 
-	: KW_LOG_FIFO_SIZE '(' LL_NUMBER ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
-	| KW_THROTTLE '(' LL_NUMBER ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
+	: KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
+	| KW_THROTTLE '(' nonnegative_integer ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
         | LL_IDENTIFIER
           {
             Plugin *p;
@@ -1144,9 +1144,9 @@ dest_writer_option
         /* NOTE: plugins need to set "last_writer_options" in order to incorporate this rule in their grammar */
 
 	: KW_FLAGS '(' dest_writer_options_flags ')' { last_writer_options->options = $3; }
-	| KW_FLUSH_LINES '(' LL_NUMBER ')'		{ last_writer_options->flush_lines = $3; }
-	| KW_FLUSH_TIMEOUT '(' LL_NUMBER ')'	{ last_writer_options->flush_timeout = $3; }
-        | KW_SUPPRESS '(' LL_NUMBER ')'            { last_writer_options->suppress = $3; }
+	| KW_FLUSH_LINES '(' positive_integer ')'		{ last_writer_options->flush_lines = $3; }
+	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ last_writer_options->flush_timeout = $3; }
+        | KW_SUPPRESS '(' nonnegative_integer ')'            { last_writer_options->suppress = $3; }
 	| KW_TEMPLATE '(' string ')'       	{
                                                   GError *error = NULL;
 
@@ -1155,8 +1155,8 @@ dest_writer_option
 	                                          free($3);
 	                                        }
 	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ log_writer_options_set_template_escape(last_writer_options, $3); }
-	| KW_PAD_SIZE '(' LL_NUMBER ')'         { last_writer_options->padding = $3; }
-	| KW_MARK_FREQ '(' LL_NUMBER ')'        { last_writer_options->mark_freq = $3; }
+	| KW_PAD_SIZE '(' nonnegative_integer ')'         { last_writer_options->padding = $3; }
+	| KW_MARK_FREQ '(' nonnegative_integer ')'        { last_writer_options->mark_freq = $3; }
         | KW_MARK_MODE '(' KW_INTERNAL ')'      { log_writer_options_set_mark_mode(last_writer_options, "internal"); }
 	| KW_MARK_MODE '(' string ')'
 	  {
@@ -1189,7 +1189,7 @@ file_perm_option
 
 template_option
 	: KW_TS_FORMAT '(' string ')'		{ last_template_options->ts_format = cfg_ts_format_value($3); free($3); }
-	| KW_FRAC_DIGITS '(' LL_NUMBER ')'	{ last_template_options->frac_digits = $3; }
+	| KW_FRAC_DIGITS '(' nonnegative_integer ')'	{ last_template_options->frac_digits = $3; }
 	| KW_TIME_ZONE '(' string ')'		{ last_template_options->time_zone[LTZ_SEND] = g_strdup($3); free($3); }
 	| KW_SEND_TIME_ZONE '(' string ')'      { last_template_options->time_zone[LTZ_SEND] = g_strdup($3); free($3); }
 	| KW_LOCAL_TIME_ZONE '(' string ')'     { last_template_options->time_zone[LTZ_LOCAL] = g_strdup($3); free($3); }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -437,6 +437,9 @@ DNSCacheOptions *last_dns_cache_options;
 %type   <num> facility_string
 %type   <num> level_string
 
+%type   <num> positive_integer
+%type   <num> nonnegative_integer
+
 /* END_DECLS */
 
 %type   <ptr> template_def
@@ -953,6 +956,20 @@ dnsmode
 	: yesno					{ $$ = $1; }
 	| KW_PERSIST_ONLY                       { $$ = 2; }
 	;
+
+nonnegative_integer
+        : LL_NUMBER
+          {
+            CHECK_ERROR(($1 >= 0), @1, "It cannot be negative");
+          }
+        ;
+
+positive_integer
+        : LL_NUMBER
+          {
+            CHECK_ERROR(($1 > 0), @1, "Must be positive");
+          }
+        ;
 
 string_or_number
         : string                                { $$ = $1; }

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -327,15 +327,6 @@ log_threaded_dest_driver_start(LogPipe *s)
       return FALSE;
     }
 
-  if (self->retries.max <= 0)
-    {
-      msg_warning("Wrong value for retries(), setting to default",
-                  evt_tag_int("value", self->retries.max),
-                  evt_tag_int("default", MAX_RETRIES_OF_FAILED_INSERT_DEFAULT),
-                  evt_tag_str("driver", self->super.super.id));
-      self->retries.max = MAX_RETRIES_OF_FAILED_INSERT_DEFAULT;
-    }
-
   stats_lock();
   stats_register_counter(0, self->stats_source | SCS_DESTINATION, self->super.super.id,
                          self->format.stats_instance(self),

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -75,7 +75,7 @@ afamqp_options
 
 afamqp_option
         : KW_HOST '(' string ')'		{ afamqp_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' LL_NUMBER ')'		{ afamqp_dd_set_port(last_driver, $3); }
+        | KW_PORT '(' positive_integer ')'		{ afamqp_dd_set_port(last_driver, $3); }
         | KW_VHOST '(' string ')'		{ afamqp_dd_set_vhost(last_driver, $3); free($3); }
 	| KW_EXCHANGE '(' string ')'		{ afamqp_dd_set_exchange(last_driver, $3); free($3); }
         | KW_EXCHANGE_DECLARE '(' yesno ')'	{ afamqp_dd_set_exchange_declare(last_driver, $3); }

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -100,8 +100,8 @@ source_affile_options
 
 source_affile_option
 	: KW_FOLLOW_FREQ '(' LL_FLOAT ')'		{ affile_sd_set_follow_freq(last_driver, (long) ($3 * 1000)); }
-	| KW_FOLLOW_FREQ '(' LL_NUMBER ')'		{ affile_sd_set_follow_freq(last_driver, ($3 * 1000)); }
-	| KW_PAD_SIZE '(' LL_NUMBER ')'			{ ((AFFileSourceDriver *) last_driver)->pad_size = $3; }
+	| KW_FOLLOW_FREQ '(' nonnegative_integer ')'		{ affile_sd_set_follow_freq(last_driver, ($3 * 1000)); }
+	| KW_PAD_SIZE '(' nonnegative_integer ')'			{ ((AFFileSourceDriver *) last_driver)->pad_size = $3; }
 	| multi_line_option
         | source_reader_option
         ;
@@ -124,7 +124,7 @@ source_afpipe_options
 
 source_afpipe_option
 	: KW_OPTIONAL '(' yesno ')'			{ last_driver->optional = $3; }
-	| KW_PAD_SIZE '(' LL_NUMBER ')'			{ ((AFFileSourceDriver *) last_driver)->pad_size = $3; }
+	| KW_PAD_SIZE '(' nonnegative_integer ')'			{ ((AFFileSourceDriver *) last_driver)->pad_size = $3; }
 	| multi_line_option
 	| file_perm_option
 	| source_reader_option
@@ -175,7 +175,7 @@ dest_affile_option
         | file_perm_option
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
-	| KW_OVERWRITE_IF_OLDER '(' LL_NUMBER ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }
+	| KW_OVERWRITE_IF_OLDER '(' nonnegative_integer ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }
 	| KW_FSYNC '(' yesno ')'		{ affile_dd_set_fsync(last_driver, $3); }
 	;
 

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -106,7 +106,7 @@ afmongodb_legacy_option
             afmongodb_dd_set_host(last_driver, $3);
             free($3);
         }
-    | KW_PORT '(' LL_NUMBER ')'
+    | KW_PORT '(' positive_integer ')'
         {
             CHECK_ERROR(afmongodb_dd_validate_network_combination(last_driver), @3,
                          "Can't mix path() & port()");

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -78,7 +78,7 @@ afsmtp_option
             afsmtp_dd_set_host(last_driver, $3);
             free($3);
           }
-        | KW_PORT '(' LL_NUMBER ')' { afsmtp_dd_set_port(last_driver, $3); }
+        | KW_PORT '(' positive_integer ')' { afsmtp_dd_set_port(last_driver, $3); }
         | KW_SUBJECT '(' template_content ')'
           {
             afsmtp_dd_set_subject(last_driver, $3);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -359,12 +359,8 @@ source_afinet_tcp_option
 
 source_afsocket_stream_params
 	: KW_KEEP_ALIVE '(' yesno ')'		{ afsocket_sd_set_keep_alive(last_driver, $3); }
-	| KW_MAX_CONNECTIONS '(' LL_NUMBER ')'	
-          {
-            CHECK_ERROR($3 > 0, @3, "max_connections must be a positive number");
-            afsocket_sd_set_max_connections(last_driver, $3);
-          }
-	| KW_LISTEN_BACKLOG '(' LL_NUMBER ')'	{ afsocket_sd_set_listen_backlog(last_driver, $3); }
+	| KW_MAX_CONNECTIONS '(' positive_integer ')'	 { afsocket_sd_set_max_connections(last_driver, $3); }
+	| KW_LISTEN_BACKLOG '(' positive_integer ')'	{ afsocket_sd_set_listen_backlog(last_driver, $3); }
 	;
 
 source_afsyslog
@@ -717,14 +713,14 @@ tls_option
 
 
 socket_option
-	: KW_SO_SNDBUF '(' LL_NUMBER ')'
+	: KW_SO_SNDBUF '(' nonnegative_integer ')'
 	{
-		CHECK_ERROR($3 >= 0 && $3 <= G_MAXINT, @3, "Invalid so_sndbuf, it has to be between 0 and %d", G_MAXINT);
+		CHECK_ERROR($3 <= G_MAXINT, @3, "Invalid so_sndbuf, it has to be less than %d", G_MAXINT);
 		last_sock_options->so_sndbuf = $3;
 	}
-	| KW_SO_RCVBUF '(' LL_NUMBER ')'
+	| KW_SO_RCVBUF '(' nonnegative_integer ')'
 	{
-		CHECK_ERROR($3 >= 0 && $3 <= G_MAXINT, @3, "Invalid so_rcvbuf, it has to be between 0 and %d", G_MAXINT);
+		CHECK_ERROR($3 <= G_MAXINT, @3, "Invalid so_rcvbuf, it has to be less than %d", G_MAXINT);
 		last_sock_options->so_rcvbuf = $3;
 	}
 	| KW_SO_BROADCAST '(' yesno ')'             { last_sock_options->so_broadcast = $3; }
@@ -733,12 +729,12 @@ socket_option
 
 inet_socket_option
 	: socket_option
-	| KW_IP_TTL '(' LL_NUMBER ')'               { ((SocketOptionsInet *) last_sock_options)->ip_ttl = $3; }
-	| KW_IP_TOS '(' LL_NUMBER ')'               { ((SocketOptionsInet *) last_sock_options)->ip_tos = $3; }
+	| KW_IP_TTL '(' nonnegative_integer ')'               { ((SocketOptionsInet *) last_sock_options)->ip_ttl = $3; }
+	| KW_IP_TOS '(' nonnegative_integer ')'               { ((SocketOptionsInet *) last_sock_options)->ip_tos = $3; }
 	| KW_IP_FREEBIND '(' yesno ')'              { ((SocketOptionsInet *) last_sock_options)->ip_freebind = $3; }
-	| KW_TCP_KEEPALIVE_TIME '(' LL_NUMBER ')'   { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_time = $3; }
-	| KW_TCP_KEEPALIVE_INTVL '(' LL_NUMBER ')'  { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_intvl = $3; }
-	| KW_TCP_KEEPALIVE_PROBES '(' LL_NUMBER ')' { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_probes = $3; }
+	| KW_TCP_KEEPALIVE_TIME '(' nonnegative_integer ')'   { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_time = $3; }
+	| KW_TCP_KEEPALIVE_INTVL '(' nonnegative_integer ')'  { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_intvl = $3; }
+	| KW_TCP_KEEPALIVE_PROBES '(' nonnegative_integer ')' { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_probes = $3; }
 	;
 
 inet_ip_protocol_option

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -114,9 +114,9 @@ dest_afsql_option
         | KW_INDEXES '(' string_list ')'        { afsql_dd_set_indexes(last_driver, $3); }
         | KW_VALUES '(' dest_afsql_values ')'		{ afsql_dd_set_values(last_driver, $3); }
         | KW_NULL '(' string ')'                { afsql_dd_set_null_value(last_driver, $3); free($3); }
-        | KW_RETRIES '(' LL_NUMBER ')'          { afsql_dd_set_retries(last_driver, $3); }
-        | KW_FLUSH_LINES '(' LL_NUMBER ')'      { afsql_dd_set_flush_lines(last_driver, $3); }
-        | KW_FLUSH_TIMEOUT '(' LL_NUMBER ')'    { afsql_dd_set_flush_timeout(last_driver, $3); }
+        | KW_RETRIES '(' nonnegative_integer ')'          { afsql_dd_set_retries(last_driver, $3); }
+        | KW_FLUSH_LINES '(' positive_integer ')'      { afsql_dd_set_flush_lines(last_driver, $3); }
+        | KW_FLUSH_TIMEOUT '(' positive_integer ')'    { afsql_dd_set_flush_timeout(last_driver, $3); }
         | KW_SESSION_STATEMENTS '(' string_list ')' { afsql_dd_set_session_statements(last_driver, $3); }
         | KW_FLAGS '(' dest_afsql_flags ')'     { afsql_dd_set_flags(last_driver, $3); }
 	| KW_CREATE_STATEMENT_APPEND '(' string ')' { afsql_dd_set_create_statement_append(last_driver, $3); free($3); }

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -177,15 +177,7 @@ void
 afsql_dd_set_retries(LogDriver *s, gint num_retries)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
-
-  if (num_retries < 1)
-    {
-      self->num_retries = 1;
-    }
-  else
-    {
-      self->num_retries = num_retries;
-    }
+  self->num_retries = num_retries;
 }
 
 void

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -71,7 +71,7 @@ afstomp_options
 
 afstomp_option
         : KW_HOST '(' string ')'		{ afstomp_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' LL_NUMBER ')'		{ afstomp_dd_set_port(last_driver, $3); }
+        | KW_PORT '(' positive_integer ')'		{ afstomp_dd_set_port(last_driver, $3); }
         | KW_STOMP_DESTINATION '(' string ')'	{ afstomp_dd_set_destination(last_driver, $3); free($3); }
         | KW_BODY '(' string ')'		{ afstomp_dd_set_body(last_driver, $3); free($3); }
         | KW_PERSISTENT '(' yesno ')'		{ afstomp_dd_set_persistent(last_driver, $3); }

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -140,7 +140,7 @@ grouping_by_opt
             CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filter_expr_parser, lexer, (gpointer *) &filter_expr, NULL), @1);
             grouping_by_set_having_condition(last_parser, filter_expr);
           } ')'
-	| KW_TIMEOUT '(' LL_NUMBER ')'				{ grouping_by_set_timeout(last_parser, $3); }
+	| KW_TIMEOUT '(' nonnegative_integer ')'		{ grouping_by_set_timeout(last_parser, $3); }
 	| KW_AGGREGATE '(' synthetic_message ')'		{ grouping_by_set_synthetic_message(last_parser, $3); }
 	| KW_TRIGGER '('
           {

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -88,10 +88,10 @@ dest_diskq_options
 
 dest_diskq_option
         : KW_RELIABLE '(' yesno ')'            { disk_queue_options_reliable_set(last_options, $3); }
-        | KW_MEM_BUF_SIZE '(' LL_NUMBER ')'    { disk_queue_options_mem_buf_size_set(last_options, $3); }
-        | KW_MEM_BUF_LENGTH '(' LL_NUMBER ')'  { disk_queue_options_mem_buf_length_set(last_options, $3); }
-        | KW_DISK_BUF_SIZE '(' LL_NUMBER ')'   { disk_queue_options_disk_buf_size_set(last_options, $3); }
-        | KW_QOUT_SIZE '(' LL_NUMBER ')'       { disk_queue_options_qout_size_set(last_options, $3); }
+        | KW_MEM_BUF_SIZE '(' nonnegative_integer ')'    { disk_queue_options_mem_buf_size_set(last_options, $3); }
+        | KW_MEM_BUF_LENGTH '(' nonnegative_integer ')'  { disk_queue_options_mem_buf_length_set(last_options, $3); }
+        | KW_DISK_BUF_SIZE '(' nonnegative_integer ')'   { disk_queue_options_disk_buf_size_set(last_options, $3); }
+        | KW_QOUT_SIZE '(' nonnegative_integer ')'       { disk_queue_options_qout_size_set(last_options, $3); }
         | KW_DIR '(' string ')'                { disk_queue_options_set_dir(last_options, $3); free($3); }
         ;
 

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -65,7 +65,7 @@ redis_option
             redis_dd_set_host(last_driver, $3);
             free($3);
           }
-        | KW_PORT '(' LL_NUMBER ')'
+        | KW_PORT '(' positive_integer ')'
           {
             redis_dd_set_port(last_driver, $3);
           }

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -77,7 +77,7 @@ riemann_option
             riemann_dd_set_server(last_driver, $3);
             free($3);
           }
-        | KW_PORT '(' LL_NUMBER ')'
+        | KW_PORT '(' positive_integer ')'
           {
             riemann_dd_set_port(last_driver, $3);
           }
@@ -121,7 +121,7 @@ riemann_option
                         "Unknown Riemann connection type: %s", $3);
             free($3);
           }
-        | KW_TIMEOUT '(' LL_NUMBER ')'
+        | KW_TIMEOUT '(' nonnegative_integer ')'
           {
             riemann_dd_set_timeout(last_driver, $3);
           }
@@ -133,7 +133,7 @@ riemann_option
           {
             riemann_dd_set_field_attributes(last_driver, last_value_pairs);
           }
-        | KW_FLUSH_LINES '(' LL_NUMBER ')'
+        | KW_FLUSH_LINES '(' positive_integer ')'
           {
             riemann_dd_set_flush_lines(last_driver,  $3);
           }

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -114,11 +114,11 @@ source_systemd_journal_option
       last_journal_reader_options->prefix = strdup($3);
       free($3);
     }
-  | KW_MAX_FIELD_SIZE '(' LL_NUMBER ')'
+  | KW_MAX_FIELD_SIZE '(' positive_integer ')'
     {
       last_journal_reader_options->max_field_size = $3;
     }
-  | KW_LOG_FETCH_LIMIT '(' LL_NUMBER ')'
+  | KW_LOG_FETCH_LIMIT '(' positive_integer ')'
     {
       last_journal_reader_options->fetch_limit = $3;
     }


### PR DESCRIPTION
Add rules to grammar to be able to require non-negative and positive integers. Some of our configuration options expected those kind of values, but they were not validated before. (Just the program crashed due an invalid setting.)

(@MrAnno collected this list before, it was reviewed and splitted into the positive and the non-negative parts. Copied from https://github.com/balabit/syslog-ng/pull/1330#issuecomment-275225263)

## Positive numbers

* [listen-backlog()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-syslog-chapter.html#idp4343616)
* [log-fetch-limit()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-syslog-chapter.html#idp4358576)
* [log-iw-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-syslog-chapter.html#idp4368480)
* [max-connections()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-unixstream.html#idp5303904)
* [retries()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-stomp.html#idp11689536)
* [log-msg-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-log-msg-size)
* [time-reap()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-time-reap)
* [time-reopen()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-time-reopen)
* [flush-lines()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-flush-lines)
* [flush-timeout()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-flush-timeout)
* stats-lifetime()
* [dns-cache-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-dns-cache-size)
* [dns-cache-expire-failed()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-dns-cache-expire-failed)
* [port(), destport()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-network-chapter.html#idp9307600) - except where string is also accepted.
* [max-field-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-journal.html#idp4900032)
* [log-fifo-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-log-fifo-size)
* [dns-cache-expire()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-dns-cache-expired)

## Non-negative numbers

* [follow-freq()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-pipe.html#idp3350624)
* [mark-freq()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-pipe.html#idp3375392)
* [so-rcvbuf()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-network.html#idp3095424)
* [so-sndbuf()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-network.html#idp3111616)
* [time-sleep()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#idp14247072)
* [pad-size() in source](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-source-file.html#idp2586352)
* [pad-size() in file destination](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-file.html#idp7278416)
* ip-ttl()
* ip-tos()
* [throttle()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-amqp.html#idp5714800)
* [frac-digits()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-frac-digits)
* [overwrite-if-older()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-file.html#idp7254400)
* [tcp-keepalive-intvl()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-network-chapter.html#idp9373040)
* [tcp-keepalive-probes()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-network-chapter.html#idp9398144)
* [tcp-keepalive-time()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-network-chapter.html#idp9423200)
* suppress()
* [stats-freq()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-options.html#global-option-stats-freq)
* [localport()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-network-chapter.html#idp9186944)
* [disk-buffer / mem-buf-length()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-http-nonjava.html#idp8012832)
* [disk-buffer / mem-buf-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-http-nonjava.html#idp8012832)
* [disk-buffer / disk-buf-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-http-nonjava.html#idp8012832)
* [disk-buffer / qout-size()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-http-nonjava.html#idp8012832)
* [sql retries()](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-sql.html#sql-option-retry-sql-inserts)
* [timeout() (riemann)](https://www.balabit.com/documents/syslog-ng-ose-3.9-guides/en/syslog-ng-ose-guide-admin/html/reference-destination-riemann.html#idp10610416)

## Not changed

* ip-protocol() - only 4 and 6 is accepted
* concurrent_requests() - handled differently, not in grammar
* stats-level() - only 0-3 values are accepted
* dir-perm() - more validation would be needed
* perm() - more validation would be needed
* disk-buf-size() - special values are allowed, documented

