### PR TITLE
Stats cluster refact

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -431,7 +431,9 @@ afinter_message_posted(LogMessage *msg)
       internal_msg_queue = g_queue_new();
 
       stats_lock();
-      stats_register_counter(0, SCS_GLOBAL, "internal_queue_length", NULL, SC_TYPE_PROCESSED, &internal_queue_length);
+      StatsClusterKey sc_key;
+      stats_cluster_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL);
+      stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
     }
 

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -432,7 +432,7 @@ afinter_message_posted(LogMessage *msg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL, stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL );
       stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
     }

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -432,7 +432,7 @@ afinter_message_posted(LogMessage *msg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL);
+      stats_cluster_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL, stats_counter_group_logpipe_init);
       stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
     }

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -96,7 +96,9 @@ test_stats()
 
   stats_init();
   stats_lock();
-  stats_register_counter(0, SCS_CENTER, "id", "received", SC_TYPE_PROCESSED, &counter);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received");
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_unlock();
 
   g_string_assign(command,"STATS");
@@ -122,7 +124,9 @@ test_reset_stats()
 
   stats_init();
   stats_lock();
-  stats_register_counter(0, SCS_CENTER, "id", "received", SC_TYPE_PROCESSED, &counter);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received");
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_counter_set(counter, 666);
   stats_unlock();
 

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -97,7 +97,7 @@ test_stats()
   stats_init();
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, "id", "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_unlock();
 
@@ -125,7 +125,7 @@ test_reset_stats()
   stats_init();
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, "id", "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_counter_set(counter, 666);
   stats_unlock();

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -97,7 +97,7 @@ test_stats()
   stats_init();
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received");
+  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received", stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_unlock();
 
@@ -125,7 +125,7 @@ test_reset_stats()
   stats_init();
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received");
+  stats_cluster_key_set(&sc_key, SCS_CENTER, "id", "received", stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_counter_set(counter, 666);
   stats_unlock();

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -131,9 +131,12 @@ log_src_driver_init_method(LogPipe *s)
     }
 
   stats_lock();
-  stats_register_counter(0, SCS_SOURCE | SCS_GROUP, self->super.group, NULL, SC_TYPE_PROCESSED,
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_register_counter(0, SCS_CENTER, NULL, "received", SC_TYPE_PROCESSED, &self->received_global_messages);
+  stats_cluster_key_set(&sc_key,  SCS_CENTER, NULL, "received");
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
 
   return TRUE;
@@ -148,9 +151,12 @@ log_src_driver_deinit_method(LogPipe *s)
     return FALSE;
 
   stats_lock();
-  stats_unregister_counter(SCS_SOURCE | SCS_GROUP, self->super.group, NULL, SC_TYPE_PROCESSED,
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL);
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_unregister_counter(SCS_CENTER, NULL, "received", SC_TYPE_PROCESSED, &self->received_global_messages);
+  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "received");
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
   return TRUE;
 }
@@ -254,9 +260,12 @@ log_dest_driver_init_method(LogPipe *s)
     }
 
   stats_lock();
-  stats_register_counter(0, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL, SC_TYPE_PROCESSED,
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_register_counter(0, SCS_CENTER, NULL, "queued", SC_TYPE_PROCESSED, &self->queued_global_messages);
+  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued");
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 
   return TRUE;
@@ -282,9 +291,12 @@ log_dest_driver_deinit_method(LogPipe *s)
   g_assert(self->queues == NULL);
 
   stats_lock();
-  stats_unregister_counter(SCS_DESTINATION | SCS_GROUP, self->super.group, NULL, SC_TYPE_PROCESSED,
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL);
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_unregister_counter(SCS_CENTER, NULL, "queued", SC_TYPE_PROCESSED, &self->queued_global_messages);
+  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued");
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 
   if (!log_driver_deinit_method(s))

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -132,10 +132,10 @@ log_src_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL);
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key,  SCS_CENTER, NULL, "received");
+  stats_cluster_key_set(&sc_key,  SCS_CENTER, NULL, "received", stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
 
@@ -152,10 +152,10 @@ log_src_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL);
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "received");
+  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "received", stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
   return TRUE;
@@ -261,10 +261,10 @@ log_dest_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL);
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued");
+  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued", stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 
@@ -292,10 +292,10 @@ log_dest_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL);
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued");
+  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued", stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -132,10 +132,10 @@ log_src_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key,  SCS_CENTER, NULL, "received", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key,  SCS_CENTER, NULL, "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
 
@@ -152,10 +152,10 @@ log_src_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "received", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, NULL, "received" );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
   return TRUE;
@@ -261,10 +261,10 @@ log_dest_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, NULL, "queued" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 
@@ -292,10 +292,10 @@ log_dest_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_key_set(&sc_key, SCS_CENTER, NULL, "queued", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, NULL, "queued" );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1720,13 +1720,13 @@ log_msg_global_init(void)
   log_msg_registry_init();
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL);
+  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL, stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_msg_clones);
 
-  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "payload_reallocs", NULL);
+  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "payload_reallocs", NULL, stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_payload_reallocs);
 
-  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "sdata_updates", NULL);
+  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "sdata_updates", NULL, stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_sdata_updates);
   stats_unlock();
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1719,9 +1719,15 @@ log_msg_global_init(void)
 {
   log_msg_registry_init();
   stats_lock();
-  stats_register_counter(0, SCS_GLOBAL, "msg_clones", NULL, SC_TYPE_PROCESSED, &count_msg_clones);
-  stats_register_counter(0, SCS_GLOBAL, "payload_reallocs", NULL, SC_TYPE_PROCESSED, &count_payload_reallocs);
-  stats_register_counter(0, SCS_GLOBAL, "sdata_updates", NULL, SC_TYPE_PROCESSED, &count_sdata_updates);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_msg_clones);
+
+  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "payload_reallocs", NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_payload_reallocs);
+
+  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "sdata_updates", NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_sdata_updates);
   stats_unlock();
 }
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1720,13 +1720,13 @@ log_msg_global_init(void)
   log_msg_registry_init();
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_msg_clones);
 
-  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "payload_reallocs", NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "payload_reallocs", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_payload_reallocs);
 
-  stats_cluster_key_set(&sc_key, SCS_GLOBAL, "sdata_updates", NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "sdata_updates", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_sdata_updates);
   stats_unlock();
 }

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -90,7 +90,7 @@ log_tags_get_by_name(const gchar *name)
 
           stats_lock();
           StatsClusterKey sc_key;
-          stats_cluster_key_set(&sc_key, SCS_TAG, name, NULL, stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, name, NULL );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
           stats_unlock();
 
@@ -176,7 +176,7 @@ log_tags_reinit_stats(void)
     {
       const gchar *name = log_tags_list[id].name;
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_TAG, name, NULL, stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, name, NULL );
    
       if (stats_check_level(3))
         stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
@@ -216,7 +216,7 @@ log_tags_global_deinit(void)
   StatsClusterKey sc_key;
   for (i = 0; i < log_tags_num; i++)
     {
-      stats_cluster_key_set(&sc_key, SCS_TAG, log_tags_list[i].name, NULL, stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, log_tags_list[i].name, NULL );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &log_tags_list[i].counter);
       g_free(log_tags_list[i].name);
     }

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -90,7 +90,7 @@ log_tags_get_by_name(const gchar *name)
 
           stats_lock();
           StatsClusterKey sc_key;
-          stats_cluster_key_set(&sc_key, SCS_TAG, name, NULL);
+          stats_cluster_key_set(&sc_key, SCS_TAG, name, NULL, stats_counter_group_logpipe_init);
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
           stats_unlock();
 
@@ -176,7 +176,7 @@ log_tags_reinit_stats(void)
     {
       const gchar *name = log_tags_list[id].name;
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_TAG, name, NULL);
+      stats_cluster_key_set(&sc_key, SCS_TAG, name, NULL, stats_counter_group_logpipe_init);
    
       if (stats_check_level(3))
         stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
@@ -216,7 +216,7 @@ log_tags_global_deinit(void)
   StatsClusterKey sc_key;
   for (i = 0; i < log_tags_num; i++)
     {
-      stats_cluster_key_set(&sc_key, SCS_TAG, log_tags_list[i].name, NULL);
+      stats_cluster_key_set(&sc_key, SCS_TAG, log_tags_list[i].name, NULL, stats_counter_group_logpipe_init);
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &log_tags_list[i].counter);
       g_free(log_tags_list[i].name);
     }

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -177,7 +177,7 @@ log_tags_reinit_stats(void)
       const gchar *name = log_tags_list[id].name;
       StatsClusterKey sc_key;
       stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, name, NULL );
-   
+
       if (stats_check_level(3))
         stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
       else

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -204,7 +204,7 @@ log_source_init(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance );
   stats_register_counter(self->stats_level, &sc_key,
                          SC_TYPE_PROCESSED, &self->recvd_messages);
   stats_register_counter(self->stats_level, &sc_key, SC_TYPE_STAMP, &self->last_message_seen);
@@ -219,7 +219,7 @@ log_source_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->recvd_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_STAMP, &self->last_message_seen);
   stats_unlock();
@@ -303,14 +303,14 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       stats_lock();
 
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_HOST | SCS_SOURCE, NULL,  log_msg_get_value(msg, LM_V_HOST, NULL), stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SOURCE, NULL,  log_msg_get_value(msg, LM_V_HOST, NULL) );
 
       stats_register_and_increment_dynamic_counter(2, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
       if (stats_check_level(3))
         {
-          stats_cluster_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL), stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL) );
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
-          stats_cluster_key_set(&sc_key, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL), stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL) );
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
         }
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -203,10 +203,11 @@ log_source_init(LogPipe *s)
   LogSource *self = (LogSource *) s;
 
   stats_lock();
-  stats_register_counter(self->stats_level, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance,
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance);
+  stats_register_counter(self->stats_level, &sc_key,
                          SC_TYPE_PROCESSED, &self->recvd_messages);
-  stats_register_counter(self->stats_level, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance,
-                         SC_TYPE_STAMP, &self->last_message_seen);
+  stats_register_counter(self->stats_level, &sc_key, SC_TYPE_STAMP, &self->last_message_seen);
   stats_unlock();
   return TRUE;
 }
@@ -217,10 +218,10 @@ log_source_deinit(LogPipe *s)
   LogSource *self = (LogSource *) s;
 
   stats_lock();
-  stats_unregister_counter(self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance, SC_TYPE_PROCESSED,
-                           &self->recvd_messages);
-  stats_unregister_counter(self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance, SC_TYPE_STAMP,
-                           &self->last_message_seen);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance);
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->recvd_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_STAMP, &self->last_message_seen);
   stats_unlock();
   return TRUE;
 }
@@ -301,14 +302,16 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
     {
       stats_lock();
 
-      stats_register_and_increment_dynamic_counter(2, SCS_HOST | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST, NULL),
-                                                   msg->timestamps[LM_TS_RECVD].tv_sec);
+      StatsClusterKey sc_key;
+      stats_cluster_key_set(&sc_key, SCS_HOST | SCS_SOURCE, NULL,  log_msg_get_value(msg, LM_V_HOST, NULL));
+
+      stats_register_and_increment_dynamic_counter(2, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
       if (stats_check_level(3))
         {
-          stats_register_and_increment_dynamic_counter(3, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM,
-                                                       NULL), msg->timestamps[LM_TS_RECVD].tv_sec);
-          stats_register_and_increment_dynamic_counter(3, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM,
-                                                       NULL), msg->timestamps[LM_TS_RECVD].tv_sec);
+          stats_cluster_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL));
+          stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
+          stats_cluster_key_set(&sc_key, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL));
+          stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
         }
 
       stats_unlock();

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -204,7 +204,7 @@ log_source_init(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance);
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
   stats_register_counter(self->stats_level, &sc_key,
                          SC_TYPE_PROCESSED, &self->recvd_messages);
   stats_register_counter(self->stats_level, &sc_key, SC_TYPE_STAMP, &self->last_message_seen);
@@ -219,7 +219,7 @@ log_source_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance);
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->recvd_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_STAMP, &self->last_message_seen);
   stats_unlock();
@@ -303,14 +303,14 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       stats_lock();
 
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_HOST | SCS_SOURCE, NULL,  log_msg_get_value(msg, LM_V_HOST, NULL));
+      stats_cluster_key_set(&sc_key, SCS_HOST | SCS_SOURCE, NULL,  log_msg_get_value(msg, LM_V_HOST, NULL), stats_counter_group_logpipe_init);
 
       stats_register_and_increment_dynamic_counter(2, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
       if (stats_check_level(3))
         {
-          stats_cluster_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL));
+          stats_cluster_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL), stats_counter_group_logpipe_init);
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
-          stats_cluster_key_set(&sc_key, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL));
+          stats_cluster_key_set(&sc_key, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL), stats_counter_group_logpipe_init);
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].tv_sec);
         }
 

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -328,15 +328,13 @@ log_threaded_dest_driver_start(LogPipe *s)
     }
 
   stats_lock();
-  stats_register_counter(0, self->stats_source | SCS_DESTINATION, self->super.super.id,
-                         self->format.stats_instance(self),
-                         SC_TYPE_STORED, &self->stored_messages);
-  stats_register_counter(0, self->stats_source | SCS_DESTINATION, self->super.super.id,
-                         self->format.stats_instance(self),
-                         SC_TYPE_DROPPED, &self->dropped_messages);
-  stats_register_counter(0, self->stats_source | SCS_DESTINATION, self->super.super.id,
-                         self->format.stats_instance(self),
-                         SC_TYPE_PROCESSED, &self->processed_messages);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
+                          self->super.super.id,
+                          self->format.stats_instance(self));
+  stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
   stats_unlock();
 
   log_queue_set_counters(self->queue, self->stored_messages,
@@ -366,15 +364,13 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
                          GINT_TO_POINTER(self->seq_num), NULL, FALSE);
 
   stats_lock();
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->super.super.id,
-                           self->format.stats_instance(self),
-                           SC_TYPE_STORED, &self->stored_messages);
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->super.super.id,
-                           self->format.stats_instance(self),
-                           SC_TYPE_DROPPED, &self->dropped_messages);
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->super.super.id,
-                           self->format.stats_instance(self),
-                           SC_TYPE_PROCESSED, &self->processed_messages);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION,
+                          self->super.super.id,
+                          self->format.stats_instance(self));
+  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
   stats_unlock();
 
   if (!log_dest_driver_deinit_method(s))

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -331,7 +331,8 @@ log_threaded_dest_driver_start(LogPipe *s)
   StatsClusterKey sc_key;
   stats_cluster_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
                           self->super.super.id,
-                          self->format.stats_instance(self));
+                          self->format.stats_instance(self),
+                          stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
@@ -367,7 +368,8 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
   StatsClusterKey sc_key;
   stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION,
                           self->super.super.id,
-                          self->format.stats_instance(self));
+                          self->format.stats_instance(self),
+                          stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -330,8 +330,8 @@ log_threaded_dest_driver_start(LogPipe *s)
   stats_lock();
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
-                          self->super.super.id,
-                          self->format.stats_instance(self));
+                                self->super.super.id,
+                                self->format.stats_instance(self));
   stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
@@ -366,8 +366,8 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
   stats_lock();
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_DESTINATION,
-                          self->super.super.id,
-                          self->format.stats_instance(self));
+                                self->super.super.id,
+                                self->format.stats_instance(self));
   stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -329,10 +329,9 @@ log_threaded_dest_driver_start(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
+  stats_cluster_logpipe_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
                           self->super.super.id,
-                          self->format.stats_instance(self),
-                          stats_counter_group_logpipe_init);
+                          self->format.stats_instance(self));
   stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
@@ -366,10 +365,9 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION,
+  stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_DESTINATION,
                           self->super.super.id,
-                          self->format.stats_instance(self),
-                          stats_counter_group_logpipe_init);
+                          self->format.stats_instance(self));
   stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1272,7 +1272,7 @@ log_writer_init(LogPipe *s)
     {
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance);
+      stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
   
       stats_register_counter(self->stats_level, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       if (self->options->suppress > 0)
@@ -1326,7 +1326,7 @@ log_writer_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance);
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
 
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1273,7 +1273,7 @@ log_writer_init(LogPipe *s)
       stats_lock();
       StatsClusterKey sc_key;
       stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance );
-  
+
       stats_register_counter(self->stats_level, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       if (self->options->suppress > 0)
         stats_register_counter(self->stats_level, &sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1271,16 +1271,15 @@ log_writer_init(LogPipe *s)
   if ((self->options->options & LWO_NO_STATS) == 0 && !self->dropped_messages)
     {
       stats_lock();
-      stats_register_counter(self->stats_level, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance,
-                             SC_TYPE_DROPPED, &self->dropped_messages);
+      StatsClusterKey sc_key;
+      stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance);
+  
+      stats_register_counter(self->stats_level, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       if (self->options->suppress > 0)
-        stats_register_counter(self->stats_level, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance,
-                               SC_TYPE_SUPPRESSED, &self->suppressed_messages);
-      stats_register_counter(self->stats_level, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance,
-                             SC_TYPE_PROCESSED, &self->processed_messages);
+        stats_register_counter(self->stats_level, &sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
+      stats_register_counter(self->stats_level, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
 
-      stats_register_counter(self->stats_level, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance,
-                             SC_TYPE_STORED, &self->stored_messages);
+      stats_register_counter(self->stats_level, &sc_key, SC_TYPE_STORED, &self->stored_messages);
       stats_unlock();
     }
   log_queue_set_counters(self->queue, self->stored_messages, self->dropped_messages);
@@ -1326,14 +1325,13 @@ log_writer_deinit(LogPipe *s)
   log_queue_set_counters(self->queue, NULL, NULL);
 
   stats_lock();
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, SC_TYPE_DROPPED,
-                           &self->dropped_messages);
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, SC_TYPE_SUPPRESSED,
-                           &self->suppressed_messages);
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, SC_TYPE_PROCESSED,
-                           &self->processed_messages);
-  stats_unregister_counter(self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, SC_TYPE_STORED,
-                           &self->stored_messages);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance);
+
+  stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unlock();
 
   return TRUE;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1272,7 +1272,7 @@ log_writer_init(LogPipe *s)
     {
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance );
   
       stats_register_counter(self->stats_level, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       if (self->options->suppress > 0)
@@ -1326,7 +1326,7 @@ log_writer_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_DESTINATION, self->stats_id, self->stats_instance );
 
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);

--- a/lib/stats/CMakeLists.txt
+++ b/lib/stats/CMakeLists.txt
@@ -9,6 +9,7 @@ set(STATS_HEADERS
     stats/stats-syslog.h
     stats/stats-query.h
     stats/stats-query-commands.h
+    stats/stats-cluster-logpipe.h
     PARENT_SCOPE)
 
 set(STATS_SOURCES
@@ -22,4 +23,5 @@ set(STATS_SOURCES
     stats/stats-syslog.c
     stats/stats-query.c
     stats/stats-query-commands.c
+    stats/stats-cluster-logpipe.c
     PARENT_SCOPE)

--- a/lib/stats/Makefile.am
+++ b/lib/stats/Makefile.am
@@ -10,7 +10,8 @@ statsinclude_HEADERS = \
 	lib/stats/stats-registry.h		\
 	lib/stats/stats-syslog.h		\
 	lib/stats/stats-query.h			\
-	lib/stats/stats-query-commands.h
+	lib/stats/stats-query-commands.h \
+	lib/stats/stats-cluster-logpipe.h
 
 stats_sources = \
 	lib/stats/stats.c			\
@@ -22,6 +23,7 @@ stats_sources = \
 	lib/stats/stats-registry.c		\
 	lib/stats/stats-syslog.c		\
 	lib/stats/stats-query.c			\
-	lib/stats/stats-query-commands.c
+	lib/stats/stats-query-commands.c \
+	lib/stats/stats-cluster-logpipe.c
 
 include lib/stats/tests/Makefile.am

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -36,7 +36,7 @@ static const gchar *tag_names[SC_TYPE_MAX] =
 
 
 StatsCluster *
-stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance)
+stats_cluster_logpipe_new(StatsClusterKey *sc_key)
 {
   StatsCounterGroup counter_group = 
   {
@@ -45,9 +45,6 @@ stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance
     .counter_names = tag_names
   };
 
-  StatsClusterKey key;
-  stats_cluster_key_set(&key, component, id, instance);
-
-  return stats_cluster_new(&key, &counter_group);
+  return stats_cluster_new(sc_key, &counter_group);
 }
 

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 2017 Laszlo Budai
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/stats-cluster-logpipe.h"
+#include "stats/stats-cluster.h"
+
+static const gchar *tag_names[SC_TYPE_MAX] =
+{
+  /* [SC_TYPE_DROPPED]   = */ "dropped",
+  /* [SC_TYPE_PROCESSED] = */ "processed",
+  /* [SC_TYPE_STORED]   = */  "stored",
+  /* [SC_TYPE_SUPPRESSED] = */ "suppressed",
+  /* [SC_TYPE_STAMP] = */ "stamp",
+};
+
+
+StatsCluster *
+stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance)
+{
+  return stats_cluster_new(component, id, instance, tag_names, g_new0(StatsCounterItem, SC_TYPE_MAX), SC_TYPE_MAX);
+}
+
+

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -38,7 +38,12 @@ static const gchar *tag_names[SC_TYPE_MAX] =
 StatsCluster *
 stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance)
 {
-  return stats_cluster_new(component, id, instance, tag_names, g_new0(StatsCounterItem, SC_TYPE_MAX), SC_TYPE_MAX);
+  StatsCounterGroup counter_group = 
+  {
+    .counters = g_new0(StatsCounterItem, SC_TYPE_MAX),
+    .capacity = SC_TYPE_MAX,
+    .counter_names = tag_names
+  };
+  return stats_cluster_new(component, id, instance, &counter_group);
 }
-
 

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -34,11 +34,17 @@ static const gchar *tag_names[SC_TYPE_MAX] =
   /* [SC_TYPE_STAMP] = */ "stamp",
 };
 
-void
-stats_counter_group_logpipe_init(StatsCounterGroup *counter_group)
+static void
+_counter_group_logpipe_init(StatsCounterGroup *counter_group)
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_MAX);
   counter_group->capacity = SC_TYPE_MAX;
   counter_group->counter_names = tag_names;
+}
+
+void
+stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance)
+{
+  stats_cluster_key_set(key, component, id, instance, _counter_group_logpipe_init);
 }
 

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -35,11 +35,18 @@ static const gchar *tag_names[SC_TYPE_MAX] =
 };
 
 static void
+_counter_group_logpipe_free(StatsCounterGroup *counter_group)
+{
+  g_free(counter_group->counters);
+}
+
+static void
 _counter_group_logpipe_init(StatsCounterGroup *counter_group)
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_MAX);
   counter_group->capacity = SC_TYPE_MAX;
   counter_group->counter_names = tag_names;
+  counter_group->free_fn = _counter_group_logpipe_free;
 }
 
 void

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -34,17 +34,11 @@ static const gchar *tag_names[SC_TYPE_MAX] =
   /* [SC_TYPE_STAMP] = */ "stamp",
 };
 
-
-StatsCluster *
-stats_cluster_logpipe_new(StatsClusterKey *sc_key)
+void
+stats_counter_group_logpipe_init(StatsCounterGroup *counter_group)
 {
-  StatsCounterGroup counter_group = 
-  {
-    .counters = g_new0(StatsCounterItem, SC_TYPE_MAX),
-    .capacity = SC_TYPE_MAX,
-    .counter_names = tag_names
-  };
-
-  return stats_cluster_new(sc_key, &counter_group);
+  counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_MAX);
+  counter_group->capacity = SC_TYPE_MAX;
+  counter_group->counter_names = tag_names;
 }
 

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -44,6 +44,10 @@ stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance
     .capacity = SC_TYPE_MAX,
     .counter_names = tag_names
   };
-  return stats_cluster_new(component, id, instance, &counter_group);
+
+  StatsClusterKey key;
+  stats_cluster_key_set(&key, component, id, instance);
+
+  return stats_cluster_new(&key, &counter_group);
 }
 

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -25,7 +25,7 @@
 #ifndef STATS_CLUSTER_LOGPIPE_H_INCLUDED
 #define STATS_CLUSTER_LOGPIPE_H_INCLUDED
 
-#include "stats/stats-counter.h" 
+#include "syslog-ng.h" 
 
 typedef enum
 {
@@ -37,7 +37,7 @@ typedef enum
   SC_TYPE_MAX
 } StatsCounterGroupLogPipe;
 
-void stats_counter_group_logpipe_init(StatsCounterGroup *counter_group);
+void stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance);
 
 #endif
 

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 2017 Laszlo Budai
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STATS_CLUSTER_LOGPIPE_H_INCLUDED
+#define STATS_CLUSTER_LOGPIPE_H_INCLUDED
+
+#include "syslog-ng.h"
+
+typedef enum
+{
+  SC_TYPE_DROPPED=0, /* number of messages dropped */
+  SC_TYPE_PROCESSED, /* number of messages processed */
+  SC_TYPE_STORED,    /* number of messages on disk */
+  SC_TYPE_SUPPRESSED,/* number of messages suppressed */
+  SC_TYPE_STAMP,     /* timestamp */
+  SC_TYPE_MAX
+} StatsCounterTypeLogPipe;
+
+StatsCluster *stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance);
+
+#endif
+

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -37,7 +37,7 @@ typedef enum
   SC_TYPE_MAX
 } StatsCounterTypeLogPipe;
 
-StatsCluster *stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance);
+StatsCluster *stats_cluster_logpipe_new(StatsClusterKey *sc_key);
 
 #endif
 

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -25,7 +25,7 @@
 #ifndef STATS_CLUSTER_LOGPIPE_H_INCLUDED
 #define STATS_CLUSTER_LOGPIPE_H_INCLUDED
 
-#include "syslog-ng.h"
+#include "stats/stats-counter.h" 
 
 typedef enum
 {
@@ -35,9 +35,9 @@ typedef enum
   SC_TYPE_SUPPRESSED,/* number of messages suppressed */
   SC_TYPE_STAMP,     /* timestamp */
   SC_TYPE_MAX
-} StatsCounterTypeLogPipe;
+} StatsCounterGroupLogPipe;
 
-StatsCluster *stats_cluster_logpipe_new(StatsClusterKey *sc_key);
+void stats_counter_group_logpipe_init(StatsCounterGroup *counter_group);
 
 #endif
 

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -233,10 +233,17 @@ stats_cluster_new(const StatsClusterKey *key)
 }
 
 void
+stats_counter_group_free(StatsCounterGroup *self)
+{
+  if (self->free_fn)
+    self->free_fn(self);
+}
+
+void
 stats_cluster_free(StatsCluster *self)
 {
   _stats_cluster_key_cloned_free(&self->key);
   g_free(self->query_key);
-  g_free(self->counter_group.counters); //TODO: dtor?
+  stats_counter_group_free(&self->counter_group);
   g_free(self);
 }

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -39,15 +39,6 @@ stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, 
     }
 }
 
-static const gchar *tag_names[SC_TYPE_MAX] =
-{
-  /* [SC_TYPE_DROPPED]   = */ "dropped",
-  /* [SC_TYPE_PROCESSED] = */ "processed",
-  /* [SC_TYPE_STORED]   = */  "stored",
-  /* [SC_TYPE_SUPPRESSED] = */ "suppressed",
-  /* [SC_TYPE_STAMP] = */ "stamp",
-};
-
 const gchar *
 stats_cluster_get_type_name(StatsCluster *self, gint type)
 {
@@ -206,12 +197,6 @@ stats_cluster_new(gint component, const gchar *id, const gchar *instance, const 
   self->max_counters = max_counters;
   g_assert(max_counters <= sizeof(self->live_mask)*8);
   return self;
-}
-
-StatsCluster *
-stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance)
-{
-  return stats_cluster_new(component, id, instance, tag_names, g_new(StatsCounterItem, SC_TYPE_MAX), SC_TYPE_MAX);
 }
 
 void

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -103,11 +103,11 @@ _get_component_prefix(gint source)
 const gchar *
 stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len)
 {
-  if ((self->component & SCS_SOURCE_MASK) == SCS_GROUP)
+  if ((self->key.component & SCS_SOURCE_MASK) == SCS_GROUP)
     {
-      if (self->component & SCS_SOURCE)
+      if (self->key.component & SCS_SOURCE)
         return "source";
-      else if (self->component & SCS_DESTINATION)
+      else if (self->key.component & SCS_DESTINATION)
         return "destination";
       else
         g_assert_not_reached();
@@ -115,8 +115,8 @@ stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len)
   else
     {
       g_snprintf(buf, buf_len, "%s%s",
-                 _get_component_prefix(self->component),
-                 _get_module_name(self->component));
+                 _get_component_prefix(self->key.component),
+                 _get_module_name(self->key.component));
       return buf;
     }
 }
@@ -124,13 +124,13 @@ stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len)
 gboolean
 stats_cluster_equal(const StatsCluster *sc1, const StatsCluster *sc2)
 {
-  return sc1->component == sc2->component && strcmp(sc1->id, sc2->id) == 0 && strcmp(sc1->instance, sc2->instance) == 0;
+  return sc1->key.component == sc2->key.component && strcmp(sc1->key.id, sc2->key.id) == 0 && strcmp(sc1->key.instance, sc2->key.instance) == 0;
 }
 
 guint
 stats_cluster_hash(const StatsCluster *self)
 {
-  return g_str_hash(self->id) + g_str_hash(self->instance) + self->component;
+  return g_str_hash(self->key.id) + g_str_hash(self->key.instance) + self->key.component;
 }
 
 StatsCounterItem *
@@ -164,13 +164,13 @@ _stats_build_query_key(StatsCluster *self)
 
   g_string_append(key, component_name);
 
-  if (self->id && self->id[0])
+  if (self->key.id && self->key.id[0])
     {
-      g_string_append_printf(key, ".%s", self->id);
+      g_string_append_printf(key, ".%s", self->key.id);
     }
-  if (self->instance && self->instance[0])
+  if (self->key.instance && self->key.instance[0])
     {
-      g_string_append_printf(key, ".%s", self->instance);
+      g_string_append_printf(key, ".%s", self->key.instance);
     }
 
   return g_string_free(key, FALSE);
@@ -187,9 +187,9 @@ stats_cluster_new(gint component, const gchar *id, const gchar *instance, StatsC
 {
   StatsCluster *self = g_new0(StatsCluster, 1);
 
-  self->component = component;
-  self->id = g_strdup(id ? : "");
-  self->instance = g_strdup(instance ? : "");
+  self->key.component = component;
+  self->key.id = g_strdup(id ? : "");
+  self->key.instance = g_strdup(instance ? : "");
   self->use_count = 0;
   self->query_key = _stats_build_query_key(self);
   self->counter_group = *group;
@@ -200,8 +200,8 @@ stats_cluster_new(gint component, const gchar *id, const gchar *instance, StatsC
 void
 stats_cluster_free(StatsCluster *self)
 {
-  g_free(self->id);
-  g_free(self->instance);
+  g_free(self->key.id);
+  g_free(self->key.instance);
   g_free(self->query_key);
   g_free(self->counter_group.counters); //TODO: dtor?
   g_free(self);

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 
-static StatsClusterKey*
+static StatsClusterKey *
 _clone_stats_cluster_key(StatsClusterKey *dst, const StatsClusterKey *src)
 {
   dst->component = src->component;
@@ -36,11 +36,12 @@ _clone_stats_cluster_key(StatsClusterKey *dst, const StatsClusterKey *src)
   return dst;
 }
 
-void 
-stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance, StatsCounterGroupInit counter_group_init)
+void
+stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance,
+                      StatsCounterGroupInit counter_group_init)
 {
   self->component = component;
-  self->id = (id?id:""); 
+  self->id = (id?id:"");
   self->instance = (instance?instance:"");
   self->counter_group_init = counter_group_init;
 }

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -149,12 +149,18 @@ stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len)
 }
 
 gboolean
+stats_cluster_key_equal(const StatsClusterKey *key1, const StatsClusterKey *key2)
+{
+  return key1->component == key2->component
+         && strcmp(key1->id, key2->id) == 0
+         && strcmp(key1->instance, key2->instance) == 0
+         && key1->counter_group_init == key2->counter_group_init;
+}
+
+gboolean
 stats_cluster_equal(const StatsCluster *sc1, const StatsCluster *sc2)
 {
-  return sc1->key.component == sc2->key.component 
-         && strcmp(sc1->key.id, sc2->key.id) == 0
-         && strcmp(sc1->key.instance, sc2->key.instance) == 0
-         && sc1->key.counter_group_init == sc2->key.counter_group_init;
+  return stats_cluster_key_equal(&sc1->key, &sc2->key);
 }
 
 guint
@@ -213,7 +219,7 @@ stats_cluster_is_alive(StatsCluster *self, gint type)
 }
 
 StatsCluster *
-stats_cluster_new(StatsClusterKey *key)
+stats_cluster_new(const StatsClusterKey *key)
 {
   StatsCluster *self = g_new0(StatsCluster, 1);
 

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -39,8 +39,8 @@ void
 stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance)
 {
   self->component = component;
-  self->id = id; 
-  self->instance = instance;
+  self->id = (id?id:""); 
+  self->instance = (instance?instance:"");
 }
 
 static void

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -25,16 +25,7 @@
 #define STATS_CLUSTER_H_INCLUDED 1
 
 #include "stats/stats-counter.h"
-
-typedef enum
-{
-  SC_TYPE_DROPPED=0, /* number of messages dropped */
-  SC_TYPE_PROCESSED, /* number of messages processed */
-  SC_TYPE_STORED,    /* number of messages on disk */
-  SC_TYPE_SUPPRESSED,/* number of messages suppressed */
-  SC_TYPE_STAMP,     /* timestamp */
-  SC_TYPE_MAX
-} StatsCounterType;
+#include "stats/stats-cluster-logpipe.h" //TODO: REMOVE
 
 enum
 {
@@ -122,7 +113,6 @@ void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterIt
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
 StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance, const gchar **tags, StatsCounterItem *counters, guint16 number_of_stats_counters);
-StatsCluster *stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance);
 void stats_cluster_free(StatsCluster *self);
 
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -25,7 +25,7 @@
 #define STATS_CLUSTER_H_INCLUDED 1
 
 #include "stats/stats-counter.h"
-#include "stats/stats-cluster-logpipe.h" //TODO: REMOVE
+#include "stats/stats-cluster-logpipe.h" 
 
 enum
 {

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -81,6 +81,14 @@ typedef struct _StatsCounterGroup
   guint16 capacity;
 } StatsCounterGroup;
 
+typedef struct _StatsClusterKey
+{
+  /* syslog-ng component/driver/subsystem that registered this cluster */
+  guint16 component;
+  gchar *id;
+  gchar *instance;
+} StatsClusterKey;
+
 /* NOTE: This struct can only be used by the stats implementation and not by client code. */
 
 /* StatsCluster encapsulates a set of related counters that are registered
@@ -92,12 +100,9 @@ typedef struct _StatsCounterGroup
  * be registered with a single hash lookup */
 typedef struct _StatsCluster
 {
+  StatsClusterKey key;
   StatsCounterGroup counter_group;
   guint16 use_count;
-  /* syslog-ng component/driver/subsystem that registered this cluster */
-  guint16 component;
-  gchar *id;
-  gchar *instance;
   guint16 live_mask;
   guint16 dynamic:1;
   gchar *query_key;

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -94,7 +94,7 @@ enum
  * be registered with a single hash lookup */
 typedef struct _StatsCluster
 {
-  StatsCounterItem counters[SC_TYPE_MAX];
+  StatsCounterItem *counters;
   guint16 use_count;
   /* syslog-ng component/driver/subsystem that registered this cluster */
   guint16 component;
@@ -103,12 +103,13 @@ typedef struct _StatsCluster
   guint16 live_mask;
   guint16 dynamic:1;
   gchar *query_key;
+  const gchar **tag_names;
+  guint16 max_counters;
 } StatsCluster;
 
 typedef void (*StatsForeachCounterFunc)(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data);
 
-const gchar *stats_cluster_get_type_name(gint type);
-gint stats_cluster_get_type_by_name(const gchar *name);
+const gchar *stats_cluster_get_type_name(StatsCluster *self, gint type);
 const gchar *stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len);
 
 void stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, gpointer user_data);
@@ -120,7 +121,8 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
-StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance);
+StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance, const gchar **tags, StatsCounterItem *counters, guint16 number_of_stats_counters);
+StatsCluster *stats_cluster_logpipe_new(gint component, const gchar *id, const gchar *instance);
 void stats_cluster_free(StatsCluster *self);
 
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -85,8 +85,8 @@ typedef struct _StatsClusterKey
 {
   /* syslog-ng component/driver/subsystem that registered this cluster */
   guint16 component;
-  gchar *id;
-  gchar *instance;
+  const gchar *id;
+  const gchar *instance;
 } StatsClusterKey;
 
 /* NOTE: This struct can only be used by the stats implementation and not by client code. */
@@ -122,7 +122,9 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
-StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance, StatsCounterGroup *counters_group);
+StatsCluster *stats_cluster_new(StatsClusterKey *key, StatsCounterGroup *counters_group);
 void stats_cluster_free(StatsCluster *self);
+
+void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance);
 
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -118,6 +118,7 @@ const gchar *stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gs
 
 void stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, gpointer user_data);
 
+gboolean stats_cluster_key_equal(const StatsClusterKey *key1, const StatsClusterKey *key2);
 gboolean stats_cluster_equal(const StatsCluster *sc1, const StatsCluster *sc2);
 guint stats_cluster_hash(const StatsCluster *self);
 
@@ -125,7 +126,7 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
-StatsCluster *stats_cluster_new(StatsClusterKey *key);
+StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
 void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance, StatsCounterGroupInit counter_group_ctor);

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -74,14 +74,18 @@ enum
   SCS_SOURCE_MASK    = 0xff
 };
 
-typedef struct _StatsCounterGroup
+typedef struct _StatsCounterGroup StatsCounterGroup;
+
+struct _StatsCounterGroup
 {
   StatsCounterItem *counters;
   const gchar **counter_names;
   guint16 capacity;
-} StatsCounterGroup;
+  void (*free_fn)(StatsCounterGroup *self);
+};
 
 typedef void (*StatsCounterGroupInit)(StatsCounterGroup *counter_group);
+void stats_counter_group_free(StatsCounterGroup *self);
 
 typedef struct _StatsClusterKey
 {

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -87,14 +87,14 @@ struct _StatsCounterGroup
 typedef void (*StatsCounterGroupInit)(StatsCounterGroup *counter_group);
 void stats_counter_group_free(StatsCounterGroup *self);
 
-typedef struct _StatsClusterKey
+struct _StatsClusterKey
 {
   /* syslog-ng component/driver/subsystem that registered this cluster */
   guint16 component;
   const gchar *id;
   const gchar *instance;
   StatsCounterGroupInit counter_group_init;
-} StatsClusterKey;
+};
 
 /* NOTE: This struct can only be used by the stats implementation and not by client code. */
 

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -74,6 +74,13 @@ enum
   SCS_SOURCE_MASK    = 0xff
 };
 
+typedef struct _StatsCounterGroup
+{
+  StatsCounterItem *counters;
+  const gchar **counter_names;
+  guint16 capacity;
+} StatsCounterGroup;
+
 /* NOTE: This struct can only be used by the stats implementation and not by client code. */
 
 /* StatsCluster encapsulates a set of related counters that are registered
@@ -85,7 +92,7 @@ enum
  * be registered with a single hash lookup */
 typedef struct _StatsCluster
 {
-  StatsCounterItem *counters;
+  StatsCounterGroup counter_group;
   guint16 use_count;
   /* syslog-ng component/driver/subsystem that registered this cluster */
   guint16 component;
@@ -94,8 +101,6 @@ typedef struct _StatsCluster
   guint16 live_mask;
   guint16 dynamic:1;
   gchar *query_key;
-  const gchar **tag_names;
-  guint16 max_counters;
 } StatsCluster;
 
 typedef void (*StatsForeachCounterFunc)(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data);
@@ -112,7 +117,7 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
-StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance, const gchar **tags, StatsCounterItem *counters, guint16 number_of_stats_counters);
+StatsCluster *stats_cluster_new(gint component, const gchar *id, const gchar *instance, StatsCounterGroup *counters_group);
 void stats_cluster_free(StatsCluster *self);
 
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -81,12 +81,15 @@ typedef struct _StatsCounterGroup
   guint16 capacity;
 } StatsCounterGroup;
 
+typedef void (*StatsCounterGroupInit)(StatsCounterGroup *counter_group);
+
 typedef struct _StatsClusterKey
 {
   /* syslog-ng component/driver/subsystem that registered this cluster */
   guint16 component;
   const gchar *id;
   const gchar *instance;
+  StatsCounterGroupInit counter_group_init;
 } StatsClusterKey;
 
 /* NOTE: This struct can only be used by the stats implementation and not by client code. */
@@ -122,9 +125,9 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 
-StatsCluster *stats_cluster_new(StatsClusterKey *key, StatsCounterGroup *counters_group);
+StatsCluster *stats_cluster_new(StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
-void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance);
+void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance, StatsCounterGroupInit counter_group_ctor);
 
 #endif

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -65,8 +65,8 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
   gchar buf[32];
   gchar state;
 
-  s_id = stats_format_csv_escapevar(sc->id);
-  s_instance = stats_format_csv_escapevar(sc->instance);
+  s_id = stats_format_csv_escapevar(sc->key.id);
+  s_instance = stats_format_csv_escapevar(sc->key.instance);
 
   if (sc->dynamic)
     state = 'd';

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -75,7 +75,7 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
   else
     state = 'a';
 
-  tag_name = stats_format_csv_escapevar(stats_cluster_get_type_name(type));
+  tag_name = stats_format_csv_escapevar(stats_cluster_get_type_name(sc, type));
   g_string_append_printf(csv, "%s;%s;%s;%c;%s;%u\n",
                          stats_cluster_get_component_name(sc, buf, sizeof(buf)),
                          s_id, s_instance, state, tag_name, stats_counter_get(&sc->counters[type]));

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -78,7 +78,7 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
   tag_name = stats_format_csv_escapevar(stats_cluster_get_type_name(sc, type));
   g_string_append_printf(csv, "%s;%s;%s;%c;%s;%u\n",
                          stats_cluster_get_component_name(sc, buf, sizeof(buf)),
-                         s_id, s_instance, state, tag_name, stats_counter_get(&sc->counters[type]));
+                         s_id, s_instance, state, tag_name, stats_counter_get(&sc->counter_group.counters[type]));
   g_free(tag_name);
   g_free(s_id);
   g_free(s_instance);

--- a/lib/stats/stats-log.c
+++ b/lib/stats/stats-log.c
@@ -36,7 +36,7 @@ stats_log_format_counter(StatsCluster *sc, gint type, StatsCounterItem *item, gp
                        sc->id,
                        (sc->id[0] && sc->instance[0]) ? "," : "",
                        sc->instance,
-                       stats_counter_get(&sc->counters[type]));
+                       stats_counter_get(&sc->counter_group.counters[type]));
   evt_rec_add_tag(e, tag);
 }
 

--- a/lib/stats/stats-log.c
+++ b/lib/stats/stats-log.c
@@ -33,9 +33,9 @@ stats_log_format_counter(StatsCluster *sc, gint type, StatsCounterItem *item, gp
 
   tag = evt_tag_printf(stats_cluster_get_type_name(sc, type), "%s(%s%s%s)=%u",
                        stats_cluster_get_component_name(sc, buf, sizeof(buf)),
-                       sc->id,
-                       (sc->id[0] && sc->instance[0]) ? "," : "",
-                       sc->instance,
+                       sc->key.id,
+                       (sc->key.id[0] && sc->key.instance[0]) ? "," : "",
+                       sc->key.instance,
                        stats_counter_get(&sc->counter_group.counters[type]));
   evt_rec_add_tag(e, tag);
 }

--- a/lib/stats/stats-log.c
+++ b/lib/stats/stats-log.c
@@ -31,7 +31,7 @@ stats_log_format_counter(StatsCluster *sc, gint type, StatsCounterItem *item, gp
   EVTTAG *tag;
   gchar buf[32];
 
-  tag = evt_tag_printf(stats_cluster_get_type_name(type), "%s(%s%s%s)=%u",
+  tag = evt_tag_printf(stats_cluster_get_type_name(sc, type), "%s(%s%s%s)=%u",
                        stats_cluster_get_component_name(sc, buf, sizeof(buf)),
                        sc->id,
                        (sc->id[0] && sc->instance[0]) ? "," : "",

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -161,7 +161,7 @@ _format_selected_counters(GList *counters, StatsFormatCb format_cb, gpointer res
   for (GList *counter = counters; counter; counter = counter->next)
     {
       NamedStatsCounterItem *c = counter->data;
-      format_cb(c->cluster, &c->cluster->counters[c->index], _get_name_of_counter_item(c), result);
+      format_cb(c->cluster, &c->cluster->counter_group.counters[c->index], _get_name_of_counter_item(c), result);
     }
 }
 
@@ -172,7 +172,7 @@ _reset_selected_counters(GList *counters)
   for (c = counters; c; c = c->next)
     {
       NamedStatsCounterItem *counter = c->data;
-      StatsCounterItem *item = &counter->cluster->counters[counter->index];
+      StatsCounterItem *item = &counter->cluster->counter_group.counters[counter->index];
       stats_counter_set(item, 0);
     }
 }
@@ -226,7 +226,7 @@ _sum_selected_counters(GList *counters, gpointer user_data)
   for (c = counters; c; c = c->next)
     {
       NamedStatsCounterItem *counter = c->data;
-      *sum += counter->cluster->counters[counter->index].value;
+      *sum += counter->cluster->counter_group.counters[counter->index].value;
     }
 }
 

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -82,7 +82,7 @@ _grab_cluster(gint stats_level, gint component, const gchar *id, const gchar *in
 }
 
 static StatsCluster *
-_register_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, StatsCounterType type,
+_register_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, gint type,
                   gboolean dynamic, StatsCounterItem **counter)
 {
   StatsCluster *sc;
@@ -114,7 +114,7 @@ _register_counter(gint stats_level, gint component, const gchar *id, const gchar
  * freed when all of these uses are unregistered.
  **/
 void
-stats_register_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, StatsCounterType type,
+stats_register_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, gint type,
                        StatsCounterItem **counter)
 {
   _register_counter(stats_level, component, id, instance, type, FALSE, counter);
@@ -122,7 +122,7 @@ stats_register_counter(gint stats_level, gint component, const gchar *id, const 
 
 StatsCluster *
 stats_register_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance,
-                               StatsCounterType type, StatsCounterItem **counter)
+                               gint type, StatsCounterItem **counter)
 {
   return _register_counter(stats_level, component, id, instance, type, TRUE, counter);
 }
@@ -162,7 +162,7 @@ stats_register_and_increment_dynamic_counter(gint stats_level, gint component, c
  * instance in order to avoid an unnecessary lookup.
  **/
 void
-stats_register_associated_counter(StatsCluster *sc, StatsCounterType type, StatsCounterItem **counter)
+stats_register_associated_counter(StatsCluster *sc, gint type, StatsCounterItem **counter)
 {
   g_assert(stats_locked);
 
@@ -175,7 +175,7 @@ stats_register_associated_counter(StatsCluster *sc, StatsCounterType type, Stats
 }
 
 void
-stats_unregister_counter(gint component, const gchar *id, const gchar *instance, StatsCounterType type,
+stats_unregister_counter(gint component, const gchar *id, const gchar *instance, gint type,
                          StatsCounterItem **counter)
 {
   StatsCluster *sc;
@@ -201,7 +201,7 @@ stats_unregister_counter(gint component, const gchar *id, const gchar *instance,
 }
 
 void
-stats_unregister_dynamic_counter(StatsCluster *sc, StatsCounterType type, StatsCounterItem **counter)
+stats_unregister_dynamic_counter(StatsCluster *sc, gint type, StatsCounterItem **counter)
 {
   g_assert(stats_locked);
   if (!sc)

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -56,9 +56,9 @@ _grab_cluster(gint stats_level, gint component, const gchar *id, const gchar *in
   if (!instance)
     instance = "";
 
-  key.component = component;
-  key.id = (gchar *) id;
-  key.instance = (gchar *) instance;
+  key.key.component = component;
+  key.key.id = (gchar *) id;
+  key.key.instance = (gchar *) instance;
 
   sc = g_hash_table_lookup(counter_hash, &key);
   if (!sc)
@@ -191,9 +191,9 @@ stats_unregister_counter(gint component, const gchar *id, const gchar *instance,
   if (!instance)
     instance = "";
 
-  key.component = component;
-  key.id = (gchar *) id;
-  key.instance = (gchar *) instance;
+  key.key.component = component;
+  key.key.id = (gchar *) id;
+  key.key.instance = (gchar *) instance;
 
   sc = g_hash_table_lookup(counter_hash, &key);
 

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -64,7 +64,7 @@ _grab_cluster(gint stats_level, gint component, const gchar *id, const gchar *in
   if (!sc)
     {
       /* no such StatsCluster instance, register one */
-      sc = stats_cluster_new(component, id, instance);
+      sc = stats_cluster_logpipe_new(component, id, instance);
       sc->dynamic = dynamic;
       g_hash_table_insert(counter_hash, sc, sc);
     }

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -57,7 +57,7 @@ _grab_cluster(gint stats_level, StatsClusterKey *sc_key, gboolean dynamic)
   if (!sc)
     {
       /* no such StatsCluster instance, register one */
-      sc = stats_cluster_logpipe_new(sc_key);
+      sc = stats_cluster_new(sc_key);
       sc->dynamic = dynamic;
       g_hash_table_insert(counter_hash, sc, sc);
     }

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -33,11 +33,11 @@ typedef gboolean (*StatsForeachClusterRemoveFunc)(StatsCluster *sc, gpointer use
 void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
-void stats_register_counter(gint level, gint component, const gchar *id, const gchar *instance, gint type, StatsCounterItem **counter);
-StatsCluster *stats_register_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, gint type, StatsCounterItem **counter);
-void stats_register_and_increment_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, time_t timestamp);
+void stats_register_counter(gint level, StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+StatsCluster *stats_register_dynamic_counter(gint stats_level, StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+void stats_register_and_increment_dynamic_counter(gint stats_level, StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
-void stats_unregister_counter(gint component, const gchar *id, const gchar *instance, gint type, StatsCounterItem **counter);
+void stats_unregister_counter(StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -33,11 +33,11 @@ typedef gboolean (*StatsForeachClusterRemoveFunc)(StatsCluster *sc, gpointer use
 void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
-void stats_register_counter(gint level, StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
-StatsCluster *stats_register_dynamic_counter(gint stats_level, StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
-void stats_register_and_increment_dynamic_counter(gint stats_level, StatsClusterKey *sc_key, time_t timestamp);
+void stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+void stats_register_and_increment_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
-void stats_unregister_counter(StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+void stats_unregister_counter(const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -33,12 +33,12 @@ typedef gboolean (*StatsForeachClusterRemoveFunc)(StatsCluster *sc, gpointer use
 void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
-void stats_register_counter(gint level, gint component, const gchar *id, const gchar *instance, StatsCounterType type, StatsCounterItem **counter);
-StatsCluster *stats_register_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, StatsCounterType type, StatsCounterItem **counter);
+void stats_register_counter(gint level, gint component, const gchar *id, const gchar *instance, gint type, StatsCounterItem **counter);
+StatsCluster *stats_register_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, gint type, StatsCounterItem **counter);
 void stats_register_and_increment_dynamic_counter(gint stats_level, gint component, const gchar *id, const gchar *instance, time_t timestamp);
-void stats_register_associated_counter(StatsCluster *handle, StatsCounterType type, StatsCounterItem **counter);
-void stats_unregister_counter(gint component, const gchar *id, const gchar *instance, StatsCounterType type, StatsCounterItem **counter);
-void stats_unregister_dynamic_counter(StatsCluster *handle, StatsCounterType type, StatsCounterItem **counter);
+void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
+void stats_unregister_counter(gint component, const gchar *id, const gchar *instance, gint type, StatsCounterItem **counter);
+void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);
 void stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data);

--- a/lib/stats/stats-syslog.c
+++ b/lib/stats/stats-syslog.c
@@ -54,19 +54,19 @@ stats_syslog_reinit(void)
   gchar name[11] = "";
   gint i;
   StatsClusterKey sc_key;
- 
+
   stats_lock();
   if (stats_check_level(3))
     {
-     /* we need these counters, register them */
-     for (i = 0; i < SEVERITY_MAX; i++)
+      /* we need these counters, register them */
+      for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
           stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
-     for (i = 0; i < FACILITY_MAX - 1; i++)
+      for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
           stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name );

--- a/lib/stats/stats-syslog.c
+++ b/lib/stats/stats-syslog.c
@@ -53,24 +53,27 @@ stats_syslog_reinit(void)
 {
   gchar name[11] = "";
   gint i;
-
+  StatsClusterKey sc_key;
+ 
   stats_lock();
   if (stats_check_level(3))
     {
-      /* we need these counters, register them */
-      for (i = 0; i < SEVERITY_MAX; i++)
+     /* we need these counters, register them */
+     for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_register_counter(3, SCS_SEVERITY | SCS_SOURCE, NULL, name, SC_TYPE_PROCESSED, &severity_counters[i]);
+          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name);
+          stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
-      for (i = 0; i < FACILITY_MAX - 1; i++)
+     for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_register_counter(3, SCS_FACILITY | SCS_SOURCE, NULL, name, SC_TYPE_PROCESSED, &facility_counters[i]);
+          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name);
+          stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_register_counter(3, SCS_FACILITY | SCS_SOURCE, NULL, "other", SC_TYPE_PROCESSED,
-                             &facility_counters[FACILITY_MAX - 1]);
+      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other");
+      stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   else
     {
@@ -78,16 +81,18 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_unregister_counter(SCS_SEVERITY | SCS_SOURCE, NULL, name, SC_TYPE_PROCESSED, &severity_counters[i]);
+          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name);
+          stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_unregister_counter(SCS_FACILITY | SCS_SOURCE, NULL, name, SC_TYPE_PROCESSED, &facility_counters[i]);
+          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name);
+          stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_unregister_counter(SCS_FACILITY | SCS_SOURCE, NULL, "other", SC_TYPE_PROCESSED,
-                               &facility_counters[FACILITY_MAX - 1]);
+      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other");
+      stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   stats_unlock();
 }

--- a/lib/stats/stats-syslog.c
+++ b/lib/stats/stats-syslog.c
@@ -62,17 +62,17 @@ stats_syslog_reinit(void)
      for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
      for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other", stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other" );
       stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   else
@@ -81,17 +81,17 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name );
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
+          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name );
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other", stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other" );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   stats_unlock();

--- a/lib/stats/stats-syslog.c
+++ b/lib/stats/stats-syslog.c
@@ -62,17 +62,17 @@ stats_syslog_reinit(void)
      for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name);
+          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
      for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name);
+          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other");
+      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other", stats_counter_group_logpipe_init);
       stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   else
@@ -81,17 +81,17 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name);
+          stats_cluster_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name);
+          stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name, stats_counter_group_logpipe_init);
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other");
+      stats_cluster_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other", stats_counter_group_logpipe_init);
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   stats_unlock();

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -100,7 +100,7 @@ stats_cluster_is_expired(StatsOptions *options, StatsCluster *sc, time_t now)
   if ((sc->live_mask & (1 << SC_TYPE_STAMP)) == 0)
     return FALSE;
 
-  tstamp = sc->counters[SC_TYPE_STAMP].value;
+  tstamp = sc->counter_group.counters[SC_TYPE_STAMP].value;
   return (tstamp <= now - options->lifetime);
 }
 
@@ -121,7 +121,7 @@ stats_prune_counter(StatsCluster *sc, StatsTimerState *st)
   expired = stats_cluster_is_expired(st->options, sc, st->now.tv_sec);
   if (expired)
     {
-      time_t tstamp = sc->counters[SC_TYPE_STAMP].value;
+      time_t tstamp = sc->counter_group.counters[SC_TYPE_STAMP].value;
       if ((st->oldest_counter) == 0 || st->oldest_counter > tstamp)
         st->oldest_counter = tstamp;
       st->dropped_counters++;

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -33,8 +33,8 @@ test_stats_cluster_logpipe_new_replaces_NULL_with_an_empty_string(void)
   StatsCluster *sc;
 
   sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, NULL, NULL);
-  assert_string(sc->id, "", "StatsCluster->id is not properly defaulted to an empty string");
-  assert_string(sc->instance, "", "StatsCluster->instance is not properly defaulted to an empty string");
+  assert_string(sc->key.id, "", "StatsCluster->id is not properly defaulted to an empty string");
+  assert_string(sc->key.instance, "", "StatsCluster->instance is not properly defaulted to an empty string");
   stats_cluster_free(sc);
 }
 

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -31,8 +31,10 @@ static void
 test_stats_cluster_logpipe_new_replaces_NULL_with_an_empty_string(void)
 {
   StatsCluster *sc;
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, NULL, NULL);
 
-  sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, NULL, NULL);
+  sc = stats_cluster_logpipe_new(&sc_key);
   assert_string(sc->key.id, "", "StatsCluster->id is not properly defaulted to an empty string");
   assert_string(sc->key.instance, "", "StatsCluster->instance is not properly defaulted to an empty string");
   stats_cluster_free(sc);
@@ -69,17 +71,26 @@ assert_stats_cluster_mismatches_and_free(StatsCluster *sc1, StatsCluster *sc2)
 static void
 test_stats_cluster_equal_if_component_id_and_instance_are_the_same(void)
 {
-  assert_stats_cluster_equals_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
-                                       stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance"));
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
+  assert_stats_cluster_equals_and_free(stats_cluster_logpipe_new(&sc_key),
+                                       stats_cluster_logpipe_new(&sc_key));
 
-  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance1"),
-                                           stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance2"));
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance1");
+  StatsClusterKey sc_key2;
+  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance2");
+  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(&sc_key),
+                                           stats_cluster_logpipe_new(&sc_key2));
 
-  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id1", "instance"),
-                                           stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id2", "instance"));
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id1", "instance");
+  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id2", "instance");
+  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(&sc_key),
+                                           stats_cluster_logpipe_new(&sc_key2));
 
-  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
-                                           stats_cluster_logpipe_new(SCS_DESTINATION | SCS_FILE, "id", "instance"));
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
+  stats_cluster_key_set(&sc_key2, SCS_DESTINATION | SCS_FILE, "id", "instance");
+  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(&sc_key),
+                                           stats_cluster_logpipe_new(&sc_key2));
 }
 
 typedef struct _ValidateCountersState
@@ -129,7 +140,9 @@ assert_stats_foreach_yielded_counters_matches(StatsCluster *sc, ...)
 static void
 test_stats_foreach_counter_yields_tracked_counters(void)
 {
-  StatsCluster *sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance");
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
+  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
 
   assert_stats_foreach_yielded_counters_matches(sc, -1);
 
@@ -144,7 +157,9 @@ test_stats_foreach_counter_yields_tracked_counters(void)
 static void
 test_stats_foreach_counter_never_forgets_untracked_counters(void)
 {
-  StatsCluster *sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance");
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
+  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
   StatsCounterItem *processed, *stamp;
 
   processed = stats_cluster_track_counter(sc, SC_TYPE_PROCESSED);
@@ -163,7 +178,9 @@ assert_stats_component_name(gint component, const gchar *expected)
 {
   gchar buf[32];
   const gchar *name;
-  StatsCluster *sc = stats_cluster_logpipe_new(component, NULL, NULL);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, component, NULL, NULL);
+  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
 
   name = stats_cluster_get_component_name(sc, buf, sizeof(buf));
   assert_string(name, expected, "component name mismatch");

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -28,11 +28,11 @@
 #define STATS_CLUSTER_TESTCASE(x) x()
 
 static void
-test_stats_cluster_new_replaces_NULL_with_an_empty_string(void)
+test_stats_cluster_logpipe_new_replaces_NULL_with_an_empty_string(void)
 {
   StatsCluster *sc;
 
-  sc = stats_cluster_new(SCS_SOURCE | SCS_FILE, NULL, NULL);
+  sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, NULL, NULL);
   assert_string(sc->id, "", "StatsCluster->id is not properly defaulted to an empty string");
   assert_string(sc->instance, "", "StatsCluster->instance is not properly defaulted to an empty string");
   stats_cluster_free(sc);
@@ -69,17 +69,17 @@ assert_stats_cluster_mismatches_and_free(StatsCluster *sc1, StatsCluster *sc2)
 static void
 test_stats_cluster_equal_if_component_id_and_instance_are_the_same(void)
 {
-  assert_stats_cluster_equals_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
-                                       stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance"));
+  assert_stats_cluster_equals_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
+                                       stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance"));
 
-  assert_stats_cluster_mismatches_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance1"),
-                                           stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance2"));
+  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance1"),
+                                           stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance2"));
 
-  assert_stats_cluster_mismatches_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id1", "instance"),
-                                           stats_cluster_new(SCS_SOURCE | SCS_FILE, "id2", "instance"));
+  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id1", "instance"),
+                                           stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id2", "instance"));
 
-  assert_stats_cluster_mismatches_and_free(stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
-                                           stats_cluster_new(SCS_DESTINATION | SCS_FILE, "id", "instance"));
+  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance"),
+                                           stats_cluster_logpipe_new(SCS_DESTINATION | SCS_FILE, "id", "instance"));
 }
 
 typedef struct _ValidateCountersState
@@ -129,7 +129,7 @@ assert_stats_foreach_yielded_counters_matches(StatsCluster *sc, ...)
 static void
 test_stats_foreach_counter_yields_tracked_counters(void)
 {
-  StatsCluster *sc = stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance");
+  StatsCluster *sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance");
 
   assert_stats_foreach_yielded_counters_matches(sc, -1);
 
@@ -144,7 +144,7 @@ test_stats_foreach_counter_yields_tracked_counters(void)
 static void
 test_stats_foreach_counter_never_forgets_untracked_counters(void)
 {
-  StatsCluster *sc = stats_cluster_new(SCS_SOURCE | SCS_FILE, "id", "instance");
+  StatsCluster *sc = stats_cluster_logpipe_new(SCS_SOURCE | SCS_FILE, "id", "instance");
   StatsCounterItem *processed, *stamp;
 
   processed = stats_cluster_track_counter(sc, SC_TYPE_PROCESSED);
@@ -163,7 +163,7 @@ assert_stats_component_name(gint component, const gchar *expected)
 {
   gchar buf[32];
   const gchar *name;
-  StatsCluster *sc = stats_cluster_new(component, NULL, NULL);
+  StatsCluster *sc = stats_cluster_logpipe_new(component, NULL, NULL);
 
   name = stats_cluster_get_component_name(sc, buf, sizeof(buf));
   assert_string(name, expected, "component name mismatch");
@@ -183,7 +183,7 @@ test_get_component_name_translates_component_to_name_properly(void)
 static void
 test_stats_cluster(void)
 {
-  STATS_CLUSTER_TESTCASE(test_stats_cluster_new_replaces_NULL_with_an_empty_string);
+  STATS_CLUSTER_TESTCASE(test_stats_cluster_logpipe_new_replaces_NULL_with_an_empty_string);
   STATS_CLUSTER_TESTCASE(test_stats_cluster_equal_if_component_id_and_instance_are_the_same);
   STATS_CLUSTER_TESTCASE(test_stats_foreach_counter_yields_tracked_counters);
   STATS_CLUSTER_TESTCASE(test_stats_foreach_counter_never_forgets_untracked_counters);

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -28,13 +28,13 @@
 #define STATS_CLUSTER_TESTCASE(x) x()
 
 static void
-test_stats_cluster_logpipe_new_replaces_NULL_with_an_empty_string(void)
+test_stats_cluster_new_replaces_NULL_with_an_empty_string(void)
 {
   StatsCluster *sc;
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, NULL, NULL);
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, NULL, NULL, stats_counter_group_logpipe_init);
 
-  sc = stats_cluster_logpipe_new(&sc_key);
+  sc = stats_cluster_new(&sc_key);
   assert_string(sc->key.id, "", "StatsCluster->id is not properly defaulted to an empty string");
   assert_string(sc->key.instance, "", "StatsCluster->instance is not properly defaulted to an empty string");
   stats_cluster_free(sc);
@@ -72,25 +72,25 @@ static void
 test_stats_cluster_equal_if_component_id_and_instance_are_the_same(void)
 {
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
-  assert_stats_cluster_equals_and_free(stats_cluster_logpipe_new(&sc_key),
-                                       stats_cluster_logpipe_new(&sc_key));
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  assert_stats_cluster_equals_and_free(stats_cluster_new(&sc_key),
+                                       stats_cluster_new(&sc_key));
 
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance1");
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance1", stats_counter_group_logpipe_init);
   StatsClusterKey sc_key2;
-  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance2");
-  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(&sc_key),
-                                           stats_cluster_logpipe_new(&sc_key2));
+  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance2", stats_counter_group_logpipe_init);
+  assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
+                                           stats_cluster_new(&sc_key2));
 
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id1", "instance");
-  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id2", "instance");
-  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(&sc_key),
-                                           stats_cluster_logpipe_new(&sc_key2));
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id1", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id2", "instance", stats_counter_group_logpipe_init);
+  assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
+                                           stats_cluster_new(&sc_key2));
 
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
-  stats_cluster_key_set(&sc_key2, SCS_DESTINATION | SCS_FILE, "id", "instance");
-  assert_stats_cluster_mismatches_and_free(stats_cluster_logpipe_new(&sc_key),
-                                           stats_cluster_logpipe_new(&sc_key2));
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_key_set(&sc_key2, SCS_DESTINATION | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
+                                           stats_cluster_new(&sc_key2));
 }
 
 typedef struct _ValidateCountersState
@@ -141,8 +141,8 @@ static void
 test_stats_foreach_counter_yields_tracked_counters(void)
 {
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
-  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  StatsCluster *sc = stats_cluster_new(&sc_key);
 
   assert_stats_foreach_yielded_counters_matches(sc, -1);
 
@@ -158,8 +158,8 @@ static void
 test_stats_foreach_counter_never_forgets_untracked_counters(void)
 {
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance");
-  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
+  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  StatsCluster *sc = stats_cluster_new(&sc_key);
   StatsCounterItem *processed, *stamp;
 
   processed = stats_cluster_track_counter(sc, SC_TYPE_PROCESSED);
@@ -179,8 +179,8 @@ assert_stats_component_name(gint component, const gchar *expected)
   gchar buf[32];
   const gchar *name;
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, component, NULL, NULL);
-  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
+  stats_cluster_key_set(&sc_key, component, NULL, NULL, stats_counter_group_logpipe_init);
+  StatsCluster *sc = stats_cluster_new(&sc_key);
 
   name = stats_cluster_get_component_name(sc, buf, sizeof(buf));
   assert_string(name, expected, "component name mismatch");
@@ -200,7 +200,7 @@ test_get_component_name_translates_component_to_name_properly(void)
 static void
 test_stats_cluster(void)
 {
-  STATS_CLUSTER_TESTCASE(test_stats_cluster_logpipe_new_replaces_NULL_with_an_empty_string);
+  STATS_CLUSTER_TESTCASE(test_stats_cluster_new_replaces_NULL_with_an_empty_string);
   STATS_CLUSTER_TESTCASE(test_stats_cluster_equal_if_component_id_and_instance_are_the_same);
   STATS_CLUSTER_TESTCASE(test_stats_foreach_counter_yields_tracked_counters);
   STATS_CLUSTER_TESTCASE(test_stats_foreach_counter_never_forgets_untracked_counters);

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -32,7 +32,7 @@ test_stats_cluster_new_replaces_NULL_with_an_empty_string(void)
 {
   StatsCluster *sc;
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, NULL, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, NULL, NULL );
 
   sc = stats_cluster_new(&sc_key);
   assert_string(sc->key.id, "", "StatsCluster->id is not properly defaulted to an empty string");
@@ -72,23 +72,23 @@ static void
 test_stats_cluster_equal_if_component_id_and_instance_are_the_same(void)
 {
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
   assert_stats_cluster_equals_and_free(stats_cluster_new(&sc_key),
                                        stats_cluster_new(&sc_key));
 
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance1", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance1" );
   StatsClusterKey sc_key2;
-  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance2", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance2" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id1", "instance", stats_counter_group_logpipe_init);
-  stats_cluster_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id2", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id1", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id2", "instance" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
-  stats_cluster_key_set(&sc_key2, SCS_DESTINATION | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_DESTINATION | SCS_FILE, "id", "instance" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 }
@@ -141,7 +141,7 @@ static void
 test_stats_foreach_counter_yields_tracked_counters(void)
 {
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
 
   assert_stats_foreach_yielded_counters_matches(sc, -1);
@@ -158,7 +158,7 @@ static void
 test_stats_foreach_counter_never_forgets_untracked_counters(void)
 {
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   StatsCounterItem *processed, *stamp;
 
@@ -179,7 +179,7 @@ assert_stats_component_name(gint component, const gchar *expected)
   gchar buf[32];
   const gchar *name;
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, component, NULL, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, component, NULL, NULL );
   StatsCluster *sc = stats_cluster_new(&sc_key);
 
   name = stats_cluster_get_component_name(sc, buf, sizeof(buf));

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -72,7 +72,7 @@ _initialize_counter_hash(void)
     {
       StatsCounterItem *item = NULL;
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, counters[i].component, counters[i].id, counters[i].instance);
+      stats_cluster_key_set(&sc_key, counters[i].component, counters[i].id, counters[i].instance, stats_counter_group_logpipe_init);
       stats_register_counter(0, &sc_key, counters[i].type, &item);
     }
 
@@ -151,8 +151,8 @@ Test(cluster_query_key, test_global_key)
 {
   const gchar *expected_key = "dst.file.d_file.instance";
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION|SCS_FILE, "d_file", "instance");
-  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION|SCS_FILE, "d_file", "instance", stats_counter_group_logpipe_init);
+  StatsCluster *sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->query_key, expected_key,
                    "generated query key(%s) does not match to the expected key(%s)",
                    sc->query_key, expected_key);

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -72,7 +72,7 @@ _initialize_counter_hash(void)
     {
       StatsCounterItem *item = NULL;
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, counters[i].component, counters[i].id, counters[i].instance, stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, counters[i].component, counters[i].id, counters[i].instance );
       stats_register_counter(0, &sc_key, counters[i].type, &item);
     }
 
@@ -151,7 +151,7 @@ Test(cluster_query_key, test_global_key)
 {
   const gchar *expected_key = "dst.file.d_file.instance";
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION|SCS_FILE, "d_file", "instance", stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION|SCS_FILE, "d_file", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->query_key, expected_key,
                    "generated query key(%s) does not match to the expected key(%s)",

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -71,7 +71,9 @@ _initialize_counter_hash(void)
   for (i = 0; i < n; i++)
     {
       StatsCounterItem *item = NULL;
-      stats_register_counter(0, counters[i].component, counters[i].id, counters[i].instance, counters[i].type, &item);
+      StatsClusterKey sc_key;
+      stats_cluster_key_set(&sc_key, counters[i].component, counters[i].id, counters[i].instance);
+      stats_register_counter(0, &sc_key, counters[i].type, &item);
     }
 
   stats_unlock();
@@ -148,7 +150,9 @@ TestSuite(cluster_query_key, .init = app_startup, .fini = app_shutdown);
 Test(cluster_query_key, test_global_key)
 {
   const gchar *expected_key = "dst.file.d_file.instance";
-  StatsCluster *sc = stats_cluster_logpipe_new(SCS_DESTINATION|SCS_FILE, "d_file", "instance");
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION|SCS_FILE, "d_file", "instance");
+  StatsCluster *sc = stats_cluster_logpipe_new(&sc_key);
   cr_assert_str_eq(sc->query_key, expected_key,
                    "generated query key(%s) does not match to the expected key(%s)",
                    sc->query_key, expected_key);

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -148,7 +148,7 @@ TestSuite(cluster_query_key, .init = app_startup, .fini = app_shutdown);
 Test(cluster_query_key, test_global_key)
 {
   const gchar *expected_key = "dst.file.d_file.instance";
-  StatsCluster *sc = stats_cluster_new(SCS_DESTINATION|SCS_FILE, "d_file", "instance");
+  StatsCluster *sc = stats_cluster_logpipe_new(SCS_DESTINATION|SCS_FILE, "d_file", "instance");
   cr_assert_str_eq(sc->query_key, expected_key,
                    "generated query key(%s) does not match to the expected key(%s)",
                    sc->query_key, expected_key);

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -50,8 +50,7 @@ typedef struct _GlobalConfig GlobalConfig;
 typedef struct _Bookmark Bookmark;
 typedef struct _AckTracker AckTracker;
 typedef struct _AckRecord AckRecord;
-typedef struct _StatsCluster StatsCluster;
-typedef struct _StatsClusterKey StatsClusterKey;
+typedef struct _StatsCounterGroup StatsCounterGroup;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -50,7 +50,7 @@ typedef struct _GlobalConfig GlobalConfig;
 typedef struct _Bookmark Bookmark;
 typedef struct _AckTracker AckTracker;
 typedef struct _AckRecord AckRecord;
-typedef struct _StatsCounterGroup StatsCounterGroup;
+typedef struct _StatsClusterKey StatsClusterKey;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -50,6 +50,7 @@ typedef struct _GlobalConfig GlobalConfig;
 typedef struct _Bookmark Bookmark;
 typedef struct _AckTracker AckTracker;
 typedef struct _AckRecord AckRecord;
+typedef struct _StatsCluster StatsCluster;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -51,6 +51,7 @@ typedef struct _Bookmark Bookmark;
 typedef struct _AckTracker AckTracker;
 typedef struct _AckRecord AckRecord;
 typedef struct _StatsCluster StatsCluster;
+typedef struct _StatsClusterKey StatsClusterKey;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1190,7 +1190,7 @@ afsql_dd_init(LogPipe *s)
   stats_lock();
     {
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self));
+      stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self), stats_counter_group_logpipe_init);
       stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
       stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       stats_unlock();
@@ -1320,7 +1320,7 @@ error:
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self));
+    stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self), stats_counter_group_logpipe_init);
     stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   }
@@ -1342,7 +1342,7 @@ afsql_dd_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self));
+  stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self), stats_counter_group_logpipe_init);
   stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unlock();

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1190,7 +1190,7 @@ afsql_dd_init(LogPipe *s)
   stats_lock();
     {
       StatsClusterKey sc_key;
-      stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self), stats_counter_group_logpipe_init);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
       stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
       stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       stats_unlock();
@@ -1320,7 +1320,7 @@ error:
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self), stats_counter_group_logpipe_init);
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
     stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   }
@@ -1342,7 +1342,7 @@ afsql_dd_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self), stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
   stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unlock();

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1188,14 +1188,15 @@ afsql_dd_init(LogPipe *s)
     }
 
   stats_lock();
-    {
-      StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
-      stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
-      stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-    }
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+                                  afsql_dd_format_stats_instance(self) );
+    stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
+    stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+  }
   stats_unlock();
- 
+
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg, afsql_dd_format_persist_sequence_number(self)));
   if (!self->seq_num)
     init_sequence_number(&self->seq_num);
@@ -1318,12 +1319,13 @@ afsql_dd_init(LogPipe *s)
 error:
 
   stats_lock();
-    {
-      StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
-      stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
-      stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-    }
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+                                  afsql_dd_format_stats_instance(self) );
+    stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+    stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+  }
   stats_unlock();
 
   return FALSE;
@@ -1342,7 +1344,8 @@ afsql_dd_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+                                afsql_dd_format_stats_instance(self) );
   stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unlock();

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1193,9 +1193,9 @@ afsql_dd_init(LogPipe *s)
       stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
       stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
       stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-      stats_unlock();
     }
-
+  stats_unlock();
+ 
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg, afsql_dd_format_persist_sequence_number(self)));
   if (!self->seq_num)
     init_sequence_number(&self->seq_num);
@@ -1318,12 +1318,12 @@ afsql_dd_init(LogPipe *s)
 error:
 
   stats_lock();
-  {
-    StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
-    stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
-    stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-  }
+    {
+      StatsClusterKey sc_key;
+      stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id, afsql_dd_format_stats_instance(self) );
+      stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+      stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+    }
   stats_unlock();
 
   return FALSE;

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -71,7 +71,7 @@ test_diskq_become_full(gboolean reliable)
   q->persist_name = "test_diskq";
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL, stats_counter_group_logpipe_init);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
   stats_counter_set(q->dropped_messages, 0);
   stats_unlock();

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -71,7 +71,7 @@ test_diskq_become_full(gboolean reliable)
   q->persist_name = "test_diskq";
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL, stats_counter_group_logpipe_init);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
   stats_counter_set(q->dropped_messages, 0);
   stats_unlock();

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -70,7 +70,9 @@ test_diskq_become_full(gboolean reliable)
 
   q->persist_name = "test_diskq";
   stats_lock();
-  stats_register_counter(0, SCS_DESTINATION, q->persist_name, NULL, SC_TYPE_DROPPED, &q->dropped_messages);
+  StatsClusterKey sc_key;
+  stats_cluster_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
+  stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
   stats_counter_set(q->dropped_messages, 0);
   stats_unlock();
   unlink(DISKQ_FILENAME);


### PR DESCRIPTION
- Motivation
    - support new types of counters that are not fit into the existing StatsCluster implementation
    - example for new types: LogQueue related metrics (queue size in bytes which is definitely not a STORED/PROCESSED/... kind of counter)
- Changes initiated by this PR
    - extracted StatsClusterKey
        - (id, component, instance)  group was used as a key for StatsCluster so this is just an equivalent change and as a side effect the interface is simpler now (number of parameters has been reduced significantly for register_counter method-family)
    - initiated StatsCounterGroup (this name is not the final one, maybe StatsClusterCounters is better... )
        - number of counters can vary
        - the group initializer(that is reponsible for allocating counters) method added to StatsClusterKey