### PR TITLE
Introduce written counter for destinations

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -22,6 +22,7 @@
  *
  */
 
+#include "stats/stats-views.h"
 #include "logthrdestdrv.h"
 #include "seqnum.h"
 
@@ -329,12 +330,15 @@ log_threaded_dest_driver_start(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
+  StatsCluster *cluster;
   stats_cluster_logpipe_key_set(&sc_key,self->stats_source | SCS_DESTINATION,
                                 self->super.super.id,
                                 self->format.stats_instance(self));
-  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
+  cluster = stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
+  stats_register_written_view(cluster, self->processed_messages, self->dropped_messages, self->queued_messages);
+
   stats_unlock();
 
   log_queue_set_counters(self->queue, self->queued_messages,

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1281,7 +1281,9 @@ log_writer_init(LogPipe *s)
       cluster = stats_register_counter(self->stats_level, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
       stats_register_counter(self->stats_level, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
       stats_register_counter(self->stats_level, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
-      stats_register_written_view(cluster, self->processed_messages, self->dropped_messages, self->queued_messages);
+
+      if (cluster != NULL)
+        stats_register_written_view(cluster, self->processed_messages, self->dropped_messages, self->queued_messages);
 
       stats_unlock();
     }

--- a/lib/stats/CMakeLists.txt
+++ b/lib/stats/CMakeLists.txt
@@ -9,6 +9,7 @@ set(STATS_HEADERS
     stats/stats-syslog.h
     stats/stats-query.h
     stats/stats-query-commands.h
+    stats/stats-views.h
     stats/stats-cluster-logpipe.h
     stats/stats-cluster-single.h
     PARENT_SCOPE)
@@ -24,6 +25,7 @@ set(STATS_SOURCES
     stats/stats-syslog.c
     stats/stats-query.c
     stats/stats-query-commands.c
+    stats/stats-views.c
     stats/stats-cluster-logpipe.c
     stats/stats-cluster-single.c
     PARENT_SCOPE)

--- a/lib/stats/Makefile.am
+++ b/lib/stats/Makefile.am
@@ -11,6 +11,7 @@ statsinclude_HEADERS = \
 	lib/stats/stats-syslog.h		\
 	lib/stats/stats-query.h			\
 	lib/stats/stats-query-commands.h \
+	lib/stats/stats-views.h           \
 	lib/stats/stats-cluster-logpipe.h \
 	lib/stats/stats-cluster-single.h
 
@@ -25,6 +26,7 @@ stats_sources = \
 	lib/stats/stats-syslog.c		\
 	lib/stats/stats-query.c			\
 	lib/stats/stats-query-commands.c \
+	lib/stats/stats-views.c          \
 	lib/stats/stats-cluster-logpipe.c \
 	lib/stats/stats-cluster-single.c
 

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -30,6 +30,7 @@ typedef struct _StatsCounterItem
 {
   gssize value;
   gchar *name;
+  gint type;
 } StatsCounterItem;
 
 

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -40,11 +40,13 @@ typedef struct _ViewRecord
   AggregatedMetricsCb aggregate;
 } ViewRecord;
 
-void
+static void
 _free_view_record(gpointer r)
 {
   ViewRecord *record = (ViewRecord *) r;
   g_list_free_full(record->queries, g_free);
+  stats_counter_free(record->counter);
+  g_free(record->counter);
   g_free(record);
 }
 
@@ -443,7 +445,7 @@ void
 stats_query_init(void)
 {
   counter_index = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
-  stats_views = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _free_view_record);
+  stats_views = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, _free_view_record);
 }
 
 void

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -454,3 +454,9 @@ stats_query_deinit(void)
   g_hash_table_destroy(stats_views);
   stats_views = NULL;
 }
+
+void
+stats_query_index_counter(StatsCluster *cluster, gint type)
+{
+  _add_counter_to_index(cluster, type);
+}

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -41,4 +41,5 @@ void stats_query_init(void);
 void stats_query_deinit(void);
 
 void stats_register_view(gchar *name, GList *queries, const AggregatedMetricsCb aggregate);
+void stats_query_index_counter(StatsCluster *cluster, gint type);
 #endif

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -87,9 +87,14 @@ _register_counter(gint stats_level, const StatsClusterKey *sc_key, gint type,
 
   sc = _grab_cluster(stats_level, sc_key, dynamic);
   if (sc)
-    *counter = stats_cluster_track_counter(sc, type);
+    {
+      *counter = stats_cluster_track_counter(sc, type);
+      (*counter)->type = type;
+    }
   else
-    *counter = NULL;
+    {
+      *counter = NULL;
+    }
   return sc;
 }
 
@@ -109,11 +114,11 @@ _register_counter(gint stats_level, const StatsClusterKey *sc_key, gint type,
  * users of the same counter in this case, thus the counter will only be
  * freed when all of these uses are unregistered.
  **/
-void
+StatsCluster *
 stats_register_counter(gint stats_level, const StatsClusterKey *sc_key, gint type,
                        StatsCounterItem **counter)
 {
-  _register_counter(stats_level, sc_key, type, FALSE, counter);
+  return _register_counter(stats_level, sc_key, type, FALSE, counter);
 }
 
 StatsCluster *

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -33,7 +33,7 @@ typedef gboolean (*StatsForeachClusterRemoveFunc)(StatsCluster *sc, gpointer use
 void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
-void stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+StatsCluster *stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 void stats_register_and_increment_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);

--- a/lib/stats/stats-views.c
+++ b/lib/stats/stats-views.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Noemi Vanyi
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#include "stats-views.h"
+
+static void
+_calculate_written_messages(GList *counters, StatsCounterItem **result)
+{
+  StatsCounterItem *processed = NULL, *dropped = NULL, *queued = NULL;
+  gssize written = 0;
+
+  for (GList *c = counters; c; c = c->next)
+    {
+      StatsCounterItem *counter = c->data;
+      if (counter->type == SC_TYPE_PROCESSED)
+        processed = counter;
+      else if (counter->type == SC_TYPE_DROPPED)
+        dropped = counter;
+      else if (counter->type == SC_TYPE_QUEUED)
+        queued = counter;
+    }
+
+  written = stats_counter_get(processed);
+  written -= stats_counter_get(dropped);
+  written -= stats_counter_get(queued);
+  stats_counter_set(*result, written);
+}
+
+static gchar *
+_construct_view_name(StatsCluster *cluster)
+{
+  GString *name = g_string_new(cluster->query_key);
+  name = g_string_append(name, ".written");
+  return g_string_free(name, FALSE);
+}
+
+static void
+_index_required_written_counters(StatsCluster *cluster)
+{
+  stats_query_index_counter(cluster, SC_TYPE_QUEUED);
+  stats_query_index_counter(cluster, SC_TYPE_DROPPED);
+  stats_query_index_counter(cluster, SC_TYPE_PROCESSED);
+}
+
+void
+stats_register_written_view(StatsCluster *cluster, StatsCounterItem *processed, StatsCounterItem *dropped,
+                            StatsCounterItem *queued)
+{
+  GList *written_query = NULL;
+  gchar *written_view_name;
+
+  written_view_name = _construct_view_name(cluster);
+  _index_required_written_counters(cluster);
+
+  written_query = g_list_append(written_query, stats_counter_get_name(queued));
+  written_query = g_list_append(written_query, stats_counter_get_name(processed));
+  written_query = g_list_append(written_query, stats_counter_get_name(dropped));
+
+  stats_register_view(written_view_name, written_query, _calculate_written_messages);
+}

--- a/lib/stats/stats-views.c
+++ b/lib/stats/stats-views.c
@@ -44,7 +44,14 @@ _calculate_written_messages(GList *counters, StatsCounterItem **result)
 
   g_assert(processed != NULL || dropped != NULL || queued != NULL);
 
+
   written = stats_counter_get(processed);
+  if (written == 0)
+    {
+      stats_counter_set(*result, written);
+      return;
+    }
+
   written -= stats_counter_get(dropped);
   written -= stats_counter_get(queued);
   stats_counter_set(*result, written);

--- a/lib/stats/stats-views.c
+++ b/lib/stats/stats-views.c
@@ -42,6 +42,8 @@ _calculate_written_messages(GList *counters, StatsCounterItem **result)
         queued = counter;
     }
 
+  g_assert(processed != NULL || dropped != NULL || queued != NULL);
+
   written = stats_counter_get(processed);
   written -= stats_counter_get(dropped);
   written -= stats_counter_get(queued);

--- a/lib/stats/stats-views.h
+++ b/lib/stats/stats-views.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Noemi Vanyi
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef STATS_VIEWS_H_INCLUDED
+#define STATS_VIEWS_H_INCLUDED 1
+
+#include "stats/stats-query.h"
+
+void stats_register_written_view(StatsCluster *cluster, StatsCounterItem *processed, StatsCounterItem *dropped, StatsCounterItem *queued);
+
+#endif
+


### PR DESCRIPTION
Add written view for every destination to see how many messages have been sent out by destinations. The method to calculate it is the following:

```
written = processed - queued - dropped
```

A module `stats-views`, which contains views, so it can be reused in different places.