### PR TITLE
map-value-pairs: add map-value-pairs() parser

### DIFF
--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -35,6 +35,7 @@ include modules/cef/Makefile.am
 include modules/diskq/Makefile.am
 include modules/add-contextual-data/Makefile.am
 include modules/getent/Makefile.am
+include modules/map-value-pairs/Makefile.am
 
 SYSLOG_NG_CORE_JAR=$(top_builddir)/modules/java/syslog-ng-core/libs/syslog-ng-core.jar
 
@@ -46,7 +47,8 @@ SYSLOG_NG_MODULES	=	\
 	mod-basicfuncs mod-cryptofuncs mod-geoip mod-afstomp \
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
 	mod-python mod-java mod-java-modules mod-kvformat mod-date \
-	mod-native mod-cef mod-add-contextual-data mod-diskq mod-getent
+	mod-native mod-cef mod-add-contextual-data mod-diskq mod-getent \
+	mod-map-value-pairs
 
 
 modules modules/: ${SYSLOG_NG_MODULES}
@@ -61,6 +63,7 @@ modules_test_subdirs	=	\
 	modules_cryptofuncs modules_geoip modules_afstomp \
 	modules_graphite modules_riemann modules_python \
 	modules_systemd_journal modules_kvformat modules_date \
-	modules_cef modules_diskq modules-add-contextual-data modules_getent
+	modules_cef modules_diskq modules-add-contextual-data modules_getent \
+	modules_map-value-pairs
 
 .PHONY: modules modules/

--- a/modules/map-value-pairs/Makefile.am
+++ b/modules/map-value-pairs/Makefile.am
@@ -1,0 +1,36 @@
+module_LTLIBRARIES				+= modules/map-value-pairs/libmap-value-pairs.la
+
+modules_map_value_pairs_libmap_value_pairs_la_CPPFLAGS		= \
+    $(AM_CPPFLAGS) \
+	-I$(top_srcdir)/modules/map-value-pairs		  \
+	-I$(top_builddir)/modules/map-value-pairs
+
+modules_map_value_pairs_libmap_value_pairs_la_LIBADD		= \
+	$(MODULE_DEPS_LIBS)
+
+modules_map_value_pairs_libmap_value_pairs_la_SOURCES		= \
+	modules/map-value-pairs/map-value-pairs.c		 	  \
+	modules/map-value-pairs/map-value-pairs.h		  	  \
+	modules/map-value-pairs/map-value-pairs-plugin.c		  \
+	modules/map-value-pairs/map-value-pairs-grammar.y		  \
+	modules/map-value-pairs/map-value-pairs-parser.c		  \
+	modules/map-value-pairs/map-value-pairs-parser.h
+
+
+modules_map_value_pairs_libmap_value_pairs_la_LDFLAGS		 = \
+	$(MODULE_LDFLAGS)
+
+modules_map_value_pairs_libmap_value_pairs_la_DEPENDENCIES=	\
+	$(MODULE_DEPS_LIBS)
+
+BUILT_SOURCES					+= \
+	modules/map-value-pairs/map-value-pairs-grammar.y		   \
+	modules/map-value-pairs/map-value-pairs-grammar.c		   \
+	modules/map-value-pairs/map-value-pairs-grammar.h
+
+modules/map-value-pairs mod-map-value-pairs: modules/map-value-pairs/libmod-map-value-pairs.la
+
+EXTRA_DIST					+= \
+	modules/map-value-pairs/map-value-pairs-grammar.ym
+
+.PHONY: modules/map-value-pairs mod-map-value-pairs

--- a/modules/map-value-pairs/map-value-pairs-grammar.ym
+++ b/modules/map-value-pairs/map-value-pairs-grammar.ym
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code requires {
+#include "parser/parser-expr.h"
+#include "map-value-pairs-parser.h"
+#include "map-value-pairs.h"
+
+}
+
+%code {
+
+#include "cfg-grammar.h"
+#include "cfg-parser.h"
+#include "plugin.h"
+}
+
+%name-prefix "map_value_pairs_"
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogParser **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_MAP_VALUE_PAIRS
+
+%%
+
+start
+	: LL_CONTEXT_PARSER KW_MAP_VALUE_PAIRS
+          {
+            last_value_pairs = value_pairs_new();
+            *instance = last_parser = map_value_pairs_new(configuration, last_value_pairs);
+          }
+          '(' map_names_options ')'				{ YYACCEPT; }
+        ;
+
+map_names_options
+	: map_names_option map_names_options
+	|
+	;
+
+map_names_option
+	: vp_option
+	;
+
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/map-value-pairs/map-value-pairs-parser.c
+++ b/modules/map-value-pairs/map-value-pairs-parser.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "map-value-pairs-parser.h"
+#include "cfg-parser.h"
+#include "map-value-pairs-grammar.h"
+
+extern int map_value_pairs_debug;
+int map_value_pairs_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
+
+static CfgLexerKeyword map_value_pairs_keywords[] =
+{
+  { "map_value_pairs",  KW_MAP_VALUE_PAIRS },
+  { NULL }
+};
+
+CfgParser map_value_pairs_parser =
+{
+#if SYSLOG_NG_ENABLE_DEBUG
+  .debug_flag = &map_value_pairs_debug,
+#endif
+  .name = "map-value-pairs",
+  .keywords = map_value_pairs_keywords,
+  .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer)) map_value_pairs_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(map_value_pairs_, LogParser **)

--- a/modules/map-value-pairs/map-value-pairs-parser.h
+++ b/modules/map-value-pairs/map-value-pairs-parser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef MAP_NAMES_PARSER_H_INCLUDED
+#define MAP_NAMES_PARSER_H_INCLUDED
+
+#include "parser/parser-expr.h"
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+
+extern CfgParser map_value_pairs_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(map_value_pairs_, LogParser **)
+
+#endif

--- a/modules/map-value-pairs/map-value-pairs-plugin.c
+++ b/modules/map-value-pairs/map-value-pairs-plugin.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser map_value_pairs_parser;
+
+static Plugin map_value_pairs_plugins[] =
+{
+  {
+    .type = LL_CONTEXT_PARSER,
+    .name = "map_value_pairs",
+    .parser = &map_value_pairs_parser,
+  },
+};
+
+gboolean
+map_value_pairs_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
+{
+  plugin_register(cfg, map_value_pairs_plugins, G_N_ELEMENTS(map_value_pairs_plugins));
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "map-value-pairs",
+  .version = SYSLOG_NG_VERSION,
+  .description = "The map-names module provides the map-names() parser for syslog-ng.",
+  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .plugins = map_value_pairs_plugins,
+  .plugins_len = G_N_ELEMENTS(map_value_pairs_plugins),
+};

--- a/modules/map-value-pairs/map-value-pairs.c
+++ b/modules/map-value-pairs/map-value-pairs.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "map-value-pairs.h"
+
+static gboolean
+_map_name_values(const gchar *name,
+                 TypeHint type, const gchar *value, gsize value_len,
+                 gpointer user_data)
+{
+  LogMessage *msg = (LogMessage *) user_data;
+
+  log_msg_set_value_by_name(msg, name, value, value_len);
+  return FALSE;
+}
+
+static gboolean
+_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
+         const gchar *input, gsize input_len)
+{
+  MapValuePairs *self = (MapValuePairs *) s;
+  LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+
+  value_pairs_foreach(self->value_pairs, _map_name_values,
+                      msg,
+                      0, LTZ_LOCAL, NULL,
+                      msg);
+
+  return TRUE;
+}
+
+static LogPipe *
+_clone(LogPipe *s)
+{
+  MapValuePairs *self = (MapValuePairs *) s;
+  MapValuePairs *cloned;
+
+  cloned = (MapValuePairs *) map_value_pairs_new(log_pipe_get_config(s), value_pairs_ref(self->value_pairs));
+  return &cloned->super.super;
+}
+
+static void
+_free(LogPipe *s)
+{
+  MapValuePairs *self = (MapValuePairs *) s;
+
+  value_pairs_unref(self->value_pairs);
+  log_parser_free_method(&self->super.super);
+}
+
+LogParser *
+map_value_pairs_new(GlobalConfig *cfg, ValuePairs *value_pairs)
+{
+  MapValuePairs *self = g_new0(MapValuePairs, 1);
+
+  log_parser_init_instance(&self->super, cfg);
+  self->super.super.free_fn = _free;
+  self->super.super.clone = _clone;
+  self->super.process = _process;
+  self->value_pairs = value_pairs;
+  return &self->super;
+}

--- a/modules/map-value-pairs/map-value-pairs.h
+++ b/modules/map-value-pairs/map-value-pairs.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef MAP_NAMES_H_INCLUDED
+#define MAP_NAMES_H_INCLUDED 1
+
+#include "parser/parser-expr.h"
+#include "value-pairs/value-pairs.h"
+
+typedef struct _MapValuePairs
+{
+  LogParser super;
+  ValuePairs *value_pairs;
+} MapValuePairs;
+
+LogParser *map_value_pairs_new(GlobalConfig *cfg, ValuePairs *value_pairs);
+
+#endif

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -53,7 +53,7 @@ tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|[^/]*$)
-modules/add-contextual-data
+modules/(add-contextual-data|map-value-pairs|[^/]*$)
 scl
 scripts
  GPLv2+_SSL,non-balabit

--- a/tests/functional/func_test.py
+++ b/tests/functional/func_test.py
@@ -85,8 +85,9 @@ import test_input_drivers
 import test_performance
 import test_sql
 import test_python
+import test_map_value_pairs
 
-tests = (test_input_drivers, test_sql, test_file_source, test_filters, test_performance, test_python)
+tests = (test_input_drivers, test_sql, test_file_source, test_filters, test_performance, test_python, test_map_value_pairs)
 
 init_env()
 seed_rnd()

--- a/tests/functional/test_map_value_pairs.py
+++ b/tests/functional/test_map_value_pairs.py
@@ -1,0 +1,67 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+from globals import *
+from log import *
+from messagegen import *
+from messagecheck import *
+from control import flush_files, stop_syslogng
+import os
+
+config = """@version: 3.9
+
+options { keep-hostname(yes); };
+
+source s_int { internal(); };
+source s_tcp { tcp(port(%(port_number)d)); };
+
+parser p_map {
+  map-value-pairs(key("MSG*" rekey(add-prefix("foo."))));
+};
+
+log {
+  source(s_tcp);
+  parser(p_map);
+  destination { file("test-map-value-pairs.log" template("$ISODATE $HOST $MSGHDR${foo.MSG}\n")); };
+};
+
+""" % locals()
+
+
+def get_source_dir():
+    return os.path.abspath(os.path.dirname(__file__))
+
+def test_map_value_pairs():
+
+    messages = (
+        'map_value_pairs1',
+        'map_value_pairs2'
+    )
+    s = SocketSender(AF_INET, ('localhost', port_number), dgram=0)
+
+    expected = []
+    for msg in messages:
+        expected.extend(s.sendMessages(msg, pri=7))
+    stopped = stop_syslogng()
+    if not stopped or not check_file_expected('test-map-value-pairs', expected, settle_time=2):
+        return False
+    return True


### PR DESCRIPTION
This patch adds a map-value-pairs() parser that can be used to map existing
name-value pairs to a different set during processing, in bulk.  Normal
value-pairs expressions can be used, just like with value-pairs based
destinations.

For example:


```
parser p_remap_name_values {
	map-value-pairs(
		key('.apache.*' rekey(add-prefix("foo")))
		pair('.apache.foobar.xxx', "bar")
		pair('123', "567")
		pair("username", '($sha1 $username)')
	);
};
```

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>