### PR TITLE
basicfuncs: add $(basename) and $(dirname) functions

### DIFF
--- a/modules/basicfuncs/Makefile.am
+++ b/modules/basicfuncs/Makefile.am
@@ -18,6 +18,7 @@ EXTRA_DIST					+=	\
 	modules/basicfuncs/context-funcs.c 		\
 	modules/basicfuncs/numeric-funcs.c 		\
 	modules/basicfuncs/str-funcs.c			\
+	modules/basicfuncs/fname-funcs.c		\
 	modules/basicfuncs/ip-funcs.c			\
 	modules/basicfuncs/misc-funcs.c			\
 	modules/basicfuncs/list-funcs.c			\

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -46,6 +46,7 @@
 #include "list-funcs.c"
 #include "tf-template.c"
 #include "context-funcs.c"
+#include "fname-funcs.c"
 
 static Plugin basicfuncs_plugins[] =
 {
@@ -69,6 +70,10 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_uppercase, "uppercase"),
   TEMPLATE_FUNCTION_PLUGIN(tf_replace_delimiter, "replace-delimiter"),
   TEMPLATE_FUNCTION_PLUGIN(tf_string_padding, "padding"),
+
+  /* fname-funcs */
+  TEMPLATE_FUNCTION_PLUGIN(tf_dirname, "dirname"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_basename, "basename"),
 
   /* list-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_list_concat, "list-concat"),

--- a/modules/basicfuncs/fname-funcs.c
+++ b/modules/basicfuncs/fname-funcs.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <string.h>
+#include <ctype.h>
+
+static void
+tf_basename(LogMessage *msg, gint argc, GString *argv[], GString *result)
+{
+  gchar *base;
+
+  base = g_path_get_basename(argv[0]->str);
+  g_string_assign(result, base);
+  g_free(base);
+}
+
+TEMPLATE_FUNCTION_SIMPLE(tf_basename);
+
+static void
+tf_dirname(LogMessage *msg, gint argc, GString *argv[], GString *result)
+{
+  gchar *dir;
+
+  dir = g_path_get_dirname(argv[0]->str);
+  g_string_assign(result, dir);
+  g_free(dir);
+}
+
+TEMPLATE_FUNCTION_SIMPLE(tf_dirname);

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -171,6 +171,19 @@ test_numeric_funcs(void)
   assert_template_format("$(- 10000000000 5000000000)", "5000000000");
 }
 
+void
+test_fname_funcs(void)
+{
+  assert_template_format("$(basename foo)", "foo");
+  assert_template_format("$(basename /foo/bar)", "bar");
+  assert_template_format("$(basename /foo/bar/baz)", "baz");
+
+  assert_template_format("$(dirname foo)", ".");
+  assert_template_format("$(dirname /foo/bar)", "/foo");
+  assert_template_format("$(dirname /foo/bar/)", "/foo");
+  assert_template_format("$(dirname /foo/bar/baz)", "/foo/bar");
+}
+
 typedef struct
 {
   const gchar *macro;


### PR DESCRIPTION
This module adds template functions to extract the filename and
the directory name from a filename.

Example usage:

$(basename $FILE_NAME)

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>