### PR TITLE
Redis auth support

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -330,9 +330,6 @@ extern struct _StatsOptions *last_stats_options;
 
 %token KW_RETRIES                     10511
 
-/* authentication */
-%token KW_AUTH                        10600
-
 /* END_DECLS */
 
 %code {
@@ -758,7 +755,7 @@ log_flags_items
 options_stmt
         : KW_OPTIONS '{' options_items '}'
 	;
-	
+
 template_stmt
         : template_def
           {
@@ -800,7 +797,7 @@ template_fn
           }
           template_content_inner						{ $$ = last_template; free($2); }
 	;
-	
+
 template_items
 	: template_item ';' template_items
 	|
@@ -1281,4 +1278,3 @@ vp_rekey_option
 
 
 %%
-

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -330,6 +330,9 @@ extern struct _StatsOptions *last_stats_options;
 
 %token KW_RETRIES                     10511
 
+/* authentication */
+%token KW_AUTH                        10600
+
 /* END_DECLS */
 
 %code {

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -72,6 +72,7 @@ redis_option
         | KW_AUTH '(' string ')'
           {
             redis_dd_set_auth(last_driver, $3);
+            free($3);
           }
         | KW_COMMAND '(' string template_content ')'
           {

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -69,6 +69,10 @@ redis_option
           {
             redis_dd_set_port(last_driver, $3);
           }
+        | KW_AUTH '(' string ')'
+          {
+            redis_dd_set_auth(last_driver, $3);
+          }
         | KW_COMMAND '(' string template_content ')'
           {
             redis_dd_set_command(last_driver, $3, $4, NULL, NULL);

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -43,6 +43,7 @@
 
 %token KW_REDIS
 %token KW_COMMAND
+%token KW_AUTH
 
 %%
 

--- a/modules/redis/redis-parser.c
+++ b/modules/redis/redis-parser.c
@@ -30,10 +30,11 @@ int redis_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 
 static CfgLexerKeyword redis_keywords[] =
 {
-  { "redis",      KW_REDIS },
-  { "command",      KW_COMMAND },
+  { "redis",    KW_REDIS },
+  { "command",  KW_COMMAND },
   { "host",     KW_HOST },
   { "port",     KW_PORT },
+  { "auth",     KW_AUTH },
   { NULL }
 };
 

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -44,13 +44,13 @@ typedef struct
 
   LogTemplateOptions template_options;
 
-  GString	*command;
-  LogTemplate	*key;
-  GString	*key_str;
-  LogTemplate	*param1;
-  GString	*param1_str;
-  LogTemplate	*param2;
-  GString	*param2_str;
+  GString *command;
+  LogTemplate *key;
+  GString *key_str;
+  LogTemplate *param1;
+  GString *param1_str;
+  LogTemplate *param2;
+  GString *param2_str;
 
   redisContext *c;
 } RedisDriver;
@@ -202,14 +202,14 @@ redis_dd_connect(RedisDriver *self, gboolean reconnect)
   if (self->auth)
     if (!authenticate_to_redis(self, self->auth))
       {
-         msg_error("REDIS: failed to authenticate");
-         return FALSE;
+        msg_error("REDIS: failed to authenticate");
+        return FALSE;
       }
 
   if (!test_connection_to_redis(self))
     {
-       msg_error("REDIS: failed to connect");
-       return FALSE;
+      msg_error("REDIS: failed to connect");
+      return FALSE;
     }
 
   msg_debug("Connecting to REDIS succeeded",
@@ -249,8 +249,8 @@ redis_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 
   if (!test_connection_to_redis(self))
     {
-       msg_error("REDIS: worker failed to connect");
-       return WORKER_INSERT_RESULT_NOT_CONNECTED;
+      msg_error("REDIS: worker failed to connect");
+      return WORKER_INSERT_RESULT_NOT_CONNECTED;
     }
 
   log_template_format(self->key, msg, &self->template_options, LTZ_SEND,

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -145,7 +145,7 @@ redis_dd_format_persist_name(const LogPipe *s)
 }
 
 static gboolean
-sendRedisCommand(RedisDriver *self, const char *format, ...)
+send_redis_command(RedisDriver *self, const char *format, ...)
 {
   va_list ap;
   va_start(ap, format);
@@ -161,13 +161,13 @@ sendRedisCommand(RedisDriver *self, const char *format, ...)
 static gboolean
 check_connection_to_redis(RedisDriver *self)
 {
-  return sendRedisCommand(self, "ping");
+  return send_redis_command(self, "ping");
 }
 
 static gboolean
 authenticate_to_redis(RedisDriver *self, const gchar *password)
 {
-  return sendRedisCommand(self, "AUTH %s", self->auth);
+  return send_redis_command(self, "AUTH %s", self->auth);
 }
 
 static gboolean

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -159,7 +159,7 @@ sendRedisCommand(RedisDriver *self, const char *format, ...)
 }
 
 static gboolean
-test_connection_to_redis(RedisDriver *self)
+check_connection_to_redis(RedisDriver *self)
 {
   return sendRedisCommand(self, "ping");
 }
@@ -206,7 +206,7 @@ redis_dd_connect(RedisDriver *self, gboolean reconnect)
         return FALSE;
       }
 
-  if (!test_connection_to_redis(self))
+  if (!check_connection_to_redis(self))
     {
       msg_error("REDIS: failed to connect");
       return FALSE;
@@ -247,7 +247,7 @@ redis_worker_insert(LogThrDestDriver *s, LogMessage *msg)
   if (self->c->err)
     return WORKER_INSERT_RESULT_ERROR;
 
-  if (!test_connection_to_redis(self))
+  if (!check_connection_to_redis(self))
     {
       msg_error("REDIS: worker failed to connect");
       return WORKER_INSERT_RESULT_NOT_CONNECTED;
@@ -364,6 +364,7 @@ redis_dd_free(LogPipe *d)
   log_template_options_destroy(&self->template_options);
 
   g_free(self->host);
+  g_free(self->auth);
   g_string_free(self->command, TRUE);
   log_template_unref(self->key);
   log_template_unref(self->param1);

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -247,6 +247,12 @@ redis_worker_insert(LogThrDestDriver *s, LogMessage *msg)
   if (self->c->err)
     return WORKER_INSERT_RESULT_ERROR;
 
+  if (!test_connection_to_redis(self))
+    {
+       msg_error("REDIS: worker failed to connect");
+       return WORKER_INSERT_RESULT_NOT_CONNECTED;
+    }
+
   log_template_format(self->key, msg, &self->template_options, LTZ_SEND,
                       self->super.seq_num, NULL, self->key_str);
 

--- a/modules/redis/redis.h
+++ b/modules/redis/redis.h
@@ -30,6 +30,7 @@ LogDriver *redis_dd_new(GlobalConfig *cfg);
 
 void redis_dd_set_host(LogDriver *d, const gchar *host);
 void redis_dd_set_port(LogDriver *d, gint port);
+void redis_dd_set_auth(LogDriver *d, const gchar *auth);
 void redis_dd_set_command(LogDriver *d, const gchar *command,
                           LogTemplate *key,
                           LogTemplate *param1, LogTemplate *param2);


### PR DESCRIPTION
For issue:
https://github.com/balabit/syslog-ng/issues/1320

```
Example config:
destination d_redis {
    redis(
	host("127.0.0.1")
	port(6379)
        auth("Pa55W0rD") # <---
	command("HINCRBY", "hosts", "$HOST", "1")
    );
};
```