### PR TITLE
cfg-lex: handle API change in flex

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -168,7 +168,7 @@ word	[^ \#'"\(\)\{\}\\;\r\n\t,|\.@:]
                              int ch;
 
                              ch = input(yyscanner);
-                             while (ch != '\n' && ch != EOF)
+                             while (ch != '\n' && ch != EOF && ch != 0)
                                {
                                  if (yyextra->token_text)
                                    g_string_append_c(yyextra->token_text, ch);


### PR DESCRIPTION
It caused infinite loop if the config file had a comment line without newline as a last expression. (We got 0 instead of EOF, so we never stopped reading.)

Fixes #1460 