### PR TITLE
Cisco parser

### DIFF
--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -108,7 +108,6 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, gint op)
   self->super.free_fn = fop_cmp_free;
   self->left = left;
   self->right = right;
-  self->super.type = "CMP";
 
   switch (op)
     {
@@ -116,37 +115,46 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, gint op)
       self->cmp_op = FCMP_NUM;
     case KW_LT:
       self->cmp_op |= FCMP_LT;
+      self->super.type = "<";
       break;
 
     case KW_NUM_LE:
       self->cmp_op = FCMP_NUM;
     case KW_LE:
       self->cmp_op |= FCMP_LT | FCMP_EQ;
+      self->super.type = "<=";
       break;
 
     case KW_NUM_EQ:
       self->cmp_op = FCMP_NUM;
     case KW_EQ:
       self->cmp_op |= FCMP_EQ;
+      self->super.type = "==";
       break;
 
     case KW_NUM_NE:
       self->cmp_op = FCMP_NUM;
     case KW_NE:
       self->cmp_op |= 0;
+      self->super.type = "!=";
       break;
 
     case KW_NUM_GE:
       self->cmp_op = FCMP_NUM;
     case KW_GE:
       self->cmp_op |= FCMP_GT | FCMP_EQ;
+      self->super.type = ">=";
       break;
 
     case KW_NUM_GT:
       self->cmp_op = FCMP_NUM;
     case KW_GT:
       self->cmp_op |= FCMP_GT;
+      self->super.type = ">";
       break;
+
+    default:
+      g_assert_not_reached();
     }
 
   if (self->cmp_op & FCMP_NUM && cfg_is_config_version_older(left->cfg, VERSION_VALUE_3_8))

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -48,6 +48,7 @@ filter_expr_eval_with_context(FilterExprNode *self, LogMessage **msg, gint num_m
 
   res = self->eval(self, msg, num_msg);
   msg_debug("Filter node evaluation result",
+            evt_tag_printf("msg", "%p", *msg),
             evt_tag_str("result", res ? "match" : "not-match"),
             evt_tag_str("type", self->type));
   return res;

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -49,7 +49,13 @@ filter_in_list_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   value = log_msg_get_value(msg, self->value_handle, &len);
   APPEND_ZERO(value, value, len);
 
-  return (g_tree_lookup(self->tree, value) != NULL) ^ s->comp;
+  gboolean result = (g_tree_lookup(self->tree, value) != NULL) ^ s->comp;
+  msg_debug("Filter in-list node evaluation result",
+            evt_tag_printf("msg", "%p", msg),
+            evt_tag_str("value", value),
+            evt_tag_str("result", result ? "match" : "not-match"));
+
+  return result;
 }
 
 static void

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -47,11 +47,13 @@ log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   gboolean res;
 
   msg_debug("Filter rule evaluation begins",
+            evt_tag_printf("msg", "%p", msg),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s));
 
   res = filter_expr_eval_root(self->expr, &msg, path_options);
   msg_debug("Filter rule evaluation result",
+            evt_tag_printf("msg", "%p", msg),
             evt_tag_str("result", res ? "match" : "not-match"),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s));

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -24,6 +24,7 @@
 
 #include "filter-re.h"
 #include "str-utils.h"
+#include "messages.h"
 
 #include <string.h>
 
@@ -31,11 +32,16 @@ static gboolean
 filter_re_eval_string(FilterExprNode *s, LogMessage *msg, gint value_handle, const gchar *str, gssize str_len)
 {
   FilterRE *self = (FilterRE *) s;
+  gboolean result;
 
   if (str_len < 0)
     str_len = strlen(str);
-
-  return log_matcher_match(self->matcher, msg, value_handle, str, str_len) ^ self->super.comp;
+  result = log_matcher_match(self->matcher, msg, value_handle, str, str_len) ^ self->super.comp;
+  msg_debug("Filter regexp node evaluation result",
+            evt_tag_printf("msg", "%p", msg),
+            evt_tag_str("input", str),
+            evt_tag_str("result", result ? "match" : "not-match"));
+  return result;
 }
 
 static gboolean
@@ -86,6 +92,7 @@ filter_re_init_instance(FilterRE *self, NVHandle value_handle)
   self->super.init = filter_re_init;
   self->super.eval = filter_re_eval;
   self->super.free_fn = filter_re_free;
+  self->super.type = "regexp";
   log_matcher_options_defaults(&self->matcher_options);
   self->matcher_options.flags |= LMF_MATCH_ONLY;
 }

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -83,5 +83,6 @@ filter_tags_new(GList *tags)
 
   self->super.eval = filter_tags_eval;
   self->super.free_fn = filter_tags_free;
+  self->super.type = "tags";
   return &self->super;
 }

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -29,6 +29,14 @@
 #include "compat/string.h"
 #include "compat/pcre.h"
 
+static gboolean
+_shall_set_values_indirectly(NVHandle value_handle)
+{
+  return value_handle != LM_V_NONE &&
+         !log_msg_is_handle_macro(value_handle) &&
+         !log_msg_is_handle_match(value_handle);
+}
+
 static void
 log_matcher_init(LogMatcher *self, const LogMatcherOptions *options)
 {
@@ -103,10 +111,11 @@ log_matcher_posix_re_feed_backrefs(LogMatcher *s, LogMessage *msg, gint value_ha
                                    const gchar *value)
 {
   gint i;
+  gboolean indirect = _shall_set_values_indirectly(value_handle);
 
   for (i = 0; i < RE_MAX_MATCHES && matches[i].rm_so != -1; i++)
     {
-      if (value_handle != LM_V_NONE && !log_msg_is_handle_macro(value_handle))
+      if (indirect)
         {
           log_msg_set_match_indirect(msg, i, value_handle, 0, matches[i].rm_so, matches[i].rm_eo - matches[i].rm_so);
         }
@@ -540,10 +549,11 @@ log_matcher_pcre_re_feed_backrefs(LogMatcher *s, LogMessage *msg, gint value_han
                                   const gchar *value)
 {
   gint i;
+  gboolean indirect = _shall_set_values_indirectly(value_handle);
 
   for (i = 0; i < (RE_MAX_MATCHES) && i < match_num; i++)
     {
-      if (value_handle != LM_V_NONE && !log_msg_is_handle_macro(value_handle))
+      if (indirect)
         {
           log_msg_set_match_indirect(msg, i, value_handle, 0, matches[2 * i], matches[2 * i + 1] - matches[2 * i]);
         }

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -72,6 +72,7 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   gint fallback;
 
   local_options.matched = &matched;
+  log_msg_write_protect(msg);
   for (fallback = 0; (fallback == 0) || (fallback == 1 && self->fallback_exists && !delivered); fallback++)
     {
       for (i = 0; i < self->next_hops->len; i++)
@@ -99,6 +100,7 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
             }
         }
     }
+  log_msg_write_unprotect(msg);
   log_pipe_forward_msg(s, msg, path_options);
 }
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1184,11 +1184,13 @@ LogMessage *
 log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
 {
   LogMessage *self = log_msg_alloc(0);
+  gsize allocated_bytes = self->allocated_bytes;
 
   stats_counter_inc(count_msg_clones);
   log_msg_write_protect(msg);
 
   memcpy(self, msg, sizeof(*msg));
+  msg->allocated_bytes = allocated_bytes;
 
   /* every field _must_ be initialized explicitly if its direct
    * copying would cause problems (like copying a pointer by value) */

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -162,7 +162,7 @@ struct _LogMessage
   AckRecord *ack_record;
   LMAckFunc ack_func;
   LogMessage *original;
-  size_t allocated_bytes;
+  gsize allocated_bytes;
 
   /* message parts */ 
   

--- a/lib/rewrite/rewrite-groupset.c
+++ b/lib/rewrite/rewrite-groupset.c
@@ -71,6 +71,8 @@ log_rewrite_groupset_process(LogRewrite *s, LogMessage **msg, const LogPathOptio
 {
   LogRewriteGroupSet *self = (LogRewriteGroupSet *) s;
   LogRewriteGroupSetCallbackData userdata;
+
+  log_msg_make_writable(msg, path_options);
   userdata.msg = *msg;
   userdata.template = self->replacement;
   value_pairs_foreach(self->query, self->vp_func, *msg, 0, LTZ_LOCAL, NULL, &userdata);

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -43,7 +43,7 @@ test_hash(void)
   assert_template_failure("$(sha1 --length 5)", "$(hash) parsing failed, invalid number of arguments");
   assert_template_failure("$(sha1 ${missingbrace)", "Invalid macro, '}' is missing, error_pos='14'");
   assert_template_failure("$(sha1 --length invalid_length_specification foo)",
-                          "Cannot parse integer value 'invalid_length_specification' for --length");
+                          "Cannot parse integer value");
   assert_template_format("$(sha1 --length 99999 foo)", "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
   assert_template_format("$(sha1 foo bar)", "8843d7f92416211de9ebb963ff4ce28125932878");
   assert_template_format("$(sha1 \"foo bar\")", "3773dea65156909838fa6c22825cafe090ff8030");

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -12,6 +12,7 @@ SCL_SUBDIRS	= \
 	kafka		\
 	hdfs		\
 	apache		\
+	cisco		\
 	loggly		\
 	logmatic
 SCL_CONFIGS	= scl.conf syslog-ng.conf

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -1,0 +1,130 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+#
+# logging timestamps
+# logging timezone
+# logging sequence-id
+# logging origin-id
+# logging fraction of a second
+#
+#
+# <pri>(sequence: )?(origin: )?(timestamp? timezone?: )?%msg
+
+#<189>29: foo: *Apr 29 13:58:40.411: %SYS-5-CONFIG_I: Configured from console by console
+#<190>30: foo: *Apr 29 13:58:46.411: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 192.168.1.239 stopped - CLI initiated
+#<190>31: foo: *Apr 29 13:58:46.411: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 192.168.1.239 started - CLI initiated<189>32: 0.0.0.0: *Apr 29 13:59:12.491: %SYS-5-CONFIG_I: Configured from console by console<189>33: 0.0.0.0: *Apr 29 13:59:26.415: %SYS-5-CONFIG_I: Configured from console by console<189>34: 0.0.0.0: *Apr 29 13:59:56.603: %SYS-5-CONFIG_I: Configured from console by console^[[<189>35: *Apr 29 14:00:16.059: %SYS-5-CONFIG_I: Configured from console by console
+
+#
+# parses a cisco timestamp with explicit date-parser
+# It ignores msec and year information
+#
+block parser cisco-timestamp-parser(template()) {
+    channel {
+        rewrite {
+            set("`template`" value('1'));
+	};
+	junction {
+	    # alternative #1, no year
+	    channel {
+                filter {
+                    match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2})' value('1') flags(store-matches));
+                };
+                parser {
+                    date-parser(format('%b %d %H:%M:%S') template("$1"));
+                };
+		flags(final);
+	    };
+
+	    channel {
+                filter {
+                    match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{4} \d{2}:\d{2}:\d{2})' value('1') flags(store-matches));
+                };
+                parser {
+                    date-parser(format('%b %d %Y %H:%M:%S') template("$1"));
+                };
+		flags(final);
+	    };
+        };
+        rewrite {
+            unset(value('1'));
+        };
+    };
+};
+
+block parser cisco-parser() {
+    channel {
+        parser {
+            # split msg and header right before the '%', Cisco messages may
+            # have a variable number of ': ' terminated values
+            csv-parser(delimiters(chars('') strings(': %'))
+                       columns('1', '2', '3') flags(greedy, drop-invalid));
+
+            csv-parser(delimiters(chars(':')) template("$2") columns('3'));
+            csv-parser(delimiters(chars('-')) template("$3")
+                       columns('.cisco.facility', '.cisco.severity', '.cisco.mnemonic'));
+        };
+        rewrite {
+            set('%$2', value("MSG"));
+
+	    # drop "<pri>seqno: " if present
+            subst("^(<[0-9]+>)?([0-9]+)?(: )?", "", value('1'));
+
+        };
+
+	junction {
+            channel {
+                parser {
+                    cisco-timestamp-parser(template("$1"));
+                };
+                flags(final);
+            };
+            channel {
+                filter {
+                    match("^(?'HOST'[^:]+): (.*)" value('1') flags(store-matches) type(pcre));
+                };
+                parser {
+                    cisco-timestamp-parser(template("$2"));
+                };
+                flags(final);
+            };
+
+            channel {
+                filter {
+                    match("^(?'HOST'[^:]+)$" value('1') flags(store-matches) type(pcre));
+                };
+                flags(final);
+            };
+            channel {
+                filter {
+                    match("^$" value('1') flags(store-matches) type(pcre));
+                };
+                flags(final);
+            };
+        };
+        rewrite {
+            unset(value("1"));
+            unset(value("2"));
+            unset(value("3"));
+        };
+    };
+};


### PR DESCRIPTION
This branch adds a parser for cisco generated messages, assuming they were received using flags(no-parse).

It works like this:

```
@version: 3.9
@include "scl.conf"
log {
    source { udp(flags(no-parse)); };
    parser { cisco-parser(); };
    destination { ... };
};
```

The parser would parse various formats generated by routers (e.g. various settings to service timestamps, service sequence-number, logging origin-id), and normalizes messages so that:

MESSAGE=%FAC-SEV-MNEMONIC: message
HOST=origin-id
DATE=<as parsed from timestamp>

It also extracts information to a number of Cisco specific name-value pairs:

${.cisco.facility}
${.cisco.severity}
${.cisco.mnemonic}

NOTE: It contains a number of improvements/fixes that were found while creating the parser, obviously those could be merged separately.
