### PR TITLE
Stardate

### DIFF
--- a/dev-utils/plugin_skeleton_creator/plugin_template_plugin.c
+++ b/dev-utils/plugin_skeleton_creator/plugin_template_plugin.c
@@ -45,9 +45,9 @@ gboolean
 const ModuleInfo module_info =
 {
   .canonical_name = "@PLUGIN_NAME_US@",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "Please fill this description",
-  .core_revision = SOURCE_REVISION,
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
   .plugins = @PLUGIN_NAME_US@_plugins,
   .plugins_len = G_N_ELEMENTS(@PLUGIN_NAME_US@_plugins),
 };

--- a/lib/template/simple-function.c
+++ b/lib/template/simple-function.c
@@ -46,7 +46,7 @@ tf_simple_func_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
   state->argv = g_malloc(sizeof(LogTemplate *) * (argc - 1));
 
-  /* NOTE: the argv argument con tains the function name as argv[0],
+  /* NOTE: the argv argument contains the function name as argv[0],
    * but the LogTemplate array doesn't. Thus the index is shifted by
    * one. */
   for (i = 0; i < argc - 1; i++)

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -36,6 +36,7 @@ include modules/diskq/Makefile.am
 include modules/add-contextual-data/Makefile.am
 include modules/getent/Makefile.am
 include modules/map-value-pairs/Makefile.am
+include modules/stardate/Makefile.am
 
 SYSLOG_NG_CORE_JAR=$(top_builddir)/modules/java/syslog-ng-core/libs/syslog-ng-core.jar
 

--- a/modules/stardate/CMakeLists.txt
+++ b/modules/stardate/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(stardate_HEADERS
+    "stardate-parser.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/stardate-grammar.h"
+)
+
+set(stardate_SOURCES
+    "stardate-plugin.c"
+    "stardate-parser.c"
+    "${CMAKE_CURRENT_BINARY_DIR}/stardate-grammar.c"
+)
+
+generate_y_from_ym(modules/stardate/stardate-grammar)
+
+bison_target(stardateGrammar
+    ${CMAKE_CURRENT_BINARY_DIR}/stardate-grammar.y
+    ${CMAKE_CURRENT_BINARY_DIR}/stardate-grammar.c
+COMPILE_FLAGS ${BISON_FLAGS})
+
+option(ENABLE_stardate "Enable stardate ON")
+
+if (ENABLE_stardate)
+  include_directories (${CMAKE_CURRENT_BINARY_DIR})
+  include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+  add_library(stardate MODULE ${stardate_SOURCES})
+  target_link_libraries(stardate PRIVATE syslog-ng)
+
+  install(TARGETS stardate
+  LIBRARY DESTINATION lib/syslog-ng/
+  COMPONENT stardate)
+endif()

--- a/modules/stardate/Makefile.am
+++ b/modules/stardate/Makefile.am
@@ -1,0 +1,19 @@
+module_LTLIBRARIES      += modules/stardate/libstardate.la
+modules_stardate_libstardate_la_SOURCES = \
+  modules/stardate/stardate-plugin.c
+
+EXTRA_DIST        +=      \
+  modules/stardate/stardate.c
+
+modules_stardate_libstardate_la_CPPFLAGS  =     \
+  $(AM_CPPFLAGS)            \
+  -I$(top_srcdir)/modules/stardate        \
+  -I$(top_builddir)/modules/stardate
+modules_stardate_libstardate_la_LIBADD  = $(MODULE_DEPS_LIBS)
+modules_stardate_libstardate_la_LDFLAGS = $(MODULE_LDFLAGS) -lm
+modules_stardate_libstardate_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)
+
+modules/stardate modules/stardate/ mod-stardate mod-file: modules/stardate/libstardate.la
+.PHONY: modules/stardate/ mod-stardate mod-file
+
+include modules/stardate/tests/Makefile.am

--- a/modules/stardate/stardate-plugin.c
+++ b/modules/stardate/stardate-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) @YEAR_AND_AUTHOR@
+ * Copyright (c) 2017 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,33 +21,31 @@
  */
 
 #include "cfg-parser.h"
+#include "stardate.c"
 #include "plugin.h"
 #include "plugin-types.h"
 
-extern CfgParser @PLUGIN_NAME_US@_parser;
+extern CfgParser stardate_parser;
 
-static Plugin @PLUGIN_NAME_US@_plugins[] =
+static Plugin stardate_plugins[] =
 {
-  {
-    .type = @PLUGIN_TYPE@,
-    .name = "@PLUGIN_KEY@",
-    .parser = &@PLUGIN_NAME_US@_parser,
-  },
+  TEMPLATE_FUNCTION_PLUGIN(tf_stardate, "stardate"),
 };
 
 gboolean
-@PLUGIN_NAME_US@_module_init(GlobalConfig *cfg, CfgArgs *args)
+stardate_module_init(GlobalConfig *cfg, CfgArgs *args)
 {
-  plugin_register(cfg, @PLUGIN_NAME_US@_plugins, G_N_ELEMENTS(@PLUGIN_NAME_US@_plugins));
+  plugin_register(cfg, stardate_plugins, G_N_ELEMENTS(stardate_plugins));
   return TRUE;
 }
 
 const ModuleInfo module_info =
 {
-  .canonical_name = "@PLUGIN_NAME_US@",
-  .version = VERSION,
-  .description = "Please fill this description",
-  .core_revision = SOURCE_REVISION,
-  .plugins = @PLUGIN_NAME_US@_plugins,
-  .plugins_len = G_N_ELEMENTS(@PLUGIN_NAME_US@_plugins),
+  .canonical_name = "stardate",
+  .version = SYSLOG_NG_VERSION,
+  .description = "This fuction provides stardate template function: "
+  "fractional years. Example: $(stardate [--digits 2] $UNIXTIME).",
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
+  .plugins = stardate_plugins,
+  .plugins_len = G_N_ELEMENTS(stardate_plugins),
 };

--- a/modules/stardate/stardate.c
+++ b/modules/stardate/stardate.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "plugin.h"
+#include "plugin-types.h"
+#include "template/simple-function.h"
+#include "messages.h"
+#include "cfg.h"
+
+#include "syslog-ng-config.h"
+
+#include <stdlib.h>
+#include <math.h>
+
+static gboolean
+_is_leap_year(int year)
+{
+  return ((year%4==0) && (year % 100!=0)) || (year%400==0);
+}
+
+static time_t
+year_in_seconds(int year)
+{
+  if (_is_leap_year(year))
+    return 31622400;
+  else
+    return 31536000;
+}
+
+typedef struct
+{
+  TFSimpleFuncState super;
+  int precision;
+} TFStardateState;
+
+static guint64 power10[10] = { 1, 10, 100, 1000, 10000,
+                               100000, 1000000, 10000000, 100000000, 1000000000
+                             };
+
+gboolean
+tf_stardate_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
+                    gint argc, gchar *argv[], GError **error)
+{
+  TFStardateState *state = (TFStardateState *) s;
+  state->precision = 2;
+
+  GOptionEntry stardate_options[] =
+  {
+    { "digits", 'd', 0, G_OPTION_ARG_INT, &state->precision, "Precision: 0-9. Default: 2.", NULL },
+    { NULL }
+  };
+
+  GOptionContext *ctx = g_option_context_new("stardate");
+  g_option_context_add_main_entries(ctx, stardate_options, NULL);
+
+  if (!g_option_context_parse(ctx, &argc, &argv, error))
+    {
+      g_option_context_free(ctx);
+      return FALSE;
+    }
+  g_option_context_free(ctx);
+
+  if (state->precision < 0 || state->precision > 9)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "stardate: digits must be between 0-9.\n");
+      return FALSE;
+    }
+
+  if (argc != 2)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "stardate: format must be: $(stardate [--digits 2] $UNIXTIME)\n");
+      return FALSE;
+    }
+
+  if (!tf_simple_func_prepare(self, state, parent, argc, argv, error))
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "stardate: stardate: prepare failed");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+tf_stardate_call(LogTemplateFunction *self, gpointer s,
+                 const LogTemplateInvokeArgs *args, GString *result)
+{
+  TFStardateState  *state = (TFStardateState *) s;
+  GString **argv;
+
+  argv = (GString **) args->bufs->pdata;
+
+  char format[7]; // "%0.xlf\0"
+  if (g_snprintf(format, sizeof(format),"%%0.%dlf", state->precision) < 0)
+    {
+      msg_error("stardate: sprintf error)",
+                evt_tag_int("precision", state->precision));
+      return;
+    }
+
+  char *status;
+  time_t time_to_convert = strtol(argv[0]->str, &status, 10);
+  if (*status)
+    {
+      msg_error("stardate: wrong format: expected unixtime like value",
+                evt_tag_str("got:", argv[0]->str));
+      return;
+    }
+
+  struct tm tm_time;
+  localtime_r(&time_to_convert, &tm_time );
+
+  struct tm secs_beginning_year = {.tm_year = tm_time.tm_year, .tm_mday = 1};
+  time_t elapsed_seconds = time_to_convert - mktime(&secs_beginning_year);
+
+  double fraction = (double)elapsed_seconds/year_in_seconds(tm_time.tm_year);
+  double truncated = (double) floor(fraction * power10[state->precision]) / power10[state->precision];
+
+  g_string_append_printf(result, format, 1900 + tm_time.tm_year + truncated);
+}
+
+TEMPLATE_FUNCTION(TFStardateState, tf_stardate, tf_stardate_prepare,
+                  tf_simple_func_eval, tf_stardate_call, tf_simple_func_free_state, NULL);

--- a/modules/stardate/tests/Makefile.am
+++ b/modules/stardate/tests/Makefile.am
@@ -1,0 +1,9 @@
+modules_stardate_tests_TESTS			= \
+	modules/stardate/tests/test_stardate
+
+check_PROGRAMS					+= ${modules_stardate_tests_TESTS}
+
+modules_stardate_tests_test_stardate_CFLAGS	= $(TEST_CFLAGS) -I$(top_builddir)/modules -lm
+modules_stardate_tests_test_stardate_LDADD	= \
+	$(TEST_LDADD)				  \
+	$(PREOPEN_SYSLOGFORMAT) -dlpreopen $(top_builddir)/modules/stardate/libstardate.la

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <syslog-ng.h>
+#include <logmsg/logmsg.h>
+#include <template_lib.h>
+#include <apphook.h>
+#include <plugin.h>
+#include "date/date-parser.h"
+
+
+MsgFormatOptions parse_options;
+
+void
+stardate_assert(const gchar *msg_str, const int precision, const gchar *expected)
+{
+
+  LogMessage *logmsg = log_msg_new(msg_str, strlen(msg_str), NULL, &parse_options);
+
+  char *template_command;
+  if (precision == -1)
+    asprintf(&template_command, "$(stardate $UNIXTIME)");
+  else
+    asprintf(&template_command, "$(stardate --digits %d $UNIXTIME)", precision);
+  assert_template_format_msg(template_command, expected, logmsg);
+  free(template_command);
+
+  log_msg_unref(logmsg);
+}
+
+void
+test_stardate()
+{
+  stardate_assert("2012-07-15T00:00:00", 1, "2012.5"); // 2012.01.01 + 365/2 day
+  stardate_assert("2013-07-01T00:00:00", 2, "2013.49");
+
+  stardate_assert("2014-01-01T00:00:00", 3, "2014.000");
+  stardate_assert("2015-12-31T23:59:59", 3, "2015.999"); // No rounding up!
+  stardate_assert("2016-12-31T23:59:59", 7, "2016.9999999"); // No rounding up!
+
+  stardate_assert("2017-01-01T00:00:00", 0, "2017");
+  stardate_assert("2018-12-01T00:00:00", 0, "2018"); // No rounding up!
+}
+
+int
+main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+{
+  app_startup();
+  init_template_tests();
+  plugin_load_module("stardate", configuration, NULL);
+
+  test_stardate();
+
+  deinit_template_tests();
+  app_shutdown();
+  return 0;
+}

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -34,6 +34,7 @@ scripts/update-patterndb$
 doc/ChangeLog\.[0-9]$
 (\.gitmodules|AUTHORS|COPYING|INSTALL|VERSION|aclocal\.m4|compile|configure|depcomp|install-sh|libtool|ltmain\.sh|missing|test-driver|ylwrap)$
 .*/[^/.]*$
+GPATH|GTAGS|GRTAGS|GSYMS
  LGPLv2.1+_SSL
 autogen\.sh$
 cmake
@@ -52,7 +53,7 @@ dev-utils/plugin_skeleton_creator/create_plugin.sh
 tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
-modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|[^/]*$)
+modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|[^/]*$)
 modules/(add-contextual-data|map-value-pairs|[^/]*$)
 scl
 scripts


### PR DESCRIPTION
Adding stardate (fractional years) template function to syslog-ng.
One can optionally parametrize the shown digits with --digits.
For example $(stardate --digits 2 $UNIXTIME).
The template function expects unixtime-like input, so the user is free
to supply any of such macros provided by syslog-ng, like $R_UNIXTIME.

Referring to:
https://github.com/balabit/syslog-ng/issues/1296
CC: @faxm0dem 
Live long and prosper!

Signed-off-by: Antal Nemes <antal.nemes@balabit.com>