### PR TITLE
syslog-ng-ctl: enable resetting counters after query

### DIFF
--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -28,8 +28,11 @@
 typedef enum _QueryCommand
 {
   QUERY_GET = 0,
+  QUERY_GET_RESET,
   QUERY_GET_SUM,
+  QUERY_GET_SUM_RESET,
   QUERY_LIST,
+  QUERY_LIST_RESET,
   QUERY_CMD_MAX
 } QueryCommand;
 
@@ -75,9 +78,21 @@ _query_get(const gchar *filter_expr, GString *result)
 }
 
 static gboolean
+_query_get_and_reset(const gchar *filter_expr, GString *result)
+{
+  return stats_query_get_and_reset_counters(filter_expr, _ctl_format_get, (gpointer)result);
+}
+
+static gboolean
 _query_list(const gchar *filter_expr, GString *result)
 {
   return stats_query_list(filter_expr, _ctl_format_name_without_value, (gpointer)result);
+}
+
+static gboolean
+_query_list_and_reset(const gchar *filter_expr, GString *result)
+{
+  return stats_query_list_and_reset_counters(filter_expr, _ctl_format_name_without_value, (gpointer)result);
 }
 
 static gboolean
@@ -86,17 +101,32 @@ _query_get_sum(const gchar *filter_expr, GString *result)
   return stats_query_get_sum(filter_expr, _ctl_format_get_sum, (gpointer)result);
 }
 
+static gboolean
+_query_get_sum_and_reset(const gchar *filter_expr, GString *result)
+{
+  return stats_query_get_sum_and_reset_counters(filter_expr, _ctl_format_get_sum, (gpointer)result);
+}
+
 static QueryCommand
 _command_str_to_id(const gchar *cmd)
 {
   if (g_str_equal(cmd, "GET_SUM"))
     return QUERY_GET_SUM;
 
+  if (g_str_equal(cmd, "GET_SUM_RESET"))
+    return QUERY_GET_SUM_RESET;
+
   if (g_str_equal(cmd, "GET"))
     return QUERY_GET;
 
+  if (g_str_equal(cmd, "GET_RESET"))
+    return QUERY_GET_RESET;
+
   if (g_str_equal(cmd, "LIST"))
     return QUERY_LIST;
+
+  if (g_str_equal(cmd, "LIST_RESET"))
+    return QUERY_LIST_RESET;
 
   msg_error("Unknown query command", evt_tag_str("command", cmd));
 
@@ -106,8 +136,11 @@ _command_str_to_id(const gchar *cmd)
 static query_cmd QUERY_CMDS[] =
 {
   _query_get,
+  _query_get_and_reset,
   _query_get_sum,
-  _query_list
+  _query_get_sum_and_reset,
+  _query_list,
+  _query_list_and_reset
 };
 
 static gboolean

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -43,6 +43,15 @@ const gint QUERY_CMD_STR = 1;
 const gint QUERY_FILTER_STR = 2;
 
 
+static void
+_append_reset_msg_if_found_matching_counters(gboolean found_match, GString *result)
+{
+  if (found_match)
+    {
+      g_string_append_printf(result, "\n%s", "The selected counters of syslog-ng have been reset to 0.");
+    }
+}
+
 static gboolean
 _ctl_format_get(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
 {
@@ -80,7 +89,12 @@ _query_get(const gchar *filter_expr, GString *result)
 static gboolean
 _query_get_and_reset(const gchar *filter_expr, GString *result)
 {
-  return stats_query_get_and_reset_counters(filter_expr, _ctl_format_get, (gpointer)result);
+  gboolean found_match;
+
+  found_match = stats_query_get_and_reset_counters(filter_expr, _ctl_format_get, (gpointer)result);
+  _append_reset_msg_if_found_matching_counters(found_match, result);
+
+  return found_match;
 }
 
 static gboolean
@@ -92,7 +106,12 @@ _query_list(const gchar *filter_expr, GString *result)
 static gboolean
 _query_list_and_reset(const gchar *filter_expr, GString *result)
 {
-  return stats_query_list_and_reset_counters(filter_expr, _ctl_format_name_without_value, (gpointer)result);
+  gboolean found_match;
+
+  found_match = stats_query_list_and_reset_counters(filter_expr, _ctl_format_name_without_value, (gpointer)result);
+  _append_reset_msg_if_found_matching_counters(found_match, result);
+
+  return found_match;
 }
 
 static gboolean
@@ -104,7 +123,12 @@ _query_get_sum(const gchar *filter_expr, GString *result)
 static gboolean
 _query_get_sum_and_reset(const gchar *filter_expr, GString *result)
 {
-  return stats_query_get_sum_and_reset_counters(filter_expr, _ctl_format_get_sum, (gpointer)result);
+  gboolean found_match;
+
+  found_match = stats_query_get_sum_and_reset_counters(filter_expr, _ctl_format_get_sum, (gpointer)result);
+  _append_reset_msg_if_found_matching_counters(found_match, result);
+
+  return found_match;
 }
 
 static QueryCommand

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -28,16 +28,6 @@
 
 #include <string.h>
 
-static const gchar *_counter_type[SC_TYPE_MAX+1] =
-{
-  "dropped",
-  "processed",
-  "stored",
-  "suppressed",
-  "stamp",
-  "MAX"
-};
-
 typedef struct _NamedStatsCounterItem
 {
   StatsCluster *cluster;
@@ -47,6 +37,31 @@ typedef struct _NamedStatsCounterItem
 typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, NamedStatsCounterItem *named_counter,
                                           StatsFormatCb format_cb, gpointer user_data);
 
+
+static const gchar *
+_get_counter_name_by_index(gint type_index)
+{
+  const gchar *_counter_type[SC_TYPE_MAX+1] =
+  {
+    "dropped",
+    "processed",
+    "stored",
+    "suppressed",
+    "stamp",
+    "MAX"
+  };
+
+  if (type_index > SC_TYPE_MAX)
+    return "";
+
+  return _counter_type[type_index];
+}
+
+static const gchar *
+_get_name_of_counter_item(NamedStatsCounterItem *item)
+{
+  return _get_counter_name_by_index(item->index);
+}
 
 static void
 _append_live_counters(StatsCluster *sc, gchar *ctr_str, GList **counters)
@@ -60,7 +75,7 @@ _append_live_counters(StatsCluster *sc, gchar *ctr_str, GList **counters)
     {
       if (stats_cluster_is_alive(sc, i))
         {
-          if (is_wildcard || !strcmp(_counter_type[i], ctr_str))
+          if (is_wildcard || !strcmp(_get_counter_name_by_index(i), ctr_str))
             {
               NamedStatsCounterItem *c = g_new0(NamedStatsCounterItem, 1);
               c->cluster = sc;
@@ -143,11 +158,10 @@ _query_counter_hash(gchar *key_str, gchar *ctr_str)
 static void
 _format_selected_counters(GList *counters, StatsFormatCb format_cb, gpointer result)
 {
-  GList *counter = NULL;
-  for (counter = counters; counter; counter = counter->next)
+  for (GList *counter = counters; counter; counter = counter->next)
     {
       NamedStatsCounterItem *c = counter->data;
-      format_cb(c->cluster, &c->cluster->counters[c->index], _counter_type[c->index], result);
+      format_cb(c->cluster, &c->cluster->counters[c->index], _get_name_of_counter_item(c), result);
     }
 }
 

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -38,97 +38,37 @@ static const gchar *_counter_type[SC_TYPE_MAX+1] =
   "MAX"
 };
 
+typedef struct _NamedStatsCounterItem
+{
+  StatsCluster *cluster;
+  gint index;
+} NamedStatsCounterItem;
 
-typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
+typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, NamedStatsCounterItem *named_counter,
                                           StatsFormatCb format_cb, gpointer user_data);
 
+
 static void
-_foreach_live_counters(StatsCluster *sc, StatsClusterCounterCb counter_cb, StatsFormatCb format_cb, gpointer user_data)
+_append_live_counters(StatsCluster *sc, gchar *ctr_str, GList **counters)
 {
-  for (gint i = 0; i < SC_TYPE_MAX; i++)
+  gint i;
+  gboolean is_wildcard = FALSE;
+  if (ctr_str[0] == '*')
+    is_wildcard = TRUE;
+
+  for (i = 0; i < SC_TYPE_MAX; i++)
     {
       if (stats_cluster_is_alive(sc, i))
-        if (!counter_cb(sc, &sc->counters[i], _counter_type[i], format_cb, user_data))
-          break;
+        {
+          if (is_wildcard || !strcmp(_counter_type[i], ctr_str))
+            {
+              NamedStatsCounterItem *c = g_new0(NamedStatsCounterItem, 1);
+              c->cluster = sc;
+              c->index = i;
+              *counters = g_list_append(*counters, c);
+            }
+        }
     }
-}
-
-static gboolean
-_append_counter_with_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, StatsFormatCb format_cb,
-                           gpointer user_data)
-{
-  return format_cb(sc, ctr, ctr_name, user_data);
-}
-
-static gboolean
-_append_counter_without_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, StatsFormatCb format_cb,
-                              gpointer user_data)
-{
-  return format_cb(sc, ctr, ctr_name, user_data);
-}
-
-static gboolean
-_append_counter_with_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
-                                                 StatsFormatCb format_cb, gpointer user_data)
-{
-  gpointer *args = (gpointer *) user_data;
-  GString *result = (GString *) args[0];
-  const gchar *requested_ctr_name = (const gchar *) args[1];
-  if (ctr_name && !strcmp(requested_ctr_name, ctr_name))
-    {
-      _append_counter_with_value(sc, ctr, ctr_name, format_cb, (gpointer) result);
-      return FALSE;
-    }
-  return TRUE;
-}
-
-static gboolean
-_append_counter_without_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
-                                                    StatsFormatCb format_cb,
-                                                    gpointer user_data)
-{
-  gpointer *args = (gpointer *) user_data;
-  GString *result = (GString *) args[0];
-  const gchar *requested_ctr_name = (const gchar *) args[1];
-  if (ctr_name && !strcmp(requested_ctr_name, ctr_name))
-    {
-      _append_counter_without_value(sc, ctr, ctr_name, format_cb, (gpointer) result);
-      return FALSE;
-    }
-  return TRUE;
-}
-
-static gboolean
-_add_counter_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, StatsFormatCb format_cb,
-                   gpointer user_data)
-{
-  if (ctr_name && g_str_equal(ctr_name, _counter_type[SC_TYPE_STAMP]))
-    return TRUE;
-
-  gpointer *args = (gpointer *) user_data;
-  gint64 *sum = (gint64 *) args[1];
-
-  *sum += ctr->value;
-
-  return format_cb(sc, ctr, ctr_name, (gpointer)args);
-}
-
-static gboolean
-_add_value_when_name_is_matching(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name,
-                                 StatsFormatCb format_cb, gpointer user_data)
-{
-  gpointer *args = (gpointer *) user_data;
-  const gchar *requested_ctr_name = (const gchar *) args[1];
-
-  if (ctr_name && g_str_equal(ctr_name, _counter_type[SC_TYPE_STAMP]))
-    return FALSE;
-
-  if (ctr_name && !strcmp(requested_ctr_name, ctr_name))
-    {
-      _add_counter_value(sc, ctr, ctr_name, format_cb, (gpointer)args[0]);
-      return FALSE;
-    }
-  return TRUE;
 }
 
 void
@@ -172,14 +112,13 @@ _find_key_by_pattern(gpointer key, gpointer value, gpointer user_data)
   return g_pattern_match_string(pattern, sc->query_key);
 }
 
-static gboolean
-_query_counter_hash(gchar *key_str, gchar *ctr_str, StatsClusterCounterCb wildcard_match_cb,
-                    StatsClusterCounterCb match_cb, StatsFormatCb format_cb, gpointer result)
+static GList *
+_query_counter_hash(gchar *key_str, gchar *ctr_str)
 {
   GHashTable *counter_hash = stats_registry_get_counter_hash();
   GPatternSpec *pattern = g_pattern_spec_new(key_str);
   StatsCluster *sc = NULL;
-  gboolean found_match = FALSE;
+  GList *counters = NULL;
   gpointer key, value;
   GHashTableIter iter;
 
@@ -191,40 +130,114 @@ _query_counter_hash(gchar *key_str, gchar *ctr_str, StatsClusterCounterCb wildca
       if (_find_key_by_pattern(key, value, (gpointer)pattern))
         {
           sc = (StatsCluster *)key;
-          if (ctr_str[0] == '*')
-            {
-              _foreach_live_counters(sc, wildcard_match_cb, format_cb, result);
-            }
-          else
-            {
-              gpointer args[] = {result, (gpointer) ctr_str};
-              _foreach_live_counters(sc, match_cb, format_cb, (gpointer) args);
-            }
-          found_match = TRUE;
+          _append_live_counters(sc, ctr_str, &counters);
+
           if (single_match)
             break;
         }
     }
   g_pattern_spec_free(pattern);
+  return counters;
+}
+
+static void
+_format_selected_counters(GList *counters, StatsFormatCb format_cb, gpointer result)
+{
+  GList *counter = NULL;
+  for (counter = counters; counter; counter = counter->next)
+    {
+      NamedStatsCounterItem *c = counter->data;
+      format_cb(c->cluster, &c->cluster->counters[c->index], _counter_type[c->index], result);
+    }
+}
+
+static void
+_reset_selected_counters(GList *counters)
+{
+  GList *c;
+  for (c = counters; c; c = c->next)
+    {
+      NamedStatsCounterItem *counter = c->data;
+      StatsCounterItem *item = &counter->cluster->counters[counter->index];
+      stats_counter_set(item, 0);
+    }
+}
+
+gboolean
+_stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
+{
+  if (!expr)
+    return FALSE;
+
+  gchar *key_str = NULL;
+  gchar *ctr_str = NULL;
+  GList *counters = NULL;
+  gboolean found_match = FALSE;
+
+  _split_expr(expr, &key_str, &ctr_str);
+  counters = _query_counter_hash(key_str, ctr_str);
+  _format_selected_counters(counters, format_cb, result);
+
+  if (must_reset)
+    _reset_selected_counters(counters);
+
+  if (g_list_length(counters) > 0)
+    found_match = TRUE;
+
+  g_list_free_full(counters, g_free);
+  g_free(key_str);
+  g_free(ctr_str);
+
   return found_match;
 }
 
 gboolean
 stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result)
 {
-  gboolean found_match;
+  return _stats_query_get(expr, format_cb, result, FALSE);
+}
 
-  if (!expr)
-    return FALSE;
+gboolean
+stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result)
+{
+  return _stats_query_get(expr, format_cb, result, TRUE);
+}
 
+void
+_sum_selected_counters(GList *counters, gpointer user_data)
+{
+  GList *c;
+  gpointer *args = (gpointer *) user_data;
+  gint64 *sum = (gint64 *) args[1];
+  for (c = counters; c; c = c->next)
+    {
+      NamedStatsCounterItem *counter = c->data;
+      *sum += counter->cluster->counters[counter->index].value;
+    }
+}
+
+gboolean
+_stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
+{
   gchar *key_str = NULL;
   gchar *ctr_str = NULL;
+  GList *counters = NULL;
+  gboolean found_match = FALSE;
+  gint64 sum = 0;
+  gpointer args[] = {result, &sum};
 
-  _split_expr(expr, &key_str, &ctr_str);
-  found_match = _query_counter_hash(key_str, ctr_str, _append_counter_with_value,
-                                    _append_counter_with_value_when_name_is_matching,
-                                    format_cb, result);
+  _setup_filter_expression(expr, &key_str, &ctr_str);
+  counters = _query_counter_hash(key_str, ctr_str);
+  _sum_selected_counters(counters, (gpointer)args);
+  _format_selected_counters(counters, format_cb, (gpointer)args);
 
+  if (must_reset)
+    _reset_selected_counters(counters);
+
+  if (g_list_length(counters) > 0)
+    found_match = TRUE;
+
+  g_list_free_full(counters, g_free);
   g_free(key_str);
   g_free(ctr_str);
 
@@ -234,16 +247,34 @@ stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result)
 gboolean
 stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result)
 {
-  gboolean found_match;
+  return _stats_query_get_sum(expr, format_cb, result, FALSE);
+}
+
+gboolean
+stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result)
+{
+  return _stats_query_get_sum(expr, format_cb, result, TRUE);
+}
+
+gboolean
+_stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
+{
   gchar *key_str = NULL;
   gchar *ctr_str = NULL;
-  gint64 sum = 0;
-  gpointer args[] = {result, (gpointer) &sum};
+  GList *counters = NULL;
+  gboolean found_match = FALSE;
 
   _setup_filter_expression(expr, &key_str, &ctr_str);
-  found_match = _query_counter_hash(key_str, ctr_str, _add_counter_value, _add_value_when_name_is_matching, format_cb,
-                                    (gpointer) args);
+  counters = _query_counter_hash(key_str, ctr_str);
+  _format_selected_counters(counters, format_cb, result);
 
+  if (must_reset)
+    _reset_selected_counters(counters);
+
+  if (g_list_length(counters) > 0)
+    found_match = TRUE;
+
+  g_list_free_full(counters, g_free);
   g_free(key_str);
   g_free(ctr_str);
 
@@ -253,16 +284,11 @@ stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result)
 gboolean
 stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result)
 {
-  gboolean found_match;
-  gchar *key_str = NULL;
-  gchar *ctr_str = NULL;
+  return _stats_query_list(expr, format_cb, result, FALSE);
+}
 
-  _setup_filter_expression(expr, &key_str, &ctr_str);
-  found_match = _query_counter_hash(key_str, ctr_str, _append_counter_without_value,
-                                    _append_counter_without_value_when_name_is_matching, format_cb, result);
-
-  g_free(key_str);
-  g_free(ctr_str);
-
-  return found_match;
+gboolean
+stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result)
+{
+  return _stats_query_list(expr, format_cb, result, TRUE);
 }

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -30,8 +30,11 @@
 typedef gboolean (*StatsFormatCb)(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data);
 
 gboolean stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result);
+gboolean stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result);
+gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result);
+gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 
 #endif
 


### PR DESCRIPTION
From now on, it is possible to reset counters after querying them. Resetting is supported for all of the query commands: `get`, `get --sum` and `list`.

Example:

```
$ syslog-ng-ctl query get --reset '*'
center.received.processed: 5
$ syslog-ng-ctl query get '*'
center.received.processed: 0
```