### PR TITLE
Db parser deadlock2

### DIFF
--- a/modules/dbparser/CMakeLists.txt
+++ b/modules/dbparser/CMakeLists.txt
@@ -21,6 +21,8 @@ set(PATTERNDB_SOURCES
     pdb-ruleset.h
     pdb-context.c
     pdb-context.h
+    pdb-ratelimit.c
+    pdb-ratelimit.h
     correllation.c
     correllation.h
     correllation-key.c

--- a/modules/dbparser/CMakeLists.txt
+++ b/modules/dbparser/CMakeLists.txt
@@ -19,6 +19,8 @@ set(PATTERNDB_SOURCES
     pdb-example.h
     pdb-ruleset.c
     pdb-ruleset.h
+    pdb-context.c
+    pdb-context.h
     correllation.c
     correllation.h
     correllation-key.c

--- a/modules/dbparser/CMakeLists.txt
+++ b/modules/dbparser/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PATTERNDB_SOURCES
     pdb-context.h
     pdb-ratelimit.c
     pdb-ratelimit.h
+    pdb-lookup-params.h
     correllation.c
     correllation.h
     correllation-key.c

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -25,6 +25,7 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/pdb-context.h				\
 	modules/dbparser/pdb-ratelimit.c			\
 	modules/dbparser/pdb-ratelimit.h			\
+	modules/dbparser/pdb-lookup-params.h			\
 	modules/dbparser/correllation.c				\
 	modules/dbparser/correllation.h				\
 	modules/dbparser/correllation-key.c			\

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -21,6 +21,8 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/pdb-example.h				\
 	modules/dbparser/pdb-ruleset.c				\
 	modules/dbparser/pdb-ruleset.h				\
+	modules/dbparser/pdb-context.c				\
+	modules/dbparser/pdb-context.h				\
 	modules/dbparser/correllation.c				\
 	modules/dbparser/correllation.h				\
 	modules/dbparser/correllation-key.c			\

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -23,6 +23,8 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/pdb-ruleset.h				\
 	modules/dbparser/pdb-context.c				\
 	modules/dbparser/pdb-context.h				\
+	modules/dbparser/pdb-ratelimit.c			\
+	modules/dbparser/pdb-ratelimit.h			\
 	modules/dbparser/correllation.c				\
 	modules/dbparser/correllation.h				\
 	modules/dbparser/correllation-key.c			\

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -685,7 +685,7 @@ _pattern_db_process(PatternDB *self, PDBLookupParams *lookup, GArray *dbg_list)
 }
 
 static void
-pdb_lookup_state_init(PDBLookupParams *lookup, LogMessage *msg)
+pdb_lookup_params_init(PDBLookupParams *lookup, LogMessage *msg)
 {
   lookup->msg = msg;
   lookup->program_handle = LM_V_PROGRAM;
@@ -698,7 +698,7 @@ pattern_db_process(PatternDB *self, LogMessage *msg)
 {
   PDBLookupParams lookup;
 
-  pdb_lookup_state_init(&lookup, msg);
+  pdb_lookup_params_init(&lookup, msg);
   return _pattern_db_process(self, &lookup, NULL);
 }
 
@@ -707,7 +707,7 @@ pattern_db_process_with_custom_message(PatternDB *self, LogMessage *msg, const g
 {
   PDBLookupParams lookup;
 
-  pdb_lookup_state_init(&lookup, msg);
+  pdb_lookup_params_init(&lookup, msg);
   lookup.message_handle = LM_V_NONE;
   lookup.message_string = message;
   lookup.message_len = message_len;
@@ -719,7 +719,7 @@ pattern_db_debug_ruleset(PatternDB *self, LogMessage *msg, GArray *dbg_list)
 {
   PDBLookupParams lookup;
 
-  pdb_lookup_state_init(&lookup, msg);
+  pdb_lookup_params_init(&lookup, msg);
   _pattern_db_process(self, &lookup, dbg_list);
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -42,11 +42,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
-static NVHandle class_handle = 0;
-static NVHandle rule_id_handle = 0;
 static NVHandle context_id_handle = 0;
-static LogTagId system_tag;
-static LogTagId unknown_tag;
+
 
 struct _PatternDB
 {
@@ -280,135 +277,6 @@ _execute_rule_actions(PatternDB *db, PDBRule *rule,
 
       _execute_action_if_triggered(db, rule, action, trigger, context, msg, buffer);
     }
-}
-
-/**
- * _add_matches_to_message:
- *
- * Adds the values from the given GArray of RParserMatch entries to the NVTable
- * of the passed LogMessage.
- *
- * @msg: the LogMessage to add the matches to
- * @matches: an array of RParserMatch entries
- * @ref_handle: if the matches are indirect matches, they are referenced based on this handle (eg. LM_V_MESSAGE)
- **/
-void
-_add_matches_to_message(LogMessage *msg, GArray *matches, NVHandle ref_handle, const gchar *input_string)
-{
-  gint i;
-  for (i = 0; i < matches->len; i++)
-    {
-      RParserMatch *match = &g_array_index(matches, RParserMatch, i);
-
-      if (match->match)
-        {
-          log_msg_set_value(msg, match->handle, match->match, match->len);
-          g_free(match->match);
-        }
-      else if (ref_handle != LM_V_NONE && log_msg_is_handle_settable_with_an_indirect_value(match->handle))
-        {
-          log_msg_set_value_indirect(msg, match->handle, ref_handle, match->type, match->ofs, match->len);
-        }
-      else
-        {
-          log_msg_set_value(msg, match->handle, input_string + match->ofs, match->len);
-        }
-    }
-}
-
-/*
- * Looks up a matching rule in the ruleset.
- *
- * NOTE: it also modifies @msg to store the name-value pairs found during lookup, so
- */
-PDBRule *
-pdb_lookup_ruleset(PDBRuleSet *rule_set, PDBLookupParams *lookup, GArray *dbg_list)
-{
-  RNode *node;
-  LogMessage *msg = lookup->msg;
-  GArray *prg_matches, *matches;
-  const gchar *program_value;
-  gssize program_len;
-
-  if (G_UNLIKELY(!rule_set->programs))
-    return FALSE;
-
-  program_value = log_msg_get_value(msg, lookup->program_handle, &program_len);
-  prg_matches = g_array_new(FALSE, TRUE, sizeof(RParserMatch));
-  node = r_find_node(rule_set->programs, (guint8 *) program_value, program_len, prg_matches);
-
-  if (node)
-    {
-      _add_matches_to_message(msg, prg_matches, lookup->program_handle, program_value);
-      g_array_free(prg_matches, TRUE);
-
-      PDBProgram *program = (PDBProgram *) node->value;
-
-      if (program->rules)
-        {
-          RNode *msg_node;
-          const gchar *message;
-          gssize message_len;
-
-          /* NOTE: We're not using g_array_sized_new as that does not
-           * correctly zero-initialize the new items even if clear_ is TRUE
-           */
-
-          matches = g_array_new(FALSE, TRUE, sizeof(RParserMatch));
-          g_array_set_size(matches, 1);
-
-          if (lookup->message_handle)
-            {
-              message = log_msg_get_value(msg, lookup->message_handle, &message_len);
-            }
-          else
-            {
-              message = lookup->message_string;
-              message_len = lookup->message_len;
-            }
-
-          if (G_UNLIKELY(dbg_list))
-            msg_node = r_find_node_dbg(program->rules, (guint8 *) message, message_len, matches, dbg_list);
-          else
-            msg_node = r_find_node(program->rules, (guint8 *) message, message_len, matches);
-
-          if (msg_node)
-            {
-              PDBRule *rule = (PDBRule *) msg_node->value;
-              GString *buffer = g_string_sized_new(32);
-
-              msg_debug("patterndb rule matches",
-                        evt_tag_str("rule_id", rule->rule_id));
-              log_msg_set_value(msg, class_handle, rule->class ? rule->class : "system", -1);
-              log_msg_set_value(msg, rule_id_handle, rule->rule_id, -1);
-
-              _add_matches_to_message(msg, matches, lookup->message_handle, message);
-              g_array_free(matches, TRUE);
-
-              if (!rule->class)
-                {
-                  log_msg_set_tag_by_id(msg, system_tag);
-                }
-              log_msg_clear_tag_by_id(msg, unknown_tag);
-              g_string_free(buffer, TRUE);
-              pdb_rule_ref(rule);
-              return rule;
-            }
-          else
-            {
-              log_msg_set_value(msg, class_handle, "unknown", 7);
-              log_msg_set_tag_by_id(msg, unknown_tag);
-            }
-          g_array_free(matches, TRUE);
-        }
-    }
-  else
-    {
-      g_array_free(prg_matches, TRUE);
-    }
-
-  return NULL;
-
 }
 
 /*********************************************************
@@ -668,7 +536,7 @@ _pattern_db_process(PatternDB *self, PDBLookupParams *lookup, GArray *dbg_list)
       g_static_rw_lock_reader_unlock(&self->lock);
       return FALSE;
     }
-  rule = pdb_lookup_ruleset(self->ruleset, lookup, dbg_list);
+  rule = pdb_ruleset_lookup(self->ruleset, lookup, dbg_list);
   g_static_rw_lock_reader_unlock(&self->lock);
   if (rule)
     _pattern_db_process_matching_rule(self, rule, msg);
@@ -770,9 +638,6 @@ pattern_db_free(PatternDB *self)
 void
 pattern_db_global_init(void)
 {
-  class_handle = log_msg_get_value_handle(".classifier.class");
-  rule_id_handle = log_msg_get_value_handle(".classifier.rule_id");
   context_id_handle = log_msg_get_value_handle(".classifier.context_id");
-  system_tag = log_tags_get_by_name(".classifier.system");
-  unknown_tag = log_tags_get_by_name(".classifier.unknown");
+  pdb_rule_set_global_init();
 }

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -265,9 +265,10 @@ _execute_action_if_triggered(PatternDB *db, PDBRule *rule, PDBAction *action,
     _execute_action(db, rule, action, context, msg, buffer);
 }
 
-void
-pdb_run_rule_actions(PDBRule *rule, PatternDB *db, PDBActionTrigger trigger, PDBContext *context, LogMessage *msg,
-                     GString *buffer)
+static void
+_execute_rule_actions(PatternDB *db, PDBRule *rule,
+                      PDBActionTrigger trigger, PDBContext *context,
+                      LogMessage *msg, GString *buffer)
 {
   gint i;
 
@@ -434,7 +435,7 @@ pattern_db_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
             evt_tag_str("last_rule", context->rule->rule_id),
             evt_tag_long("utc", timer_wheel_get_time(pdb->timer_wheel)));
   if (pdb->emit)
-    pdb_run_rule_actions(context->rule, pdb, RAT_TIMEOUT, context, msg, buffer);
+    _execute_rule_actions(pdb, context->rule, RAT_TIMEOUT, context, msg, buffer);
   g_hash_table_remove(pdb->correllation.state, &context->super.key);
   g_string_free(buffer, TRUE);
 
@@ -633,7 +634,7 @@ _pattern_db_process_matching_rule(PatternDB *self, PDBRule *rule, LogMessage *ms
     {
       g_static_rw_lock_writer_unlock(&self->lock);
       self->emit(msg, FALSE, self->emit_data);
-      pdb_run_rule_actions(rule, self, RAT_MATCH, context, msg, buffer);
+      _execute_rule_actions(self, rule, RAT_MATCH, context, msg, buffer);
       g_static_rw_lock_writer_lock(&self->lock);
     }
   pdb_rule_unref(rule);

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -27,6 +27,7 @@
 #include "pdb-program.h"
 #include "pdb-ruleset.h"
 #include "pdb-load.h"
+#include "pdb-context.h"
 #include "correllation.h"
 #include "logmsg/logmsg.h"
 #include "template/templates.h"
@@ -99,40 +100,6 @@ struct _PatternDB
  *    states even if there are no incoming messages
  *
  */
-
-
-/**************************************************************************
- * PDBContext, represents a correllation state in the state hash table, is
- * marked with PSK_CONTEXT in the hash table key
- **************************************************************************/
-
-/* This class encapsulates a correllation context, keyed by CorrellationKey, type == PSK_RULE. */
-typedef struct _PDBContext
-{
-  CorrellationContext super;
-  /* back reference to the last rule touching this context */
-  PDBRule *rule;
-} PDBContext;
-
-static void
-pdb_context_free(CorrellationContext *s)
-{
-  PDBContext *self = (PDBContext *) s;
-
-  if (self->rule)
-    pdb_rule_unref(self->rule);
-  correllation_context_free_method(s);
-}
-
-PDBContext *
-pdb_context_new(CorrellationKey *key)
-{
-  PDBContext *self = g_new0(PDBContext, 1);
-
-  correllation_context_init(&self->super, key);
-  self->super.free_fn = pdb_context_free;
-  return self;
-}
 
 /***************************************************************************
  * PDBRateLimit

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -170,8 +170,8 @@ _is_action_triggered(PatternDB *db, PDBRule *rule, PDBAction *action, PDBActionT
   return TRUE;
 }
 
-LogMessage *
-pdb_generate_message(PDBAction *action, PDBContext *context, LogMessage *msg, GString *buffer)
+static LogMessage *
+_generate_synthetic_message(PDBAction *action, PDBContext *context, LogMessage *msg, GString *buffer)
 {
   if (context)
     return synthetic_message_generate_with_context(&action->content.message, &context->super, buffer);
@@ -184,7 +184,7 @@ pdb_execute_action_message(PDBAction *action, PatternDB *db, PDBContext *context
 {
   LogMessage *genmsg;
 
-  genmsg = pdb_generate_message(action, context, msg, buffer);
+  genmsg = _generate_synthetic_message(action, context, msg, buffer);
   db->emit(genmsg, TRUE, db->emit_data);
   log_msg_unref(genmsg);
 }

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -179,8 +179,8 @@ _generate_synthetic_message(PDBAction *action, PDBContext *context, LogMessage *
     return synthetic_message_generate_without_context(&action->content.message, msg, buffer);
 }
 
-void
-pdb_execute_action_message(PDBAction *action, PatternDB *db, PDBContext *context, LogMessage *msg, GString *buffer)
+static void
+_execute_action_message(PatternDB *db, PDBAction *action, PDBContext *context, LogMessage *msg, GString *buffer)
 {
   LogMessage *genmsg;
 
@@ -245,7 +245,7 @@ pdb_execute_action(PDBAction *action, PatternDB *db, PDBRule *rule, PDBContext *
     case RAC_NONE:
       break;
     case RAC_MESSAGE:
-      pdb_execute_action_message(action, db, context, msg, buffer);
+      _execute_action_message(db, action, context, msg, buffer);
       break;
     case RAC_CREATE_CONTEXT:
       pdb_execute_action_create_context(action, db, rule, context, msg, buffer);

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -237,8 +237,8 @@ _execute_action_create_context(PatternDB *db, PDBAction *action, PDBRule *rule, 
   new_context->rule = pdb_rule_ref(rule);
 }
 
-void
-pdb_execute_action(PDBAction *action, PatternDB *db, PDBRule *rule, PDBContext *context, LogMessage *msg, GString *buffer)
+static void
+_execute_action(PatternDB *db, PDBRule *rule, PDBAction *action, PDBContext *context, LogMessage *msg, GString *buffer)
 {
   switch (action->content_type)
     {
@@ -261,7 +261,7 @@ pdb_trigger_action(PDBAction *action, PatternDB *db, PDBRule *rule, PDBActionTri
                    LogMessage *msg, GString *buffer)
 {
   if (_is_action_triggered(db, rule, action, trigger, context, msg, buffer))
-    pdb_execute_action(action, db, rule, context, msg, buffer);
+    _execute_action(db, rule, action, context, msg, buffer);
 }
 
 void

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -147,9 +147,9 @@ _is_action_within_rate_limit(PatternDB *db, PDBRule *rule, PDBAction *action, Lo
   return FALSE;
 }
 
-gboolean
-pdb_is_action_triggered(PDBAction *action, PatternDB *db, PDBRule *rule, PDBActionTrigger trigger, PDBContext *context,
-                        LogMessage *msg, GString *buffer)
+static gboolean
+_is_action_triggered(PatternDB *db, PDBRule *rule, PDBAction *action, PDBActionTrigger trigger, PDBContext *context,
+                     LogMessage *msg, GString *buffer)
 {
   if (action->trigger != trigger)
     return FALSE;
@@ -260,7 +260,7 @@ void
 pdb_trigger_action(PDBAction *action, PatternDB *db, PDBRule *rule, PDBActionTrigger trigger, PDBContext *context,
                    LogMessage *msg, GString *buffer)
 {
-  if (pdb_is_action_triggered(action, db, rule, trigger, context, msg, buffer))
+  if (_is_action_triggered(db, rule, action, trigger, context, msg, buffer))
     pdb_execute_action(action, db, rule, context, msg, buffer);
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -29,6 +29,7 @@
 #include "pdb-load.h"
 #include "pdb-context.h"
 #include "pdb-ratelimit.h"
+#include "pdb-lookup-params.h"
 #include "correllation.h"
 #include "logmsg/logmsg.h"
 #include "template/templates.h"
@@ -46,16 +47,6 @@ static NVHandle rule_id_handle = 0;
 static NVHandle context_id_handle = 0;
 static LogTagId system_tag;
 static LogTagId unknown_tag;
-
-typedef struct _PDBLookupParams PDBLookupParams;
-struct _PDBLookupParams
-{
-  LogMessage *msg;
-  NVHandle program_handle;
-  NVHandle message_handle;
-  const gchar *message_string;
-  gssize message_len;
-};
 
 struct _PatternDB
 {
@@ -684,14 +675,6 @@ _pattern_db_process(PatternDB *self, PDBLookupParams *lookup, GArray *dbg_list)
   return rule != NULL;
 }
 
-static void
-pdb_lookup_params_init(PDBLookupParams *lookup, LogMessage *msg)
-{
-  lookup->msg = msg;
-  lookup->program_handle = LM_V_PROGRAM;
-  lookup->message_handle = LM_V_MESSAGE;
-  lookup->message_len = 0;
-}
 
 gboolean
 pattern_db_process(PatternDB *self, LogMessage *msg)

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -191,9 +191,9 @@ _execute_action_message(PatternDB *db, PDBAction *action, PDBContext *context, L
 
 static void pattern_db_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data);
 
-void
-pdb_execute_action_create_context(PDBAction *action, PatternDB *db, PDBRule *rule, PDBContext *triggering_context,
-                                  LogMessage *triggering_msg, GString *buffer)
+static void
+_execute_action_create_context(PatternDB *db, PDBAction *action, PDBRule *rule, PDBContext *triggering_context,
+                               LogMessage *triggering_msg, GString *buffer)
 {
   CorrellationKey key;
   PDBContext *new_context;
@@ -248,7 +248,7 @@ pdb_execute_action(PDBAction *action, PatternDB *db, PDBRule *rule, PDBContext *
       _execute_action_message(db, action, context, msg, buffer);
       break;
     case RAC_CREATE_CONTEXT:
-      pdb_execute_action_create_context(action, db, rule, context, msg, buffer);
+      _execute_action_create_context(db, action, rule, context, msg, buffer);
       break;
     default:
       g_assert_not_reached();

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -256,9 +256,10 @@ _execute_action(PatternDB *db, PDBRule *rule, PDBAction *action, PDBContext *con
     }
 }
 
-void
-pdb_trigger_action(PDBAction *action, PatternDB *db, PDBRule *rule, PDBActionTrigger trigger, PDBContext *context,
-                   LogMessage *msg, GString *buffer)
+static void
+_execute_action_if_triggered(PatternDB *db, PDBRule *rule, PDBAction *action,
+                             PDBActionTrigger trigger, PDBContext *context,
+                             LogMessage *msg, GString *buffer)
 {
   if (_is_action_triggered(db, rule, action, trigger, context, msg, buffer))
     _execute_action(db, rule, action, context, msg, buffer);
@@ -276,7 +277,7 @@ pdb_run_rule_actions(PDBRule *rule, PatternDB *db, PDBActionTrigger trigger, PDB
     {
       PDBAction *action = (PDBAction *) g_ptr_array_index(rule->actions, i);
 
-      pdb_trigger_action(action, db, rule, trigger, context, msg, buffer);
+      _execute_action_if_triggered(db, rule, action, trigger, context, msg, buffer);
     }
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -28,6 +28,7 @@
 #include "pdb-ruleset.h"
 #include "pdb-load.h"
 #include "pdb-context.h"
+#include "pdb-ratelimit.h"
 #include "correllation.h"
 #include "logmsg/logmsg.h"
 #include "template/templates.h"
@@ -101,47 +102,6 @@ struct _PatternDB
  *
  */
 
-/***************************************************************************
- * PDBRateLimit
- ***************************************************************************/
-
-/* This class encapsulates a rate-limit state stored in
-   db->state. */
-typedef struct _PDBRateLimit
-{
-  /* key in the hashtable. NOTE: host/program/pid/session_id are allocated, thus they need to be freed when the structure is freed. */
-  CorrellationKey key;
-  gint buckets;
-  guint64 last_check;
-} PDBRateLimit;
-
-PDBRateLimit *
-pdb_rate_limit_new(CorrellationKey *key)
-{
-  PDBRateLimit *self = g_new0(PDBRateLimit, 1);
-
-  memcpy(&self->key, key, sizeof(*key));
-  if (self->key.pid)
-    self->key.pid = g_strdup(self->key.pid);
-  if (self->key.program)
-    self->key.program = g_strdup(self->key.program);
-  if (self->key.host)
-    self->key.host = g_strdup(self->key.host);
-  return self;
-}
-
-void
-pdb_rate_limit_free(PDBRateLimit *self)
-{
-  if (self->key.host)
-    g_free((gchar *) self->key.host);
-  if (self->key.program)
-    g_free((gchar *) self->key.program);
-  if (self->key.pid)
-    g_free((gchar *) self->key.pid);
-  g_free(self->key.session_id);
-  g_free(self);
-}
 
 /*********************************************
  * Rule evaluation

--- a/modules/dbparser/patterndb.h
+++ b/modules/dbparser/patterndb.h
@@ -34,11 +34,11 @@ typedef void (*PatternDBEmitFunc)(LogMessage *msg, gboolean synthetic, gpointer 
 void pattern_db_set_emit_func(PatternDB *self, PatternDBEmitFunc emit_func, gpointer emit_data);
 
 PDBRuleSet *pattern_db_get_ruleset(PatternDB *self);
-TimerWheel *pattern_db_get_timer_wheel(PatternDB *self);
 const gchar *pattern_db_get_ruleset_version(PatternDB *self);
 const gchar *pattern_db_get_ruleset_pub_date(PatternDB *self);
 gboolean pattern_db_reload_ruleset(PatternDB *self, GlobalConfig *cfg, const gchar *pdb_file);
 
+void pattern_db_advance_time(PatternDB *self, gint timeout);
 void pattern_db_timer_tick(PatternDB *self);
 gboolean pattern_db_process(PatternDB *self, LogMessage *msg);
 gboolean pattern_db_process_with_custom_message(PatternDB *self, LogMessage *msg, const gchar *message, gssize message_len);

--- a/modules/dbparser/pdb-context.c
+++ b/modules/dbparser/pdb-context.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "pdb-context.h"
+
+static void
+pdb_context_free(CorrellationContext *s)
+{
+  PDBContext *self = (PDBContext *) s;
+
+  if (self->rule)
+    pdb_rule_unref(self->rule);
+  correllation_context_free_method(s);
+}
+
+PDBContext *
+pdb_context_new(CorrellationKey *key)
+{
+  PDBContext *self = g_new0(PDBContext, 1);
+
+  correllation_context_init(&self->super, key);
+  self->super.free_fn = pdb_context_free;
+  return self;
+}

--- a/modules/dbparser/pdb-context.h
+++ b/modules/dbparser/pdb-context.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PATTERNDB_PDB_CONTEXT_H_INCLUDED
+#define PATTERNDB_PDB_CONTEXT_H_INCLUDED
+
+#include "pdb-rule.h"
+
+/**************************************************************************
+ * PDBContext, represents a correllation state in the state hash table, is
+ * marked with PSK_CONTEXT in the hash table key
+ **************************************************************************/
+
+/* This class encapsulates a correllation context, keyed by CorrellationKey, type == PSK_RULE. */
+typedef struct _PDBContext
+{
+  CorrellationContext super;
+  /* back reference to the last rule touching this context */
+  PDBRule *rule;
+} PDBContext;
+
+PDBContext *pdb_context_new(CorrellationKey *key);
+
+#endif

--- a/modules/dbparser/pdb-lookup-params.h
+++ b/modules/dbparser/pdb-lookup-params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PATTERNDB_PDB_LOOKUP_PARAMS_H_INCLUDED
+#define PATTERNDB_PDB_LOOKUP_PARAMS_H_INCLUDED
+
+typedef struct _PDBLookupParams PDBLookupParams;
+struct _PDBLookupParams
+{
+  LogMessage *msg;
+  NVHandle program_handle;
+  NVHandle message_handle;
+  const gchar *message_string;
+  gssize message_len;
+};
+
+static inline void
+pdb_lookup_params_init(PDBLookupParams *lookup, LogMessage *msg)
+{
+  lookup->msg = msg;
+  lookup->program_handle = LM_V_PROGRAM;
+  lookup->message_handle = LM_V_MESSAGE;
+  lookup->message_len = 0;
+}
+
+#endif

--- a/modules/dbparser/pdb-ratelimit.c
+++ b/modules/dbparser/pdb-ratelimit.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "pdb-ratelimit.h"
+#include <string.h>
+
+/***************************************************************************
+ * PDBRateLimit
+ ***************************************************************************/
+
+PDBRateLimit *
+pdb_rate_limit_new(CorrellationKey *key)
+{
+  PDBRateLimit *self = g_new0(PDBRateLimit, 1);
+
+  memcpy(&self->key, key, sizeof(*key));
+  if (self->key.pid)
+    self->key.pid = g_strdup(self->key.pid);
+  if (self->key.program)
+    self->key.program = g_strdup(self->key.program);
+  if (self->key.host)
+    self->key.host = g_strdup(self->key.host);
+  return self;
+}
+
+void
+pdb_rate_limit_free(PDBRateLimit *self)
+{
+  if (self->key.host)
+    g_free((gchar *) self->key.host);
+  if (self->key.program)
+    g_free((gchar *) self->key.program);
+  if (self->key.pid)
+    g_free((gchar *) self->key.pid);
+  g_free(self->key.session_id);
+  g_free(self);
+}

--- a/modules/dbparser/pdb-ratelimit.h
+++ b/modules/dbparser/pdb-ratelimit.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PATTERNDB_PDB_RATELIMIT_H_INCLUDED
+#define PATTERNDB_PDB_RATELIMIT_H_INCLUDED
+
+#include "correllation-key.h"
+
+/* This class encapsulates a rate-limit state stored in
+   db->state. */
+typedef struct _PDBRateLimit
+{
+  /* key in the hashtable. NOTE: host/program/pid/session_id are allocated, thus they need to be freed when the structure is freed. */
+  CorrellationKey key;
+  gint buckets;
+  guint64 last_check;
+} PDBRateLimit;
+
+PDBRateLimit *pdb_rate_limit_new(CorrellationKey *key);
+void pdb_rate_limit_free(PDBRateLimit *self);
+
+#endif

--- a/modules/dbparser/pdb-ruleset.h
+++ b/modules/dbparser/pdb-ruleset.h
@@ -25,6 +25,8 @@
 
 #include "syslog-ng.h"
 #include "radix.h"
+#include "pdb-lookup-params.h"
+#include "pdb-rule.h"
 
 /* rules loaded from a pdb file */
 typedef struct _PDBRuleSet
@@ -35,7 +37,11 @@ typedef struct _PDBRuleSet
   gboolean is_empty;
 } PDBRuleSet;
 
+PDBRule *pdb_ruleset_lookup(PDBRuleSet *rule_set, PDBLookupParams *lookup, GArray *dbg_list);
 PDBRuleSet *pdb_rule_set_new(void);
 void pdb_rule_set_free(PDBRuleSet *self);
+
+void pdb_rule_set_global_init(void);
+
 
 #endif

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -126,8 +126,7 @@ static void
 _advance_time(gint timeout)
 {
   if (timeout)
-    timer_wheel_set_time(pattern_db_get_timer_wheel(patterndb),
-                         timer_wheel_get_time(pattern_db_get_timer_wheel(patterndb)) + timeout + 1);
+    pattern_db_advance_time(patterndb, timeout + 1);
 }
 
 static LogMessage *


### PR DESCRIPTION
This series of patches incorporate a number of refactoring steps within db-parser and also fix a deadlock situation reported by Evan Rempel.

The refactoring steps aim at two things:
 * split out a few helper classes to modules of their own
 * introduce a per-thread state that is used throughout pattern_db_proces() and its chain of function calls to simplify parameter lists

The fix itself builds on the second refactoring step: we use this state to store a list of messages to be emitted, instead of emitting them right away. This way we can release all locks through log_db_parser_emit(), which resolves the deadlock. Earlier a number of workarounds were present in the code, that were only partial fixes, this patch removes the workarounds and resolves the situation for good.
