### PR TITLE
readd reverted refactoring patch of LogThreadedDestination's retry logging

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -440,6 +440,10 @@ log_threaded_dest_driver_message_drop(LogThrDestDriver *self,
                                       LogMessage *msg)
 {
   stats_counter_inc(self->dropped_messages);
+  msg_error("Multiple failures while sending message to destination, message dropped",
+            evt_tag_str("driver", self->super.super.id),
+            evt_tag_int("number_of_retries", self->retries.max));
+
   log_threaded_dest_driver_message_accept(self, msg);
 }
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -365,13 +365,10 @@ _worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
-  msg_error(
-    "Multiple failures while inserting this record into the database, "
-    "message dropped",
-    evt_tag_str("driver", self->super.super.super.id),
-    evt_tag_int("number_of_retries", s->retries.max),
-    evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
-                        LTZ_SEND, &self->template_options));
+  msg_error("Dropped message",
+            evt_tag_str("driver", self->super.super.super.id),
+            evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
+                                LTZ_SEND, &self->template_options));
 }
 
 static worker_insert_result_t

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -482,16 +482,6 @@ __send_message(AFSMTPDriver *self, smtp_session_t session)
   return success;
 }
 
-static void
-__worker_message_retry_over(LogThrDestDriver *self, LogMessage *msg)
-{
-  msg_error("Multiple failures while sending message in email to the server, "
-            "message dropped",
-            evt_tag_str("driver", self->super.super.id),
-            evt_tag_int("attempts", self->retries.counter),
-            evt_tag_int("max-attempts", self->retries.max));
-}
-
 static worker_insert_result_t
 afsmtp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 {
@@ -684,8 +674,6 @@ afsmtp_dd_new(GlobalConfig *cfg)
 
   self->super.format.stats_instance = afsmtp_dd_format_stats_instance;
   self->super.stats_source = SCS_SMTP;
-
-  self->super.messages.retry_over = __worker_message_retry_over;
 
   afsmtp_dd_set_host((LogDriver *)self, "127.0.0.1");
   afsmtp_dd_set_port((LogDriver *)self, 25);

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -242,13 +242,6 @@ java_dd_free(LogPipe *s)
   g_string_free(self->class_path, TRUE);
 }
 
-static void
-__retry_over_message(LogThrDestDriver *s, LogMessage *msg)
-{
-  msg_error("Multiple failures while inserting this record to the java destination, message dropped",
-            evt_tag_int("number_of_retries", s->retries.max));
-}
-
 LogTemplateOptions *
 java_dd_get_template_options(LogDriver *s)
 {
@@ -275,7 +268,6 @@ java_dd_new(GlobalConfig *cfg)
   self->super.worker.worker_message_queue_empty = java_worker_message_queue_empty;
 
   self->super.format.stats_instance = java_dd_format_stats_instance;
-  self->super.messages.retry_over = __retry_over_message;
   self->super.stats_source = SCS_JAVA;
 
   self->template = log_template_new(cfg, "java_dd_template");


### PR DESCRIPTION
This patch was reverted on master, as it caused @kira-syslogng tests to break. This branch contains the offending patch and should go through the testing/review process again.

The breaking patch is: 484e27665f68013a31eab3e762dcf20ef49e97e8
The revert is: 5a7ecae21cc54bb7506968c5eadbbcb681b8bdc2

Once this is green, it can go in again.
