### PR TITLE
python-parser: add macros to keys()

### DIFF
--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -27,6 +27,7 @@
 #include "template/macros.h"
 #include "template/escaping.h"
 #include "cfg.h"
+#include "logstamp.h"
 
 static void
 log_template_reset_compiled(LogTemplate *self)
@@ -324,7 +325,7 @@ log_template_options_defaults(LogTemplateOptions *options)
 {
   memset(options, 0, sizeof(LogTemplateOptions));
   options->frac_digits = -1;
-  options->ts_format = -1;
+  options->ts_format = TS_FMT_ISO;
   options->on_error = -1;
 }
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -61,8 +61,15 @@ _py_log_message_setattr(PyObject *o, PyObject *key, PyObject *value)
   gchar *name = PyBytes_AsString(key);
   NVHandle handle = log_msg_get_value_handle(name);
   PyObject *value_as_strobj = PyObject_Str(value);
-  log_msg_set_value(py_msg->msg, handle, PyBytes_AsString(value_as_strobj), -1);
-  Py_DECREF(value_as_strobj);
+  if (value_as_strobj)
+    {
+      log_msg_set_value(py_msg->msg, handle, PyBytes_AsString(value_as_strobj), -1);
+      Py_DECREF(value_as_strobj);
+    }
+  else
+    {
+      msg_warning("Cannot set value in logmsg", evt_tag_str("name", name));
+    }
 
   return 0;
 }


### PR DESCRIPTION
Please note, that hard macros are also added to the list of keys.
Hard macros are cannot be overwritten.

Fixes: #1379

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>