### PR TITLE
stats: replace type of StatsCounter value from gint to gssize

### DIFF
--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -28,45 +28,52 @@
 
 typedef struct _StatsCounterItem
 {
-  gint value;
+  gssize value;
   gchar *name;
 } StatsCounterItem;
 
 
 static inline void
-stats_counter_add(StatsCounterItem *counter, gint add)
+stats_counter_add(StatsCounterItem *counter, gssize add)
 {
   if (counter)
-    g_atomic_int_add(&counter->value, add);
+    g_atomic_pointer_add(&counter->value, add);
+}
+
+static inline void
+stats_counter_sub(StatsCounterItem *counter, gssize sub)
+{
+  if (counter)
+    g_atomic_pointer_add(&counter->value, -1 * sub);
 }
 
 static inline void
 stats_counter_inc(StatsCounterItem *counter)
 {
   if (counter)
-    g_atomic_int_inc(&counter->value);
+    g_atomic_pointer_add(&counter->value, 1);
 }
 
 static inline void
 stats_counter_dec(StatsCounterItem *counter)
 {
   if (counter)
-    g_atomic_int_add(&counter->value, -1);
+    g_atomic_pointer_add(&counter->value, -1);
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
 static inline void
-stats_counter_set(StatsCounterItem *counter, guint32 value)
+stats_counter_set(StatsCounterItem *counter, gsize value)
 {
   if (counter)
     counter->value = value;
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
-static inline guint32
+static inline gsize
 stats_counter_get(StatsCounterItem *counter)
 {
-  guint32 result = 0;
+  gssize result = 0;
 
   if (counter)
     result = counter->value;

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -76,7 +76,7 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
     state = 'a';
 
   tag_name = stats_format_csv_escapevar(stats_cluster_get_type_name(sc, type));
-  g_string_append_printf(csv, "%s;%s;%s;%c;%s;%u\n",
+  g_string_append_printf(csv, "%s;%s;%s;%c;%s;%"G_GSIZE_FORMAT"\n",
                          stats_cluster_get_component_name(sc, buf, sizeof(buf)),
                          s_id, s_instance, state, tag_name, stats_counter_get(&sc->counter_group.counters[type]));
   g_free(tag_name);

--- a/lib/stats/stats-log.c
+++ b/lib/stats/stats-log.c
@@ -31,7 +31,7 @@ stats_log_format_counter(StatsCluster *sc, gint type, StatsCounterItem *item, gp
   EVTTAG *tag;
   gchar buf[32];
 
-  tag = evt_tag_printf(stats_cluster_get_type_name(sc, type), "%s(%s%s%s)=%u",
+  tag = evt_tag_printf(stats_cluster_get_type_name(sc, type), "%s(%s%s%s)=%"G_GSIZE_FORMAT,
                        stats_cluster_get_component_name(sc, buf, sizeof(buf)),
                        sc->key.id,
                        (sc->key.id[0] && sc->key.instance[0]) ? "," : "",

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -56,7 +56,7 @@ static gboolean
 _ctl_format_get(StatsCounterItem *ctr, gpointer user_data)
 {
   GString *str = (GString *)user_data;
-  g_string_append_printf(str, "%s: %d\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
+  g_string_append_printf(str, "%s: %"G_GSIZE_FORMAT"\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
   return TRUE;
 }
 

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -86,7 +86,7 @@ _test_format_log_msg_get(StatsCounterItem *ctr, gpointer user_data)
   LogMessage *msg = (LogMessage *)user_data;
 
   name = g_strdup_printf("%s", stats_counter_get_name(ctr));
-  value = g_strdup_printf("%d", stats_counter_get(ctr));
+  value = g_strdup_printf("%"G_GSIZE_FORMAT, stats_counter_get(ctr));
 
   log_msg_set_value_by_name(msg, name, value, -1);
 
@@ -100,7 +100,7 @@ static gboolean
 _test_format_str_get(StatsCounterItem *ctr, gpointer user_data)
 {
   GString *str = (GString *)user_data;
-  g_string_append_printf(str, "%s: %d\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
+  g_string_append_printf(str, "%s: %"G_GSIZE_FORMAT"\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
 
   return TRUE;
 }


### PR DESCRIPTION
On 64 bit platforms we can use 64 bit atomic counters.

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>