### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,7 +105,7 @@
 
  * Support was added for OpenSSL 1.1.x (#1281)
 
-#Notes to the Developers
+# Notes to the Developers
 
  * We started to standardize our tests on the criterion unit testing
    framework, please submit all new tests using this framework. Patches to
@@ -118,7 +118,7 @@
  * debian/ directory has been removed from the "master" branch and is now
    maintained in a separate "release" branch.
 
-#Credits
+# Credits
 
 syslog-ng is developed as a community project, and as such it relies
 on volunteers, to do the work necessarily to produce syslog-ng.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Just send an email to feedback (at) syslog-ng.org.
 
 Should not take more than a minute, right?  Now go ahead. Please.
 
-#FeedbackPowersOpenSource.
+# FeedbackPowersOpenSource.
 
 Installation from Source
 ========================


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
