### PR TITLE
cfg-lexer: fix token duplication in the output of '--preprocess-into'

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -818,10 +818,9 @@ relex:
           *yylloc = self->include_stack[self->include_depth].lloc;
           tok = token->type;
           if (token->type == LL_TOKEN)
-            {
-              tok = token->token;
-              injected = TRUE;
-            }
+            tok = token->token;
+
+          injected = TRUE;
 
           goto exit;
         }

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -795,18 +795,12 @@ _invoke__cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
   return _cfg_lexer_lex(yylval, yylloc, self->state);
 }
 
-int
-cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
+static gboolean
+cfg_lexer_consume_next_injected_token(CfgLexer *self, gint *tok, YYSTYPE *yylval, YYLTYPE *yylloc)
 {
-  CfgBlockGenerator *gen;
   CfgTokenBlock *block;
   YYSTYPE *token;
-  gint tok;
-  gboolean injected;
 
-relex:
-
-  injected = FALSE;
   while (self->token_blocks)
     {
       block = self->token_blocks->data;
@@ -816,13 +810,13 @@ relex:
         {
           *yylval = *token;
           *yylloc = self->include_stack[self->include_depth].lloc;
-          tok = token->type;
+
           if (token->type == LL_TOKEN)
-            tok = token->token;
+            *tok = token->token;
+          else
+            *tok = token->type;
 
-          injected = TRUE;
-
-          goto exit;
+          return TRUE;
         }
       else
         {
@@ -831,23 +825,39 @@ relex:
         }
     }
 
-  if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_CONTENT)
-    cfg_lexer_start_block_state(self, "{}");
-  else if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_ARG)
-    cfg_lexer_start_block_state(self, "()");
+  return FALSE;
+}
 
-  yylval->type = 0;
+int
+cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
+{
+  CfgBlockGenerator *gen;
+  gint tok;
+  gboolean injected;
 
-  g_string_truncate(self->token_text, 0);
-  g_string_truncate(self->token_pretext, 0);
+relex:
 
-  tok = _invoke__cfg_lexer_lex(self, yylval, yylloc);
-  if (yylval->type == 0)
-    yylval->type = tok;
+  injected = cfg_lexer_consume_next_injected_token(self, &tok, yylval, yylloc);
 
-  if (self->preprocess_output)
-    g_string_append_printf(self->preprocess_output, "%s", self->token_pretext->str);
-exit:
+  if (!injected)
+    {
+      if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_CONTENT)
+        cfg_lexer_start_block_state(self, "{}");
+      else if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_ARG)
+        cfg_lexer_start_block_state(self, "()");
+
+      yylval->type = 0;
+
+      g_string_truncate(self->token_text, 0);
+      g_string_truncate(self->token_pretext, 0);
+
+      tok = _invoke__cfg_lexer_lex(self, yylval, yylloc);
+      if (yylval->type == 0)
+        yylval->type = tok;
+
+      if (self->preprocess_output)
+        g_string_append_printf(self->preprocess_output, "%s", self->token_pretext->str);
+    }
 
   if (self->ignore_pragma)
     {


### PR DESCRIPTION
This PR fixes an old token duplication issue in the output of the `--preprocess-into` command line option.

Since every token in a `CfgTokenBlock` is an 'injected token', the injected flag should be set in all cases.

---------------------------

## Configuration

- `etc/syslog-ng-example.conf`:
```
@version: 3.9

parser p_parser {};
filter f_filter { host(""); };
rewrite r_rewrite {};

source s_source {};
destination d_destination {};

log {};
```

## Steps to reproduce

1. Start syslog-ng: `sbin/syslog-ng -Fedv -f etc/syslog-ng-example.conf --preprocess-into test.txt`

2. cat test.txt

Example output (notice the duplicated '}' tokens):

```
@version: 3.9

parser p_parserke {}};
filter f_filter { host(""); }};
rewrite r_rewrite {}};

source s_source {};
destination d_destination {};

log {};
```
