### PR TITLE
python: retries support for python destination

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -440,6 +440,10 @@ log_threaded_dest_driver_message_drop(LogThrDestDriver *self,
                                       LogMessage *msg)
 {
   stats_counter_inc(self->dropped_messages);
+  msg_error("Multiple failures while sending message to destination, message dropped",
+            evt_tag_str("driver", self->super.super.id),
+            evt_tag_int("number_of_retries", self->retries.max));
+
   log_threaded_dest_driver_message_accept(self, msg);
 }
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -365,13 +365,10 @@ _worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
-  msg_error(
-    "Multiple failures while inserting this record into the database, "
-    "message dropped",
-    evt_tag_str("driver", self->super.super.super.id),
-    evt_tag_int("number_of_retries", s->retries.max),
-    evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
-                        LTZ_SEND, &self->template_options));
+  msg_error("Dropped message",
+            evt_tag_str("driver", self->super.super.super.id),
+            evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
+                                LTZ_SEND, &self->template_options));
 }
 
 static worker_insert_result_t

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -482,16 +482,6 @@ __send_message(AFSMTPDriver *self, smtp_session_t session)
   return success;
 }
 
-static void
-__worker_message_retry_over(LogThrDestDriver *self, LogMessage *msg)
-{
-  msg_error("Multiple failures while sending message in email to the server, "
-            "message dropped",
-            evt_tag_str("driver", self->super.super.id),
-            evt_tag_int("attempts", self->retries.counter),
-            evt_tag_int("max-attempts", self->retries.max));
-}
-
 static worker_insert_result_t
 afsmtp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 {
@@ -684,8 +674,6 @@ afsmtp_dd_new(GlobalConfig *cfg)
 
   self->super.format.stats_instance = afsmtp_dd_format_stats_instance;
   self->super.stats_source = SCS_SMTP;
-
-  self->super.messages.retry_over = __worker_message_retry_over;
 
   afsmtp_dd_set_host((LogDriver *)self, "127.0.0.1");
   afsmtp_dd_set_port((LogDriver *)self, 25);

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -242,13 +242,6 @@ java_dd_free(LogPipe *s)
   g_string_free(self->class_path, TRUE);
 }
 
-static void
-__retry_over_message(LogThrDestDriver *s, LogMessage *msg)
-{
-  msg_error("Multiple failures while inserting this record to the java destination, message dropped",
-            evt_tag_int("number_of_retries", s->retries.max));
-}
-
 LogTemplateOptions *
 java_dd_get_template_options(LogDriver *s)
 {
@@ -275,7 +268,6 @@ java_dd_new(GlobalConfig *cfg)
   self->super.worker.worker_message_queue_empty = java_worker_message_queue_empty;
 
   self->super.format.stats_instance = java_dd_format_stats_instance;
-  self->super.messages.retry_over = __retry_over_message;
   self->super.stats_source = SCS_JAVA;
 
   self->template = log_template_new(cfg, "java_dd_template");

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -53,6 +53,7 @@ typedef struct
     PyObject *class;
     PyObject *instance;
     PyObject *is_opened;
+    PyObject *retry_error;
     PyObject *send;
   } py;
 } PythonDestDriver;
@@ -145,6 +146,13 @@ _dd_py_invoke_bool_function(PythonDestDriver *self, PyObject *func, PyObject *ar
 }
 
 static void
+_dd_py_invoke_void_function(PythonDestDriver *self, PyObject *func, PyObject *arg)
+{
+  _py_invoke_void_function(func, arg, self->class, self->super.super.super.id);
+}
+
+
+static void
 _dd_py_invoke_void_method_by_name(PythonDestDriver *self, const gchar *method_name)
 {
   _py_invoke_void_method_by_name(self->py.instance, method_name, self->class, self->super.super.super.id);
@@ -171,6 +179,14 @@ _py_invoke_is_opened(PythonDestDriver *self)
     return TRUE;
 
   return _dd_py_invoke_bool_function(self, self->py.is_opened, NULL);
+}
+
+static void
+_py_invoke_retry_error(PythonDestDriver *self, PyObject *dict)
+{
+  if (!self->py.retry_error)
+    return;
+  _dd_py_invoke_void_function(self, self->py.retry_error, dict);
 }
 
 static gboolean
@@ -232,6 +248,7 @@ _py_init_bindings(PythonDestDriver *self)
 
   /* these are fast paths, store references to be faster */
   self->py.is_opened = _py_get_attr_or_null(self->py.instance, "is_opened");
+  self->py.retry_error = _py_get_attr_or_null(self->py.instance, "retry_error");
   self->py.send = _py_get_attr_or_null(self->py.instance, "send");
   if (!self->py.send)
     {
@@ -249,6 +266,7 @@ _py_free_bindings(PythonDestDriver *self)
   Py_CLEAR(self->py.instance);
   Py_CLEAR(self->py.is_opened);
   Py_CLEAR(self->py.send);
+  Py_CLEAR(self->py.retry_error);
 }
 
 static gboolean
@@ -264,12 +282,32 @@ _py_init_object(PythonDestDriver *self)
   return TRUE;
 }
 
+static gboolean
+_py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_object)
+{
+  gboolean success;
+  *msg_object = NULL;
+
+  if (self->vp)
+    {
+      success = py_value_pairs_apply(self->vp, &self->template_options, self->super.seq_num, msg, msg_object);
+      if (!success && (self->template_options.on_error & ON_ERROR_DROP_MESSAGE))
+        return FALSE;
+    }
+  else
+    {
+      *msg_object = py_log_message_new(msg);
+    }
+
+  return TRUE;
+}
+
+
 static worker_insert_result_t
 python_dd_insert(LogThrDestDriver *d, LogMessage *msg)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
   worker_insert_result_t result = WORKER_INSERT_RESULT_ERROR;
-  gboolean success;
   PyObject *msg_object;
   PyGILState_STATE gstate;
 
@@ -279,21 +317,11 @@ python_dd_insert(LogThrDestDriver *d, LogMessage *msg)
       result = WORKER_INSERT_RESULT_NOT_CONNECTED;
       goto exit;
     }
-  if (self->vp)
-    {
-      success = py_value_pairs_apply(self->vp, &self->template_options, self->super.seq_num, msg, &msg_object);
-      if (!success && (self->template_options.on_error & ON_ERROR_DROP_MESSAGE))
-        {
-          goto exit;
-        }
-    }
-  else
-    {
-      msg_object = py_log_message_new(msg);
-    }
 
-  success = _py_invoke_send(self, msg_object);
-  if (success)
+  if (!_py_construct_message(self, msg, &msg_object))
+    goto exit;
+
+  if (_py_invoke_send(self, msg_object))
     {
       result = WORKER_INSERT_RESULT_SUCCESS;
     }
@@ -322,6 +350,23 @@ python_dd_open(PythonDestDriver *self)
 
   PyGILState_Release(gstate);
 }
+
+static void
+python_dd_retry_error(PythonDestDriver *self, LogMessage *msg)
+{
+  PyGILState_STATE gstate;
+  PyObject *msg_object;
+
+  gstate = PyGILState_Ensure();
+  if(_py_construct_message(self, msg, &msg_object))
+    {
+      _py_invoke_retry_error(self, msg_object);
+      Py_DECREF(msg_object);
+    }
+
+  PyGILState_Release(gstate);
+}
+
 
 static void
 python_dd_close(PythonDestDriver *self)
@@ -356,6 +401,13 @@ python_dd_disconnect(LogThrDestDriver *d)
   PythonDestDriver *self = (PythonDestDriver *) d;
 
   python_dd_close(self);
+}
+
+static void
+python_dd_over_message(LogThrDestDriver *s, LogMessage *msg)
+{
+  PythonDestDriver *self = (PythonDestDriver *)s;
+  python_dd_retry_error(self, msg);
 }
 
 static gboolean
@@ -445,6 +497,8 @@ python_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.deinit = python_dd_deinit;
   self->super.super.super.super.free_fn = python_dd_free;
   self->super.super.super.super.generate_persist_name = python_dd_format_persist_name;
+
+  self->super.messages.retry_over = python_dd_over_message;
 
   self->super.worker.thread_init = python_dd_worker_init;
   self->super.worker.thread_deinit = python_dd_worker_deinit;

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -94,6 +94,7 @@ python_dd_option
             python_dd_set_imports(last_driver, $3);
           }
         | KW_OPTIONS '(' python_dd_custom_options ')'
+        | threaded_dest_driver_option
         | value_pair_option
           {
             python_dd_set_value_pairs(last_driver, $1);


### PR DESCRIPTION
With this patch one can use retries() option for
python destination. For example:
destination d_python {
  python(class("ClassFoo") retries(3));
};
See:
https://github.com/balabit/syslog-ng/issues/1424