### PR TITLE
groupunset: fix clone function

### DIFF
--- a/lib/rewrite/rewrite-groupset.c
+++ b/lib/rewrite/rewrite-groupset.c
@@ -103,6 +103,7 @@ log_rewrite_groupset_clone(LogPipe *s)
       log_pipe_get_config(&self->super.super) );
   value_pairs_unref(cloned->query);
   cloned->query = value_pairs_ref(self->query);
+  cloned->vp_func = self->vp_func;
 
   if (self->super.condition)
     cloned->super.condition = filter_expr_ref(self->super.condition);


### PR DESCRIPTION
# Description

Syslog-ng crashes if 2 instance is used of a groupunset rewrite rule.

# Technical root cause

The groupunset is a bit modified groupset object. But the clone method of the groupset object did not copy the modification, so it had to be implemented there.

# Minimal config

```
@version: 3.9

rewrite r_test {
    set ("Hello Core dump!", value ("TEST"));
    groupunset(values("TEST"));
};

log {
    source {file ("/opt/syslog-ng/etc/in.log");};
    rewrite(r_test);
    rewrite(r_test);
};
```

# Incoming log entry

```
<30>Sep 17 23:54:54 test test[1234]: test
```
