### PR TITLE
Monitoring buffers: memory_usage

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -266,7 +266,7 @@ log_msg_update_sdata_slow(LogMessage *self, NVHandle handle, const gchar *name, 
 
   if (self->alloc_sdata <= self->num_sdata)
     {
-      alloc_sdata = MAX(self->num_sdata + 1, (self->num_sdata + 8) & ~7);
+      alloc_sdata = MAX(self->num_sdata + 1, STRICT_ROUND_TO_NEXT_EIGHT(self->num_sdata));
       if (alloc_sdata > 255)
         alloc_sdata = 255;
     }
@@ -1771,6 +1771,16 @@ log_msg_lookup_time_stamp_name(const gchar *name)
   else if (strcmp(name, "recvd") == 0)
     return LM_TS_RECVD;
   return -1;
+}
+
+gssize log_msg_get_size(LogMessage *self)
+{
+  return
+    sizeof(LogMessage) + // msg.static fields
+    + self->alloc_sdata * sizeof(self->sdata[0]) +
+    sizeof(GSockAddr) + sizeof (GSockAddrFuncs) + // msg.saddr + msg.saddr.sa_func
+    ((self->num_tags) ? sizeof(self->tags[0]) * self->num_tags : 0) +
+    nv_table_get_memory_consumption(self->payload); // msg.payload (nvtable)
 }
 
 #ifdef __linux__

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef LOGMSG_H_INCLUDED
 #define LOGMSG_H_INCLUDED
 
@@ -55,6 +55,8 @@ typedef enum
 #define IS_ACK_SUSPENDED(x) ((x) == AT_SUSPENDED ? 1 : 0)
 
 #define IS_SUSPENDFLAG_ON(x) ((x) == 1 ? TRUE : FALSE)
+
+#define STRICT_ROUND_TO_NEXT_EIGHT(x)  ((x + 8) & ~7)
 
 typedef struct _LogPathOptions LogPathOptions;
 
@@ -138,7 +140,7 @@ typedef struct _LogMessageQueueNode
 } LogMessageQueueNode;
 
 
-/* NOTE: the members are ordered according to the presumed use frequency. 
+/* NOTE: the members are ordered according to the presumed use frequency.
  * The structure itself is 2 cachelines, the border is right after the "msg"
  * member */
 struct _LogMessage
@@ -164,8 +166,8 @@ struct _LogMessage
   LogMessage *original;
   size_t allocated_bytes;
 
-  /* message parts */ 
-  
+  /* message parts */
+
   /* the contents of the members below is directly copied into another
    * LogMessage with pointer values.  To change any of the fields please use
    * log_msg_set_*() functions, which will handle borrowed data members
@@ -332,5 +334,7 @@ void log_msg_global_deinit(void);
 void log_msg_registry_foreach(GHFunc func, gpointer user_data);
 
 gint log_msg_lookup_time_stamp_name(const gchar *name);
+
+gssize log_msg_get_size(LogMessage *self);
 
 #endif

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -406,4 +406,12 @@ nv_table_get_ofs_for_an_entry(NVTable *self, NVEntry *entry)
   return (nv_table_get_top(self) - (gchar *) entry);
 }
 
+static inline gssize
+nv_table_get_memory_consumption(NVTable *self)
+{
+  return sizeof(*self)+
+    self->num_static_entries*sizeof(self->static_entries[0])+
+    self->used;
+}
+
 #endif

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -103,6 +103,19 @@ typedef struct _LogQueueFifo
  * log_queue_fifo_push_head() or log_queue_fifo_rewind_backlog().
  *
  */
+
+static void
+iv_list_update_msg_size(LogQueueFifo *self, struct iv_list_head *head)
+{
+  LogMessage *msg;
+  struct iv_list_head *ilh, *ilh2;
+  iv_list_for_each_safe(ilh, ilh2, head)
+  {
+    msg = iv_list_entry(ilh, LogMessageQueueNode, list)->msg;
+    stats_counter_add(self->super.memory_usage, log_msg_get_size(msg));
+  }
+}
+
 static gint64
 log_queue_fifo_get_length(LogQueue *s)
 {
@@ -196,6 +209,8 @@ log_queue_fifo_move_input_unlocked(LogQueueFifo *self, gint thread_id)
                 evt_tag_str("persist_name", self->super.persist_name));
     }
   stats_counter_add(self->super.queued_messages, self->qoverflow_input[thread_id].len);
+  iv_list_update_msg_size(self, &self->qoverflow_input[thread_id].items);
+
   iv_list_splice_tail_init(&self->qoverflow_input[thread_id].items, &self->qoverflow_wait);
   self->qoverflow_wait_len += self->qoverflow_input[thread_id].len;
   self->qoverflow_input[thread_id].len = 0;
@@ -296,8 +311,8 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
       iv_list_add_tail(&node->list, &self->qoverflow_wait);
       self->qoverflow_wait_len++;
       log_queue_push_notify(&self->super);
-
       stats_counter_inc(self->super.queued_messages);
+      stats_counter_add(self->super.memory_usage, log_msg_get_size(msg));
       g_static_mutex_unlock(&self->super.lock);
 
       log_msg_unref(msg);
@@ -343,6 +358,7 @@ log_queue_fifo_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
   log_msg_unref(msg);
 
   stats_counter_inc(self->super.queued_messages);
+  stats_counter_add(self->super.memory_usage, log_msg_get_size(msg));
 }
 
 /*
@@ -397,6 +413,7 @@ log_queue_fifo_pop_head(LogQueue *s, LogPathOptions *path_options)
       return NULL;
     }
   stats_counter_dec(self->super.queued_messages);
+  stats_counter_sub(self->super.memory_usage, log_msg_get_size(msg));
 
   if (self->super.use_backlog)
     {
@@ -451,6 +468,8 @@ log_queue_fifo_rewind_backlog_all(LogQueue *s)
   LogQueueFifo *self = (LogQueueFifo *) s;
 
   iv_list_splice_tail_init(&self->qbacklog, &self->qoverflow_output);
+  iv_list_update_msg_size(self, &self->qbacklog);
+
   self->qoverflow_output_len += self->qbacklog_len;
   stats_counter_add(self->super.queued_messages, self->qbacklog_len);
   self->qbacklog_len = 0;
@@ -479,6 +498,7 @@ log_queue_fifo_rewind_backlog(LogQueue *s, guint rewind_count)
       self->qbacklog_len--;
       self->qoverflow_output_len++;
       stats_counter_inc(self->super.queued_messages);
+      stats_counter_add(self->super.memory_usage, log_msg_get_size(node->msg));
     }
 }
 

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -169,10 +169,12 @@ log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc para
 }
 
 void
-log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages)
+log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages,
+                       StatsCounterItem *memory_usage)
 {
   self->queued_messages = queued_messages;
   self->dropped_messages = dropped_messages;
+  self->memory_usage = memory_usage;
   stats_counter_set(self->queued_messages, log_queue_get_length(self));
 }
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -49,6 +49,7 @@ struct _LogQueue
   gchar *persist_name;
   StatsCounterItem *queued_messages;
   StatsCounterItem *dropped_messages;
+  StatsCounterItem *memory_usage;
 
   GStaticMutex lock;
   LogQueuePushNotifyFunc parallel_push_notify;
@@ -195,7 +196,7 @@ void log_queue_push_notify(LogQueue *self);
 void log_queue_reset_parallel_push(LogQueue *self);
 void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data, GDestroyNotify user_data_destroy);
 gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data, GDestroyNotify user_data_destroy);
-void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages);
+void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages, StatsCounterItem *memory_usage);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
 void log_queue_free_method(LogQueue *self);
 

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -337,12 +337,12 @@ log_threaded_dest_driver_start(LogPipe *s)
   cluster = stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_MEMORY_USAGE, &self->memory_usage);
   stats_register_written_view(cluster, self->processed_messages, self->dropped_messages, self->queued_messages);
-
   stats_unlock();
 
   log_queue_set_counters(self->queue, self->queued_messages,
-                         self->dropped_messages);
+                         self->dropped_messages, self->memory_usage);
 
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
                                                            log_threaded_dest_driver_format_seqnum_for_persist(self)));
@@ -361,7 +361,7 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
 
   log_queue_reset_parallel_push(self->queue);
 
-  log_queue_set_counters(self->queue, NULL, NULL);
+  log_queue_set_counters(self->queue, NULL, NULL, NULL);
 
   cfg_persist_config_add(log_pipe_get_config(s),
                          log_threaded_dest_driver_format_seqnum_for_persist(self),
@@ -375,6 +375,7 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
   stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_MEMORY_USAGE, &self->memory_usage);
   stats_unlock();
 
   if (!log_dest_driver_deinit_method(s))

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -50,6 +50,7 @@ struct _LogThrDestDriver
   StatsCounterItem *dropped_messages;
   StatsCounterItem *queued_messages;
   StatsCounterItem *processed_messages;
+  StatsCounterItem *memory_usage;
 
   gboolean suspended;
   time_t time_reopen;

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -32,6 +32,7 @@ static const gchar *tag_names[SC_TYPE_MAX] =
   /* [SC_TYPE_QUEUED]   = */  "queued",
   /* [SC_TYPE_SUPPRESSED] = */ "suppressed",
   /* [SC_TYPE_STAMP] = */ "stamp",
+  /* [SC_TYPE_MEMORY_USAGE] = */ "memory_usage",
 };
 
 static void
@@ -57,4 +58,3 @@ stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gch
     tag_names, _counter_group_logpipe_init
   });
 }
-

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -34,6 +34,7 @@ typedef enum
   SC_TYPE_QUEUED,    /* number of messages on disk */
   SC_TYPE_SUPPRESSED,/* number of messages suppressed */
   SC_TYPE_STAMP,     /* timestamp */
+  SC_TYPE_MEMORY_USAGE,
   SC_TYPE_MAX
 } StatsCounterGroupLogPipe;
 

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -39,7 +39,7 @@ static GString *
 control_connection_reset_stats(GString *command, gpointer user_data)
 {
   GString *result = g_string_new("The statistics of syslog-ng have been reset to 0.");
-  stats_reset_non_stored_counters();
+  stats_reset_counters();
   return result;
 }
 

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -32,19 +32,23 @@ _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer 
 }
 
 static inline void
-_reset_non_stored_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
+_reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  if (type != SC_TYPE_QUEUED)
+  switch (type)
     {
+    case SC_TYPE_QUEUED:
+    case SC_TYPE_MEMORY_USAGE:
+      return;
+    default:
       _reset_counter(sc, type, counter, user_data);
     }
 }
 
 void
-stats_reset_non_stored_counters(void)
+stats_reset_counters(void)
 {
   stats_lock();
-  stats_foreach_counter(_reset_non_stored_counter, NULL);
+  stats_foreach_counter(_reset_counter_if_needed, NULL);
   stats_unlock();
 }
 

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -89,7 +89,7 @@ stats_counter_get_name(StatsCounterItem *counter)
   return NULL;
 }
 
-void stats_reset_non_stored_counters(void);
+void stats_reset_counters(void);
 void stats_counter_free(StatsCounterItem *counter);
 
 #endif

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1213,7 +1213,7 @@ afsql_dd_init(LogPipe *s)
       if (self->flags & AFSQL_DDF_EXPLICIT_COMMITS)
         log_queue_set_use_backlog(self->queue, TRUE);
     }
-  log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages);
+  log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages, self->memory_usage);
   if (!self->fields)
     {
       GList *col, *value;
@@ -1339,7 +1339,7 @@ afsql_dd_deinit(LogPipe *s)
 
   log_queue_reset_parallel_push(self->queue);
 
-  log_queue_set_counters(self->queue, NULL, NULL);
+  log_queue_set_counters(self->queue, NULL, NULL, NULL);
   cfg_persist_config_add(log_pipe_get_config(s), afsql_dd_format_persist_sequence_number(self),
                          GINT_TO_POINTER(self->seq_num), NULL, FALSE);
 

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -98,6 +98,7 @@ typedef struct _AFSqlDestDriver
 
   StatsCounterItem *dropped_messages;
   StatsCounterItem *queued_messages;
+  StatsCounterItem *memory_usage;
 
   GHashTable *dbd_options;
   GHashTable *dbd_options_numeric;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -135,7 +135,6 @@ static void
 _rewind_backlog(LogQueue *s, guint rewind_count)
 {
   LogQueueDisk *self = (LogQueueDisk *) s;
-
   g_static_mutex_lock(&self->super.lock);
 
   if (self->rewind_backlog)

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -190,12 +190,30 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
   gint i;
 
   q = log_queue_fifo_new(OVERFLOW_SIZE, NULL);
+
+  StatsClusterKey sc_key;
+  stats_lock();
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
+  stats_unlock();
+
   log_queue_set_use_backlog(q, TRUE);
+
+  cr_assert_eq(q->queued_messages->value, 0);
 
   fed_messages = 0;
   acked_messages = 0;
+  feed_some_messages(q, 1, &parse_options);
+  cr_assert_eq(stats_counter_get(q->queued_messages), 1);
+  cr_assert_neq(stats_counter_get(q->memory_usage), 0);
+  gint size_when_single_msg = stats_counter_get(q->memory_usage);
+
   for (i = 0; i < 10; i++)
     feed_some_messages(q, 10, &parse_options);
+
+  cr_assert_eq(stats_counter_get(q->queued_messages), 101);
+  cr_assert_eq(stats_counter_get(q->memory_usage), 101*size_when_single_msg);
 
   send_some_messages(q, fed_messages);
   app_ack_some_messages(q, fed_messages);


### PR DESCRIPTION
New counter that measures the memory used by messages in the different kind of queue types in bytes: logqueue-fifos, reliable disks and non-reliable disks.