### PR TITLE
Setup for CI environment seems to fail for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,6 @@ matrix:
             hiredis
             libdbi
             libnet
-            python
             riemann-client
         - geoipupdate
         - pip install -r requirements.txt


### PR DESCRIPTION
Failure because manifest tries to install python, but it's already installed.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>