### PR TITLE
Add SSL/TLS options to the http (curl) module

### DIFF
--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -665,6 +665,12 @@ tls_option
         : KW_IFDEF {
 }
 
+	| KW_PEER_VERIFY '(' yesno ')'
+	  {
+	    last_tls_context->verify_mode = $3
+		? (TVM_REQUIRED | TVM_TRUSTED)
+		: (TVM_OPTIONAL | TVM_UNTRUSTED);
+          }
 	| KW_PEER_VERIFY '(' string ')'
 	  {
 	    last_tls_context->verify_mode = tls_lookup_verify_mode($3);

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -61,6 +61,7 @@
 %token KW_CERT_FILE
 %token KW_KEY_FILE
 %token KW_CIPHER_SUITE
+%token KW_SSL_VERSION
 %token KW_PEER_VERIFY
 
 %type   <ptr> driver
@@ -110,6 +111,7 @@ http_option
     | KW_CERT_FILE  '(' string ')'            { http_dd_set_cert_file(last_driver, $3); free($3); }
     | KW_KEY_FILE   '(' string ')'            { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
+    | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
     | KW_PEER_VERIFY '(' string ')'           { http_dd_set_peer_verify(last_driver, $3); free($3); }
     | dest_driver_option
     | threaded_dest_driver_option

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -56,6 +56,12 @@
 %token KW_METHOD
 %token KW_HEADERS
 %token KW_BODY
+%token KW_CA_DIR
+%token KW_CA_FILE
+%token KW_CERT_FILE
+%token KW_KEY_FILE
+%token KW_CIPHER_SUITE
+%token KW_PEER_VERIFY
 
 %type   <ptr> driver
 %type   <ptr> http_destination
@@ -99,6 +105,12 @@ http_option
     | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free($3); }
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
+    | KW_CA_DIR     '(' string ')'            { http_dd_set_ca_dir(last_driver, $3); free($3); }
+    | KW_CA_FILE    '(' string ')'            { http_dd_set_ca_file(last_driver, $3); free($3); }
+    | KW_CERT_FILE  '(' string ')'            { http_dd_set_cert_file(last_driver, $3); free($3); }
+    | KW_KEY_FILE   '(' string ')'            { http_dd_set_key_file(last_driver, $3); free($3); }
+    | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
+    | KW_PEER_VERIFY '(' string ')'           { http_dd_set_peer_verify(last_driver, $3); free($3); }
     | dest_driver_option
     | threaded_dest_driver_option
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -112,7 +112,7 @@ http_option
     | KW_KEY_FILE   '(' string ')'            { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
     | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
-    | KW_PEER_VERIFY '(' string ')'           { http_dd_set_peer_verify(last_driver, $3); free($3); }
+    | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
     | dest_driver_option
     | threaded_dest_driver_option
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -43,6 +43,7 @@ static CfgLexerKeyword http_keywords[] =
   { "cert_file",    KW_CERT_FILE },
   { "key_file",     KW_KEY_FILE },
   { "cipher_suite", KW_CIPHER_SUITE },
+  { "ssl_version",  KW_SSL_VERSION },
   { "peer_verify",  KW_PEER_VERIFY },
   { NULL }
 };

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -38,6 +38,12 @@ static CfgLexerKeyword http_keywords[] =
   { "headers",      KW_HEADERS },
   { "method",       KW_METHOD },
   { "body",         KW_BODY },
+  { "ca_dir",       KW_CA_DIR },
+  { "ca_file",      KW_CA_FILE },
+  { "cert_file",    KW_CERT_FILE },
+  { "key_file",     KW_KEY_FILE },
+  { "cipher_suite", KW_CIPHER_SUITE },
+  { "peer_verify",  KW_PEER_VERIFY },
   { NULL }
 };
 

--- a/modules/http/http-plugin.h
+++ b/modules/http/http-plugin.h
@@ -38,7 +38,13 @@ typedef struct
   gchar *password;
   GList *headers;
   gchar *user_agent;
+  gchar *ca_dir;
+  gchar *ca_file;
+  gchar *cert_file;
+  gchar *key_file;
+  gchar *ciphers;
   short int method_type;
+  gboolean peer_verify;
   LogTemplate *body_template;
   LogTemplateOptions template_options;
 } HTTPDestinationDriver;
@@ -53,6 +59,12 @@ void http_dd_set_method(LogDriver *d, const gchar *method);
 void http_dd_set_user_agent(LogDriver *d, const gchar *user_agent);
 void http_dd_set_headers(LogDriver *d, GList *headers);
 void http_dd_set_body(LogDriver *d, LogTemplate *body);
+void http_dd_set_ca_dir(LogDriver *d, const gchar *ca_dir);
+void http_dd_set_ca_file(LogDriver *d, const gchar *ca_file);
+void http_dd_set_cert_file(LogDriver *d, const gchar *cert_file);
+void http_dd_set_key_file(LogDriver *d, const gchar *key_file);
+void http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers);
+void http_dd_set_peer_verify(LogDriver *d, const gchar *verify);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 
 #endif

--- a/modules/http/http-plugin.h
+++ b/modules/http/http-plugin.h
@@ -43,8 +43,9 @@ typedef struct
   gchar *cert_file;
   gchar *key_file;
   gchar *ciphers;
-  short int method_type;
+  int ssl_version;
   gboolean peer_verify;
+  short int method_type;
   LogTemplate *body_template;
   LogTemplateOptions template_options;
 } HTTPDestinationDriver;
@@ -64,6 +65,7 @@ void http_dd_set_ca_file(LogDriver *d, const gchar *ca_file);
 void http_dd_set_cert_file(LogDriver *d, const gchar *cert_file);
 void http_dd_set_key_file(LogDriver *d, const gchar *key_file);
 void http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers);
+void http_dd_set_ssl_version(LogDriver *d, const gchar *value);
 void http_dd_set_peer_verify(LogDriver *d, const gchar *verify);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 

--- a/modules/http/http-plugin.h
+++ b/modules/http/http-plugin.h
@@ -66,7 +66,7 @@ void http_dd_set_cert_file(LogDriver *d, const gchar *cert_file);
 void http_dd_set_key_file(LogDriver *d, const gchar *key_file);
 void http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers);
 void http_dd_set_ssl_version(LogDriver *d, const gchar *value);
-void http_dd_set_peer_verify(LogDriver *d, const gchar *verify);
+void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 
 #endif

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -396,20 +396,11 @@ http_dd_set_ssl_version(LogDriver *d, const gchar *value)
 }
 
 void
-http_dd_set_peer_verify(LogDriver *d, const gchar *value)
+http_dd_set_peer_verify(LogDriver *d, gboolean verify)
 {
-  gboolean verify;
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
-  if (type_cast_to_boolean(value, &verify, NULL))
-    {
-      self->peer_verify = verify;
-    }
-  else
-    {
-      msg_warning("curl: non-boolean value for TLS peer verify",
-                  evt_tag_str("peer_verify", value));
-    }
+  self->peer_verify = verify;
 }
 
 gboolean

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -353,7 +353,11 @@ http_dd_set_ssl_version(LogDriver *d, const gchar *value)
 
   if (strcmp(value, "default") == 0)
     {
-      /* libcurl default, currently TLS 1.x */
+      /*
+       * Negotiate the version based on what the remote server supports.
+       * SSLv2 is disabled by default as of libcurl 7.18.1.
+       * SSLv3 is disabled by default as of libcurl 7.39.0.
+       */
       self->ssl_version = CURL_SSLVERSION_DEFAULT;
 
     }
@@ -373,21 +377,27 @@ http_dd_set_ssl_version(LogDriver *d, const gchar *value)
       /* SSL 3 only */
       self->ssl_version = CURL_SSLVERSION_SSLv3;
     }
+#ifdef CURL_SSLVERSION_TLSv1_0
   else if (strcmp(value, "tlsv1_0") == 0)
     {
       /* TLS 1.0 only */
       self->ssl_version = CURL_SSLVERSION_TLSv1_0;
     }
+#endif
+#ifdef CURL_SSLVERSION_TLSv1_1
   else if (strcmp(value, "tlsv1_1") == 0)
     {
       /* TLS 1.1 only */
       self->ssl_version = CURL_SSLVERSION_TLSv1_1;
     }
+#endif
+#ifdef CURL_SSLVERSION_TLSv1_2
   else if (strcmp(value, "tlsv1_2") == 0)
     {
       /* TLS 1.2 only */
       self->ssl_version = CURL_SSLVERSION_TLSv1_2;
     }
+#endif
   else
     {
       msg_warning("curl: unsupported SSL version",

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -168,6 +168,8 @@ _set_curl_opt(HTTPDestinationDriver *self, LogMessage *msg, struct curl_slist *c
   if (self->ciphers)
     curl_easy_setopt(self->curl, CURLOPT_SSL_CIPHER_LIST, self->ciphers);
 
+  curl_easy_setopt(self->curl, CURLOPT_SSLVERSION, self->ssl_version);
+
   curl_easy_setopt(self->curl, CURLOPT_SSL_VERIFYHOST, self->peer_verify ? 2L : 0L);
   curl_easy_setopt(self->curl, CURLOPT_SSL_VERIFYPEER, self->peer_verify ? 1L : 0L);
 
@@ -345,6 +347,55 @@ http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers)
 }
 
 void
+http_dd_set_ssl_version(LogDriver *d, const gchar *value)
+{
+  HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
+
+  if (strcmp(value, "default") == 0)
+    {
+      /* libcurl default, currently TLS 1.x */
+      self->ssl_version = CURL_SSLVERSION_DEFAULT;
+
+    }
+  else if (strcmp(value, "tlsv1") == 0)
+    {
+      /* TLS 1.x */
+      self->ssl_version = CURL_SSLVERSION_TLSv1;
+    }
+  else if (strcmp(value, "sslv2") == 0)
+    {
+      /* SSL 2 only */
+      self->ssl_version = CURL_SSLVERSION_SSLv2;
+
+    }
+  else if (strcmp(value, "sslv3") == 0)
+    {
+      /* SSL 3 only */
+      self->ssl_version = CURL_SSLVERSION_SSLv3;
+    }
+  else if (strcmp(value, "tlsv1_0") == 0)
+    {
+      /* TLS 1.0 only */
+      self->ssl_version = CURL_SSLVERSION_TLSv1_0;
+    }
+  else if (strcmp(value, "tlsv1_1") == 0)
+    {
+      /* TLS 1.1 only */
+      self->ssl_version = CURL_SSLVERSION_TLSv1_1;
+    }
+  else if (strcmp(value, "tlsv1_2") == 0)
+    {
+      /* TLS 1.2 only */
+      self->ssl_version = CURL_SSLVERSION_TLSv1_2;
+    }
+  else
+    {
+      msg_warning("curl: unsupported SSL version",
+                  evt_tag_str("ssl_version", value));
+    }
+}
+
+void
 http_dd_set_peer_verify(LogDriver *d, const gchar *value)
 {
   gboolean verify;
@@ -436,6 +487,7 @@ http_dd_new(GlobalConfig *cfg)
 
       return NULL;
     }
+  self->ssl_version = CURL_SSLVERSION_DEFAULT;
   self->peer_verify = TRUE;
 
   return &self->super.super.super;


### PR DESCRIPTION
Add SSL/TLS related options to the http (curl) module.  It is already possible to use https URLs (since curl supports this natively) but there is no way to control the SSL/TLS parameters.  This diff add the following options: ca_dir, ca_file, cert_file, key_file, cipher_suite and peer_verify.  Note that unlike the main syslog-ng peer_verify option, this one just takes a boolean value.

Closes https://github.com/balabit/syslog-ng/issues/1436

Signed-off-by: Todd C. Miller <Todd.Miller@courtesan.com>