### PR TITLE
Apply timezone configuration in Java destinations

### DIFF
--- a/modules/java/proxies/java-destination-proxy.c
+++ b/modules/java/proxies/java-destination-proxy.c
@@ -236,7 +236,7 @@ __queue_native_message(JavaDestinationProxy *self, JNIEnv *env, LogMessage *msg)
 static gboolean
 __queue_formatted_message(JavaDestinationProxy *self, JNIEnv *env, LogMessage *msg)
 {
-  log_template_format(self->template, msg, NULL, LTZ_LOCAL, 0, NULL, self->formatted_message);
+  log_template_format(self->template, msg, NULL, LTZ_SEND, 0, NULL, self->formatted_message);
   jstring message = CALL_JAVA_FUNCTION(env, NewStringUTF, self->formatted_message->str);
   jboolean res = CALL_JAVA_FUNCTION(env, CallBooleanMethod, self->dest_impl.dest_object, self->dest_impl.mi_send,
                                     message);


### PR DESCRIPTION
Previously the log messages were always in local timezone independently from the `time-zone()` configuration option.

# Issue

## Configuration

We have a simple file destination and the dummy Java destination, which just prints the received log message to the console. We expect to have the same message in both cases.

```
@version: 3.9

options {
  time_zone("-08:00");
};

source s_oneline { program("echo syslog-ng-test-oneline"); };

destination d_outfile {file(
    '/home/matefarkas/work/syslog-ng/install/out.txt'
    template("FILE / ${DATE} / ${ISODATE}")
);};


destination d_java {
  java(
    class_path("/home/matefarkas/work/syslog-ng/install/lib/syslog-ng/java-modules/*.jar")
    class_name("org.syslog_ng.DummyTextDestination")
    template("JAVA / ${DATE} / ${ISODATE}")
    option("name", "timezonetest")
  );
};

log {
  source(s_oneline);
  destination(d_java);
  destination(d_outfile);
};
```

## Output logs

```
FILE / Mar  2 02:35:55 / 2017-03-02T02:35:55-08:00
JAVA / Mar  2 11:35:55 / 2017-03-02T11:35:55+01:00;
```

It was originally [reported](https://gitter.im/balabit/syslog-ng/archives/2015/05/15) by @faxm0dem.