### PR TITLE
syslog-ng-ctl: return 1 when response of the server is empty

### DIFF
--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -65,13 +65,19 @@ slng_run_command(const gchar *command)
   return control_client_read_reply(control_client);
 }
 
+static gboolean
+_is_response_empty(GString *response)
+{
+  return (response == NULL || g_str_equal(response->str, ""));
+}
+
 static gint
 _dispatch_command(const gchar *cmd)
 {
   gchar *dispatchable_command = g_strdup_printf("%s\n", cmd);
   GString *rsp = slng_run_command(dispatchable_command);
 
-  if (rsp == NULL)
+  if (_is_response_empty(rsp))
     return 1;
 
   printf("%s\n", rsp->str);


### PR DESCRIPTION
This patch makes it possible to detect if no counter matched the filter specified using `syslog-ng-ctl query`. Thus, `syslog-ng-ctl query` can be utilized in scripts.