### PR TITLE
csvparser: scratch-buffers2-ification

### DIFF
--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -24,6 +24,7 @@
 #include "csv-scanner.h"
 #include "str-utils.h"
 #include "string-list.h"
+#include "scratch-buffers2.h"
 
 #include <string.h>
 
@@ -396,7 +397,7 @@ csv_scanner_init(CSVScanner *scanner, CSVScannerOptions *options, const gchar *i
 {
   memset(scanner, 0, sizeof(*scanner));
   scanner->src = input;
-  scanner->current_value = g_string_sized_new(128);
+  scanner->current_value = scratch_buffers2_alloc();
   scanner->current_column = NULL;
   scanner->options = options;
 }
@@ -404,7 +405,6 @@ csv_scanner_init(CSVScanner *scanner, CSVScannerOptions *options, const gchar *i
 void
 csv_scanner_deinit(CSVScanner *self)
 {
-  g_string_free(self->current_value, TRUE);
 }
 
 const gchar *

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -21,12 +21,15 @@
  */
 
 #include "context-info-db.h"
+#include "scratch-buffers2.h"
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
 #include <stdio.h>
 #include <string.h>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+TestSuite(add_contextual_data, .init=scratch_buffers2_allocator_init, .fini=scratch_buffers2_allocator_deinit);
 
 static void
 _count_records(gpointer arg, const ContextualDataRecord *record)

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -24,6 +24,7 @@
 #include "csvparser.h"
 #include "scanner/csv-scanner/csv-scanner.h"
 #include "parser/parser-expr.h"
+#include "scratch-buffers2.h"
 
 #include <string.h>
 
@@ -31,7 +32,6 @@ typedef struct _CSVParser
 {
   LogParser super;
   CSVScannerOptions options;
-  GString *formatted_key;
   gchar *prefix;
   gint prefix_len;
 } CSVParser;
@@ -97,16 +97,25 @@ csv_parser_set_prefix(LogParser *s, const gchar *prefix)
 }
 
 static const gchar *
-_get_formatted_key(CSVParser *self, const gchar *key)
+_format_key_for_prefix(GString *scratch, const gchar *key, const gint prefix_len)
 {
-  if (!self->prefix)
-    return key;
-  else if (self->formatted_key->len > 0)
-    g_string_truncate(self->formatted_key, self->prefix_len);
-  else
-    g_string_assign(self->formatted_key, self->prefix);
-  g_string_append(self->formatted_key, key);
-  return self->formatted_key->str;
+  g_string_truncate(scratch, prefix_len);
+  g_string_append(scratch, key);
+  return scratch->str;
+}
+
+static const gchar *
+_return_key(GString *scratch, const gchar *key, const gint prefix_len)
+{
+  return key;
+}
+
+typedef const gchar *(*key_formatter_t)(GString *scratch, const gchar *key, const gint prefix_len);
+
+static key_formatter_t
+dispatch_key_formatter(gchar *prefix)
+{
+  return prefix ? _format_key_for_prefix : _return_key;
 }
 
 static gboolean
@@ -118,11 +127,17 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
 
   CSVScanner scanner;
   csv_scanner_init(&scanner, &self->options, input);
+
+  GString *key_scratch = scratch_buffers2_alloc();
+  if (self->prefix)
+    g_string_assign(key_scratch, self->prefix);
+
+  key_formatter_t _key_formatter = dispatch_key_formatter(self->prefix);
   while (csv_scanner_scan_next(&scanner))
     {
 
       log_msg_set_value_by_name(msg,
-                                _get_formatted_key(self, csv_scanner_get_current_name(&scanner)),
+                                _key_formatter(key_scratch, csv_scanner_get_current_name(&scanner), self->prefix_len),
                                 csv_scanner_get_current_value(&scanner),
                                 csv_scanner_get_current_value_len(&scanner));
     }
@@ -150,7 +165,6 @@ csv_parser_free(LogPipe *s)
   CSVParser *self = (CSVParser *) s;
 
   csv_scanner_options_clean(&self->options);
-  g_string_free(self->formatted_key, TRUE);
   g_free(self->prefix);
   log_parser_free_method(s);
 }
@@ -167,7 +181,6 @@ csv_parser_new(GlobalConfig *cfg)
   self->super.super.free_fn = csv_parser_free;
   self->super.super.clone = csv_parser_clone;
   self->super.process = csv_parser_process;
-  self->formatted_key = g_string_sized_new(32);
   csv_scanner_options_set_delimiters(&self->options, " ");
   csv_scanner_options_set_quote_pairs(&self->options, "\"\"''");
   csv_scanner_options_set_flags(&self->options, CSV_SCANNER_STRIP_WHITESPACE);

--- a/modules/csvparser/tests/test_csvparser_perf.c
+++ b/modules/csvparser/tests/test_csvparser_perf.c
@@ -24,6 +24,7 @@
 #include "csvparser.h"
 #include "logmsg/logmsg.h"
 #include "string-list.h"
+#include "scratch-buffers2.h"
 
 LogParser *
 _construct_parser(gint max_columns, gint dialect, gchar *delimiters, gchar *quotes, gchar *null_value,
@@ -145,6 +146,7 @@ int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
   stats_init();
+  scratch_buffers2_allocator_init();
   log_msg_global_init();
   test_escaped_parsers();
   log_msg_global_deinit();


### PR DESCRIPTION
Improving csvparser performance by using scratch-buffer2.
For: https://github.com/balabit/syslog-ng/issues/1426
