### PR TITLE
csv-parser appears not to be thread safe when attached to a network source

### DIFF
--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -392,24 +392,17 @@ csv_scanner_is_scan_finished(CSVScanner *self)
 }
 
 void
-csv_scanner_input(CSVScanner *self, const gchar *input)
+csv_scanner_init(CSVScanner *scanner, CSVScannerOptions *options, const gchar *input)
 {
-  self->src = input;
-  self->current_column = NULL;
+  memset(scanner, 0, sizeof(*scanner));
+  scanner->src = input;
+  scanner->current_value = g_string_sized_new(128);
+  scanner->current_column = NULL;
+  scanner->options = options;
 }
 
 void
-csv_scanner_state_init(CSVScanner *self, CSVScannerOptions *options)
-{
-  self->options = options;
-  self->current_column = options->columns;
-  self->src = NULL;
-  self->current_value = g_string_sized_new(128);
-  self->current_quote = 0;
-}
-
-void
-csv_scanner_state_clean(CSVScanner *self)
+csv_scanner_deinit(CSVScanner *self)
 {
   g_string_free(self->current_value, TRUE);
 }

--- a/lib/scanner/csv-scanner/csv-scanner.h
+++ b/lib/scanner/csv-scanner/csv-scanner.h
@@ -64,8 +64,7 @@ void csv_scanner_options_set_quotes(CSVScannerOptions *options, const gchar *quo
 void csv_scanner_options_set_quote_pairs(CSVScannerOptions *options, const gchar *quote_pairs);
 void csv_scanner_options_set_null_value(CSVScannerOptions *options, const gchar *null_value);
 
-typedef struct _CSVScanner
-{
+typedef struct {
   CSVScannerOptions *options;
   GList *current_column;
   const gchar *src;
@@ -80,9 +79,7 @@ gboolean csv_scanner_scan_next(CSVScanner *pstate);
 gboolean csv_scanner_is_scan_finished(CSVScanner *pstate);
 gchar *csv_scanner_dup_current_value(CSVScanner *self);
 
-void csv_scanner_input(CSVScanner *pstate, const gchar *input);
-gboolean csv_scanner_parse_input(CSVScanner *pstate);
-void csv_scanner_state_init(CSVScanner *pstate, CSVScannerOptions *options);
-void csv_scanner_state_clean(CSVScanner *pstate);
+void csv_scanner_init(CSVScanner *pstate, CSVScannerOptions *options, const gchar *input);
+void csv_scanner_deinit(CSVScanner *pstate);
 
 #endif

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.h
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.h
@@ -31,7 +31,6 @@ typedef struct _CSVContextualDataRecordScanner
   ContextualDataRecordScanner super;
   CSVScanner scanner;
   CSVScannerOptions options;
-
 } CSVContextualDataRecordScanner;
 
 ContextualDataRecordScanner *csv_contextual_data_record_scanner_new();

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -31,7 +31,6 @@ typedef struct _CSVParser
 {
   LogParser super;
   CSVScannerOptions options;
-  CSVScanner scanner;
   GString *formatted_key;
   gchar *prefix;
   gint prefix_len;
@@ -117,17 +116,19 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
   CSVParser *self = (CSVParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
 
-  csv_scanner_input(&self->scanner, input);
-  while (csv_scanner_scan_next(&self->scanner))
+  CSVScanner scanner;
+  csv_scanner_init(&scanner, &self->options, input);
+  while (csv_scanner_scan_next(&scanner))
     {
 
       log_msg_set_value_by_name(msg,
-                                _get_formatted_key(self, csv_scanner_get_current_name(&self->scanner)),
-                                csv_scanner_get_current_value(&self->scanner),
-                                csv_scanner_get_current_value_len(&self->scanner));
+                                _get_formatted_key(self, csv_scanner_get_current_name(&scanner)),
+                                csv_scanner_get_current_value(&scanner),
+                                csv_scanner_get_current_value_len(&scanner));
     }
 
-  return csv_scanner_is_scan_finished(&self->scanner);
+  csv_scanner_deinit(&scanner);
+  return csv_scanner_is_scan_finished(&scanner);
 }
 
 static LogPipe *
@@ -149,7 +150,6 @@ csv_parser_free(LogPipe *s)
   CSVParser *self = (CSVParser *) s;
 
   csv_scanner_options_clean(&self->options);
-  csv_scanner_state_clean(&self->scanner);
   g_string_free(self->formatted_key, TRUE);
   g_free(self->prefix);
   log_parser_free_method(s);
@@ -172,7 +172,6 @@ csv_parser_new(GlobalConfig *cfg)
   csv_scanner_options_set_quote_pairs(&self->options, "\"\"''");
   csv_scanner_options_set_flags(&self->options, CSV_SCANNER_STRIP_WHITESPACE);
   csv_scanner_options_set_dialect(&self->options, CSV_SCANNER_ESCAPE_NONE);
-  csv_scanner_state_init(&self->scanner, &self->options);
   return &self->super;
 }
 


### PR DESCRIPTION
csv-parser appears not to be thread safe when attached to a network source

https://github.com/balabit/syslog-ng/issues/1334
csv scanner object contained a few fields that are used for iterating
through columns. As multiple threads uses the same scanner object,
those threads broke the state of the common scanner. This patch creates
the scanner object on the stack of the parse function of the parser,
so each threads will have their own dedicated scanner objects.

Signed-off-by: Antal Nemes <antal.nemes@balabit.com>