### PR TITLE
stats: support custom tagnames for StatsCounterGroups

### DIFF
--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -41,17 +41,20 @@ _counter_group_logpipe_free(StatsCounterGroup *counter_group)
 }
 
 static void
-_counter_group_logpipe_init(StatsCounterGroup *counter_group)
+_counter_group_logpipe_init(StatsCounterGroupInit *self, StatsCounterGroup *counter_group)
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_MAX);
   counter_group->capacity = SC_TYPE_MAX;
-  counter_group->counter_names = tag_names;
+  counter_group->counter_names = self->counter_names;
   counter_group->free_fn = _counter_group_logpipe_free;
 }
 
 void
 stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance)
 {
-  stats_cluster_key_set(key, component, id, instance, _counter_group_logpipe_init);
+  stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
+  {
+    tag_names, _counter_group_logpipe_init
+  });
 }
 

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -37,17 +37,55 @@ _counter_group_free(StatsCounterGroup *counter_group)
 }
 
 static void
-_counter_group_init(StatsCounterGroup *counter_group)
+_counter_group_init(StatsCounterGroupInit *self, StatsCounterGroup *counter_group)
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_SINGLE_MAX);
   counter_group->capacity = SC_TYPE_SINGLE_MAX;
-  counter_group->counter_names = tag_names;
+  counter_group->counter_names = self->counter_names;
   counter_group->free_fn = _counter_group_free;
 }
 
 void
 stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance)
 {
-  stats_cluster_key_set(key, component, id, instance, _counter_group_init);
+  stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
+  {
+    tag_names,_counter_group_init
+  });
+}
+
+static void
+_counter_group_with_name_free(StatsCounterGroup *counter_group)
+{
+  g_free(counter_group->counter_names);
+  _counter_group_free(counter_group);
+}
+
+static void
+_counter_group_init_with_name(StatsCounterGroupInit *self, StatsCounterGroup *counter_group)
+{
+  counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_SINGLE_MAX);
+  counter_group->capacity = SC_TYPE_SINGLE_MAX;
+  counter_group->counter_names = self->counter_names;
+  counter_group->free_fn = _counter_group_with_name_free;
+}
+
+static gboolean
+_group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupInit *other)
+{
+  g_assert(self != NULL && other != NULL && self->counter_names != NULL && other->counter_names != NULL);
+  return (self->init == other->init) && (g_strcmp0(self->counter_names[0], other->counter_names[0]) == 0);
+}
+
+void
+stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance,
+                                       const gchar *name)
+{
+  stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
+  {
+    tag_names, _counter_group_init_with_name, _group_init_equals
+  });
+  key->counter_group_init.counter_names = g_new0(const char *, 1);
+  key->counter_group_init.counter_names[0] = name;
 }
 

--- a/lib/stats/stats-cluster-single.h
+++ b/lib/stats/stats-cluster-single.h
@@ -34,6 +34,7 @@ typedef enum
 } StatsCounterGroupSingle;
 
 void stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance);
+void stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance, const gchar *name);
 
 #endif
 

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -75,6 +75,7 @@ enum
 };
 
 typedef struct _StatsCounterGroup StatsCounterGroup;
+typedef struct _StatsCounterGroupInit StatsCounterGroupInit;
 
 struct _StatsCounterGroup
 {
@@ -84,7 +85,15 @@ struct _StatsCounterGroup
   void (*free_fn)(StatsCounterGroup *self);
 };
 
-typedef void (*StatsCounterGroupInit)(StatsCounterGroup *counter_group);
+struct _StatsCounterGroupInit
+{
+  const gchar **counter_names;
+  void (*init)(StatsCounterGroupInit *self, StatsCounterGroup *counter_group);
+  gboolean (*equals)(const StatsCounterGroupInit *self, const StatsCounterGroupInit *other);
+};
+
+gboolean stats_counter_group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupInit *other);
+
 void stats_counter_group_free(StatsCounterGroup *self);
 
 struct _StatsClusterKey

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -107,6 +107,26 @@ test_stats_cluster_equal_if_component_id_and_instance_are_the_same(void)
                                            stats_cluster_new(&sc_key2));
 }
 
+static void
+test_stats_cluster_key_not_equal_when_custom_tags_are_different(void)
+{
+  StatsClusterKey sc_key1;
+  StatsClusterKey sc_key2;
+  stats_cluster_single_key_set_with_name(&sc_key1, SCS_SOURCE | SCS_FILE, "id", "instance", "name1");
+  stats_cluster_single_key_set_with_name(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance", "name2");
+  assert_gboolean(stats_cluster_key_equal(&sc_key1, &sc_key2), FALSE, __FUNCTION__);
+}
+
+static void
+test_stats_cluster_key_equal_when_custom_tags_are_the_same(void)
+{
+  StatsClusterKey sc_key1;
+  StatsClusterKey sc_key2;
+  stats_cluster_single_key_set_with_name(&sc_key1, SCS_SOURCE | SCS_FILE, "id", "instance", "name");
+  stats_cluster_single_key_set_with_name(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance", "name");
+  assert_gboolean(stats_cluster_key_equal(&sc_key1, &sc_key2), TRUE, __FUNCTION__);
+}
+
 typedef struct _ValidateCountersState
 {
   gint type1;
@@ -220,6 +240,8 @@ test_stats_cluster(void)
   STATS_CLUSTER_TESTCASE(test_stats_foreach_counter_never_forgets_untracked_counters);
   STATS_CLUSTER_TESTCASE(test_get_component_name_translates_component_to_name_properly);
   STATS_CLUSTER_TESTCASE(test_stats_cluster_single);
+  STATS_CLUSTER_TESTCASE(test_stats_cluster_key_not_equal_when_custom_tags_are_different);
+  STATS_CLUSTER_TESTCASE(test_stats_cluster_key_equal_when_custom_tags_are_the_same);
 }
 
 int

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -99,6 +99,19 @@ _register_counters(const CounterHashContent *counters, size_t n, ClusterKeySet k
 }
 
 static void
+_register_single_counter_with_name()
+{
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    StatsCounterItem *ctr_item;
+    stats_cluster_single_key_set_with_name(&sc_key, SCS_GLOBAL, "id", "instance", "name");
+    stats_register_counter(0, &sc_key, SC_TYPE_SINGLE_VALUE, &ctr_item);
+  }
+  stats_unlock();
+}
+
+static void
 _initialize_counter_hash(void)
 {
   const CounterHashContent logpipe_cluster_counters[] =
@@ -119,6 +132,7 @@ _initialize_counter_hash(void)
   app_startup();
   _register_counters(logpipe_cluster_counters, ARRAY_SIZE(logpipe_cluster_counters), stats_cluster_logpipe_key_set);
   _register_counters(single_cluster_counters, ARRAY_SIZE(single_cluster_counters), stats_cluster_single_key_set);
+  _register_single_counter_with_name();
 }
 
 static gboolean
@@ -242,6 +256,7 @@ ParameterizedTestParameters(stats_query, test_stats_query_get_str_out)
     {"dst.*.*.*.*", "dst.tcp.guba.labda.received.dropped: 0\n"},
     {"src.java.*.*", ""},
     {"src.ja*.*.*", ""},
+    {"global.id.instance.name", "global.id.instance.name: 0\n"},
     {
       "*.aliased", ".aliased: 2\n"
       "guba.frizbi.aliased: 2\n"


### PR DESCRIPTION
This change is needed by implementing some new counters.
@kvch   : you will use this refact, so it is up to you whether you just use this refact as a first patch of your PR, or merge this as is.

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>