### PR TITLE
Add "index" to counter container

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -222,6 +222,13 @@ stats_cluster_is_alive(StatsCluster *self, gint type)
   return ((1<<type) & self->live_mask);
 }
 
+
+gboolean
+stats_cluster_is_indexed(StatsCluster *self, gint type)
+{
+  return ((1<<type) & self->indexed_mask);
+}
+
 StatsCluster *
 stats_cluster_new(const StatsClusterKey *key)
 {

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -219,6 +219,8 @@ _stats_build_query_key(StatsCluster *self)
 gboolean
 stats_cluster_is_alive(StatsCluster *self, gint type)
 {
+  g_assert(type < self->counter_group.capacity);
+
   return ((1<<type) & self->live_mask);
 }
 
@@ -226,6 +228,8 @@ stats_cluster_is_alive(StatsCluster *self, gint type)
 gboolean
 stats_cluster_is_indexed(StatsCluster *self, gint type)
 {
+  g_assert(type < self->counter_group.capacity);
+
   return ((1<<type) & self->indexed_mask);
 }
 

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -242,11 +242,18 @@ stats_counter_group_free(StatsCounterGroup *self)
     self->free_fn(self);
 }
 
+static void
+_free_stats_counters_in_cluster(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
+{
+  stats_counter_free(counter);
+}
+
 void
 stats_cluster_free(StatsCluster *self)
 {
   _stats_cluster_key_cloned_free(&self->key);
   g_free(self->query_key);
   stats_counter_group_free(&self->counter_group);
+  stats_cluster_foreach_counter(self, _free_stats_counters_in_cluster, NULL);
   g_free(self);
 }

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -111,6 +111,7 @@ typedef struct _StatsCluster
   StatsCounterGroup counter_group;
   guint16 use_count;
   guint16 live_mask;
+  guint16 indexed_mask;
   guint16 dynamic:1;
   gchar *query_key;
 } StatsCluster;
@@ -129,6 +130,7 @@ guint stats_cluster_hash(const StatsCluster *self);
 StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
+gboolean stats_cluster_is_indexed(StatsCluster *self, gint type);
 
 StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -48,3 +48,9 @@ stats_reset_non_stored_counters(void)
   stats_unlock();
 }
 
+void
+stats_counter_free(StatsCounterItem *counter)
+{
+  if (counter->name)
+    g_free(counter->name);
+}

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -29,6 +29,7 @@
 typedef struct _StatsCounterItem
 {
   gint value;
+  gchar *name;
 } StatsCounterItem;
 
 
@@ -72,6 +73,15 @@ stats_counter_get(StatsCounterItem *counter)
   return result;
 }
 
+static inline gchar *
+stats_counter_get_name(StatsCounterItem *counter)
+{
+  if (counter && counter->name)
+    return counter->name;
+  return NULL;
+}
+
 void stats_reset_non_stored_counters(void);
+void stats_counter_free(StatsCounterItem *counter);
 
 #endif

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -53,23 +53,23 @@ _append_reset_msg_if_found_matching_counters(gboolean found_match, GString *resu
 }
 
 static gboolean
-_ctl_format_get(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+_ctl_format_get(StatsCounterItem *ctr, gpointer user_data)
 {
   GString *str = (GString *)user_data;
-  g_string_append_printf(str, "%s.%s: %d\n", sc->query_key, ctr_name ? ctr_name : "", ctr->value);
+  g_string_append_printf(str, "%s: %d\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
   return TRUE;
 }
 
 static gboolean
-_ctl_format_name_without_value(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+_ctl_format_name_without_value(StatsCounterItem *ctr, gpointer user_data)
 {
   GString *str = (GString *)user_data;
-  g_string_append_printf(str, "%s.%s\n", sc->query_key, ctr_name ? ctr_name : "");
+  g_string_append_printf(str, "%s\n", stats_counter_get_name(ctr));
   return TRUE;
 }
 
 static gboolean
-_ctl_format_get_sum(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data)
+_ctl_format_get_sum(StatsCounterItem *ctr, gpointer user_data)
 {
   gpointer *args = (gpointer *) user_data;
   GString *result = (GString *) args[0];

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -219,10 +219,8 @@ stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, g
 static gboolean
 _is_timestamp(gchar *counter_name)
 {
-  gint counter_name_len = strlen(counter_name);
-  gint timestamp_len = strlen(".stamp");
-
-  return timestamp_len < counter_name_len && g_str_equal(counter_name + (counter_name_len - timestamp_len), ".stamp");
+  gchar *last_dot = strrchr(counter_name, '.');
+  return (g_strcmp0(last_dot, ".stamp") == 0);
 }
 
 void

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -213,6 +213,15 @@ stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, g
   return _stats_query_get(expr, format_cb, result, TRUE);
 }
 
+gboolean
+_is_timestamp(gchar *counter_name)
+{
+   gint counter_name_len = strlen(counter_name);
+   gint timestamp_len = strlen(".stamp");
+
+   return timestamp_len < counter_name_len && g_str_equal(counter_name + (counter_name_len - timestamp_len), ".stamp");
+}
+
 void
 _sum_selected_counters(GList *counters, gpointer user_data)
 {
@@ -222,7 +231,8 @@ _sum_selected_counters(GList *counters, gpointer user_data)
   for (c = counters; c; c = c->next)
     {
       StatsCounterItem *counter = c->data;
-      *sum += stats_counter_get(counter);
+      if (!_is_timestamp(stats_counter_get_name(counter)))
+        *sum += stats_counter_get(counter);
     }
 }
 

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -28,125 +28,124 @@
 
 #include <string.h>
 
-typedef struct _NamedStatsCounterItem
-{
-  StatsCluster *cluster;
-  gint index;
-} NamedStatsCounterItem;
 
 static GHashTable *counter_index;
-typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, NamedStatsCounterItem *named_counter,
-                                          StatsFormatCb format_cb, gpointer user_data);
 
-
-static const gchar *
-_get_counter_name_by_index(gint type_index)
+static void
+_setup_filter_expression(const gchar *expr, gchar **key_str)
 {
-  const gchar *_counter_type[SC_TYPE_MAX+1] =
-  {
-    "dropped",
-    "processed",
-    "stored",
-    "suppressed",
-    "stamp",
-    "MAX"
-  };
-
-  if (type_index > SC_TYPE_MAX)
-    return "";
-
-  return _counter_type[type_index];
+  if (!expr || g_str_equal(expr, ""))
+    {
+      *key_str = g_strdup("*");
+    }
+  else
+    {
+      *key_str = g_strdup(expr);
+    }
 }
 
-static const gchar *
-_get_name_of_counter_item(NamedStatsCounterItem *item)
+static gchar *
+_construct_counter_item_name(StatsCluster *sc, gint type)
 {
-  return _get_counter_name_by_index(item->index);
+  GString *name = g_string_new("");
+
+  g_string_append(name, sc->query_key);
+  g_string_append(name, ".");
+  g_string_append(name, stats_cluster_get_type_name(sc, type));
+
+  return g_string_free(name, FALSE);
 }
 
 static void
-_append_live_counters(StatsCluster *sc, gchar *ctr_str, GList **counters)
+_add_counter_to_index(StatsCluster *sc, gint type, StatsCounterItem *counter)
 {
-  gint i;
-  gboolean is_wildcard = FALSE;
-  if (ctr_str[0] == '*')
-    is_wildcard = TRUE;
+  gchar *counter_full_name = NULL;
 
-  for (i = 0; i < SC_TYPE_MAX; i++)
+  counter_full_name = stats_counter_get_name(counter);
+  if (counter_full_name == NULL)
+    counter_full_name = _construct_counter_item_name(sc, type);
+
+  sc->counter_group.counters[type].name = counter_full_name;
+  g_hash_table_insert(counter_index, counter_full_name, &sc->counter_group.counters[type]);
+  sc->indexed_mask |= type;
+}
+
+static void
+_remove_counter_from_index(StatsCluster *sc, gint type)
+{
+  gchar *key = stats_counter_get_name(&sc->counter_group.counters[type]);
+  g_hash_table_remove(counter_index, key);
+  sc->indexed_mask |= type;
+}
+
+static void
+_index_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
+{
+  if (!stats_cluster_is_indexed(sc, type) && stats_cluster_is_alive(sc, type))
     {
-      if (stats_cluster_is_alive(sc, i))
-        {
-          if (is_wildcard || !strcmp(_get_counter_name_by_index(i), ctr_str))
-            {
-              NamedStatsCounterItem *c = g_new0(NamedStatsCounterItem, 1);
-              c->cluster = sc;
-              c->index = i;
-              *counters = g_list_append(*counters, c);
-            }
-        }
+      _add_counter_to_index(sc, type, counter);
+    }
+  else if (stats_cluster_is_indexed(sc, type) && !stats_cluster_is_alive(sc, type))
+    {
+      _remove_counter_from_index(sc, type);
     }
 }
 
-void
-_split_expr(const gchar *expr, gchar **key, gchar **ctr)
+static void
+_update_indexes_of_cluster_if_needed(gpointer key, gpointer value)
 {
-  const gchar *last_delim_pos = strrchr(expr, '.');
-  size_t expr_len = strlen(expr);
-  if (last_delim_pos)
-    {
-      size_t key_len = last_delim_pos - expr ;
-      *key = g_strndup(expr, key_len);
-      *ctr = g_strndup(expr + key_len + 1, expr_len - key_len - 1);
-    }
-  else
-    {
-      *key = g_strdup(expr);
-      *ctr = g_strdup("*");
-    }
+  StatsCluster *sc = (StatsCluster *)key;
+  stats_cluster_foreach_counter(sc, _index_counter, NULL);
 }
 
-void
-_setup_filter_expression(const gchar *expr, gchar **key_str, gchar **ctr_str)
+static void
+_update_index(void)
 {
-  if (!expr)
+  GHashTable *counter_container = stats_registry_get_container();
+  gpointer key, value;
+  GHashTableIter iter;
+
+  g_hash_table_iter_init(&iter, counter_container);
+  while (g_hash_table_iter_next(&iter, &key, &value))
     {
-      *key_str = g_strdup("*");
-      *ctr_str = g_strdup("*");
-    }
-  else
-    {
-      _split_expr(expr, key_str, ctr_str);
+      _update_indexes_of_cluster_if_needed(key, value);
     }
 }
 
 static gboolean
-_find_key_by_pattern(gpointer key, gpointer value, gpointer user_data)
+_is_pattern_matches_key(GPatternSpec *pattern, gpointer key)
 {
-  StatsCluster *sc = (StatsCluster *)key;
-  GPatternSpec *pattern = (GPatternSpec *)user_data;
+  gchar *counter_name = (gchar *) key;
+  return g_pattern_match_string(pattern, counter_name);
+}
 
-  return g_pattern_match_string(pattern, sc->query_key);
+static gboolean
+_is_single_match(gchar *key_str)
+{
+  gboolean is_wildcard = strchr(key_str, '*') ? TRUE : FALSE;
+  gboolean is_joker = strchr(key_str, '?') ? TRUE : FALSE;
+
+  return !is_wildcard && !is_joker;
 }
 
 static GList *
-_query_counter_hash(gchar *key_str, gchar *ctr_str)
+_query_counter_hash(gchar *key_str)
 {
-  GHashTable *counter_hash = stats_registry_get_container();
   GPatternSpec *pattern = g_pattern_spec_new(key_str);
-  StatsCluster *sc = NULL;
   GList *counters = NULL;
   gpointer key, value;
   GHashTableIter iter;
+  gboolean single_match;
 
-  g_hash_table_iter_init (&iter, counter_hash);
-
-  gboolean single_match = strchr(key_str, '*') ? FALSE : TRUE;
+  _update_index();
+  single_match = _is_single_match(key_str);
+  g_hash_table_iter_init(&iter, counter_index);
   while (g_hash_table_iter_next(&iter, &key, &value))
     {
-      if (_find_key_by_pattern(key, value, (gpointer)pattern))
+      if (_is_pattern_matches_key(pattern, key))
         {
-          sc = (StatsCluster *)key;
-          _append_live_counters(sc, ctr_str, &counters);
+          StatsCounterItem *counter = (StatsCounterItem *) value;
+          counters = g_list_append(counters, counter);
 
           if (single_match)
             break;
@@ -161,8 +160,8 @@ _format_selected_counters(GList *counters, StatsFormatCb format_cb, gpointer res
 {
   for (GList *counter = counters; counter; counter = counter->next)
     {
-      NamedStatsCounterItem *c = counter->data;
-      format_cb(c->cluster, &c->cluster->counter_group.counters[c->index], _get_name_of_counter_item(c), result);
+      StatsCounterItem *c = counter->data;
+      format_cb(c, result);
     }
 }
 
@@ -172,9 +171,8 @@ _reset_selected_counters(GList *counters)
   GList *c;
   for (c = counters; c; c = c->next)
     {
-      NamedStatsCounterItem *counter = c->data;
-      StatsCounterItem *item = &counter->cluster->counter_group.counters[counter->index];
-      stats_counter_set(item, 0);
+      StatsCounterItem *counter = c->data;
+      stats_counter_set(counter, 0);
     }
 }
 
@@ -185,12 +183,11 @@ _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gb
     return FALSE;
 
   gchar *key_str = NULL;
-  gchar *ctr_str = NULL;
   GList *counters = NULL;
   gboolean found_match = FALSE;
 
-  _split_expr(expr, &key_str, &ctr_str);
-  counters = _query_counter_hash(key_str, ctr_str);
+  _setup_filter_expression(expr, &key_str);
+  counters = _query_counter_hash(key_str);
   _format_selected_counters(counters, format_cb, result);
 
   if (must_reset)
@@ -199,9 +196,7 @@ _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gb
   if (g_list_length(counters) > 0)
     found_match = TRUE;
 
-  g_list_free_full(counters, g_free);
   g_free(key_str);
-  g_free(ctr_str);
 
   return found_match;
 }
@@ -226,23 +221,25 @@ _sum_selected_counters(GList *counters, gpointer user_data)
   gint64 *sum = (gint64 *) args[1];
   for (c = counters; c; c = c->next)
     {
-      NamedStatsCounterItem *counter = c->data;
-      *sum += counter->cluster->counter_group.counters[counter->index].value;
+      StatsCounterItem *counter = c->data;
+      *sum += stats_counter_get(counter);
     }
 }
 
 gboolean
 _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
 {
+  if (!expr)
+    return FALSE;
+
   gchar *key_str = NULL;
-  gchar *ctr_str = NULL;
   GList *counters = NULL;
   gboolean found_match = FALSE;
   gint64 sum = 0;
   gpointer args[] = {result, &sum};
 
-  _setup_filter_expression(expr, &key_str, &ctr_str);
-  counters = _query_counter_hash(key_str, ctr_str);
+  _setup_filter_expression(expr, &key_str);
+  counters = _query_counter_hash(key_str);
   _sum_selected_counters(counters, (gpointer)args);
   _format_selected_counters(counters, format_cb, (gpointer)args);
 
@@ -252,9 +249,7 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
   if (g_list_length(counters) > 0)
     found_match = TRUE;
 
-  g_list_free_full(counters, g_free);
   g_free(key_str);
-  g_free(ctr_str);
 
   return found_match;
 }
@@ -275,12 +270,11 @@ gboolean
 _stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
 {
   gchar *key_str = NULL;
-  gchar *ctr_str = NULL;
   GList *counters = NULL;
   gboolean found_match = FALSE;
 
-  _setup_filter_expression(expr, &key_str, &ctr_str);
-  counters = _query_counter_hash(key_str, ctr_str);
+  _setup_filter_expression(expr, &key_str);
+  counters = _query_counter_hash(key_str);
   _format_selected_counters(counters, format_cb, result);
 
   if (must_reset)
@@ -289,9 +283,7 @@ _stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, g
   if (g_list_length(counters) > 0)
     found_match = TRUE;
 
-  g_list_free_full(counters, g_free);
   g_free(key_str);
-  g_free(ctr_str);
 
   return found_match;
 }

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -130,7 +130,7 @@ _find_key_by_pattern(gpointer key, gpointer value, gpointer user_data)
 static GList *
 _query_counter_hash(gchar *key_str, gchar *ctr_str)
 {
-  GHashTable *counter_hash = stats_registry_get_counter_hash();
+  GHashTable *counter_hash = stats_registry_get_container();
   GPatternSpec *pattern = g_pattern_spec_new(key_str);
   StatsCluster *sc = NULL;
   GList *counters = NULL;

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -34,6 +34,7 @@ typedef struct _NamedStatsCounterItem
   gint index;
 } NamedStatsCounterItem;
 
+static GHashTable *counter_index;
 typedef gboolean (*StatsClusterCounterCb)(StatsCluster *sc, NamedStatsCounterItem *named_counter,
                                           StatsFormatCb format_cb, gpointer user_data);
 
@@ -305,4 +306,17 @@ gboolean
 stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result)
 {
   return _stats_query_list(expr, format_cb, result, TRUE);
+}
+
+void
+stats_query_index_init(void)
+{
+  counter_index = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
+}
+
+void
+stats_query_index_deinit(void)
+{
+  g_hash_table_destroy(counter_index);
+  counter_index = NULL;
 }

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -36,5 +36,7 @@ gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb for
 gboolean stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 
-#endif
+void stats_query_index_init(void);
+void stats_query_index_deinit(void);
 
+#endif

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -27,7 +27,7 @@
 #include "stats-cluster.h"
 #include "syslog-ng.h"
 
-typedef gboolean (*StatsFormatCb)(StatsCluster *sc, StatsCounterItem *ctr, const gchar *ctr_name, gpointer user_data);
+typedef gboolean (*StatsFormatCb)(StatsCounterItem *ctr, gpointer user_data);
 
 gboolean stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -256,7 +256,7 @@ void
 stats_registry_init(void)
 {
   stats_cluster_container = g_hash_table_new_full((GHashFunc) stats_cluster_hash, (GEqualFunc) stats_cluster_equal, NULL,
-                                       (GDestroyNotify) stats_cluster_free);
+                                                  (GDestroyNotify) stats_cluster_free);
   g_static_mutex_init(&stats_mutex);
 }
 
@@ -273,4 +273,3 @@ stats_registry_get_container(void)
 {
   return stats_cluster_container;
 }
-

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -47,6 +47,6 @@ void stats_foreach_cluster_remove(StatsForeachClusterRemoveFunc func, gpointer u
 void stats_registry_init(void);
 void stats_registry_deinit(void);
 
-GHashTable* stats_registry_get_counter_hash(void);
+GHashTable* stats_registry_get_container(void);
 
 #endif

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -22,11 +22,12 @@
  *
  */
 
-#include "stats/stats.h"
-#include "stats/stats-syslog.h"
-#include "stats/stats-registry.h"
-#include "stats/stats-log.h"
 #include "stats/stats-control.h"
+#include "stats/stats-log.h"
+#include "stats/stats-query.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-syslog.h"
+#include "stats/stats.h"
 #include "timeutils.h"
 
 #include <string.h>
@@ -238,6 +239,7 @@ void
 stats_init(void)
 {
   stats_registry_init();
+  stats_query_index_init();
   stats_register_control_commands();
 }
 
@@ -245,6 +247,7 @@ void
 stats_destroy(void)
 {
   stats_registry_deinit();
+  stats_query_index_deinit();
 }
 
 void


### PR DESCRIPTION
Motivation
========

The main goal of this PR is to support fully globbing when searching for counters and eliminate workarounds introduced in an earlier PR. So from now on it is possible to search using `src.*` and get all of the counters which name stats with `src.`. There is no need to add further `.*` to get all counters.

Changes
=======

* `StatsCounterItem` has an attribute named `name` which consist of the `query_id` of its `StatsCluster` and the name of the type.
* Add `counter_index` hash table where the key is name of the counter and the value is the pointer to the counter. As the construction of the key is expensive, it is only generated once when a `StatsCounterItem` is queried.
* Introduce `indexed_mask` for `StatsCluster`s to know which counter is in `counter_index`.

Dependencies
------------------

- [x] It is rebased on top of #1454 and can be merged after that one.