### PR TITLE
Remove hardcoded Werror

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,8 +44,8 @@ AM_CFLAGS =
 if ENABLE_EXTRA_WARNINGS
 AM_CFLAGS += \
 	-Wshadow	\
-	-Wno-initializer-overrides
-
+	-Wno-initializer-overrides \
+	-Wno-error=deprecated-declarations
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest $(AM_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -391,7 +391,7 @@ dnl ***************************************************************************
 dnl Set up CFLAGS
 
 if test "x$ac_compiler_gnu" = "xyes"; then
-        CFLAGS="${CFLAGS} -Wall -Werror -Wno-error=deprecated-declarations"
+        CFLAGS="${CFLAGS} -Wall -Wno-error=deprecated-declarations"
         if test "x$enable_debug" = "xyes"; then
                 CFLAGS="${ac_cv_env_CFLAGS_value} -Wall -g"
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -391,7 +391,7 @@ dnl ***************************************************************************
 dnl Set up CFLAGS
 
 if test "x$ac_compiler_gnu" = "xyes"; then
-        CFLAGS="${CFLAGS} -Wall -Wno-error=deprecated-declarations"
+        CFLAGS="${CFLAGS} -Wall"
         if test "x$enable_debug" = "xyes"; then
                 CFLAGS="${ac_cv_env_CFLAGS_value} -Wall -g"
         fi


### PR DESCRIPTION
We have the `Werror` flag in Travis, but we do not want to enforce it in every build environment.

This is a continuation of #1398.