### PR TITLE
Python stat fix

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -117,7 +117,8 @@ _get_module_name(gint source)
     "riemann",
     "journald",
     "java",
-    "http"
+    "http",
+    "python"
   };
   return module_names[source & SCS_SOURCE_MASK];
 }

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -25,14 +25,14 @@
 #define STATS_CLUSTER_H_INCLUDED 1
 
 #include "stats/stats-counter.h"
-#include "stats/stats-cluster-logpipe.h" 
+#include "stats/stats-cluster-logpipe.h"
 
 enum
 {
   /* direction bits, used to distinguish between source/destination drivers */
   SCS_SOURCE         = 0x0100,
   SCS_DESTINATION    = 0x0200,
-  
+
   /* drivers, this should be registered dynamically */
   SCS_FILE           = 1,
   SCS_PIPE           = 2,
@@ -70,6 +70,7 @@ enum
   SCS_JOURNALD       = 34,
   SCS_JAVA           = 35,
   SCS_HTTP           = 36,
+  SCS_PYTHON         = 37,
   SCS_MAX,
   SCS_SOURCE_MASK    = 0xff
 };

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -33,10 +33,6 @@
 #include "str-utils.h"
 #include "messages.h"
 
-#ifndef SCS_PYTHON
-#define SCS_PYTHON 0
-#endif
-
 typedef struct
 {
   LogThrDestDriver super;

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -310,8 +310,12 @@ python_dd_insert(LogThrDestDriver *d, LogMessage *msg)
   gstate = PyGILState_Ensure();
   if (!_py_invoke_is_opened(self))
     {
-      result = WORKER_INSERT_RESULT_NOT_CONNECTED;
-      goto exit;
+      _py_invoke_open(self);
+      if (!_py_invoke_is_opened(self))
+        {
+          result = WORKER_INSERT_RESULT_NOT_CONNECTED;
+          goto exit;
+        }
     }
 
   if (!_py_construct_message(self, msg, &msg_object))


### PR DESCRIPTION
This patchset fixes two issues related to python destionation.
- counter statistics: emit dst.python instead of dst.none
https://github.com/balabit/syslog-ng/issues/1362
- during retry-send, code only checked if is_opened(), but did not try to open if not.
https://github.com/balabit/syslog-ng/issues/1422

Stats error counter feature depends on both.