### PR TITLE
geoip: crash when start->deleting geoip.dat->reload

### DIFF
--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -156,8 +156,6 @@ geoip_parser_free(LogPipe *s)
   g_free(self->database);
   g_free(self->prefix);
 
-  GeoIP_delete(self->gi);
-
   log_parser_free_method(s);
 }
 
@@ -165,11 +163,22 @@ static gboolean
 geoip_parser_init(LogPipe *s)
 {
   GeoIPParser *self = (GeoIPParser *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
 
   geoip_parser_reset_fields(self);
 
   if (self->database)
-    self->gi = GeoIP_open(self->database, GEOIP_MMAP_CACHE);
+    {
+      GeoIP *_gi = GeoIP_open(self->database, GEOIP_MMAP_CACHE);
+      if (_gi)
+        {
+          if (self->gi)
+            GeoIP_delete(self->gi);
+          self->gi = _gi;
+        }
+      else
+        self->gi = cfg_persist_config_fetch(cfg, "geoip-obj");
+    }
   else
     self->gi = GeoIP_new(GEOIP_MMAP_CACHE);
 
@@ -178,6 +187,18 @@ geoip_parser_init(LogPipe *s)
   return log_parser_init_method(s);
 }
 
+static gboolean
+geoip_parser_deinit(LogPipe *s)
+{
+  GeoIPParser *self = (GeoIPParser *)s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  cfg_persist_config_add(cfg, "geoip-obj", self->gi,
+                         (GDestroyNotify) GeoIP_delete, FALSE);
+  return TRUE;
+}
+
+
 LogParser *
 geoip_parser_new(GlobalConfig *cfg)
 {
@@ -185,6 +206,7 @@ geoip_parser_new(GlobalConfig *cfg)
 
   log_parser_init_instance(&self->super, cfg);
   self->super.super.init = geoip_parser_init;
+  self->super.super.deinit = geoip_parser_deinit;
   self->super.super.free_fn = geoip_parser_free;
   self->super.super.clone = geoip_parser_clone;
   self->super.process = geoip_parser_process;

--- a/modules/geoip/tests/test_geoip_parser.c
+++ b/modules/geoip/tests/test_geoip_parser.c
@@ -122,7 +122,7 @@ int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
   app_startup();
-
+  configuration = cfg_new(VERSION_VALUE);
   test_geoip_parser();
   app_shutdown();
   return 0;


### PR DESCRIPTION
By this patch, syslog-ng will store geoip data in persistent
config. When syslog-ng is reloaded and the data file is not available,
syslog-ng will fall back to the cached data.

Correction for:
https://github.com/balabit/syslog-ng/issues/1447