### PR TITLE
Rename stored to queued

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -195,7 +195,7 @@ log_queue_fifo_move_input_unlocked(LogQueueFifo *self, gint thread_id)
                 evt_tag_int("count", n),
                 evt_tag_str("persist_name", self->super.persist_name));
     }
-  stats_counter_add(self->super.stored_messages, self->qoverflow_input[thread_id].len);
+  stats_counter_add(self->super.queued_messages, self->qoverflow_input[thread_id].len);
   iv_list_splice_tail_init(&self->qoverflow_input[thread_id].items, &self->qoverflow_wait);
   self->qoverflow_wait_len += self->qoverflow_input[thread_id].len;
   self->qoverflow_input[thread_id].len = 0;
@@ -297,7 +297,7 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
       self->qoverflow_wait_len++;
       log_queue_push_notify(&self->super);
 
-      stats_counter_inc(self->super.stored_messages);
+      stats_counter_inc(self->super.queued_messages);
       g_static_mutex_unlock(&self->super.lock);
 
       log_msg_unref(msg);
@@ -342,7 +342,7 @@ log_queue_fifo_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
   self->qoverflow_output_len++;
   log_msg_unref(msg);
 
-  stats_counter_inc(self->super.stored_messages);
+  stats_counter_inc(self->super.queued_messages);
 }
 
 /*
@@ -396,7 +396,7 @@ log_queue_fifo_pop_head(LogQueue *s, LogPathOptions *path_options)
        */
       return NULL;
     }
-  stats_counter_dec(self->super.stored_messages);
+  stats_counter_dec(self->super.queued_messages);
 
   if (self->super.use_backlog)
     {
@@ -452,7 +452,7 @@ log_queue_fifo_rewind_backlog_all(LogQueue *s)
 
   iv_list_splice_tail_init(&self->qbacklog, &self->qoverflow_output);
   self->qoverflow_output_len += self->qbacklog_len;
-  stats_counter_add(self->super.stored_messages, self->qbacklog_len);
+  stats_counter_add(self->super.queued_messages, self->qbacklog_len);
   self->qbacklog_len = 0;
 }
 
@@ -478,7 +478,7 @@ log_queue_fifo_rewind_backlog(LogQueue *s, guint rewind_count)
 
       self->qbacklog_len--;
       self->qoverflow_output_len++;
-      stats_counter_inc(self->super.stored_messages);
+      stats_counter_inc(self->super.queued_messages);
     }
 }
 

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -169,11 +169,11 @@ log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc para
 }
 
 void
-log_queue_set_counters(LogQueue *self, StatsCounterItem *stored_messages, StatsCounterItem *dropped_messages)
+log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages)
 {
-  self->stored_messages = stored_messages;
+  self->queued_messages = queued_messages;
   self->dropped_messages = dropped_messages;
-  stats_counter_set(self->stored_messages, log_queue_get_length(self));
+  stats_counter_set(self->queued_messages, log_queue_get_length(self));
 }
 
 void

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -47,7 +47,7 @@ struct _LogQueue
   GTimeVal last_throttle_check;
 
   gchar *persist_name;
-  StatsCounterItem *stored_messages;
+  StatsCounterItem *queued_messages;
   StatsCounterItem *dropped_messages;
 
   GStaticMutex lock;
@@ -195,7 +195,7 @@ void log_queue_push_notify(LogQueue *self);
 void log_queue_reset_parallel_push(LogQueue *self);
 void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data, GDestroyNotify user_data_destroy);
 gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data, GDestroyNotify user_data_destroy);
-void log_queue_set_counters(LogQueue *self, StatsCounterItem *stored_messages, StatsCounterItem *dropped_messages);
+void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
 void log_queue_free_method(LogQueue *self);
 

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -332,12 +332,12 @@ log_threaded_dest_driver_start(LogPipe *s)
   stats_cluster_logpipe_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
                                 self->super.super.id,
                                 self->format.stats_instance(self));
-  stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
   stats_unlock();
 
-  log_queue_set_counters(self->queue, self->stored_messages,
+  log_queue_set_counters(self->queue, self->queued_messages,
                          self->dropped_messages);
 
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
@@ -368,7 +368,7 @@ log_threaded_dest_driver_deinit_method(LogPipe *s)
   stats_cluster_logpipe_key_set(&sc_key, self->stats_source | SCS_DESTINATION,
                                 self->super.super.id,
                                 self->format.stats_instance(self));
-  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
   stats_unlock();

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -48,7 +48,7 @@ struct _LogThrDestDriver
   LogDestDriver super;
 
   StatsCounterItem *dropped_messages;
-  StatsCounterItem *stored_messages;
+  StatsCounterItem *queued_messages;
   StatsCounterItem *processed_messages;
 
   gboolean suspended;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -65,7 +65,7 @@ struct _LogWriter
   StatsCounterItem *dropped_messages;
   StatsCounterItem *suppressed_messages;
   StatsCounterItem *processed_messages;
-  StatsCounterItem *stored_messages;
+  StatsCounterItem *queued_messages;
   LogPipe *control;
   LogWriterOptions *options;
   LogMessage *last_msg;
@@ -1279,10 +1279,10 @@ log_writer_init(LogPipe *s)
         stats_register_counter(self->stats_level, &sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
       stats_register_counter(self->stats_level, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
 
-      stats_register_counter(self->stats_level, &sc_key, SC_TYPE_STORED, &self->stored_messages);
+      stats_register_counter(self->stats_level, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
       stats_unlock();
     }
-  log_queue_set_counters(self->queue, self->stored_messages, self->dropped_messages);
+  log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages);
   if (self->proto)
     {
       LogProtoClient *proto;
@@ -1331,7 +1331,7 @@ log_writer_deinit(LogPipe *s)
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
-  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_unlock();
 
   return TRUE;

--- a/lib/scratch-buffers2.c
+++ b/lib/scratch-buffers2.c
@@ -298,9 +298,9 @@ scratch_buffers2_global_init(void)
 
   stats_lock();
   stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_count", NULL);
-  stats_register_counter(0, &sc_key, SC_TYPE_STORED, &stats_scratch_buffers_count);
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_count);
   stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_bytes", NULL);
-  stats_register_counter(0, &sc_key, SC_TYPE_STORED, &stats_scratch_buffers_bytes);
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_bytes);
   stats_unlock();
 }
 
@@ -311,8 +311,8 @@ scratch_buffers2_global_deinit(void)
 
   stats_lock();
   stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_count", NULL);
-  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &stats_scratch_buffers_count);
+  stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_count);
   stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_bytes", NULL);
-  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &stats_scratch_buffers_bytes);
+  stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_bytes);
   stats_unlock();
 }

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -29,7 +29,7 @@ static const gchar *tag_names[SC_TYPE_MAX] =
 {
   /* [SC_TYPE_DROPPED]   = */ "dropped",
   /* [SC_TYPE_PROCESSED] = */ "processed",
-  /* [SC_TYPE_STORED]   = */  "stored",
+  /* [SC_TYPE_QUEUED]   = */  "queued",
   /* [SC_TYPE_SUPPRESSED] = */ "suppressed",
   /* [SC_TYPE_STAMP] = */ "stamp",
 };

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -31,7 +31,7 @@ typedef enum
 {
   SC_TYPE_DROPPED=0, /* number of messages dropped */
   SC_TYPE_PROCESSED, /* number of messages processed */
-  SC_TYPE_STORED,    /* number of messages on disk */
+  SC_TYPE_QUEUED,    /* number of messages on disk */
   SC_TYPE_SUPPRESSED,/* number of messages suppressed */
   SC_TYPE_STAMP,     /* timestamp */
   SC_TYPE_MAX

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -34,7 +34,7 @@ _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer 
 static inline void
 _reset_non_stored_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  if (type != SC_TYPE_STORED)
+  if (type != SC_TYPE_QUEUED)
     {
       _reset_counter(sc, type, counter, user_data);
     }

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -108,7 +108,7 @@ _initialize_counter_hash(void)
     {SCS_GLOBAL, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
     {SCS_PIPE | SCS_SOURCE, "guba.gumi.disz", "frozen", SC_TYPE_SUPPRESSED},
     {SCS_TCP | SCS_DESTINATION, "guba.labda", "received", SC_TYPE_DROPPED},
-    {SCS_TCP | SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_STORED},
+    {SCS_TCP | SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_QUEUED},
   };
 
   const CounterHashContent single_cluster_counters[] =

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1193,7 +1193,7 @@ afsql_dd_init(LogPipe *s)
     StatsClusterKey sc_key;
     stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
                                   afsql_dd_format_stats_instance(self) );
-    stats_register_counter(0, &sc_key, SC_TYPE_STORED, &self->stored_messages);
+    stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
     stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   }
   stats_unlock();
@@ -1213,7 +1213,7 @@ afsql_dd_init(LogPipe *s)
       if (self->flags & AFSQL_DDF_EXPLICIT_COMMITS)
         log_queue_set_use_backlog(self->queue, TRUE);
     }
-  log_queue_set_counters(self->queue, self->stored_messages, self->dropped_messages);
+  log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages);
   if (!self->fields)
     {
       GList *col, *value;
@@ -1324,7 +1324,7 @@ error:
     StatsClusterKey sc_key;
     stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
                                   afsql_dd_format_stats_instance(self) );
-    stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+    stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   }
   stats_unlock();
@@ -1347,7 +1347,7 @@ afsql_dd_deinit(LogPipe *s)
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
                                 afsql_dd_format_stats_instance(self) );
-  stats_unregister_counter(&sc_key, SC_TYPE_STORED, &self->stored_messages);
+  stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_unlock();
 

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -97,7 +97,7 @@ typedef struct _AFSqlDestDriver
   LogTemplateOptions template_options;
 
   StatsCounterItem *dropped_messages;
-  StatsCounterItem *stored_messages;
+  StatsCounterItem *queued_messages;
 
   GHashTable *dbd_options;
   GHashTable *dbd_options_numeric;

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -195,7 +195,7 @@ _rewind_backlog (LogQueueDisk *s, guint rewind_count)
       g_queue_push_head (self->qout, ptr_opt);
       g_queue_push_head (self->qout, ptr_msg);
 
-      stats_counter_inc (self->super.super.stored_messages);
+      stats_counter_inc (self->super.super.queued_messages);
     }
 }
 
@@ -248,7 +248,7 @@ _push_head (LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options
   g_static_mutex_lock(&self->super.super.lock);
   g_queue_push_head (self->qout, LOG_PATH_OPTIONS_TO_POINTER (path_options));
   g_queue_push_head (self->qout, msg);
-  stats_counter_inc (self->super.super.stored_messages);
+  stats_counter_inc (self->super.super.queued_messages);
   g_static_mutex_unlock(&self->super.super.lock);
 }
 

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -189,7 +189,7 @@ _rewind_backlog(LogQueueDisk *s, guint rewind_count)
   qdisk_set_reader_head (self->super.qdisk, new_read_head);
   qdisk_set_length (self->super.qdisk, qdisk_get_length (self->super.qdisk) + rewind_count);
 
-  stats_counter_add (self->super.super.stored_messages, rewind_count);
+  stats_counter_add (self->super.super.queued_messages, rewind_count);
 }
 
 static LogMessage *

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -66,7 +66,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
       if (self->push_tail(self, msg, &local_options, path_options))
         {
           log_queue_push_notify (&self->super);
-          stats_counter_inc(self->super.stored_messages);
+          stats_counter_inc(self->super.queued_messages);
           log_msg_ack(msg, &local_options, AT_PROCESSED);
           log_msg_unref(msg);
           g_static_mutex_unlock(&self->super.lock);
@@ -110,7 +110,7 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
     }
   if (msg != NULL)
     {
-      stats_counter_dec(self->super.stored_messages);
+      stats_counter_dec(self->super.queued_messages);
     }
   g_static_mutex_unlock(&self->super.lock);
   return msg;


### PR DESCRIPTION
From now on `stored` counter is going to be called `queued`. Log messages which are `queued` are  sent out to destinations.

Please make sure that you follow up the changes in your scripts, because it might broke if you depend on the name `stored`. The Kira check is expected to be red, as it checks for the counter names.

Signed-off-by: Noémi Ványi <sitbackandwait@gmail.com>