### PR TITLE
Add osquery scl to syslog-ng

### DIFF
--- a/scl/osquery/plugin.conf
+++ b/scl/osquery/plugin.conf
@@ -1,0 +1,29 @@
+#############################################################################
+# Copyright (c) 2017 Peter Czanik <peter at czanik.hu>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+block source osquery(file("/var/log/osquery/osqueryd.results.log") prefix(".osquery.")) {
+  channel {
+    source { file(`file` program-override("osquery") flags(no-parse)); };
+    parser { json-parser (prefix(`prefix`)); };
+  };
+};

--- a/scl/osquery/plugin.conf
+++ b/scl/osquery/plugin.conf
@@ -23,7 +23,7 @@
 
 block source osquery(file("/var/log/osquery/osqueryd.results.log") prefix(".osquery.")) {
   channel {
-    source { file(`file` program-override("osquery") flags(no-parse)); };
-    parser { json-parser (prefix(`prefix`)); };
+    source { file("`file`" program-override("osquery") flags(no-parse)); };
+    parser { json-parser (prefix("`prefix`")); };
   };
 };

--- a/scl/osquery/plugin.conf
+++ b/scl/osquery/plugin.conf
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2017 Peter Czanik <peter at czanik.hu>
+# Copyright (c) 2017 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published


### PR DESCRIPTION
It reads the osquery log file and parses with the JSON parser,
creating name-vaule pairs with an .osquery. prefix by default.

file() and prefix() can be overriden.

Example usage:

source s_osquery { osquery(prefix("micimaci.")); };
destination d_json { file("/var/log/test.json" template("$(format_json --scope rfc5424 --scope nv-pairs)\n\n")); };
log { source(s_osquery); destination(d_json); };

Signed-off-by: Peter Czanik <peter@czanik.hu>