### PR TITLE
HDFS destination: Added kerberos support

### DIFF
--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
@@ -37,6 +37,8 @@ public class HdfsOptions {
   public static String RESOURCES = "hdfs_resources";
   public static String MAX_FILENAME_LENGTH = "hdfs_max_filename_length";
   public static String MAX_FILENAME_LENGTH_DEFAULT = "255";
+  public static String KERBEROS_PRINCIPAL = "kerberos_principal";
+  public static String KERBEROS_KEYTAB_FILE = "kerberos_keytab_file";
 
   private LogDestination owner;
   private Options options;
@@ -79,6 +81,14 @@ public class HdfsOptions {
      return options.get(MAX_FILENAME_LENGTH).getValueAsInteger();
   }
 
+  public String getKerberosPrincipal() {
+      return options.get(KERBEROS_PRINCIPAL).getValue();
+  }
+
+  public String getKerberosKeytabFile() {
+      return options.get(KERBEROS_KEYTAB_FILE).getValue();
+  }
+
   private void fillOptions() {
     fillStringOptions();
   }
@@ -89,6 +99,8 @@ public class HdfsOptions {
 		options.put(new StringOption(owner, ARCHIVE_DIR));
 		options.put(new StringOption(owner, RESOURCES));
 		options.put(new StringOption(owner, MAX_FILENAME_LENGTH, MAX_FILENAME_LENGTH_DEFAULT));
+		options.put(new StringOption(owner, KERBEROS_PRINCIPAL));
+		options.put(new StringOption(owner, KERBEROS_KEYTAB_FILE));
   }
 
 }

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -29,6 +29,8 @@ block destination hdfs(
   hdfs_file("")
   hdfs_max_filename_length("")
   client_lib_dir("")
+  kerberos_principal("")
+  kerberos_keytab_file("")
 )
 {
   java(
@@ -39,6 +41,8 @@ block destination hdfs(
     option("hdfs_archive_dir", `hdfs_archive_dir`)
     option("hdfs_resources", `hdfs_resources`)
     option("hdfs_max_filename_length", `hdfs_max_filename_length`)
+    option("kerberos_principal", `kerberos_principal`)
+    option("kerberos_keytab_file", `kerberos_keytab_file`)
     `__VARARGS__`
   );
 };


### PR DESCRIPTION
Example:

```
destination d_hdfs{
    hdfs(client-lib-dir(/hdfs-libs)
 hdfs-uri("hdfs://myhdp.com:8020")
 hdfs_file("/hdfs/text.txt")
 kerberos_keytab_file("/opt/syslog-ng/etc/hdfs.headless.keytab")
 kerberos_principal("hdfs-hdpcluster@MYREALM"));
};
```

Signed-off-by: Zoltan Pallagi <pzoleex@gmail.com>