### PR TITLE
Introduce calculated metrics

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -253,18 +253,11 @@ stats_counter_group_free(StatsCounterGroup *self)
     self->free_fn(self);
 }
 
-static void
-_free_stats_counters_in_cluster(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
-{
-  stats_counter_free(counter);
-}
-
 void
 stats_cluster_free(StatsCluster *self)
 {
   _stats_cluster_key_cloned_free(&self->key);
   g_free(self->query_key);
   stats_counter_group_free(&self->counter_group);
-  stats_cluster_foreach_counter(self, _free_stats_counters_in_cluster, NULL);
   g_free(self);
 }

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -239,6 +239,7 @@ _get_views(const gchar *filter)
 
   single_match = _is_single_match(filter);
 
+  g_static_mutex_lock(&stats_query_mutex);
   g_hash_table_iter_init(&iter, stats_views);
   while (g_hash_table_iter_next(&iter, &key, &value))
     {
@@ -251,6 +252,8 @@ _get_views(const gchar *filter)
             break;
         }
     }
+  g_static_mutex_unlock(&stats_query_mutex);
+
   g_pattern_spec_free(pattern);
   return views;
 }

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -224,6 +224,7 @@ _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gb
     found_match = TRUE;
 
   g_free(key_str);
+  g_list_free(counters);
 
   return found_match;
 }
@@ -285,6 +286,7 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
     found_match = TRUE;
 
   g_free(key_str);
+  g_list_free(counters);
 
   return found_match;
 }
@@ -319,6 +321,7 @@ _stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, g
     found_match = TRUE;
 
   g_free(key_str);
+  g_list_free(counters);
 
   return found_match;
 }

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -49,7 +49,7 @@ _free_view_record(gpointer r)
 }
 
 void
-stats_views_add_new(gchar *name, GList *queries, const AggregatedMetricsCb aggregate)
+stats_register_view(gchar *name, GList *queries, const AggregatedMetricsCb aggregate)
 {
   ViewRecord *record = g_new0(ViewRecord, 1);
   record->counter = g_new0(StatsCounterItem, 1);
@@ -153,7 +153,7 @@ _is_pattern_matches_key(GPatternSpec *pattern, gpointer key)
 }
 
 static gboolean
-_is_single_match(gchar *key_str)
+_is_single_match(const gchar *key_str)
 {
   gboolean is_wildcard = strchr(key_str, '*') ? TRUE : FALSE;
   gboolean is_joker = strchr(key_str, '?') ? TRUE : FALSE;
@@ -162,7 +162,7 @@ _is_single_match(gchar *key_str)
 }
 
 static GList *
-_query_counter_hash(gchar *key_str)
+_query_counter_hash(const gchar *key_str)
 {
   GPatternSpec *pattern = g_pattern_spec_new(key_str);
   GList *counters = NULL;
@@ -193,15 +193,14 @@ _query_counter_hash(gchar *key_str)
 }
 
 static GList *
-_get_input_counters_of_view(ViewRecord *view)
+_get_input_counters_of_view(const ViewRecord *view)
 {
   GList *counters_of_view = NULL;
   for (GList *q = view->queries; q; q = q->next)
     {
-      GList *selected_counters = NULL;
       gchar *query = q->data;
+      GList *selected_counters = _query_counter_hash(query);
 
-      selected_counters = _query_counter_hash(query);
       if (selected_counters == NULL)
         continue;
 
@@ -230,7 +229,7 @@ _get_aggregated_counters_from_views(GList *views)
 }
 
 static GList *
-_get_views(gchar *filter)
+_get_views(const gchar *filter)
 {
   GPatternSpec *pattern = g_pattern_spec_new(filter);
   GList *views = NULL;
@@ -257,7 +256,7 @@ _get_views(gchar *filter)
 }
 
 static GList *
-_get_aggregated_counters(gchar *filter)
+_get_aggregated_counters(const gchar *filter)
 {
   GList *views = _get_views(filter);
   GList *counters = _get_aggregated_counters_from_views(views);
@@ -267,7 +266,7 @@ _get_aggregated_counters(gchar *filter)
 }
 
 static GList *
-_get_counters(gchar *key_str)
+_get_counters(const gchar *key_str)
 {
   GList *simple_counters = _query_counter_hash(key_str);
   GList *aggregated_counters = _get_aggregated_counters(key_str);

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -40,5 +40,5 @@ gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb
 void stats_query_init(void);
 void stats_query_deinit(void);
 
-void stats_views_add_new(gchar *name, GList *queries, const AggregatedMetricsCb aggregate);
+void stats_register_view(gchar *name, GList *queries, const AggregatedMetricsCb aggregate);
 #endif

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -40,4 +40,5 @@ gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb
 void stats_query_init(void);
 void stats_query_deinit(void);
 
+void stats_views_add_new(gchar *name, GList *queries, const AggregatedMetricsCb aggregate);
 #endif

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -28,6 +28,7 @@
 #include "syslog-ng.h"
 
 typedef gboolean (*StatsFormatCb)(StatsCounterItem *ctr, gpointer user_data);
+typedef void (*AggregatedMetricsCb)(GList *counters, StatsCounterItem **result);
 
 gboolean stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
@@ -36,7 +37,7 @@ gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb for
 gboolean stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 
-void stats_query_index_init(void);
-void stats_query_index_deinit(void);
+void stats_query_init(void);
+void stats_query_deinit(void);
 
 #endif

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -239,7 +239,7 @@ void
 stats_init(void)
 {
   stats_registry_init();
-  stats_query_index_init();
+  stats_query_init();
   stats_register_control_commands();
 }
 
@@ -247,7 +247,7 @@ void
 stats_destroy(void)
 {
   stats_registry_deinit();
-  stats_query_index_deinit();
+  stats_query_deinit();
 }
 
 void

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -246,8 +246,8 @@ stats_init(void)
 void
 stats_destroy(void)
 {
-  stats_registry_deinit();
   stats_query_deinit();
+  stats_registry_deinit();
 }
 
 void

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -105,7 +105,7 @@ _initialize_counter_hash(void)
 
       gchar *name = _construct_view_name(counters[i].id);
       GList *queries = _construct_view_query_list(counters[i].instance);
-      stats_views_add_new(name, queries, _add_two_to_value);
+      stats_register_view(name, queries, _add_two_to_value);
     }
 
   stats_unlock();


### PR DESCRIPTION
Aggregated `StatsCounterItem` is introduced using views on `stats_cluster_container`. These counters can be used to query calculated values from syslog-ng and to alias existing counters.

A view consist of a list of queries, which is used to collect input counters. After input counters are collected, an aggregator function is called on these and a single `StatsCounterItem` is returned.

It is possible to create a new view using:
```
void
_aggregator_function(GList *input_counters, StatsCounterItem **result)
{
   gint sum = 0;
   for (GList *counter = input_counters; counter; counter = counter->next)
    {
      StatsCounterItem *item = (StatsCounterItem *) counter;
      sum += stats_counter_get(item);
    } 
}

void
setup_my_view(void)
{
  GList *queries = NULL;
  queries = g_list_append(queries, "src.pipe.my_source");
  stats_view_new("src.pipe.my_source.sum_everything", queries, _aggregator_function);
}
```

So, it can be queried lated:
```
$ syslog-ng-ctl query get 'src.pipe.my_source.*'
src.pipe.my_source.processed: 10
src.pipe.my_source.dropped: 5
src.pipe.my_source.stored: 5
src.pipe.my_source.sum_everything: 20
```
Please not that the name of the views must be unique.