### PR TITLE
Scratch buffers2

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -102,6 +102,7 @@ set (LIB_HEADERS
     rcptid.h
     run-id.h
     scratch-buffers.h
+    scratch-buffers2.h
     serialize.h
     service-management.h
     seqnum.h
@@ -185,6 +186,7 @@ set(LIB_SOURCES
     reloc.c
     run-id.c
     scratch-buffers.c
+    scratch-buffers2.c
     serialize.c
     service-management.c
     str-format.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -137,6 +137,7 @@ pkginclude_HEADERS			+= \
 	lib/rcptid.h			\
 	lib/run-id.h			\
 	lib/scratch-buffers.h		\
+	lib/scratch-buffers2.h		\
 	lib/serialize.h			\
 	lib/service-management.h	\
 	lib/seqnum.h			\
@@ -216,6 +217,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/reloc.c			\
 	lib/run-id.c			\
 	lib/scratch-buffers.c		\
+	lib/scratch-buffers2.c		\
 	lib/serialize.c			\
 	lib/service-management.c	\
 	lib/str-format.c		\

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -40,6 +40,7 @@
 #include "service-management.h"
 #include "crypto.h"
 #include "value-pairs/value-pairs.h"
+#include "scratch-buffers2.h"
 
 #include <iv.h>
 #include <iv_work.h>
@@ -135,6 +136,8 @@ app_startup(void)
   log_template_global_init();
   value_pairs_global_init();
   service_management_init();
+  scratch_buffers2_global_init();
+  scratch_buffers2_allocator_init();
 }
 
 void
@@ -160,6 +163,8 @@ void
 app_shutdown(void)
 {
   run_application_hook(AH_SHUTDOWN);
+  scratch_buffers2_allocator_deinit();
+  scratch_buffers2_global_deinit();
   value_pairs_global_deinit();
   log_template_global_deinit();
   log_tags_global_deinit();
@@ -193,6 +198,7 @@ void
 app_thread_start(void)
 {
   scratch_buffers_init();
+  scratch_buffers2_allocator_init();
   dns_caching_thread_init();
   main_loop_call_thread_init();
 }
@@ -200,7 +206,8 @@ app_thread_start(void)
 void
 app_thread_stop(void)
 {
+  main_loop_call_thread_deinit();
   dns_caching_thread_deinit();
   scratch_buffers_free();
-  main_loop_call_thread_deinit();
+  scratch_buffers2_allocator_deinit();
 }

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -917,6 +917,7 @@ relex:
 
           self->preprocess_suppress_tokens--;
           success = cfg_lexer_generate_block(self, cfg_lexer_get_context_type(self), yylval->cptr, gen, args);
+          free(yylval->cptr);
           cfg_args_unref(args);
           if (success)
             {
@@ -925,6 +926,7 @@ relex:
         }
       else
         {
+          free(yylval->cptr);
           self->preprocess_suppress_tokens--;
         }
       return LL_ERROR;

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -483,7 +483,10 @@ dns_caching_global_init(void)
 void
 dns_caching_global_deinit(void)
 {
+  G_LOCK(unused_dns_caches);
   g_list_foreach(unused_dns_caches, (GFunc) dns_cache_free, NULL);
   g_list_free(unused_dns_caches);
+  unused_dns_caches = NULL;
+  G_UNLOCK(unused_dns_caches);
   dns_cache_options_destroy(&effective_dns_cache_options);
 }

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -24,7 +24,7 @@
 
 #include "filter/filter-cmp.h"
 #include "filter/filter-expr-grammar.h"
-#include "scratch-buffers.h"
+#include "scratch-buffers2.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -45,20 +45,21 @@ gboolean
 fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 {
   FilterCmp *self = (FilterCmp *) s;
-  SBGString *left_buf = sb_gstring_acquire();
-  SBGString *right_buf = sb_gstring_acquire();
+  ScratchBuffersMarker marker;
+  GString *left_buf = scratch_buffers2_alloc_and_mark(&marker);
+  GString *right_buf = scratch_buffers2_alloc();
   gboolean result = FALSE;
   gint cmp;
 
-  log_template_format_with_context(self->left, msgs, num_msg, NULL, LTZ_LOCAL, 0, NULL, sb_gstring_string(left_buf));
-  log_template_format_with_context(self->right, msgs, num_msg, NULL, LTZ_LOCAL, 0, NULL, sb_gstring_string(right_buf));
+  log_template_format_with_context(self->left, msgs, num_msg, NULL, LTZ_LOCAL, 0, NULL, left_buf);
+  log_template_format_with_context(self->right, msgs, num_msg, NULL, LTZ_LOCAL, 0, NULL, right_buf);
 
   if (self->cmp_op & FCMP_NUM)
     {
       gint l, r;
 
-      l = atoi(sb_gstring_string(left_buf)->str);
-      r = atoi(sb_gstring_string(right_buf)->str);
+      l = atoi(left_buf->str);
+      r = atoi(right_buf->str);
       if (l == r)
         cmp = 0;
       else if (l < r)
@@ -68,7 +69,7 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
     }
   else
     {
-      cmp = strcmp(sb_gstring_string(left_buf)->str, sb_gstring_string(right_buf)->str);
+      cmp = strcmp(left_buf->str, right_buf->str);
     }
 
   if (cmp == 0)
@@ -84,8 +85,7 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       result = self->cmp_op & FCMP_GT || self->cmp_op == 0;
     }
 
-  sb_gstring_release(left_buf);
-  sb_gstring_release(right_buf);
+  scratch_buffers2_reclaim_marked(marker);
   return result ^ s->comp;
 }
 

--- a/lib/logmsg/tags-serialize.c
+++ b/lib/logmsg/tags-serialize.c
@@ -23,16 +23,16 @@
  */
 
 #include "tags-serialize.h"
-#include "scratch-buffers.h"
+#include "scratch-buffers2.h"
 
 gboolean
 tags_deserialize(LogMessage *msg, SerializeArchive *sa)
 {
-  SBGString *sb = sb_gstring_acquire();
+  ScratchBuffersMarker marker;
+  GString *buf = scratch_buffers2_alloc_and_mark(&marker);
 
   while (1)
     {
-      GString *buf = sb_gstring_string(sb);
       if (!serialize_read_string(sa, buf))
         return FALSE;
       if (buf->len == 0)
@@ -45,7 +45,7 @@ tags_deserialize(LogMessage *msg, SerializeArchive *sa)
 
   msg->flags |= LF_STATE_OWN_TAGS;
 
-  sb_gstring_release(sb);
+  scratch_buffers2_reclaim_marked(marker);
   return TRUE;
 }
 

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -25,6 +25,7 @@
 #include "mainloop-call.h"
 #include "tls-support.h"
 #include "apphook.h"
+#include "scratch-buffers2.h"
 
 #include <iv.h>
 
@@ -176,14 +177,22 @@ main_loop_worker_thread_start(void *cookie)
   _allocate_thread_id();
   INIT_IV_LIST_HEAD(&batch_callbacks);
   app_thread_start();
+  scratch_buffers2_automatic_gc_init();
 }
 
 /* Call this function from worker threads, when you stop */
 void
 main_loop_worker_thread_stop(void)
 {
+  scratch_buffers2_automatic_gc_deinit();
   app_thread_stop();
   _release_thread_id();
+}
+
+void
+main_loop_worker_run_gc(void)
+{
+  scratch_buffers2_explicit_gc();
 }
 
 /*

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -74,6 +74,7 @@ void main_loop_worker_job_complete(void);
 
 void main_loop_worker_thread_start(void *cookie);
 void main_loop_worker_thread_stop(void);
+void main_loop_worker_run_gc(void);
 
 void main_loop_create_worker_thread(WorkerThreadFunc func, WorkerExitNotificationFunc terminate_func, gpointer data, WorkerOptions *worker_options);
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -39,6 +39,7 @@
 #include "debugger/debugger-main.h"
 #include "plugin.h"
 #include "resolved-configurable-paths.h"
+#include "scratch-buffers2.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -443,6 +444,7 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
 
   self->options = options;
   main_thread_handle = get_thread_id();
+  scratch_buffers2_automatic_gc_init();
   main_loop_worker_init();
   main_loop_io_worker_init();
   main_loop_call_init();
@@ -500,6 +502,7 @@ main_loop_deinit(MainLoop *self)
   main_loop_call_deinit();
   main_loop_io_worker_deinit();
   main_loop_worker_deinit();
+  scratch_buffers2_automatic_gc_deinit();
 }
 
 void

--- a/lib/scratch-buffers2.c
+++ b/lib/scratch-buffers2.c
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "scratch-buffers2.h"
+#include "tls-support.h"
+#include "stats/stats-registry.h"
+#include "timeutils.h"
+#include "messages.h"
+#include <iv.h>
+
+/*
+ * scratch_buffers
+ *
+ * The design of this API is to allow call-sites to use GString based string
+ * buffers easily, without incurring the allocation overhead at all such
+ * invocations and the need to always explicitly free them.
+ *
+ * Use-cases:
+ *   - something needs a set of GString buffers, such that their number is
+ *     not determinable at init time, so no preallocation is possible.
+ *     Allocating/freeing these buffers on-demand generates a non-trivial
+ *     overhead.
+ *
+ *   - We need a GString buffer that is needed for the duration of the
+ *     processing of the given message, for example CSVScanner/KVScanner's
+ *     buffers.  Right now, these are locked data structures or GString's
+ *     are allocated on demand, both of which slows them down.  By using
+ *     this API, these could reuse existing allocations and only free them
+ *     once processing is finished of the given message.
+ *
+ * Design principles:
+ *   - you can allocate a GString instance using scratch_buffers2_alloc()
+ *
+ *   - these are thread specific allocations and should not be leaked
+ *     through thread boundaries, not until your own next invocation
+ *
+ *   - you need to assume that once you return from your functions, the
+ *     previous allocations are gone!
+ *
+ *   - you don't need to free these allocations, as they get released
+ *     automatically at the end of the message processing by the worker
+ *     thread machinery
+ *
+ *   - if you produce too much garbage, you can still explicitly free these
+ *     buffers in bulk using the mark/reclaim functions.
+ *
+ *   - reclaim works by freeing _all_ allocations up to a mark, so even
+ *     those that are allocated by the functions you called.  Please make
+ *     sure that those do not hold references after returning.
+ *
+ * Other notes:
+ *   - this is not a complete garbage collector, but a very simple allocator for
+ *     buffers that creates coupling between various/independent parts of
+ *     the codebase.
+ *
+ *   - ONLY USE IT IF YOU UNDERSTAND THE IMPLICATIONS AND PROVIDES A
+ *     MEASURABLE PERFORMANCE IMPACT.
+ */
+
+TLS_BLOCK_START
+{
+  GPtrArray *scratch_buffers;
+  gint scratch_buffers_used;
+  glong scratch_buffers_bytes_reported;
+  time_t scratch_buffers_time_of_last_maintenance;
+  struct iv_task scratch_buffers_gc;
+  gboolean scratch_buffers_gc_executed;
+}
+TLS_BLOCK_END;
+
+/* accessed by the test program */
+StatsCounterItem *stats_scratch_buffers_count;
+StatsCounterItem *stats_scratch_buffers_bytes;
+
+#define scratch_buffers       __tls_deref(scratch_buffers)
+#define scratch_buffers_used  __tls_deref(scratch_buffers_used)
+#define scratch_buffers_bytes_reported  __tls_deref(scratch_buffers_bytes_reported)
+#define scratch_buffers_time_of_last_maintenance  __tls_deref(scratch_buffers_time_of_last_maintenance)
+#define scratch_buffers_gc  __tls_deref(scratch_buffers_gc)
+#define scratch_buffers_gc_executed  __tls_deref(scratch_buffers_gc_executed)
+
+/* update allocation counters once every period, in seconds */
+#define SCRATCH_BUFFERS_MAINTENANCE_PERIOD 5
+
+static void _register_gc_task(void);
+
+void
+scratch_buffers2_mark(ScratchBuffersMarker *marker)
+{
+  *marker = scratch_buffers_used;
+}
+
+GString *
+scratch_buffers2_alloc_and_mark(ScratchBuffersMarker *marker)
+{
+  _register_gc_task();
+  if (marker)
+    scratch_buffers2_mark(marker);
+  if (scratch_buffers_used >= scratch_buffers->len)
+    {
+      g_ptr_array_add(scratch_buffers, g_string_sized_new(255));
+      stats_counter_inc(stats_scratch_buffers_count);
+    }
+
+  GString *buffer = g_ptr_array_index(scratch_buffers, scratch_buffers_used);
+  g_string_truncate(buffer, 0);
+  scratch_buffers_used++;
+  return buffer;
+}
+
+GString *
+scratch_buffers2_alloc(void)
+{
+  return scratch_buffers2_alloc_and_mark(NULL);
+}
+
+void
+scratch_buffers2_reclaim_allocations(void)
+{
+  scratch_buffers2_reclaim_marked(0);
+}
+
+void
+scratch_buffers2_reclaim_marked(ScratchBuffersMarker marker)
+{
+  scratch_buffers_used = marker;
+}
+
+/* get a snapshot of the global allocation counter, can be racy */
+gint
+scratch_buffers2_get_global_allocation_count(void)
+{
+  return stats_counter_get(stats_scratch_buffers_count);
+}
+
+/* get the number of thread-local allocations does not race */
+gint
+scratch_buffers2_get_local_allocation_count(void)
+{
+  return scratch_buffers->len;
+}
+
+glong
+scratch_buffers2_get_local_allocation_bytes(void)
+{
+  glong bytes = 0;
+
+  for (gint i = 0; i < scratch_buffers->len; i++)
+    {
+      GString *str = g_ptr_array_index(scratch_buffers, i);
+      bytes += str->allocated_len;
+    }
+  return bytes;
+}
+
+gint
+scratch_buffers2_get_local_usage_count(void)
+{
+  return scratch_buffers_used;
+}
+
+void
+scratch_buffers2_update_stats(void)
+{
+  glong prev_reported = scratch_buffers_bytes_reported;
+  scratch_buffers_bytes_reported = scratch_buffers2_get_local_allocation_bytes();
+  stats_counter_add(stats_scratch_buffers_bytes, -prev_reported + scratch_buffers_bytes_reported);
+}
+
+void
+scratch_buffers2_allocator_init(void)
+{
+  scratch_buffers = g_ptr_array_sized_new(256);
+}
+
+void
+scratch_buffers2_allocator_deinit(void)
+{
+  /* check if GC was executed */
+  if (scratch_buffers_used > 0 && !scratch_buffers_gc_executed)
+    {
+      msg_warning("WARNING: an exiting thread left behind scratch buffers garbage without ever calling the GC. This message could indicate a memory leak",
+                  evt_tag_int("count", scratch_buffers->len),
+                  evt_tag_long("bytes", scratch_buffers_bytes_reported));
+    }
+
+  /* remove our values from stats */
+  stats_counter_add(stats_scratch_buffers_count, -scratch_buffers->len);
+  stats_counter_add(stats_scratch_buffers_bytes, -scratch_buffers_bytes_reported);
+
+  /* free thread local scratch buffers */
+  for (int i = 0; i < scratch_buffers->len; i++)
+    {
+      GString *buffer = g_ptr_array_index(scratch_buffers, i);
+      g_string_free(buffer, TRUE);
+    }
+  g_ptr_array_free(scratch_buffers, TRUE);
+}
+
+/*********************************************************
+ * Lazy stats update
+ *********************************************************/
+
+static gboolean
+_thread_maintenance_period_elapsed(void)
+{
+  if (!scratch_buffers_time_of_last_maintenance)
+    return TRUE;
+
+  if (scratch_buffers_time_of_last_maintenance - cached_g_current_time_sec() >= SCRATCH_BUFFERS_MAINTENANCE_PERIOD)
+    return TRUE;
+  return FALSE;
+}
+
+static void
+_thread_maintenance_update_time(void)
+{
+  scratch_buffers_time_of_last_maintenance = cached_g_current_time_sec();
+}
+
+void
+scratch_buffers2_lazy_update_stats(void)
+{
+  if (_thread_maintenance_period_elapsed())
+    {
+      scratch_buffers2_update_stats();
+      _thread_maintenance_update_time();
+    }
+}
+
+/*********************************************************
+ * Ivykis task based garbage collector
+ *********************************************************/
+
+void
+scratch_buffers2_explicit_gc(void)
+{
+  scratch_buffers2_lazy_update_stats();
+  scratch_buffers2_reclaim_allocations();
+  scratch_buffers_gc_executed = TRUE;
+}
+
+static void
+_garbage_collect_scratch_buffers(gpointer arg)
+{
+  scratch_buffers2_explicit_gc();
+}
+
+static void
+_register_gc_task(void)
+{
+  if (scratch_buffers_gc.handler && iv_inited() && !iv_task_registered(&scratch_buffers_gc))
+    iv_task_register(&scratch_buffers_gc);
+}
+
+void
+scratch_buffers2_automatic_gc_init(void)
+{
+  IV_TASK_INIT(&scratch_buffers_gc);
+  if (iv_inited())
+    {
+      /* the automatic GC requires an ivykis thread */
+      scratch_buffers_gc.handler = _garbage_collect_scratch_buffers;
+    }
+}
+
+void
+scratch_buffers2_automatic_gc_deinit(void)
+{
+  if (iv_task_registered(&scratch_buffers_gc))
+    iv_task_unregister(&scratch_buffers_gc);
+}
+
+void
+scratch_buffers2_global_init(void)
+{
+  StatsClusterKey sc_key;
+
+  stats_lock();
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_count", NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_STORED, &stats_scratch_buffers_count);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_bytes", NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_STORED, &stats_scratch_buffers_bytes);
+  stats_unlock();
+}
+
+void
+scratch_buffers2_global_deinit(void)
+{
+  StatsClusterKey sc_key;
+
+  stats_lock();
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_count", NULL);
+  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &stats_scratch_buffers_count);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_bytes", NULL);
+  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &stats_scratch_buffers_bytes);
+  stats_unlock();
+}

--- a/lib/scratch-buffers2.h
+++ b/lib/scratch-buffers2.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SCRATCH_BUFFERS2_H_INCLUDED
+#define SCRATCH_BUFFERS2_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+typedef gint32 ScratchBuffersMarker;
+
+GString *scratch_buffers2_alloc(void);
+GString *scratch_buffers2_alloc_and_mark(ScratchBuffersMarker *marker);
+void scratch_buffers2_mark(ScratchBuffersMarker *marker);
+void scratch_buffers2_reclaim_allocations(void);
+void scratch_buffers2_reclaim_marked(ScratchBuffersMarker marker);
+
+gint scratch_buffers2_get_global_allocation_count(void);
+gint scratch_buffers2_get_local_allocation_count(void);
+glong scratch_buffers2_get_local_allocation_bytes(void);
+gint scratch_buffers2_get_local_usage_count(void);
+void scratch_buffers2_update_stats(void);
+
+/* lazy stats update */
+void scratch_buffers2_lazy_update_stats(void);
+
+/* garbage collector */
+void scratch_buffers2_explicit_gc(void);
+
+void scratch_buffers2_allocator_init(void);
+void scratch_buffers2_allocator_deinit(void);
+void scratch_buffers2_automatic_gc_init(void);
+void scratch_buffers2_automatic_gc_deinit(void);
+
+void scratch_buffers2_global_init(void);
+void scratch_buffers2_global_deinit(void);
+
+#endif

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -69,6 +69,7 @@ lib_tests_test_runid_CFLAGS	=	\
 lib_tests_test_runid_LDADD	=	\
 	$(TEST_LDADD)
 
+
 lib_tests_test_str_format_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_str_format_LDADD	=	\
@@ -107,6 +108,7 @@ if ENABLE_CRITERION
 
 lib_tests_TESTS		+= \
 	lib/tests/test_cache		\
+	lib/tests/test_scratch_buffers 	\
 	lib/tests/test_timeutils
 
 lib_tests_test_cache_CFLAGS	=	\
@@ -118,5 +120,11 @@ lib_tests_test_timeutils_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_timeutils_LDADD	=	\
 	$(TEST_LDADD)
+
+lib_tests_test_scratch_buffers_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_scratch_buffers_LDADD	=	\
+	$(TEST_LDADD)
+
 
 endif

--- a/lib/tests/test_scratch_buffers.c
+++ b/lib/tests/test_scratch_buffers.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "scratch-buffers2.h"
+#include "stats/stats-registry.h"
+#include <criterion/criterion.h>
+#include <iv.h>
+
+#define ITERATIONS 10
+#define DEFAULT_ALLOC_SIZE 256L
+
+static void
+_do_something_with_a_gstring(GString *str)
+{
+  g_string_assign(str, "foobar");
+  g_string_append(str, "len");
+  g_string_truncate(str, 0);
+}
+
+Test(scratch_buffers, alloc_returns_a_gstring_instance)
+{
+  GString *str = scratch_buffers2_alloc();
+
+  cr_assert_not_null(str);
+  _do_something_with_a_gstring(str);
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), 1);
+}
+
+Test(scratch_buffers, reclaim_allocations_drops_all_allocs)
+{
+  for (gint i = 0; i < ITERATIONS; i++)
+    {
+      GString *str = scratch_buffers2_alloc();
+      cr_assert_not_null(str);
+      _do_something_with_a_gstring(str);
+    }
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), ITERATIONS);
+  scratch_buffers2_reclaim_allocations();
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), 0);
+}
+
+Test(scratch_buffers, reclaim_marked_allocs)
+{
+  ScratchBuffersMarker marker;
+  GString *str;
+
+  str = scratch_buffers2_alloc();
+  cr_assert_not_null(str);
+  _do_something_with_a_gstring(str);
+
+  scratch_buffers2_mark(&marker);
+
+  for (gint i = 0; i < ITERATIONS; i++)
+    {
+      str = scratch_buffers2_alloc();
+      cr_assert_not_null(str);
+      _do_something_with_a_gstring(str);
+    }
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), ITERATIONS + 1);
+  scratch_buffers2_reclaim_marked(marker);
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), 1);
+}
+
+Test(scratch_buffers, reclaim_up_to_a_marked_alloc)
+{
+  ScratchBuffersMarker marker;
+  GString *str;
+
+  str = scratch_buffers2_alloc();
+  cr_assert_not_null(str);
+  _do_something_with_a_gstring(str);
+
+  str = scratch_buffers2_alloc_and_mark(&marker);
+  cr_assert_not_null(str);
+  _do_something_with_a_gstring(str);
+
+  for (gint i = 0; i < ITERATIONS; i++)
+    {
+      str = scratch_buffers2_alloc();
+      cr_assert_not_null(str);
+      _do_something_with_a_gstring(str);
+    }
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), ITERATIONS + 2);
+  scratch_buffers2_reclaim_marked(marker);
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), 1);
+}
+
+Test(scratch_buffers, local_usage_metrics_measure_allocs)
+{
+  GString *str;
+
+  str = scratch_buffers2_alloc();
+  cr_assert_not_null(str);
+  _do_something_with_a_gstring(str);
+
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), 1);
+  cr_assert_eq(scratch_buffers2_get_local_allocation_bytes(), DEFAULT_ALLOC_SIZE);
+
+  str = scratch_buffers2_alloc();
+  cr_assert_not_null(str);
+  _do_something_with_a_gstring(str);
+  cr_assert_eq(scratch_buffers2_get_local_usage_count(), 2);
+  cr_assert_eq(scratch_buffers2_get_local_allocation_bytes(), 2*DEFAULT_ALLOC_SIZE);
+}
+
+/* not published via the header */
+extern StatsCounterItem *stats_scratch_buffers_count;
+extern StatsCounterItem *stats_scratch_buffers_bytes;
+
+Test(scratch_buffers, stats_counters_are_updated)
+{
+  GString *str;
+
+  for (gint count = 1; count <= ITERATIONS; count++)
+    {
+      str = scratch_buffers2_alloc();
+      cr_assert_not_null(str);
+
+      /* check through accessor functions */
+      cr_assert(scratch_buffers2_get_local_usage_count() == count,
+                "get_local_usage_count() not returning proper value, value=%d, expected=%d",
+                scratch_buffers2_get_local_usage_count(), count);
+
+      cr_assert(scratch_buffers2_get_local_allocation_bytes() == count * DEFAULT_ALLOC_SIZE,
+                "get_local_allocation_bytes() not returning proper value, value=%ld, expected=%ld",
+                scratch_buffers2_get_local_allocation_bytes(), count * DEFAULT_ALLOC_SIZE);
+
+      /* check through metrics */
+      cr_assert(stats_counter_get(stats_scratch_buffers_count) == count,
+                "Statistic scratch_buffers_count is not updated properly, value=%d, expected=%d",
+                (gint) stats_counter_get(stats_scratch_buffers_count), count);
+
+      /* check if byte counter is updated */
+      scratch_buffers2_update_stats();
+      cr_assert_eq(stats_counter_get(stats_scratch_buffers_bytes), count * DEFAULT_ALLOC_SIZE);
+    }
+}
+
+static void
+setup(void)
+{
+  g_thread_init(NULL);
+  stats_init();
+  scratch_buffers2_global_init();
+  scratch_buffers2_allocator_init();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers2_allocator_deinit();
+  scratch_buffers2_global_deinit();
+  stats_destroy();
+}
+
+TestSuite(scratch_buffers, .init = setup, .fini = teardown);

--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -23,7 +23,7 @@
  */
 #include "transport-unix-socket.h"
 #include "transport/transport-socket.h"
-#include "scratch-buffers.h"
+#include "scratch-buffers2.h"
 #include "str-format.h"
 #include "unix-credentials.h"
 
@@ -37,13 +37,13 @@
 static void
 _add_nv_pair_int(LogTransportAuxData *aux, const gchar *name, gint value)
 {
-  SBGString *sbbuf = sb_gstring_acquire();
-  GString *buf = sb_gstring_string(sbbuf);
+  ScratchBuffersMarker marker;
+  GString *buf = scratch_buffers2_alloc_and_mark(&marker);
 
   g_string_truncate(buf, 0);
   format_uint32_padded(buf, -1, 0, 10, value);
   log_transport_aux_data_add_nv_pair(aux, name, buf->str);
-  sb_gstring_release(sbbuf);
+  scratch_buffers2_reclaim_marked(marker);
 }
 
 static void

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1047,6 +1047,7 @@ afsql_dd_database_thread(gpointer arg)
               evt_tag_str("driver", self->super.super.id));
   while (!self->db_thread_terminate)
     {
+      main_loop_worker_run_gc();
       g_mutex_lock(self->db_thread_mutex);
       if (self->db_thread_suspended)
         {

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -1144,7 +1144,7 @@ pdb_rule_set_load(PDBRuleSet *self, GlobalConfig *cfg, const gchar *config, GLis
       msg_error("Error opening classifier configuration file",
                 evt_tag_str(EVT_TAG_FILENAME, config),
                 evt_tag_errno(EVT_TAG_OSERROR, errno));
-      goto error;
+      return FALSE;
     }
 
   memset(&state, 0x0, sizeof(state));

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -43,6 +43,7 @@
 #include "resolved-configurable-paths.h"
 #include "crypto.h"
 #include "compat/openssl_support.h"
+#include "scratch-buffers2.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -1224,6 +1225,8 @@ main(int argc, char *argv[])
   msg_init(TRUE);
   resolved_configurable_paths_init(&resolvedConfigurablePaths);
   stats_init();
+  scratch_buffers2_global_init();
+  scratch_buffers2_allocator_init();
   log_msg_global_init();
   log_template_global_init();
   log_tags_global_init();
@@ -1248,6 +1251,8 @@ main(int argc, char *argv[])
     colors = full_colors;
 
   ret = modes[mode].main(argc, argv);
+  scratch_buffers2_allocator_deinit();
+  scratch_buffers2_global_deinit();
   stats_destroy();
   log_tags_global_deinit();
   log_msg_global_deinit();

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -31,6 +31,7 @@
 #include "logqueue-disk-reliable.h"
 #include "logqueue-disk-non-reliable.h"
 #include "logmsg/logmsg-serialize.h"
+#include "scratch-buffers2.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -289,16 +290,22 @@ main(int argc, char *argv[])
       return 0;
     }
 
-  configuration = cfg_new(0x0307);
+  configuration = cfg_new(VERSION_VALUE);
   configuration->template_options.frac_digits = 3;
   configuration->template_options.time_zone_info[LTZ_LOCAL] = time_zone_info_new(NULL);
 
   msg_init(TRUE);
+  stats_init();
+  scratch_buffers2_global_init();
+  scratch_buffers2_allocator_init();
   log_template_global_init();
   log_msg_registry_init();
   log_tags_global_init();
   modes[mode].main(argc, argv);
   log_tags_global_deinit();
+  scratch_buffers2_allocator_deinit();
+  scratch_buffers2_global_deinit();
+  stats_destroy();
   msg_deinit();
   return 0;
 

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -23,7 +23,7 @@
 
 #include "geoip-parser.h"
 #include "parser/parser-expr.h"
-#include "scratch-buffers.h"
+#include "scratch-buffers2.h"
 
 #include <GeoIPCity.h>
 
@@ -82,7 +82,7 @@ geoip_parser_process(LogParser *s, LogMessage **pmsg,
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
   GeoIPRecord *record;
-  SBGString *value;
+  GString *value;
 
   if (!self->dest.country_code &&
       !self->dest.latitude &&
@@ -109,22 +109,21 @@ geoip_parser_process(LogParser *s, LogMessage **pmsg,
                               record->country_code,
                               strlen(record->country_code));
 
-  value = sb_gstring_acquire();
+  value = scratch_buffers2_alloc();
 
-  g_string_printf(sb_gstring_string(value), "%f",
+  g_string_printf(value, "%f",
                   record->latitude);
   log_msg_set_value_by_name(msg, self->dest.latitude,
-                            sb_gstring_string(value)->str,
-                            sb_gstring_string(value)->len);
+                            value->str,
+                            value->len);
 
-  g_string_printf(sb_gstring_string(value), "%f",
+  g_string_printf(value, "%f",
                   record->longitude);
   log_msg_set_value_by_name(msg, self->dest.longitude,
-                            sb_gstring_string(value)->str,
-                            sb_gstring_string(value)->len);
+                            value->str,
+                            value->len);
 
   GeoIPRecord_delete(record);
-  sb_gstring_release(value);
 
   return TRUE;
 }

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -22,7 +22,7 @@
 
 #include "json-parser.h"
 #include "dot-notation.h"
-#include "scratch-buffers.h"
+#include "scratch-buffers2.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -78,61 +78,61 @@ json_parser_process_single(struct json_object *jso,
                            const gchar *obj_key,
                            LogMessage *msg)
 {
-  SBGString *key, *value;
+  GString *key, *value;
   gboolean parsed = FALSE;
 
   if (!jso)
     return;
 
-  key = sb_gstring_acquire();
-  value = sb_gstring_acquire();
+  key = scratch_buffers2_alloc();
+  value = scratch_buffers2_alloc();
 
   switch (json_object_get_type(jso))
     {
     case json_type_boolean:
       parsed = TRUE;
       if (json_object_get_boolean(jso))
-        g_string_assign(sb_gstring_string(value), "true");
+        g_string_assign(value, "true");
       else
-        g_string_assign(sb_gstring_string(value), "false");
+        g_string_assign(value, "false");
       break;
     case json_type_double:
       parsed = TRUE;
-      g_string_printf(sb_gstring_string(value), "%f",
+      g_string_printf(value, "%f",
                       json_object_get_double(jso));
       break;
     case json_type_int:
       parsed = TRUE;
-      g_string_printf(sb_gstring_string(value), "%i",
+      g_string_printf(value, "%i",
                       json_object_get_int(jso));
       break;
     case json_type_string:
       parsed = TRUE;
-      g_string_assign(sb_gstring_string(value),
+      g_string_assign(value,
                       json_object_get_string(jso));
       break;
     case json_type_object:
       if (prefix)
-        g_string_assign(sb_gstring_string(key), prefix);
-      g_string_append(sb_gstring_string(key), obj_key);
-      g_string_append_c(sb_gstring_string(key), '.');
-      json_parser_process_object(jso, sb_gstring_string(key)->str, msg);
+        g_string_assign(key, prefix);
+      g_string_append(key, obj_key);
+      g_string_append_c(key, '.');
+      json_parser_process_object(jso, key->str, msg);
       break;
     case json_type_array:
     {
       gint i, plen;
 
-      g_string_assign(sb_gstring_string(key), obj_key);
+      g_string_assign(key, obj_key);
 
-      plen = sb_gstring_string(key)->len;
+      plen = key->len;
 
       for (i = 0; i < json_object_array_length(jso); i++)
         {
-          g_string_truncate(sb_gstring_string(key), plen);
-          g_string_append_printf(sb_gstring_string(key), "[%d]", i);
+          g_string_truncate(key, plen);
+          g_string_append_printf(key, "[%d]", i);
           json_parser_process_single(json_object_array_get_idx(jso, i),
                                      prefix,
-                                     sb_gstring_string(key)->str, msg);
+                                     key->str, msg);
         }
       break;
     }
@@ -148,22 +148,20 @@ json_parser_process_single(struct json_object *jso,
     {
       if (prefix)
         {
-          g_string_assign(sb_gstring_string(key), prefix);
-          g_string_append(sb_gstring_string(key), obj_key);
+          g_string_assign(key, prefix);
+          g_string_append(key, obj_key);
           log_msg_set_value_by_name(msg,
-                                    sb_gstring_string(key)->str,
-                                    sb_gstring_string(value)->str,
-                                    sb_gstring_string(value)->len);
+                                    key->str,
+                                    value->str,
+                                    value->len);
         }
       else
         log_msg_set_value_by_name(msg,
                                   obj_key,
-                                  sb_gstring_string(value)->str,
-                                  sb_gstring_string(value)->len);
+                                  value->str,
+                                  value->len);
     }
 
-  sb_gstring_release(key);
-  sb_gstring_release(value);
 }
 
 static void

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -27,7 +27,7 @@
 #include "timeutils.h"
 #include "cfg.h"
 #include "str-format.h"
-#include "scratch-buffers.h"
+#include "scratch-buffers2.h"
 
 #include <ctype.h>
 #include <string.h>
@@ -274,7 +274,7 @@ kmsg_parse_key_value_pair(const guchar *data, gsize *pos, gsize length,
                           LogMessage *msg)
 {
   gsize name_start, name_len, value_start, value_len;
-  SBGString *name;
+  GString *name;
 
   while (*pos < length && (data[*pos] == ' ' || data[*pos] == '\t'))
     (*pos)++;
@@ -302,15 +302,14 @@ kmsg_parse_key_value_pair(const guchar *data, gsize *pos, gsize length,
       return TRUE;
     }
 
-  name = sb_gstring_acquire();
+  name = scratch_buffers2_alloc();
 
-  g_string_assign(sb_gstring_string(name), ".linux.");
-  g_string_append_len(sb_gstring_string(name), (const gchar *)data + name_start, name_len);
+  g_string_assign(name, ".linux.");
+  g_string_append_len(name, (const gchar *)data + name_start, name_len);
 
   log_msg_set_value(msg,
-                    log_msg_get_value_handle(sb_gstring_string(name)->str),
+                    log_msg_get_value_handle(name->str),
                     (const gchar *)data + value_start, value_len);
-  sb_gstring_release(name);
 
   return TRUE;
 }

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -90,8 +90,8 @@ _threaded_feed(gpointer args)
   sum_time += diff;
   g_static_mutex_unlock(&tlock);
   log_msg_unref(tmpl);
-  iv_deinit();
   main_loop_worker_thread_stop();
+  iv_deinit();
   return NULL;
 }
 
@@ -151,6 +151,8 @@ static gpointer
 _output_thread(gpointer args)
 {
   WorkerOptions wo;
+
+  iv_init();
   wo.is_output_thread = TRUE;
   main_loop_worker_thread_start(&wo);
   struct timespec ns;


### PR DESCRIPTION
This branch implements an alternative scratch buffers implementation that should be easier to use and that solves the per-thread buffer allocation which is freed automatically.
