### PR TITLE
cfg.c: default log_msg_size is increased to 64Kbyte from 8Kb

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -303,7 +303,7 @@ cfg_new(gint version)
   self->time_reap = 60;
 
   self->log_fifo_size = 10000;
-  self->log_msg_size = 8192;
+  self->log_msg_size = 65536;
 
   file_perm_options_global_defaults(&self->file_perm_options);
 


### PR DESCRIPTION
Because in modern log infrastructure the general log size is higher
and syslog-ng should process it by default.

Signed-off-by: Zoltan Pallagi <pzoleex@gmail.com>