### PR TITLE
cc-mask: Removed unnecessary group name

### DIFF
--- a/scl/rewrite/cc-mask.conf
+++ b/scl/rewrite/cc-mask.conf
@@ -38,7 +38,7 @@
 # A notable difference compared to the blog post, is that the hash_cc
 # rule is called credit-card-hash and mask_cc is credit-card-mask.
 
-@define balabit.credit-card-regexp "(?P<1>:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})"
+@define balabit.credit-card-regexp "(:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})"
 
 block rewrite credit-card-hash(value("MESSAGE"))
 {


### PR DESCRIPTION
syslog-ng automatically stores the first result in the $1 macro thus
we don't need to name it.
Otherwise the original solution did not work because PCRE does not supported group names
started with digits anymore.