### PR TITLE
syslogformat: If the parsing of a message failed, then we had to find the problem with eyegrep

### DIFF
--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -37,15 +37,15 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
   msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
   log_msg_set_value(msg, LM_V_HOST, "", 0);
 
-  g_snprintf(buf, sizeof(buf), "Error processing log message (at position %d): %.*s", problem_position, (gint) length,
-             data);
+  g_snprintf(buf, sizeof(buf), "Error processing log message: %.*s>@<%.*s", (gint) problem_position-1,
+             data,(gint) (length-problem_position+1), data+problem_position-1);
+
   log_msg_set_value(msg, LM_V_MESSAGE, buf, -1);
   log_msg_set_value(msg, LM_V_PROGRAM, "syslog-ng", 9);
   g_snprintf(buf, sizeof(buf), "%d", (int) getpid());
   log_msg_set_value(msg, LM_V_PID, buf, -1);
 
   msg->pri = LOG_SYSLOG | LOG_ERR;
-
 }
 
 void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -28,7 +28,7 @@
 #include "plugin-types.h"
 
 void
-msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length)
+msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length, gint problem_position)
 {
   gchar buf[2048];
 
@@ -36,13 +36,16 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length)
 
   msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
   log_msg_set_value(msg, LM_V_HOST, "", 0);
-  g_snprintf(buf, sizeof(buf), "Error processing log message: %.*s", (gint) length, data);
+
+  g_snprintf(buf, sizeof(buf), "Error processing log message (at position %d): %.*s", problem_position, (gint) length,
+             data);
   log_msg_set_value(msg, LM_V_MESSAGE, buf, -1);
   log_msg_set_value(msg, LM_V_PROGRAM, "syslog-ng", 9);
   g_snprintf(buf, sizeof(buf), "%d", (int) getpid());
   log_msg_set_value(msg, LM_V_PID, buf, -1);
 
   msg->pri = LOG_SYSLOG | LOG_ERR;
+
 }
 
 void

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -89,6 +89,6 @@ void msg_format_options_copy(MsgFormatOptions *options, const MsgFormatOptions *
 
 gboolean msg_format_options_process_flag(MsgFormatOptions *options, gchar *flag);
 
-void msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length);
+void msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length, gint problem_position);
 
 #endif

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -129,6 +129,8 @@ test_kmsg_device_parsing(void)
                        " DEVICE=n8\n";
   gchar msg_unknown[] = "6,202,98513;Fake message\n" \
                         " DEVICE=w12345\n";
+  gchar msg_invalid_block[] = "6,202;Fake message\n" \
+                              " DEVICE=b12:1\n";
   LogMessage *parsed_message;
 
   testcase_begin("Testing /dev/kmsg DEVICE= parsing");
@@ -158,6 +160,11 @@ test_kmsg_device_parsing(void)
   parsed_message = kmsg_parse_message(msg_unknown);
   assert_log_kmsg_value(parsed_message, ".linux.DEVICE.type", "<unknown>");
   assert_log_kmsg_value(parsed_message, ".linux.DEVICE.name", "w12345");
+  log_msg_unref(parsed_message);
+
+  parsed_message = kmsg_parse_message(msg_invalid_block);
+  assert_log_message_value(parsed_message, LM_V_MESSAGE,
+                           "Error processing log message (at position 6): 6,202;Fake message\n DEVICE=b12:1");
   log_msg_unref(parsed_message);
 
   testcase_end();

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -164,7 +164,7 @@ test_kmsg_device_parsing(void)
 
   parsed_message = kmsg_parse_message(msg_invalid_block);
   assert_log_message_value(parsed_message, LM_V_MESSAGE,
-                           "Error processing log message (at position 6): 6,202;Fake message\n DEVICE=b12:1");
+                           "Error processing log message: 6,202>@<;Fake message\n DEVICE=b12:1");
   log_msg_unref(parsed_message);
 
   testcase_end();

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -939,7 +939,7 @@ error:
 static gboolean
 log_msg_parse_legacy(const MsgFormatOptions *parse_options,
                      const guchar *data, gint length,
-                     LogMessage *self)
+                     LogMessage *self, gint *position)
 {
   const guchar *src;
   gint left;
@@ -950,7 +950,7 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
 
   if (!log_msg_parse_pri(self, &src, &left, parse_options->flags, parse_options->default_pri))
     {
-      return FALSE;
+      goto error;
     }
 
   log_msg_parse_seq(self, &src, &left);
@@ -1055,6 +1055,9 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
     }
 
   return TRUE;
+error:
+  *position = src - data;
+  return FALSE;
 }
 
 /**
@@ -1063,7 +1066,8 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
  * Parse a message according to the latest syslog-protocol drafts.
  **/
 static gboolean
-log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *data, gint length, LogMessage *self)
+log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *data, gint length, LogMessage *self,
+                           gint *position)
 {
   /**
    *  SYSLOG-MSG      = HEADER SP STRUCTURED-DATA [SP MSG]
@@ -1087,24 +1091,26 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
   if (!log_msg_parse_pri(self, &src, &left, parse_options->flags, parse_options->default_pri) ||
       !log_msg_parse_version(self, &src, &left))
     {
-      return log_msg_parse_legacy(parse_options, data, length, self);
+      return log_msg_parse_legacy(parse_options, data, length, self, position);
     }
 
   if (!log_msg_parse_skip_space(self, &src, &left))
-    return FALSE;
+    {
+      goto error;
+    }
 
   /* ISO time format */
   if (!log_msg_parse_date(self, &src, &left, parse_options->flags,
                           time_zone_info_get_offset(parse_options->recv_time_zone_info, time(NULL))))
-    return FALSE;
+    goto error;
 
   if (!log_msg_parse_skip_space(self, &src, &left))
-    return FALSE;
+    goto error;
 
   /* hostname 255 ascii */
   log_msg_parse_hostname(self, &src, &left, &hostname_start, &hostname_len, parse_options->flags, NULL);
   if (!log_msg_parse_skip_space(self, &src, &left))
-    return FALSE;
+    goto error;
 
   /* If we did manage to find a hostname, store it. */
   if (hostname_start && hostname_len == 1 && *hostname_start == '-')
@@ -1117,21 +1123,21 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
   /* application name 48 ascii*/
   log_msg_parse_column(self, LM_V_PROGRAM, &src, &left, 48);
   if (!log_msg_parse_skip_space(self, &src, &left))
-    return FALSE;
+    goto error;
 
   /* process id 128 ascii */
   log_msg_parse_column(self, LM_V_PID, &src, &left, 128);
   if (!log_msg_parse_skip_space(self, &src, &left))
-    return FALSE;
+    goto error;
 
   /* message id 32 ascii */
   log_msg_parse_column(self, LM_V_MSGID, &src, &left, 32);
   if (!log_msg_parse_skip_space(self, &src, &left))
-    return FALSE;
+    goto error;
 
   /* structured data part */
   if (!log_msg_parse_sd(self, &src, &left, parse_options))
-    return FALSE;
+    goto error;
 
   /* checking if there are remaining data in log message */
   if (left == 0)
@@ -1143,7 +1149,7 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
   /* optional part of the log message [SP MSG] */
   if (!log_msg_parse_skip_space(self, &src, &left))
     {
-      return FALSE;
+      goto error;
     }
 
   if (left >= 3 && memcmp(src, "\xEF\xBB\xBF", 3) == 0)
@@ -1159,6 +1165,9 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
     }
   log_msg_set_value(self, LM_V_MESSAGE, (gchar *) src, left);
   return TRUE;
+error:
+  *position = src - data;
+  return FALSE;
 }
 
 
@@ -1168,6 +1177,7 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
                       LogMessage *self)
 {
   gboolean success;
+  gint problem_position = 0;
   gchar *p;
 
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
@@ -1188,14 +1198,14 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
 
   self->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
-    success = log_msg_parse_syslog_proto(parse_options, data, length, self);
+    success = log_msg_parse_syslog_proto(parse_options, data, length, self, &problem_position);
   else
-    success = log_msg_parse_legacy(parse_options, data, length, self);
+    success = log_msg_parse_legacy(parse_options, data, length, self, &problem_position);
   self->initial_parse = FALSE;
 
   if (G_UNLIKELY(!success))
     {
-      msg_format_inject_parse_error(self, data, length);
+      msg_format_inject_parse_error(self, data, length, problem_position);
       return;
     }
 

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -231,7 +231,7 @@ Test(msgparse, test_failed_to_parse_too_long_sd_id)
       0, 0, 0,  // timestamp (sec/usec/zone)
       "", //host
       "syslog-ng", //app
-      "Error processing log message: <5>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [timeQuality isSynced=\"0\"][1234567890123456789012345678901234 i=\"long_33\"] An application event log entry...", // msg
+      "Error processing log message (at position 117): <5>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [timeQuality isSynced=\"0\"][1234567890123456789012345678901234 i=\"long_33\"] An application event log entry...", // msg
       "", // sd str,
       0, // processid
       0, // msgid,
@@ -254,7 +254,7 @@ Test(msgparse, test_bad_sd_data_unescaped)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...", // msg
+      "Error processing log message (at position 67): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -678,7 +678,7 @@ Test(msgparse, test_expected_sd_pairs_1)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message: <7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...", // msg
+      "Error processing log message (at position 69): <7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...", // msg
       "",
       NULL,//processid
       NULL,//msgid
@@ -798,7 +798,7 @@ Test(msgparse, test_expected_sd_pairs_4)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",         // host
       "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...", // msg
+      "Error processing log message (at position 93): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -846,7 +846,7 @@ Test(msgparse, test_expected_sd_pairs_too_long)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"] An application event log entry...", // msg
+      "Error processing log message (at position 95): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -889,7 +889,7 @@ Test(msgparse, test_unescaped_too_long_message_parts)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "", //host
       "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa evntslog - - [a i=\"ok\"] An application event log entry...",        // msg
+      "Error processing log message (at position 37): <132>1 2006-10-29T01:59:59.156+01:00 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa evntslog - - [a i=\"ok\"] An application event log entry...",        // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -945,7 +945,7 @@ Test(msgparse, test_unescaped_too_long_message_parts)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"]ok\"] An application event log entry...", // msg
+      "Error processing log message (at position 66): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"]ok\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -960,7 +960,7 @@ Test(msgparse, test_unescaped_too_long_message_parts)
       0, 0, 0, // timestamp (sec/usec/zone)
       "",    // host
       "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...", // msg
+      "Error processing log message (at position 67): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -231,7 +231,7 @@ Test(msgparse, test_failed_to_parse_too_long_sd_id)
       0, 0, 0,  // timestamp (sec/usec/zone)
       "", //host
       "syslog-ng", //app
-      "Error processing log message (at position 117): <5>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [timeQuality isSynced=\"0\"][1234567890123456789012345678901234 i=\"long_33\"] An application event log entry...", // msg
+      "Error processing log message: <5>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [timeQuality isSynced=\"0\"][1234567890123456789012345678901>@<234 i=\"long_33\"] An application event log entry...", // msg
       "", // sd str,
       0, // processid
       0, // msgid,
@@ -254,7 +254,7 @@ Test(msgparse, test_bad_sd_data_unescaped)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message (at position 67): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...", // msg
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\">@<\"ok\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -678,7 +678,7 @@ Test(msgparse, test_expected_sd_pairs_1)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message (at position 69): <7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...", // msg
+      "Error processing log message: <7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 >@<[ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...", // msg
       "",
       NULL,//processid
       NULL,//msgid
@@ -798,7 +798,7 @@ Test(msgparse, test_expected_sd_pairs_4)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",         // host
       "syslog-ng", //app
-      "Error processing log message (at position 93): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...", // msg
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaa i=\"long_33\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -846,7 +846,7 @@ Test(msgparse, test_expected_sd_pairs_too_long)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message (at position 95): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"] An application event log entry...", // msg
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaa=\"long_33\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -889,7 +889,7 @@ Test(msgparse, test_unescaped_too_long_message_parts)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "", //host
       "syslog-ng", //app
-      "Error processing log message (at position 37): <132>1 2006-10-29T01:59:59.156+01:00 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa evntslog - - [a i=\"ok\"] An application event log entry...",        // msg
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 >@<aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa evntslog - - [a i=\"ok\"] An application event log entry...",        // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -945,7 +945,7 @@ Test(msgparse, test_unescaped_too_long_message_parts)
       0, 0, 0,    // timestamp (sec/usec/zone)
       "",        // host
       "syslog-ng", //app
-      "Error processing log message (at position 66): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"]ok\"] An application event log entry...", // msg
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\">@<]ok\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid
@@ -960,7 +960,7 @@ Test(msgparse, test_unescaped_too_long_message_parts)
       0, 0, 0, // timestamp (sec/usec/zone)
       "",    // host
       "syslog-ng", //app
-      "Error processing log message (at position 67): <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...", // msg
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\">@<\"ok\"] An application event log entry...", // msg
       "", //sd_str
       0,//processid
       0,//msgid


### PR DESCRIPTION
The solution is that print the position where the parsing was failed,
not only a something evil happened message

fixes: #SYSLOGMT-643

Signed-off-by: Juhász Viktor <viktor.juhasz@balabit.com>
Signed-off-by: László Várady <laszlo.varady@balabit.com>
Signed-off-by: Antal Nemes <antal.nemes@balabit.com>