### PR TITLE
affile-source: add exit_on_eof options

### DIFF
--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -123,6 +123,13 @@ log_proto_server_get_fd(LogProtoServer *s)
   return s->transport->fd;
 }
 
+static inline gboolean
+log_proto_server_get_exit_on_eof(LogProtoServer *s)
+{
+  /* FIXME: Layering violation */
+  return s->transport->exit_on_eof;
+}
+
 static inline void
 log_proto_server_reset_error(LogProtoServer *s)
 {

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -23,6 +23,7 @@
  */
 
 #include "logreader.h"
+#include "mainloop.h"
 #include "mainloop-io-worker.h"
 #include "mainloop-call.h"
 #include "ack_tracker.h"
@@ -359,6 +360,11 @@ log_reader_fetch_log(LogReader *self)
       switch (status)
         {
         case LPS_EOF:
+          if (log_proto_server_get_exit_on_eof(self->proto))
+            {
+              MainLoop *main_loop = main_loop_get_instance();
+              main_loop_exit(main_loop);
+            }
         case LPS_ERROR:
           g_sockaddr_unref(aux.peer_addr);
           return status == LPS_ERROR ? NC_READ_ERROR : NC_CLOSE;

--- a/lib/transport/logtransport.c
+++ b/lib/transport/logtransport.c
@@ -44,6 +44,13 @@ log_transport_init_instance(LogTransport *self, gint fd)
   self->fd = fd;
   self->cond = 0;
   self->free_fn = log_transport_free_method;
+  self->exit_on_eof = FALSE;
+}
+
+void
+log_transport_exit_on_eof(LogTransport *self)
+{
+  self->exit_on_eof = TRUE;
 }
 
 void

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2002-2017 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
@@ -37,6 +37,8 @@ struct _LogTransport
   gssize (*read)(LogTransport *self, gpointer buf, gsize count, LogTransportAuxData *aux);
   gssize (*write)(LogTransport *self, const gpointer buf, gsize count);
   void (*free_fn)(LogTransport *self);
+
+  gboolean exit_on_eof;
 };
 
 static inline gssize 
@@ -52,6 +54,7 @@ log_transport_read(LogTransport *self, gpointer buf, gsize count, LogTransportAu
 }
 
 void log_transport_init_instance(LogTransport *s, gint fd);
+void log_transport_exit_on_eof(LogTransport *self);
 void log_transport_free_method(LogTransport *s);
 void log_transport_free(LogTransport *s);
 

--- a/lib/transport/transport-file.c
+++ b/lib/transport/transport-file.c
@@ -40,7 +40,11 @@ log_transport_file_read_method(LogTransport *s, gpointer buf, gsize buflen, LogT
 
   if (rc == 0)
     {
-      /* regular files should never return EOF, they just need to be read again */
+      if (&self->super.exit_on_eof)
+        {
+          return rc;
+        }
+
       rc = -1;
       errno = EAGAIN;
     }
@@ -77,5 +81,6 @@ log_transport_file_new(gint fd)
   LogTransportFile *self = g_new0(LogTransportFile, 1);
 
   log_transport_file_init_instance(self, fd);
+
   return &self->super;
 }

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -59,6 +59,7 @@
 
 %token KW_FSYNC
 %token KW_FOLLOW_FREQ
+%token KW_EXIT_ON_EOF
 %token KW_OVERWRITE_IF_OLDER
 %token KW_MULTI_LINE_MODE
 %token KW_MULTI_LINE_PREFIX
@@ -101,6 +102,7 @@ source_affile_options
 source_affile_option
 	: KW_FOLLOW_FREQ '(' LL_FLOAT ')'		{ affile_sd_set_follow_freq(last_driver, (long) ($3 * 1000)); }
 	| KW_FOLLOW_FREQ '(' nonnegative_integer ')'		{ affile_sd_set_follow_freq(last_driver, ($3 * 1000)); }
+	| KW_EXIT_ON_EOF '(' yesno ')'		    { affile_sd_set_exit_on_eof(last_driver, $3); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'			{ ((AFFileSourceDriver *) last_driver)->pad_size = $3; }
 	| multi_line_option
         | source_reader_option

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -39,6 +39,7 @@ static CfgLexerKeyword affile_keywords[] =
   { "remove_if_older",    KW_OVERWRITE_IF_OLDER, KWS_OBSOLETE, "overwrite_if_older" },
   { "overwrite_if_older", KW_OVERWRITE_IF_OLDER },
   { "follow_freq",        KW_FOLLOW_FREQ },
+  { "exit_on_eof",        KW_EXIT_ON_EOF },
   { "multi_line_mode",    KW_MULTI_LINE_MODE  },
   { "multi_line_prefix",  KW_MULTI_LINE_PREFIX },
   { "multi_line_garbage", KW_MULTI_LINE_GARBAGE },

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -48,6 +48,7 @@ typedef struct _AFFileSourceDriver
   FileOpenOptions file_open_options;
   gint pad_size;
   gint follow_freq;
+  gboolean exit_on_eof;
   gint multi_line_mode;
   MultiLineRegexp *multi_line_prefix, *multi_line_garbage;
   /* state information to follow a set of files using a wildcard expression */
@@ -60,6 +61,7 @@ gboolean affile_sd_set_multi_line_prefix(LogDriver *s, const gchar *prefix_regex
 gboolean affile_sd_set_multi_line_garbage(LogDriver *s, const gchar *garbage_regexp, GError **error);
 gboolean affile_sd_set_multi_line_mode(LogDriver *s, const gchar *mode);
 void affile_sd_set_follow_freq(LogDriver *s, gint follow_freq);
+void affile_sd_set_exit_on_eof(LogDriver *s, gboolean exit_on_eof);
 
 void affile_sd_set_recursion(LogDriver *s, const gint recursion);
 void affile_sd_set_pri_level(LogDriver *s, const gint16 severity);


### PR DESCRIPTION
This PR is the next step to implement the command line functionality. It is the reimplementation of the  infrastructural part of exiting on EOF in #1326 based on feedbacks.

From now on it is possible to configure file and pipe sources to exit when EOF is reached.
```
file("/dev/stdin", exit_on_eof(yes));
```

Exit on EOF option was introduced for `LogTransport`, so it will be easier
to include more modules in the future.

However, another layering violation was introduced by
`log_proto_server_get_exit_on_eof`. I selected this point for the layering
violation, because there was already one and both of the violations are
the consequence of the same root cause. So next time if someone
re-factors the proto and transport parts, it will be easier to eliminate
these violations with the same method.
Another solution would have been to store `exit_on_eof` in
`LogProtoServerOptions` and change behaviour of `LogTransport` based on it.
This way the value could have been accessible both from `LogReader` and
`LogTransport`.  But it would have required more boilerplate code and
more complex "solution".

We agreed that `main_loop_exit` would be called from `GlobalConfig`. But it would have introduced circular dependencies, so `main_loop_exit` is called directly from `logreader.c`.

Signed-off-by: Noémi Ványi <sitbackandwait@gmail.com>