### PR TITLE
kvformat: invalidate value_was_quoted before extracting the next value

### DIFF
--- a/modules/kvformat/kv-scanner.c
+++ b/modules/kvformat/kv-scanner.c
@@ -267,6 +267,7 @@ _decode_value(KVScanner *self)
 static void
 _extract_value(KVScanner *self)
 {
+  self->value_was_quoted = FALSE;
   _skip_initial_spaces(self);
   _decode_value(self);
 }

--- a/modules/kvformat/tests/test_kv_scanner.c
+++ b/modules/kvformat/tests/test_kv_scanner.c
@@ -595,7 +595,7 @@ Test(kv_scanner, spaces_around_value_separator_are_ignored)
   {
     .kv_separator=':',
   };
-  _IMPL_EXPECT_KV(config, "key1: value1 key2 : value2 key3 :value3 ",
+  _IMPL_EXPECT_KV(config, "key1: \"value1\" key2 : value2 key3 :value3 ",
   {"key1", "value1"},
   {"key2", "value2"},
   {"key3", "value3"});


### PR DESCRIPTION
`_skip_initial_spaces()` calls the `_match_delimiter()` function which uses the value of `value_was_quoted`.

Since this variable contains the state of the previously parsed value, it should be invalidated.