### PR TITLE
openssl_compat: improve ifdefs to break the code into independent pieces

### DIFF
--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -259,7 +259,6 @@ tf_sanitize_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, 
 
   if (!tf_simple_func_prepare(self, state, parent, argc, argv, error))
     {
-      g_free(state);
       goto exit;
     }
   state->ctrl_chars = ctrl_chars;

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -138,6 +138,7 @@ test_str_funcs(void)
   assert_template_format("$(sanitize -C alma\x1b_bela)", "alma\x1b_bela");
 
   assert_template_format("$(sanitize $HOST $PROGRAM)", "bzorp/syslog-ng");
+  assert_template_failure("$(sanitize ${missingbrace)", "Invalid macro, '}' is missing, error_pos='14'");
 
   assert_template_format("$(indent-multi-line 'foo\nbar')", "foo\n\tbar");
 

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -90,7 +90,6 @@ tf_hash_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
 
   if (!tf_simple_func_prepare(self, state, parent, argc, argv, error))
     {
-      g_free(state);
       return FALSE;
     }
   state->length = length;

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -40,6 +40,8 @@ test_hash(void)
   assert_template_format("$(sha1 --length 5 foo)", "0beec");
   assert_template_format("$(sha1 -l 5 foo)", "0beec");
   assert_template_failure("$(sha1 --length 5)", "$(hash) parsing failed, invalid number of arguments");
+  assert_template_failure("$(sha1 --length 5)", "$(hash) parsing failed, invalid number of arguments");
+  assert_template_failure("$(sha1 ${missingbrace)", "Invalid macro, '}' is missing, error_pos='14'");
   assert_template_failure("$(sha1 --length invalid_length_specification foo)",
                           "Cannot parse integer value 'invalid_length_specification' for --length");
   assert_template_format("$(sha1 --length 99999 foo)", "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");


### PR DESCRIPTION
This branch follows up #1397 and improves readability of the various #ifdef cases.

This patch improves the readability of the code by breaking it up
along logical pieces instead of driven by openssl versions and code
required for various versions.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>