### PR TITLE
snmptrapd parser

### DIFF
--- a/lib/scanner/kv-scanner/kv-scanner.c
+++ b/lib/scanner/kv-scanner/kv-scanner.c
@@ -308,25 +308,20 @@ _clone(KVScanner *self)
   return scanner;
 }
 
-void
-kv_scanner_free(KVScanner *self)
+void kv_scanner_free_method(KVScanner *self)
 {
-  if (!self)
-    return;
   g_string_free(self->key, TRUE);
   g_string_free(self->value, TRUE);
   g_string_free(self->decoded_value, TRUE);
   if (self->stray_words)
     g_string_free(self->stray_words, TRUE);
   g_free(self->pair_separator);
-  g_free(self);
 }
 
-KVScanner *
-kv_scanner_new(gchar value_separator, const gchar *pair_separator, gboolean extract_stray_words)
+void
+kv_scanner_init_instance(KVScanner *self, gchar value_separator, const gchar *pair_separator,
+                         gboolean extract_stray_words)
 {
-  KVScanner *self = g_new0(KVScanner, 1);
-
   self->key = g_string_sized_new(32);
   self->value = g_string_sized_new(64);
   self->decoded_value = g_string_sized_new(64);
@@ -335,7 +330,16 @@ kv_scanner_new(gchar value_separator, const gchar *pair_separator, gboolean extr
   self->value_separator = value_separator;
   self->pair_separator = g_strdup(pair_separator ? : ", ");
   self->pair_separator_len = self->pair_separator ? strlen(self->pair_separator) : 0;
+
   self->clone = _clone;
+  self->free_fn = kv_scanner_free_method;
+}
+
+KVScanner *
+kv_scanner_new(gchar value_separator, const gchar *pair_separator, gboolean extract_stray_words)
+{
+  KVScanner *self = g_new0(KVScanner, 1);
+  kv_scanner_init_instance(self, value_separator, pair_separator, extract_stray_words);
 
   return self;
 }

--- a/lib/scanner/kv-scanner/kv-scanner.c
+++ b/lib/scanner/kv-scanner/kv-scanner.c
@@ -49,7 +49,7 @@ _locate_start_of_key(KVScanner *self, const gchar *end_of_key, const gchar **sta
   const gchar *cur;
 
   cur = end_of_key;
-  while (cur > input && _is_valid_key_character(*(cur - 1)))
+  while (cur > input && self->is_valid_key_character(*(cur - 1)))
     cur--;
   *start_of_key = cur;
 }
@@ -146,7 +146,7 @@ _key_follows(KVScanner *self, const gchar *cur)
 {
   const gchar *key = cur;
 
-  while (_is_valid_key_character(*key))
+  while (self->is_valid_key_character(*key))
     key++;
 
   while (*key == ' ')
@@ -305,6 +305,7 @@ _clone(KVScanner *self)
                                       self->pair_separator,
                                       self->stray_words != NULL);
   kv_scanner_set_transform_value(scanner, self->transform_value);
+  kv_scanner_set_valid_key_character_func(scanner, self->is_valid_key_character);
   return scanner;
 }
 
@@ -330,6 +331,7 @@ kv_scanner_init_instance(KVScanner *self, gchar value_separator, const gchar *pa
   self->value_separator = value_separator;
   self->pair_separator = g_strdup(pair_separator ? : ", ");
   self->pair_separator_len = self->pair_separator ? strlen(self->pair_separator) : 0;
+  self->is_valid_key_character = _is_valid_key_character;
 
   self->clone = _clone;
   self->free_fn = kv_scanner_free_method;

--- a/lib/scanner/kv-scanner/kv-scanner.c
+++ b/lib/scanner/kv-scanner/kv-scanner.c
@@ -278,6 +278,13 @@ _decode_value(KVScanner *self)
 }
 
 static void
+_extract_optional_annotation(KVScanner *self)
+{
+  if (self->extract_annotation)
+    self->extract_annotation(self);
+}
+
+static void
 _extract_value(KVScanner *self)
 {
   self->value_was_quoted = FALSE;
@@ -307,6 +314,8 @@ kv_scanner_scan_next(KVScanner *s)
   if (!_extract_key(self))
     return FALSE;
 
+  _extract_optional_annotation(self);
+
   _extract_value(self);
   _transform_value(s);
 
@@ -322,6 +331,7 @@ _clone(KVScanner *self)
   kv_scanner_set_transform_value(scanner, self->transform_value);
   kv_scanner_set_valid_key_character_func(scanner, self->is_valid_key_character);
   kv_scanner_set_stop_character(scanner, self->stop_char);
+  kv_scanner_set_extract_annotation_func(scanner, self->extract_annotation);
   return scanner;
 }
 

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -44,12 +44,14 @@ struct _KVScanner
   gchar *pair_separator;
   gsize pair_separator_len;
   gchar quote_char;
+
   KVTransformValueFunc transform_value;
   KVScanner* (*clone)(KVScanner *self);
+  void (*free_fn)(KVScanner *self);
 };
 
-void kv_scanner_init(KVScanner *self, gchar value_separator, KVTransformValueFunc transform_value);
-void kv_scanner_free(KVScanner *self);
+void kv_scanner_init_instance(KVScanner *self, gchar value_separator, const gchar *pair_separator, gboolean extract_stray_words);
+void kv_scanner_free_method(KVScanner *self);
 
 static inline void
 kv_scanner_input(KVScanner *self, const gchar *input)
@@ -88,6 +90,16 @@ static inline void
 kv_scanner_set_transform_value(KVScanner *self, KVTransformValueFunc transform_value)
 {
   self->transform_value = transform_value;
+}
+
+static inline void
+kv_scanner_free(KVScanner *self)
+{
+  if (!self)
+    return;
+
+  self->free_fn(self);
+  g_free(self);
 }
 
 gboolean kv_scanner_scan_next(KVScanner *self);

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -30,6 +30,7 @@
 typedef struct _KVScanner KVScanner;
 
 typedef gboolean (*KVTransformValueFunc)(KVScanner *);
+typedef gboolean (*KVIsValidKeyCharFunc)(gchar c);
 
 struct _KVScanner
 {
@@ -46,6 +47,7 @@ struct _KVScanner
   gchar quote_char;
 
   KVTransformValueFunc transform_value;
+  KVIsValidKeyCharFunc is_valid_key_character;
   KVScanner* (*clone)(KVScanner *self);
   void (*free_fn)(KVScanner *self);
 };
@@ -90,6 +92,12 @@ static inline void
 kv_scanner_set_transform_value(KVScanner *self, KVTransformValueFunc transform_value)
 {
   self->transform_value = transform_value;
+}
+
+static inline void
+kv_scanner_set_valid_key_character_func(KVScanner *self, KVIsValidKeyCharFunc is_valid_key_character)
+{
+  self->is_valid_key_character = is_valid_key_character;
 }
 
 static inline void

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -117,7 +117,7 @@ kv_scanner_set_stop_character(KVScanner *self, gchar stop_char)
 static inline void
 kv_scanner_free(KVScanner *self)
 {
-  if (!self)
+  if (!self || !self->free_fn)
     return;
 
   self->free_fn(self);

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -45,6 +45,7 @@ struct _KVScanner
   gchar *pair_separator;
   gsize pair_separator_len;
   gchar quote_char;
+  gchar stop_char;
 
   KVTransformValueFunc transform_value;
   KVIsValidKeyCharFunc is_valid_key_character;
@@ -98,6 +99,12 @@ static inline void
 kv_scanner_set_valid_key_character_func(KVScanner *self, KVIsValidKeyCharFunc is_valid_key_character)
 {
   self->is_valid_key_character = is_valid_key_character;
+}
+
+static inline void
+kv_scanner_set_stop_character(KVScanner *self, gchar stop_char)
+{
+  self->stop_char = stop_char;
 }
 
 static inline void

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -30,6 +30,7 @@
 typedef struct _KVScanner KVScanner;
 
 typedef gboolean (*KVTransformValueFunc)(KVScanner *);
+typedef void (*KVExtractAnnotationFunc)(KVScanner *);
 typedef gboolean (*KVIsValidKeyCharFunc)(gchar c);
 
 struct _KVScanner
@@ -47,6 +48,7 @@ struct _KVScanner
   gchar stop_char;
 
   KVTransformValueFunc transform_value;
+  KVExtractAnnotationFunc extract_annotation;
   KVIsValidKeyCharFunc is_valid_key_character;
   KVScanner* (*clone)(KVScanner *self);
   void (*free_fn)(KVScanner *self);
@@ -92,6 +94,12 @@ static inline void
 kv_scanner_set_transform_value(KVScanner *self, KVTransformValueFunc transform_value)
 {
   self->transform_value = transform_value;
+}
+
+static inline void
+kv_scanner_set_extract_annotation_func(KVScanner *self, KVExtractAnnotationFunc extract_annotation)
+{
+  self->extract_annotation = extract_annotation;
 }
 
 static inline void

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -44,7 +44,6 @@ struct _KVScanner
   gchar value_separator;
   gchar *pair_separator;
   gsize pair_separator_len;
-  gchar quote_char;
   gchar stop_char;
 
   KVTransformValueFunc transform_value;

--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -339,6 +339,29 @@ scan_expect_char(const gchar **buf, gint *left, gchar value)
 }
 
 gboolean
+scan_expect_str(const gchar **buf, gint *left, const gchar *value)
+{
+  const gchar *original_buf = *buf;
+  gint original_left = *left;
+
+  while (*value)
+    {
+      if (*left == 0 || *value != **buf)
+        {
+          *buf = original_buf;
+          *left = original_left;
+          return FALSE;
+        }
+
+      (*buf)++;
+      (*left)--;
+      value++;
+    }
+
+  return TRUE;
+}
+
+gboolean
 scan_day_abbrev(const gchar **buf, gint *left, gint *wday)
 {
   *wday = -1;

--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -520,3 +520,24 @@ scan_bsd_timestamp(const gchar **buf, gint *left, struct tm *tm)
     return FALSE;
   return TRUE;
 }
+
+gboolean
+scan_std_timestamp(const gchar **buf, gint *left, struct tm *tm)
+{
+  /* YYYY-MM-DD HH:MM:SS */
+  if (!scan_int(buf, left, 4, &tm->tm_year) ||
+      !scan_expect_char(buf, left, '-') ||
+      !scan_int(buf, left, 2, &tm->tm_mon) ||
+      !scan_expect_char(buf, left, '-') ||
+      !scan_int(buf, left, 2, &tm->tm_mday) ||
+      !scan_expect_char(buf, left, ' ') ||
+      !scan_int(buf, left, 2, &tm->tm_hour) ||
+      !scan_expect_char(buf, left, ':') ||
+      !scan_int(buf, left, 2, &tm->tm_min) ||
+      !scan_expect_char(buf, left, ':') ||
+      !scan_int(buf, left, 2, &tm->tm_sec))
+    return FALSE;
+  tm->tm_year -= 1900;
+  tm->tm_mon -= 1;
+  return TRUE;
+}

--- a/lib/str-format.h
+++ b/lib/str-format.h
@@ -38,6 +38,9 @@ gchar *format_hex_string_with_delimiter(gpointer str, gsize str_len, gchar *resu
 
 
 gboolean
+scan_expect_char(const gchar **buf, gint *left, gchar value);
+
+gboolean
 scan_iso_timestamp(const gchar **buf, gint *left, struct tm *tm);
 gboolean
 scan_pix_timestamp(const gchar **buf, gint *left, struct tm *tm);

--- a/lib/str-format.h
+++ b/lib/str-format.h
@@ -39,6 +39,8 @@ gchar *format_hex_string_with_delimiter(gpointer str, gsize str_len, gchar *resu
 
 gboolean
 scan_expect_char(const gchar **buf, gint *left, gchar value);
+gboolean
+scan_expect_str(const gchar **buf, gint *left, const gchar *value);
 
 gboolean
 scan_iso_timestamp(const gchar **buf, gint *left, struct tm *tm);

--- a/lib/str-format.h
+++ b/lib/str-format.h
@@ -45,5 +45,7 @@ gboolean
 scan_linksys_timestamp(const gchar **buf, gint *left, struct tm *tm);
 gboolean
 scan_bsd_timestamp(const gchar **buf, gint *left, struct tm *tm);
+gboolean
+scan_std_timestamp(const gchar **buf, gint *left, struct tm *tm);
 
 #endif

--- a/lib/str-repr/decode.c
+++ b/lib/str-repr/decode.c
@@ -86,7 +86,8 @@ _invoke_match_delimiter(StrReprDecodeState *state, const gchar **new_cur)
 
   if (options->delimiter_chars[0])
     {
-      if (*state->cur == options->delimiter_chars[0] || *state->cur == options->delimiter_chars[1])
+      if (*state->cur == options->delimiter_chars[0] || *state->cur == options->delimiter_chars[1]
+          || *state->cur == options->delimiter_chars[2])
         {
           if (options->match_delimiter)
             return options->match_delimiter(state->cur, new_cur, options->match_delimiter_data);

--- a/lib/str-repr/decode.h
+++ b/lib/str-repr/decode.h
@@ -32,7 +32,7 @@ typedef struct _StrReprDecodeOptions
 {
   MatchDelimiterFunc match_delimiter;
   gpointer match_delimiter_data;
-  gchar delimiter_chars[2];
+  gchar delimiter_chars[3];
 } StrReprDecodeOptions;
 
 gboolean str_repr_decode(GString *value, const gchar *input, const gchar **end);

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -37,6 +37,7 @@ include modules/add-contextual-data/Makefile.am
 include modules/getent/Makefile.am
 include modules/map-value-pairs/Makefile.am
 include modules/stardate/Makefile.am
+include modules/snmptrapd-parser/Makefile.am
 
 SYSLOG_NG_CORE_JAR=$(top_builddir)/modules/java/syslog-ng-core/libs/syslog-ng-core.jar
 
@@ -49,7 +50,7 @@ SYSLOG_NG_MODULES	=	\
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
 	mod-python mod-java mod-java-modules mod-kvformat mod-date \
 	mod-native mod-cef mod-add-contextual-data mod-diskq mod-getent \
-	mod-map-value-pairs
+	mod-map-value-pairs mod-snmptrapd-parser
 
 
 modules modules/: ${SYSLOG_NG_MODULES}

--- a/modules/snmptrapd-parser/CMakeLists.txt
+++ b/modules/snmptrapd-parser/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(snmptrapd_parser_HEADERS
+    "snmptrapd-parser-parser.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/snmptrapd-parser-grammar.h"
+)
+
+set(snmptrapd_parser_SOURCES
+    "snmptrapd-parser-plugin.c"
+    "snmptrapd-parser-parser.c"
+    "${CMAKE_CURRENT_BINARY_DIR}/snmptrapd-parser-grammar.c"
+)
+
+generate_y_from_ym(modules/snmptrapd-parser/snmptrapd-parser-grammar)
+
+bison_target(snmptrapd-parserGrammar
+    ${CMAKE_CURRENT_BINARY_DIR}/snmptrapd-parser-grammar.y
+    ${CMAKE_CURRENT_BINARY_DIR}/snmptrapd-parser-grammar.c
+COMPILE_FLAGS ${BISON_FLAGS})
+
+option(ENABLE_snmptrapd_parser "Enable snmptrapd-parser ON")
+
+if (ENABLE_snmptrapd_parser)
+  include_directories (${CMAKE_CURRENT_BINARY_DIR})
+  include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+  add_library(snmptrapd_parser MODULE ${snmptrapd-parser_SOURCES})
+  target_link_libraries(snmptrapd_parser PRIVATE syslog-ng)
+
+  install(TARGETS snmptrapd_parser
+  LIBRARY DESTINATION lib/syslog-ng/
+  COMPONENT snmptrapd_parser)
+endif()

--- a/modules/snmptrapd-parser/Makefile.am
+++ b/modules/snmptrapd-parser/Makefile.am
@@ -1,0 +1,34 @@
+module_LTLIBRARIES      += modules/snmptrapd-parser/libsnmptrapd-parser.la
+modules_snmptrapd_parser_libsnmptrapd_parser_la_SOURCES =   \
+  modules/snmptrapd-parser/snmptrapd-parser.c               \
+  modules/snmptrapd-parser/snmptrapd-parser.h               \
+  modules/snmptrapd-parser/snmptrapd-parser-grammar.y       \
+  modules/snmptrapd-parser/snmptrapd-parser-parser.c        \
+  modules/snmptrapd-parser/snmptrapd-parser-parser.h        \
+  modules/snmptrapd-parser/snmptrapd-parser-plugin.c        \
+  modules/snmptrapd-parser/varbindlist-scanner.h            \
+  modules/snmptrapd-parser/varbindlist-scanner.c            \
+  modules/snmptrapd-parser/snmptrapd-header-parser.h        \
+  modules/snmptrapd-parser/snmptrapd-header-parser.c        \
+  modules/snmptrapd-parser/snmptrapd-nv-context.h
+
+BUILT_SOURCES       += \
+  modules/snmptrapd-parser/snmptrapd-parser-grammar.y       \
+  modules/snmptrapd-parser/snmptrapd-parser-grammar.c       \
+  modules/snmptrapd-parser/snmptrapd-parser-grammar.h
+
+EXTRA_DIST          += \
+  modules/snmptrapd-parser/snmptrapd-parser-grammar.ym
+
+modules_snmptrapd_parser_libsnmptrapd_parser_la_CPPFLAGS =  \
+  $(AM_CPPFLAGS)                                            \
+  -I$(top_srcdir)/modules/snmptrapd-parser                  \
+  -I$(top_builddir)/modules/snmptrapd-parser
+modules_snmptrapd_parser_libsnmptrapd_parser_la_LIBADD  = $(MODULE_DEPS_LIBS)
+modules_snmptrapd_parser_libsnmptrapd_parser_la_LDFLAGS = $(MODULE_LDFLAGS)
+modules_snmptrapd_parser_libsnmptrapd_parser_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)
+
+modules/snmptrapd-parser modules/snmptrapd-parser/ mod-snmptrapd-parser mod-file: modules/snmptrapd-parser/libsnmptrapd-parser.la
+.PHONY: modules/snmptrapd-parser/ mod-snmptrapd-parser mod-file
+
+include modules/snmptrapd-parser/tests/Makefile.am

--- a/modules/snmptrapd-parser/snmptrapd-header-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-header-parser.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "snmptrapd-header-parser.h"
+
+#include "str-format.h"
+#include "timeutils.h"
+
+#include <string.h>
+#include <ctype.h>
+
+typedef struct
+{
+  SnmpTrapdNVContext *nv_context;
+  const gchar **input;
+  gsize *input_len;
+} SnmpTrapdHeaderParser;
+
+typedef gboolean (*SnmpTrapdHeaderParserStep)(SnmpTrapdHeaderParser *self);
+
+
+static inline void
+_skip_spaces(SnmpTrapdHeaderParser *self)
+{
+  const gchar *current_char = *self->input;
+
+  while (*self->input_len > 0 && *current_char == ' ')
+    {
+      ++current_char;
+      --(*self->input_len);
+    }
+
+  *self->input = current_char;
+}
+
+
+static gboolean
+_run_header_parser(SnmpTrapdHeaderParser *self,
+                   SnmpTrapdHeaderParserStep *parser_steps, gsize parser_steps_size)
+{
+  SnmpTrapdHeaderParserStep parser_step;
+
+  for (gsize step_index = 0; step_index < parser_steps_size; ++step_index)
+    {
+      _skip_spaces(self);
+
+      parser_step = parser_steps[step_index];
+      if (!parser_step(self))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+
+static inline gboolean
+_expect_char(SnmpTrapdHeaderParser *self, gchar c)
+{
+  return scan_expect_char(self->input, (gint *) self->input_len, c);
+}
+
+static inline gboolean
+_expect_newline(SnmpTrapdHeaderParser *self)
+{
+  return _expect_char(self, '\n');
+}
+
+static inline gboolean
+_expect_newline_or_eom(SnmpTrapdHeaderParser *self)
+{
+  return _expect_newline(self) || *self->input_len == 0;
+}
+
+static inline gboolean
+_expect_colon(SnmpTrapdHeaderParser *self)
+{
+  return _expect_char(self, ':');
+}
+
+static inline gboolean
+_expect_tab(SnmpTrapdHeaderParser *self)
+{
+  return _expect_char(self, '\t');
+}
+
+static inline void
+_scroll_to_eom(SnmpTrapdHeaderParser *self)
+{
+  while (*self->input_len > 0 || **self->input)
+    {
+      ++(*self->input);
+      --(*self->input_len);
+    }
+}
+
+static gboolean
+_parse_v1_uptime(SnmpTrapdHeaderParser *self)
+{
+  if (!scan_expect_str(self->input, (gint *) self->input_len, "Uptime:"))
+    return FALSE;
+
+  _skip_spaces(self);
+
+  const gchar *uptime_start = *self->input;
+
+  const gchar *uptime_end = strchr(uptime_start, '\n');
+  if (!uptime_end)
+    {
+      _scroll_to_eom(self);
+      snmptrapd_nv_context_add_name_value(self->nv_context, "uptime", uptime_start, *self->input - uptime_start);
+      return TRUE;
+    }
+
+  snmptrapd_nv_context_add_name_value(self->nv_context, "uptime", uptime_start, uptime_end - uptime_start);
+
+  *self->input_len -= uptime_end - *self->input;
+  *self->input = uptime_end;
+  return TRUE;
+}
+
+static gboolean
+_parse_v1_trap_type_and_subtype(SnmpTrapdHeaderParser *self)
+{
+  const gchar *type_start = *self->input;
+
+  const gchar *type_end = strpbrk(type_start, "(\n");
+  gboolean type_exists = type_end && *type_end == '(';
+
+  if (!type_exists)
+    return FALSE;
+
+  const gchar *subtype_start = type_end + 1;
+
+  if (*(type_end - 1) == ' ')
+    --type_end;
+
+  snmptrapd_nv_context_add_name_value(self->nv_context, "type", type_start, type_end - type_start);
+
+  const gchar *subtype_end = strpbrk(subtype_start, ")\n");
+  gboolean subtype_exists = subtype_end && *subtype_end == ')';
+
+  if (!subtype_exists)
+    return FALSE;
+
+  snmptrapd_nv_context_add_name_value(self->nv_context, "subtype", subtype_start, subtype_end - subtype_start);
+
+  *self->input_len -= (subtype_end + 1) - *self->input;
+  *self->input = subtype_end + 1;
+  return TRUE;
+}
+
+static gboolean
+_parse_v1_enterprise_oid(SnmpTrapdHeaderParser *self)
+{
+  const gchar *enterprise_string_start = *self->input;
+  gsize input_left = *self->input_len;
+
+  while (*self->input_len > 0 && !g_ascii_isspace(**self->input))
+    {
+      ++(*self->input);
+      --(*self->input_len);
+    }
+
+  gsize enterprise_string_length = input_left - *self->input_len;
+
+  /* enterprise_string is optional */
+  if (enterprise_string_length == 0)
+    return TRUE;
+
+  snmptrapd_nv_context_add_name_value(self->nv_context, "enterprise_oid",
+                                      enterprise_string_start, enterprise_string_length);
+
+  return TRUE;
+}
+
+
+static gboolean
+_parse_transport_info(SnmpTrapdHeaderParser *self)
+{
+  if(!scan_expect_char(self->input, (gint *) self->input_len, '['))
+    return FALSE;
+
+  _skip_spaces(self);
+
+  const gchar *transport_info_start = *self->input;
+
+  const gchar *transport_info_end = strchr(transport_info_start, '\n');
+  if (!transport_info_end)
+    return FALSE;
+
+  while(*transport_info_end != ']')
+    {
+      --transport_info_end;
+      if(transport_info_end == transport_info_start)
+        return FALSE;
+    }
+
+  gsize transport_info_len = transport_info_end - transport_info_start;
+
+  snmptrapd_nv_context_add_name_value(self->nv_context, "transport_info", transport_info_start, transport_info_len);
+
+  *self->input_len -= (transport_info_end + 1) - *self->input;
+  *self->input = transport_info_end + 1;
+  return TRUE;
+}
+
+static gboolean
+_parse_hostname(SnmpTrapdHeaderParser *self)
+{
+  const gchar *hostname_start = *self->input;
+  gsize input_left = *self->input_len;
+
+  while (*self->input_len > 0 && !g_ascii_isspace(**self->input))
+    {
+      ++(*self->input);
+      --(*self->input_len);
+    }
+
+  gsize hostname_length = input_left - *self->input_len;
+  if (hostname_length == 0)
+    return FALSE;
+
+  snmptrapd_nv_context_add_name_value(self->nv_context, "hostname", hostname_start, hostname_length);
+  return TRUE;
+}
+
+static gboolean
+_parse_timestamp(SnmpTrapdHeaderParser *self)
+{
+  GTimeVal now;
+  cached_g_current_time(&now);
+  time_t now_tv_sec = (time_t) now.tv_sec;
+
+  LogStamp *stamp = &self->nv_context->msg->timestamps[LM_TS_STAMP];
+  stamp->tv_usec = 0;
+  stamp->zone_offset = -1;
+
+  /* NOTE: we initialize various unportable fields in tm using a
+   * localtime call, as the value of tm_gmtoff does matter but it does
+   * not exist on all platforms and 0 initializing it causes trouble on
+   * time-zone barriers */
+
+  struct tm tm;
+  cached_localtime(&now_tv_sec, &tm);
+  if (!scan_std_timestamp(self->input, (gint *)self->input_len, &tm))
+    return FALSE;
+
+  stamp->tv_sec = cached_mktime(&tm);
+  stamp->zone_offset = get_local_timezone_ofs(stamp->tv_sec);
+
+  return TRUE;
+}
+
+static gboolean
+_try_parse_v1_info(SnmpTrapdHeaderParser *self)
+{
+  /* detect v1 format */
+  const gchar *new_line = strchr(*self->input, '\n');
+  if (new_line && new_line[1] != '\t')
+    return TRUE;
+
+  SnmpTrapdHeaderParserStep v1_info_parser_steps[] =
+  {
+    _parse_v1_enterprise_oid,
+    _expect_newline,
+    _expect_tab,
+    _parse_v1_trap_type_and_subtype,
+    _parse_v1_uptime
+  };
+
+  return _run_header_parser(self, v1_info_parser_steps,
+                            sizeof(v1_info_parser_steps) / sizeof(SnmpTrapdHeaderParserStep));
+}
+
+gboolean
+snmptrapd_header_parser_parse(SnmpTrapdNVContext *nv_context, const gchar **input, gsize *input_len)
+{
+  /*
+   * DATE HOST [TRANSPORT_INFO]: V1_ENTERPRISE_OID
+   * <TAB> V1_TRAP_TYPE (V1_TRAP_SUBTYPE) "Uptime:" UPTIME
+   */
+
+  SnmpTrapdHeaderParser self =
+  {
+    .nv_context = nv_context,
+    .input = input,
+    .input_len = input_len
+  };
+
+  SnmpTrapdHeaderParserStep parser_steps[] =
+  {
+    _parse_timestamp,
+    _parse_hostname,
+    _parse_transport_info,
+    _expect_colon,
+    _try_parse_v1_info,
+    _expect_newline_or_eom
+  };
+
+  return _run_header_parser(&self, parser_steps, sizeof(parser_steps) / sizeof(SnmpTrapdHeaderParserStep));
+}

--- a/modules/snmptrapd-parser/snmptrapd-header-parser.h
+++ b/modules/snmptrapd-parser/snmptrapd-header-parser.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#ifndef SNMPTRAPD_HEADER_PARSER_H_INCLUDED
+#define SNMPTRAPD_HEADER_PARSER_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "logmsg/logmsg.h"
+#include "snmptrapd-nv-context.h"
+
+gboolean snmptrapd_header_parser_parse(SnmpTrapdNVContext *nv_context, const gchar **input, gsize *input_len);
+
+#endif
+

--- a/modules/snmptrapd-parser/snmptrapd-nv-context.h
+++ b/modules/snmptrapd-parser/snmptrapd-nv-context.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#ifndef SNMPTRAPD_NV_CONTEXT_H_INCLUDED
+#define SNMPTRAPD_NV_CONTEXT_H_INCLUDED
+
+typedef struct _SnmpTrapdNVContext SnmpTrapdNVContext;
+
+struct _SnmpTrapdNVContext
+{
+  GString *key_prefix;
+  LogMessage *msg;
+  GString *generated_message;
+
+  void (*add_name_value)(SnmpTrapdNVContext *nv_context, const gchar *key, const gchar *value, gsize value_length);
+};
+
+static inline void
+snmptrapd_nv_context_add_name_value(SnmpTrapdNVContext *nv_context, const gchar *key,
+                                    const gchar *value, gsize value_length)
+{
+  nv_context->add_name_value(nv_context, key, value, value_length);
+}
+
+#endif

--- a/modules/snmptrapd-parser/snmptrapd-parser-grammar.ym
+++ b/modules/snmptrapd-parser/snmptrapd-parser-grammar.ym
@@ -54,7 +54,7 @@
 
 %token KW_SNMPTRAPD_PARSER
 %token KW_PREFIX
-%token KW_GENERATE_MESSAGE
+%token KW_SET_MESSAGE_MACRO
 
 %type	<ptr> parser_expr_snmptrapd
 
@@ -79,7 +79,7 @@ snmptrapd_parser_options
 
 snmptrapd_parser_option
         : KW_PREFIX '(' string ')'              { snmptrapd_parser_set_prefix(last_parser, $3); free($3); }
-        | KW_GENERATE_MESSAGE '(' yesno ')'     { snmptrapd_parser_set_generate_message(last_parser, $3); }
+        | KW_SET_MESSAGE_MACRO '(' yesno ')'    { snmptrapd_parser_set_set_message_macro(last_parser, $3); }
         | parser_opt
         ;
 

--- a/modules/snmptrapd-parser/snmptrapd-parser-grammar.ym
+++ b/modules/snmptrapd-parser/snmptrapd-parser-grammar.ym
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "snmptrapd-parser-parser.h"
+
+}
+
+
+%code {
+
+#include "snmptrapd-parser.h"
+#include "cfg-parser.h"
+#include "snmptrapd-parser-grammar.h"
+#include "syslog-names.h"
+#include "messages.h"
+#include "plugin.h"
+#include "cfg-grammar.h"
+
+#include <string.h>
+
+}
+
+%name-prefix "snmptrapd_parser_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogParser **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_SNMPTRAPD_PARSER
+%token KW_PREFIX
+%token KW_GENERATE_MESSAGE
+
+%type	<ptr> parser_expr_snmptrapd
+
+%%
+
+start
+        : LL_CONTEXT_PARSER parser_expr_snmptrapd  { YYACCEPT; }
+        ;
+
+parser_expr_snmptrapd
+        : KW_SNMPTRAPD_PARSER '('
+          {
+            last_parser = *instance = (LogParser *) snmptrapd_parser_new(configuration);
+          }
+          snmptrapd_parser_options ')'					{ $$ = last_parser; }
+        ;
+
+snmptrapd_parser_options
+        : snmptrapd_parser_option snmptrapd_parser_options
+        |
+        ;
+
+snmptrapd_parser_option
+        : KW_PREFIX '(' string ')'              { snmptrapd_parser_set_prefix(last_parser, $3); free($3); }
+        | KW_GENERATE_MESSAGE '(' yesno ')'     { snmptrapd_parser_set_generate_message(last_parser, $3); }
+        | parser_opt
+        ;
+
+
+/* INCLUDE_RULES */
+
+%%
+

--- a/modules/snmptrapd-parser/snmptrapd-parser-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser-parser.c
@@ -32,7 +32,7 @@ static CfgLexerKeyword snmptrapd_parser_keywords[] =
 {
   { "snmptrapd_parser",  KW_SNMPTRAPD_PARSER },
   { "prefix",            KW_PREFIX },
-  { "generate_message",  KW_GENERATE_MESSAGE },
+  { "set_message_macro", KW_SET_MESSAGE_MACRO },
   { NULL }
 };
 

--- a/modules/snmptrapd-parser/snmptrapd-parser-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser-parser.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "snmptrapd-parser.h"
+#include "cfg-parser.h"
+#include "snmptrapd-parser-grammar.h"
+
+extern int snmptrapd_parser_debug;
+
+int snmptrapd_parser_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
+
+static CfgLexerKeyword snmptrapd_parser_keywords[] =
+{
+  { "snmptrapd_parser",  KW_SNMPTRAPD_PARSER },
+  { "prefix",            KW_PREFIX },
+  { "generate_message",  KW_GENERATE_MESSAGE },
+  { NULL }
+};
+
+CfgParser snmptrapd_parser_parser =
+{
+#if ENABLE_DEBUG
+  .debug_flag = &snmptrapd_parser_debug,
+#endif
+  .name = "snmptrapd-parser",
+  .keywords = snmptrapd_parser_keywords,
+  .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) snmptrapd_parser_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(snmptrapd_parser_, LogParser **)
+

--- a/modules/snmptrapd-parser/snmptrapd-parser-parser.h
+++ b/modules/snmptrapd-parser/snmptrapd-parser-parser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNMPTRAPD_PARSER_PARSER_H_INCLUDED
+#define SNMPTRAPD_PARSER_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+#include "parser/parser-expr.h"
+
+extern CfgParser snmptrapd_parser_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(snmptrapd_parser_, LogParser **)
+
+#endif
+

--- a/modules/snmptrapd-parser/snmptrapd-parser-plugin.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser-plugin.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-parser.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser snmptrapd_parser_parser;
+
+static Plugin snmptrapd_parser_plugins[] =
+{
+  {
+    .type = LL_CONTEXT_PARSER,
+    .name = "snmptrapd-parser",
+    .parser = &snmptrapd_parser_parser,
+  },
+};
+
+gboolean
+snmptrapd_parser_module_init(GlobalConfig *cfg, CfgArgs *args)
+{
+  plugin_register(cfg, snmptrapd_parser_plugins, G_N_ELEMENTS(snmptrapd_parser_plugins));
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "snmptrapd_parser",
+  .version = SYSLOG_NG_VERSION,
+  .description = "The snmptrapd module provides parsing support for snmptrapd output in syslog-ng",
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
+  .plugins = snmptrapd_parser_plugins,
+  .plugins_len = G_N_ELEMENTS(snmptrapd_parser_plugins),
+};
+

--- a/modules/snmptrapd-parser/snmptrapd-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser.c
@@ -31,7 +31,7 @@ typedef struct _SnmpTrapdParser
 {
   LogParser super;
   GString *prefix;
-  gboolean generate_message;
+  gboolean set_message_macro;
 } SnmpTrapdParser;
 
 void
@@ -46,11 +46,11 @@ snmptrapd_parser_set_prefix(LogParser *s, const gchar *prefix)
 }
 
 void
-snmptrapd_parser_set_generate_message(LogParser *s, gboolean generate_message)
+snmptrapd_parser_set_set_message_macro(LogParser *s, gboolean set_message_macro)
 {
   SnmpTrapdParser *self = (SnmpTrapdParser *) s;
 
-  self->generate_message = generate_message;
+  self->set_message_macro = set_message_macro;
 }
 
 static inline gboolean
@@ -180,7 +180,7 @@ snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *
   APPEND_ZERO(input, input, input_len);
 
   GString *generated_message = NULL;
-  if (self->generate_message)
+  if (self->set_message_macro)
     generated_message = scratch_buffers2_alloc_and_mark(&marker);
 
 
@@ -201,7 +201,7 @@ snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *
     return FALSE;
 
 
-  if (self->generate_message)
+  if (self->set_message_macro)
     {
       log_msg_set_value(nv_context.msg, LM_V_MESSAGE, nv_context.generated_message->str, -1);
       scratch_buffers2_reclaim_marked(marker);
@@ -222,7 +222,7 @@ snmptrapd_parser_clone(LogPipe *s)
   SnmpTrapdParser *cloned = (SnmpTrapdParser *) snmptrapd_parser_new(s->cfg);
 
   snmptrapd_parser_set_prefix(&cloned->super, self->prefix->str);
-  snmptrapd_parser_set_generate_message(&cloned->super, self->generate_message);
+  snmptrapd_parser_set_set_message_macro(&cloned->super, self->set_message_macro);
 
   /* log_parser_clone_method() is missing.. */
   log_parser_set_template(&cloned->super, log_template_ref(self->super.template));
@@ -251,7 +251,7 @@ snmptrapd_parser_new(GlobalConfig *cfg)
   self->super.process = snmptrapd_parser_process;
 
   self->prefix = g_string_new(".snmp.");
-  self->generate_message = TRUE;
+  self->set_message_macro = TRUE;
 
   return &self->super;
 }

--- a/modules/snmptrapd-parser/snmptrapd-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser.c
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "snmptrapd-parser.h"
+#include "snmptrapd-header-parser.h"
+#include "snmptrapd-nv-context.h"
+#include "varbindlist-scanner.h"
+#include "scratch-buffers2.h"
+#include "utf8utils.h"
+#include "str-utils.h"
+
+typedef struct _SnmpTrapdParser
+{
+  LogParser super;
+  GString *prefix;
+  gboolean generate_message;
+} SnmpTrapdParser;
+
+void
+snmptrapd_parser_set_prefix(LogParser *s, const gchar *prefix)
+{
+  SnmpTrapdParser *self = (SnmpTrapdParser *) s;
+
+  if (!prefix)
+    g_string_truncate(self->prefix, 0);
+  else
+    g_string_assign(self->prefix, prefix);
+}
+
+void
+snmptrapd_parser_set_generate_message(LogParser *s, gboolean generate_message)
+{
+  SnmpTrapdParser *self = (SnmpTrapdParser *) s;
+
+  self->generate_message = generate_message;
+}
+
+static inline gboolean
+_is_unwanted_key_char(gchar c)
+{
+  return (c == ':');
+}
+
+static inline void
+_move_and_replace_unwanted_key_chars(GString *key, gsize unwanted_key_count, gchar **curr_char_addr)
+{
+  gsize number_of_removed_chars = unwanted_key_count - 1;
+  gchar *curr_pos = *curr_char_addr;
+  gchar *end_of_str = key->str + key->len;
+  gchar *replace_pos = curr_pos - unwanted_key_count;
+
+  if (unwanted_key_count > 1)
+    {
+      memmove(replace_pos, curr_pos - 1, end_of_str - (curr_pos - 1));
+      g_string_truncate(key, key->len - number_of_removed_chars);
+    }
+  *replace_pos = '_';
+  *curr_char_addr -= unwanted_key_count;
+}
+
+static const gchar *
+_normalize_key(GString *key)
+{
+  gsize unwanted_key_count = 0;
+  gchar *curr_char = key->str;
+  while (*curr_char)
+    {
+      if (_is_unwanted_key_char(*curr_char))
+        {
+          unwanted_key_count++;
+        }
+      else if (unwanted_key_count > 0)
+        {
+          _move_and_replace_unwanted_key_chars(key, unwanted_key_count, &curr_char);
+          unwanted_key_count = 0;
+        }
+      curr_char++;
+    }
+  if (unwanted_key_count)
+    _move_and_replace_unwanted_key_chars(key, unwanted_key_count, &curr_char);
+
+  return key->str;
+}
+
+static const gchar *
+_get_formatted_key(const gchar *key, const GString *prefix, GString *formatted_key)
+{
+  g_string_truncate(formatted_key, 0);
+
+  if (prefix->len > 0)
+    g_string_assign(formatted_key, prefix->str);
+
+  g_string_append(formatted_key, key);
+
+  _normalize_key(formatted_key);
+
+  return formatted_key->str;
+}
+
+static void
+_append_name_value_to_generated_message(GString *generated_message, const gchar *key,
+                                        const gchar *value, gsize value_length)
+{
+  ScratchBuffersMarker marker;
+  GString *escaped_value = scratch_buffers2_alloc_and_mark(&marker);
+
+  if (generated_message->len > 0)
+    g_string_append(generated_message, ", ");
+
+  append_unsafe_utf8_as_escaped_text(escaped_value, value, value_length, "'");
+  g_string_append_printf(generated_message, "%s='%s'", key, escaped_value->str);
+
+  scratch_buffers2_reclaim_marked(marker);
+}
+
+static void
+_add_name_value(SnmpTrapdNVContext *nv_context, const gchar *key,
+                const gchar *value, gsize value_length)
+{
+  ScratchBuffersMarker marker;
+  GString *formatted_key = scratch_buffers2_alloc_and_mark(&marker);
+
+  const gchar *prefixed_key = _get_formatted_key(key, nv_context->key_prefix, formatted_key);
+  log_msg_set_value_by_name(nv_context->msg, prefixed_key, value, value_length);
+
+  if (nv_context->generated_message)
+    _append_name_value_to_generated_message(nv_context->generated_message, key, value, value_length);
+
+  scratch_buffers2_reclaim_marked(marker);
+}
+
+static gboolean
+_parse_varbindlist(SnmpTrapdNVContext *nv_context, const gchar **input, gsize *input_len)
+{
+  VarBindListScanner varbindlist_scanner;
+  const gchar *key, *value;
+
+  varbindlist_scanner_init(&varbindlist_scanner);
+
+  varbindlist_scanner_input(&varbindlist_scanner, *input);
+  while (varbindlist_scanner_scan_next(&varbindlist_scanner))
+    {
+      key = varbindlist_scanner_get_current_key(&varbindlist_scanner);
+      value = varbindlist_scanner_get_current_value(&varbindlist_scanner);
+
+      snmptrapd_nv_context_add_name_value(nv_context, key, value, -1);
+    }
+
+  varbindlist_scanner_deinit(&varbindlist_scanner);
+  return TRUE;
+}
+
+static gboolean
+snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
+                         const gchar *input, gsize input_len)
+{
+  SnmpTrapdParser *self = (SnmpTrapdParser *) s;
+  ScratchBuffersMarker marker;
+
+  log_msg_make_writable(pmsg, path_options);
+
+  APPEND_ZERO(input, input, input_len);
+
+  GString *generated_message = NULL;
+  if (self->generate_message)
+    generated_message = scratch_buffers2_alloc_and_mark(&marker);
+
+
+  SnmpTrapdNVContext nv_context =
+  {
+    .key_prefix = self->prefix,
+    .msg = *pmsg,
+    .generated_message = generated_message,
+    .add_name_value = _add_name_value
+  };
+
+  log_msg_set_value(nv_context.msg, LM_V_PROGRAM, "snmptrapd", -1);
+
+  if (!snmptrapd_header_parser_parse(&nv_context, &input, &input_len))
+    return FALSE;
+
+  if (!_parse_varbindlist(&nv_context, &input, &input_len))
+    return FALSE;
+
+
+  if (self->generate_message)
+    {
+      log_msg_set_value(nv_context.msg, LM_V_MESSAGE, nv_context.generated_message->str, -1);
+      scratch_buffers2_reclaim_marked(marker);
+    }
+  else
+    {
+      log_msg_unset_value(nv_context.msg, LM_V_MESSAGE);
+    }
+
+  return TRUE;
+}
+
+static LogPipe *
+snmptrapd_parser_clone(LogPipe *s)
+{
+  SnmpTrapdParser *self = (SnmpTrapdParser *) s;
+
+  SnmpTrapdParser *cloned = (SnmpTrapdParser *) snmptrapd_parser_new(s->cfg);
+
+  snmptrapd_parser_set_prefix(&cloned->super, self->prefix->str);
+  snmptrapd_parser_set_generate_message(&cloned->super, self->generate_message);
+
+  /* log_parser_clone_method() is missing.. */
+  log_parser_set_template(&cloned->super, log_template_ref(self->super.template));
+
+  return &cloned->super.super;
+}
+
+static void
+snmptrapd_parser_free(LogPipe *s)
+{
+  SnmpTrapdParser *self = (SnmpTrapdParser *) s;
+
+  g_string_free(self->prefix, TRUE);
+
+  log_parser_free_method(s);
+}
+
+LogParser *
+snmptrapd_parser_new(GlobalConfig *cfg)
+{
+  SnmpTrapdParser *self = g_new0(SnmpTrapdParser, 1);
+
+  log_parser_init_instance(&self->super, cfg);
+  self->super.super.free_fn = snmptrapd_parser_free;
+  self->super.super.clone = snmptrapd_parser_clone;
+  self->super.process = snmptrapd_parser_process;
+
+  self->prefix = g_string_new(".snmp.");
+  self->generate_message = TRUE;
+
+  return &self->super;
+}

--- a/modules/snmptrapd-parser/snmptrapd-parser.h
+++ b/modules/snmptrapd-parser/snmptrapd-parser.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#ifndef SNMPTRAPD_PARSER_H_INCLUDED
+#define SNMPTRAPD_PARSER_H_INCLUDED
+
+#include "parser/parser-expr.h"
+
+LogParser *snmptrapd_parser_new(GlobalConfig *cfg);
+void snmptrapd_parser_set_prefix(LogParser *s, const gchar *prefix);
+void snmptrapd_parser_set_generate_message(LogParser *s, gboolean generate_message);
+
+#endif

--- a/modules/snmptrapd-parser/snmptrapd-parser.h
+++ b/modules/snmptrapd-parser/snmptrapd-parser.h
@@ -26,6 +26,6 @@
 
 LogParser *snmptrapd_parser_new(GlobalConfig *cfg);
 void snmptrapd_parser_set_prefix(LogParser *s, const gchar *prefix);
-void snmptrapd_parser_set_generate_message(LogParser *s, gboolean generate_message);
+void snmptrapd_parser_set_set_message_macro(LogParser *s, gboolean set_message_macro);
 
 #endif

--- a/modules/snmptrapd-parser/tests/Makefile.am
+++ b/modules/snmptrapd-parser/tests/Makefile.am
@@ -1,0 +1,19 @@
+if ENABLE_CRITERION
+
+modules_snmptrapd_parser_tests_TESTS                             = \
+  modules/snmptrapd-parser/tests/test_varbindlist_scanner          \
+  modules/snmptrapd-parser/tests/test_snmptrapd_parser
+
+check_PROGRAMS                                                   += ${modules_snmptrapd_parser_tests_TESTS}
+
+modules_snmptrapd_parser_tests_test_varbindlist_scanner_CFLAGS   = \
+  $(TEST_CFLAGS) -I$(top_srcdir)/modules/snmptrapd-parser
+modules_snmptrapd_parser_tests_test_varbindlist_scanner_LDADD    = $(TEST_LDADD) \
+  -dlpreopen $(top_builddir)/modules/snmptrapd-parser/libsnmptrapd-parser.la
+
+modules_snmptrapd_parser_tests_test_snmptrapd_parser_CFLAGS   = \
+  $(TEST_CFLAGS) -I$(top_srcdir)/modules/snmptrapd-parser
+modules_snmptrapd_parser_tests_test_snmptrapd_parser_LDADD    = $(TEST_LDADD) \
+  -dlpreopen $(top_builddir)/modules/snmptrapd-parser/libsnmptrapd-parser.la
+
+endif

--- a/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
+++ b/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
@@ -37,7 +37,7 @@ typedef struct
 typedef struct
 {
   const gchar *key_prefix;
-  gboolean generate_message;
+  gboolean set_message_macro;
 } TestParserOptions;
 
 static LogParser *
@@ -50,7 +50,7 @@ create_parser(TestParserOptions *options)
       if (options->key_prefix)
         snmptrapd_parser_set_prefix(snmptrapd_parser, options->key_prefix);
 
-      snmptrapd_parser_set_generate_message(snmptrapd_parser, options->generate_message);
+      snmptrapd_parser_set_set_message_macro(snmptrapd_parser, options->set_message_macro);
     }
 
   log_pipe_init((LogPipe *)snmptrapd_parser);
@@ -240,7 +240,7 @@ Test(snmptrapd_parser, test_v2_with_generated_message)
 {
   TestParserOptions options =
   {
-    .generate_message = TRUE
+    .set_message_macro = TRUE
   };
 
   const gchar *input =
@@ -266,7 +266,7 @@ Test(snmptrapd_parser, test_v2_with_generated_message_escaped)
 {
   TestParserOptions options =
   {
-    .generate_message = TRUE
+    .set_message_macro = TRUE
   };
 
   const gchar *input =

--- a/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
+++ b/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+
+#include "snmptrapd-parser.h"
+#include "testutils.h"
+#include "apphook.h"
+#include "msg_parse_lib.h"
+
+#define SIZE_OF_ARRAY(array) (sizeof(array) / sizeof((array)[0]))
+
+typedef struct
+{
+  const gchar *name;
+  const gchar *value;
+} TestNameValue;
+
+typedef struct
+{
+  const gchar *key_prefix;
+  gboolean generate_message;
+} TestParserOptions;
+
+static LogParser *
+create_parser(TestParserOptions *options)
+{
+  LogParser *snmptrapd_parser = snmptrapd_parser_new(configuration);
+
+  if (options)
+    {
+      if (options->key_prefix)
+        snmptrapd_parser_set_prefix(snmptrapd_parser, options->key_prefix);
+
+      snmptrapd_parser_set_generate_message(snmptrapd_parser, options->generate_message);
+    }
+
+  log_pipe_init((LogPipe *)snmptrapd_parser);
+  return snmptrapd_parser;
+}
+
+static void
+destroy_parser(LogParser *snmptrapd_parser)
+{
+  log_pipe_deinit((LogPipe *)snmptrapd_parser);
+  log_pipe_unref((LogPipe *)snmptrapd_parser);
+}
+
+static LogMessage *
+copy_str_into_log_message(const gchar *message)
+{
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value(msg, LM_V_MESSAGE, message, -1);
+
+  return msg;
+}
+
+static gboolean
+_process_log_message(LogParser *parser, LogMessage *msg)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  return log_parser_process_message(parser, &msg, &path_options);
+}
+
+static LogMessage *
+parse_str_into_log_message(LogParser *parser, const gchar *message)
+{
+  LogMessage *msg = copy_str_into_log_message(message);
+
+  cr_assert(_process_log_message(parser, msg));
+
+  return msg;
+}
+
+static void
+assert_log_message_dropped(const gchar *input)
+{
+  LogParser *parser = create_parser(NULL);
+  LogMessage *msg = copy_str_into_log_message(input);
+
+  cr_assert_not(_process_log_message(parser, msg));
+
+  log_msg_unref(msg);
+  destroy_parser(parser);
+}
+
+static void
+assert_log_message_name_values_with_options(TestParserOptions *options, const gchar *input,
+                                            TestNameValue *expected, gsize number_of_expected)
+{
+  LogParser *parser = create_parser(options);
+  LogMessage *msg = parse_str_into_log_message(parser, input);
+
+  for (int i=0; i < number_of_expected; i++)
+    assert_log_message_value_by_name(msg, expected[i].name, expected[i].value);
+
+  log_msg_unref(msg);
+  destroy_parser(parser);
+}
+
+static void
+assert_log_message_name_values(const gchar *input, TestNameValue *expected, gsize number_of_expected)
+{
+  assert_log_message_name_values_with_options(NULL, input, expected, number_of_expected);
+}
+
+void
+setup(void)
+{
+  configuration = cfg_new(0x0390);
+  app_startup();
+}
+
+void
+teardown(void)
+{
+  app_shutdown();
+  cfg_free(configuration);
+}
+
+TestSuite(snmptrapd_parser, .init = setup, .fini = teardown);
+
+Test(snmptrapd_parser, test_general_v2_message_with_oids)
+{
+  const gchar *input =
+    "2017-05-10 12:46:14 web2-kukorica.syslog_ng.balabit [UDP: [127.0.0.1]:34257->[127.0.0.1]:162]:\n"
+    "iso.3.6.1.2.1.1.3.0 = Timeticks: (875496867) 101 days, 7:56:08.67\t"
+    "iso.3.6.1.6.3.1.1.4.1.0 = OID: iso.3.6.1.4.1.8072.2.3.0.1       "
+    "iso.3.6.1.4.1.8072.2.3.2.1 = INTEGER: 60        \t "
+    "iso.3.6.1.4.1.8072.2.1.3 = \"\"";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "web2-kukorica.syslog_ng.balabit" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:34257->[127.0.0.1]:162" },
+    { ".snmp.iso.3.6.1.2.1.1.3.0", "(875496867) 101 days, 7:56:08.67" },
+    { ".snmp.iso.3.6.1.6.3.1.1.4.1.0", "iso.3.6.1.4.1.8072.2.3.0.1" },
+    { ".snmp.iso.3.6.1.4.1.8072.2.3.2.1", "60" },
+    { ".snmp.iso.3.6.1.4.1.8072.2.1.3", "" },
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_general_v1_message_with_oids)
+{
+  const gchar *input =
+    "2017-05-10 13:23:16 localhost [UDP: [127.0.0.1]:53831->[127.0.0.1]:162]: iso.3.6.1.4.1.8072.2.3.1\n"
+    "\t Enterprise Specific Trap (.17) Uptime: 18:41:07.83\n"
+    "iso.3.6.1.4.1.8072.2.1.1 = INTEGER: 123456";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:53831->[127.0.0.1]:162" },
+    { ".snmp.enterprise_oid", "iso.3.6.1.4.1.8072.2.3.1" },
+    { ".snmp.type", "Enterprise Specific Trap" },
+    { ".snmp.subtype", ".17" },
+    { ".snmp.uptime", "18:41:07.83" },
+    { ".snmp.iso.3.6.1.4.1.8072.2.1.1", "123456" }
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_v2_with_symbolic_names_and_various_types)
+{
+  const gchar *input =
+    "2017-05-13 12:17:32 localhost [UDP: [127.0.0.1]:52407->[127.0.0.1]:162]:  \n "
+    "mib-2.1.3.0 = Timeticks: (875496867) 101 days, 7:56:08.67 \t"
+    "snmpModules.1.1.4.1.0 = OID: netSnmpExampleHeartbeatNotification "
+    "netSnmpExampleHeartbeatRate = INTEGER: 60\t"
+    "netSnmpExampleString = STRING: \"string innerkey='innervalue'\"\t"
+    "org.2.2 = Gauge32: 22\t"
+    "org.1.1 = Counter32: 11123123   "
+    "org.5.3 = Hex-STRING: A0 BB CC DD EF \t"
+    "org.8.8 = NULL\t"
+    "dod.7 = IpAddress: 192.168.1.0\t  "
+    "org.5.9 = STRING: \"@\"";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:52407->[127.0.0.1]:162" },
+    { ".snmp.snmpModules.1.1.4.1.0", "netSnmpExampleHeartbeatNotification" },
+    { ".snmp.netSnmpExampleHeartbeatRate", "60" },
+    { ".snmp.netSnmpExampleString", "string innerkey='innervalue'" },
+    { ".snmp.org.2.2", "22" },
+    { ".snmp.org.1.1", "11123123" },
+    { ".snmp.org.5.3", "A0 BB CC DD EF" },
+    { ".snmp.org.8.8", "NULL" },
+    { ".snmp.dod.7", "192.168.1.0" },
+    { ".snmp.org.5.9", "@" }
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_v1_with_symbolic_names)
+{
+  const gchar *input =
+    "2017-05-13 12:18:30  localhost  [UDP: [127.0.0.1]:58143->[127.0.0.1]:162] : netSnmpExampleNotification \n"
+    "\t Warm Start Trap (1) Uptime:  27 days, 2:39:02.34\n "
+    "netSnmpExampleInteger = INTEGER: 123456 \t netSnmpExampleString = STRING: random string";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:58143->[127.0.0.1]:162" },
+    { ".snmp.enterprise_oid", "netSnmpExampleNotification" },
+    { ".snmp.type", "Warm Start Trap" },
+    { ".snmp.subtype", "1" },
+    { ".snmp.uptime", "27 days, 2:39:02.34" },
+    { ".snmp.netSnmpExampleInteger", "123456" },
+    { ".snmp.netSnmpExampleString", "random string" }
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_v2_with_generated_message)
+{
+  TestParserOptions options =
+  {
+    .generate_message = TRUE
+  };
+
+  const gchar *input =
+    "2017-05-17 13:26:04 localhost [UDP: [127.0.0.1]:34257->[127.0.0.1]:162]:\n"
+    "iso.3.6.1.4.1.18372.3.2.1.1.1.6 = STRING: \"test\"";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:34257->[127.0.0.1]:162" },
+    { ".snmp.iso.3.6.1.4.1.18372.3.2.1.1.1.6", "test" },
+
+    {
+      "MESSAGE", "hostname='localhost', transport_info='UDP: [127.0.0.1]:34257->[127.0.0.1]:162', "
+      "iso.3.6.1.4.1.18372.3.2.1.1.1.6='test'"
+    }
+  };
+
+  assert_log_message_name_values_with_options(&options, input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_v2_with_generated_message_escaped)
+{
+  TestParserOptions options =
+  {
+    .generate_message = TRUE
+  };
+
+  const gchar *input =
+    "2017-05-17 13:26:04 localhost [UDP: [127.0.0.1]:34257->[127.0.0.1]:162]:\n"
+    "iso.3.6.1.4.1.18372.3.2.1.1.1.6 = STRING: \"test 'escaped'\"";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:34257->[127.0.0.1]:162" },
+    { ".snmp.iso.3.6.1.4.1.18372.3.2.1.1.1.6", "test 'escaped'" },
+
+    {
+      "MESSAGE", "hostname='localhost', transport_info='UDP: [127.0.0.1]:34257->[127.0.0.1]:162', "
+      "iso.3.6.1.4.1.18372.3.2.1.1.1.6='test \\'escaped\\''"
+    }
+  };
+
+  assert_log_message_name_values_with_options(&options, input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_v2_without_prefix)
+{
+  TestParserOptions options =
+  {
+    .key_prefix = ""
+  };
+
+  const gchar *input =
+    "2017-05-17 13:26:04 localhost [UDP: [127.0.0.1]:34257->[127.0.0.1]:162]:\n"
+    "iso.3.6.1.4.1.18372.3.2.1.1.1.6 = test";
+
+  TestNameValue expected[] =
+  {
+    { "hostname", "localhost" },
+    { "transport_info", "UDP: [127.0.0.1]:34257->[127.0.0.1]:162" },
+    { "iso.3.6.1.4.1.18372.3.2.1.1.1.6", "test" }
+  };
+
+  assert_log_message_name_values_with_options(&options, input, expected, SIZE_OF_ARRAY(expected));
+}
+
+
+Test(snmptrapd_parser, test_v2_key_normalization)
+{
+  const gchar *input =
+    "2017-05-13 12:17:32 localhost [UDP: [127.0.0.1]:52407->[127.0.0.1]:162]:  \n "
+    "mib-2.1.3.0 = Timeticks: (875496867) 101 days, 7:56:08.67 \t"
+    "NET-SNMP-EXAMPLES-MIB:netSnmpExampleString = STRING: \"random fact\" \t"
+    "NET-SNMP-EXAMPLES-MIB::netSnmpColons = STRING: \"Colossus colons\" \t"
+    "NET-SNMP-EXAMPLES-MIB::::::::::::::::::::::::::Trail = STRING: \"Gary Indiana\" \t"
+    ":NET-SNMP-EXAMPLES::::::::::::::::::::::::::::::MIB: = INTEGER: 1234 \t";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:52407->[127.0.0.1]:162" },
+    { ".snmp.NET-SNMP-EXAMPLES-MIB_netSnmpExampleString", "random fact" },
+    { ".snmp.NET-SNMP-EXAMPLES-MIB_netSnmpColons", "Colossus colons" },
+    { ".snmp.NET-SNMP-EXAMPLES-MIB_Trail", "Gary Indiana" },
+    { ".snmp._NET-SNMP-EXAMPLES_MIB_", "1234" }
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_general_v1_message_without_varbindlist)
+{
+  const gchar *input =
+    "2017-05-10 13:23:16 localhost [UDP: [127.0.0.1]:53831->[127.0.0.1]:162]: iso.3.6.1.4.1.8072.2.3.1\n"
+    "\t Enterprise Specific Trap (.17) Uptime: 18:41:07.83";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:53831->[127.0.0.1]:162" },
+    { ".snmp.enterprise_oid", "iso.3.6.1.4.1.8072.2.3.1" },
+    { ".snmp.type", "Enterprise Specific Trap" },
+    { ".snmp.subtype", ".17" },
+    { ".snmp.uptime", "18:41:07.83" }
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(snmptrapd_parser, test_snmptrapd_debug_message_with_timestamp)
+{
+  const gchar *input =
+    "2017-05-19 10:00:00 NET-SNMP version 5.7.3 Stopped.\nStopping snmptrapd";
+
+  assert_log_message_dropped(input);
+}
+
+Test(snmptrapd_parser, test_v2_varbindlist_starts_with_tab)
+{
+  const gchar *input =
+    "2017-05-19 13:37:00 localhost [UDP: [127.0.0.1]:36324->[127.0.0.1]:162]:\n"
+    "\tiso.3.6.1.2.1.1.3.0 = Timeticks: (875496867) 101 days, 7:56:08.67 \t"
+    "iso.3.6.1.6.3.1.1.4.1.0 = OID: iso.3.6.1.4.1.8072.2.3.0.1 \t"
+    "iso.3.6.1.4.1.8072.2.3.2.1 = INTEGER: 60";
+
+  assert_log_message_dropped(input);
+}

--- a/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
+++ b/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
@@ -370,3 +370,22 @@ Test(snmptrapd_parser, test_v2_varbindlist_starts_with_tab)
 
   assert_log_message_dropped(input);
 }
+
+Test(snmptrapd_parser, test_v2_message_with_garbage)
+{
+  const gchar *input =
+    "2017-05-10 12:46:14 localhost [UDP: [127.0.0.1]:34257->[127.0.0.1]:162]:\n"
+    "iso.3.6.1.2.1.1.3.0 = Timeticks: (875496867) 101 days, 7:56:08.67\t"
+    "iso.3.6.1.6.3.1.1.4.1.0 = OID: iso.3.6.1.4.1.8072.2.3.0.1\n"
+    "garbage = stop here";
+
+  TestNameValue expected[] =
+  {
+    { ".snmp.hostname", "localhost" },
+    { ".snmp.transport_info", "UDP: [127.0.0.1]:34257->[127.0.0.1]:162" },
+    { ".snmp.iso.3.6.1.2.1.1.3.0", "(875496867) 101 days, 7:56:08.67" },
+    { ".snmp.iso.3.6.1.6.3.1.1.4.1.0", "iso.3.6.1.4.1.8072.2.3.0.1" }
+  };
+
+  assert_log_message_name_values(input, expected, SIZE_OF_ARRAY(expected));
+}

--- a/modules/snmptrapd-parser/tests/test_varbindlist_scanner.c
+++ b/modules/snmptrapd-parser/tests/test_varbindlist_scanner.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+#include "varbindlist-scanner.h"
+
+#define SIZE_OF_ARRAY(array) (sizeof(array) / sizeof((array)[0]))
+
+typedef struct
+{
+  const gchar *key;
+  const gchar *type;
+  const gchar *value;
+} TestVarBind;
+
+static void
+_expect_no_more_tokens(VarBindListScanner *scanner)
+{
+  cr_expect_not(varbindlist_scanner_scan_next(scanner));
+}
+
+static void
+_expect_next_key_type_value(VarBindListScanner *scanner, const gchar *key, const gchar *type,
+                            const gchar *value)
+{
+  cr_expect(varbindlist_scanner_scan_next(scanner));
+  cr_expect_str_eq(varbindlist_scanner_get_current_key(scanner), key);
+  cr_expect_str_eq(varbindlist_scanner_get_current_type(scanner), type);
+  cr_expect_str_eq(varbindlist_scanner_get_current_value(scanner), value);
+}
+
+static VarBindListScanner *
+create_scanner(void)
+{
+  VarBindListScanner *scanner = varbindlist_scanner_new();
+
+  VarBindListScanner *cloned = varbindlist_scanner_clone(scanner);
+  varbindlist_scanner_free(scanner);
+  return cloned;
+}
+
+static void
+expect_varbindlist(const gchar *input, TestVarBind *expected, gsize number_of_expected)
+{
+  VarBindListScanner *scanner = create_scanner();
+  varbindlist_scanner_input(scanner, input);
+
+  for (int i=0; i < number_of_expected; i++)
+    _expect_next_key_type_value(scanner, expected[i].key, expected[i].type, expected[i].value);
+
+  _expect_no_more_tokens(scanner);
+
+  varbindlist_scanner_free(scanner);
+}
+
+Test(varbindlist_scanner, test_spaces_as_separator)
+{
+  const gchar *input = "iso.3.6.1.6.3.1.1.4.1.0 = OID: iso.3.6.1.4.1.18372.3.2.1.1.2.2       "
+                       "iso.3.6.1.4.1.18372.3.2.1.1.1.6 = STRING: \"svc/w4joHeFNzpFNrC8u9umJhc/ssh_4eyes_user_subjects:3/ssh\"";
+
+  TestVarBind expected[] =
+  {
+    {"iso.3.6.1.6.3.1.1.4.1.0", "OID", "iso.3.6.1.4.1.18372.3.2.1.1.2.2"},
+    {"iso.3.6.1.4.1.18372.3.2.1.1.1.6", "STRING", "svc/w4joHeFNzpFNrC8u9umJhc/ssh_4eyes_user_subjects:3/ssh"}
+  };
+
+  expect_varbindlist(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(varbindlist_scanner, test_tabs_and_spaces_as_separator)
+{
+  const gchar *input = "\t iso.3.6.1.6.3.1.1.4.1.0 = OID: iso.3.6.1.4.1.18372.3.2.1.1.2.2\t"
+                       "iso.3.6.1.4.1.18372.3.2.1.1.1.6 = STRING: \"svc/w4joHeFNzpFNrC8u9umJhc/ssh_4eyes_user_subjects:3/ssh\"\t\t"
+                       "iso.1.2 = INTEGER: 40 \t"
+                       "iso.3.4 = INTEGER: 30\t "
+                       "iso.5.6 = INTEGER: 20  \t\t "
+                       "iso.7.8 = INTEGER: 10";
+
+  TestVarBind expected[] =
+  {
+    {"iso.3.6.1.6.3.1.1.4.1.0", "OID", "iso.3.6.1.4.1.18372.3.2.1.1.2.2"},
+    {"iso.3.6.1.4.1.18372.3.2.1.1.1.6", "STRING", "svc/w4joHeFNzpFNrC8u9umJhc/ssh_4eyes_user_subjects:3/ssh"},
+    {"iso.1.2", "INTEGER", "40"},
+    {"iso.3.4", "INTEGER", "30"},
+    {"iso.5.6", "INTEGER", "20"},
+    {"iso.7.8", "INTEGER", "10"}
+  };
+
+  expect_varbindlist(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(varbindlist_scanner, test_key_representations)
+{
+  const gchar *input = ".1.3.6.1.2.1.1.3.0 = STRING: \"\"\t"
+                       "IP-MIB::ipForwarding.0 = INTEGER: 0\t"
+                       "sysUpTime.0 = Timeticks: 1:15:09:27.63\t"
+                       "SNMP-VIEW-BASED-ACM-MIB::vacmSecurityModel.0.3.119.101.115 = xxx";
+
+  TestVarBind expected[] =
+  {
+    { ".1.3.6.1.2.1.1.3.0", "STRING", "" },
+    { "IP-MIB::ipForwarding.0", "INTEGER", "0" },
+    { "sysUpTime.0", "Timeticks", "1:15:09:27.63" },
+    { "SNMP-VIEW-BASED-ACM-MIB::vacmSecurityModel.0.3.119.101.115", "", "xxx" }
+  };
+
+  expect_varbindlist(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(varbindlist_scanner, test_all_varbind_type)
+{
+  const gchar *input =
+    ".iso.org.dod.internet.mgmt.mib-2.system.sysUpTime.0 = Timeticks: (875496867) 101 days, 7:56:08.67\t"
+    "iso.3.6.1.6.3.1.1.4.1.0 = OID: iso.3.6.1.4.1.8072.2.3.0.1\t"
+    "iso.3.6.1.4.1.8072.2.3.2.1 = INTEGER: 60\t"
+    "SNMP-VIEW-BASED-ACM-MIB::vacmSecurityModel.0.3.119.101.115 = STRING: \"random string\"\t"
+    "iso.3.2.2 = Gauge32: 22\t"
+    "iso.3.1.1 = Counter32: 11123123 \t"
+    "iso.3.5.3 = Hex-STRING: A0 BB CC DD EF\t"
+    "iso.3.8.8 = NULL \t"
+    "iso.2.1.1 = Timeticks: (34234234) 3 days, 23:05:42.34\t"
+    "SNMP-VIEW-BASED-ACM-MIB::vacmSecurityModel.0.wes = IpAddress: 192.168.1.0";
+
+  TestVarBind expected[] =
+  {
+    { ".iso.org.dod.internet.mgmt.mib-2.system.sysUpTime.0", "Timeticks", "(875496867) 101 days, 7:56:08.67" },
+    { "iso.3.6.1.6.3.1.1.4.1.0", "OID", "iso.3.6.1.4.1.8072.2.3.0.1" },
+    { "iso.3.6.1.4.1.8072.2.3.2.1", "INTEGER", "60" },
+    { "SNMP-VIEW-BASED-ACM-MIB::vacmSecurityModel.0.3.119.101.115", "STRING", "random string" },
+    { "iso.3.2.2", "Gauge32", "22" },
+    { "iso.3.1.1", "Counter32", "11123123" },
+    { "iso.3.5.3", "Hex-STRING", "A0 BB CC DD EF" },
+    { "iso.3.8.8", "", "NULL" },
+    { "iso.2.1.1", "Timeticks", "(34234234) 3 days, 23:05:42.34" },
+    { "SNMP-VIEW-BASED-ACM-MIB::vacmSecurityModel.0.wes", "IpAddress", "192.168.1.0" }
+  };
+
+  expect_varbindlist(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(varbindlist_scanner, test_separator_inside_of_quoted_value)
+{
+  const gchar *input =
+    "iso.1.2.3 = STRING: \"quoted = string \t innerkey='innervalue'\" \t"
+    "iso.3.8.8 = NULL\t";
+
+  TestVarBind expected[] =
+  {
+    { "iso.1.2.3", "STRING", "quoted = string \t innerkey='innervalue'" },
+    { "iso.3.8.8", "", "NULL" }
+  };
+
+  expect_varbindlist(input, expected, SIZE_OF_ARRAY(expected));
+}
+
+Test(varbindlist_scanner, test_multiline_quouted_value)
+{
+  const gchar *input =
+    "iso.3.6.1.4.1.18372.3.2.1.1.1.6 = STRING: \"multi \n line\r\nvalue\" \t"
+    "iso.3.8.8 = NULL";
+
+  TestVarBind expected[] =
+  {
+    { "iso.3.6.1.4.1.18372.3.2.1.1.1.6", "STRING", "multi \n line\r\nvalue" },
+    { "iso.3.8.8", "", "NULL" }
+  };
+
+  expect_varbindlist(input, expected, SIZE_OF_ARRAY(expected));
+}

--- a/modules/snmptrapd-parser/varbindlist-scanner.c
+++ b/modules/snmptrapd-parser/varbindlist-scanner.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "varbindlist-scanner.h"
+#include "str-utils.h"
+
+static inline gboolean
+_is_valid_key_character(gchar c)
+{
+  return (c >= 'a' && c <= 'z') ||
+         (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') ||
+         (c == '_') ||
+         (c == '.') ||
+         (c == '-') ||
+         (c == ':');
+}
+
+static inline void
+_skip_whitespaces(const gchar **input)
+{
+  const gchar *current_char = *input;
+
+  while (*current_char == ' ' || *current_char == '\t')
+    ++current_char;
+
+  *input = current_char;
+}
+
+static void
+_extract_type(KVScanner *scanner)
+{
+  VarBindListScanner *self = (VarBindListScanner *) scanner;
+
+  const gchar *type_start = &scanner->input[scanner->input_pos];
+  _skip_whitespaces(&type_start);
+  const gchar *type_end = strpbrk(type_start, ": \t");
+
+  gboolean type_exists = type_end && *type_end == ':';
+  if (!type_exists)
+    {
+      g_string_truncate(self->varbind_type, 0);
+      return;
+    }
+
+  gsize type_len = type_end - type_start;
+  g_string_assign_len(self->varbind_type, type_start, type_len);
+
+  scanner->input_pos = type_end - scanner->input + 1;
+}
+
+static KVScanner *
+_clone(KVScanner *s)
+{
+  VarBindListScanner *scanner = varbindlist_scanner_new();
+  return &scanner->super;
+}
+
+static void
+_free(KVScanner *s)
+{
+  VarBindListScanner *self = (VarBindListScanner *) s;
+  varbindlist_scanner_deinit(self);
+}
+
+void
+varbindlist_scanner_init(VarBindListScanner *self)
+{
+  memset(self, 0, sizeof(VarBindListScanner));
+  kv_scanner_init_instance(&self->super, '=', "\t", FALSE);
+  kv_scanner_set_extract_annotation_func(&self->super, _extract_type);
+  kv_scanner_set_valid_key_character_func(&self->super, _is_valid_key_character);
+
+  self->varbind_type = g_string_sized_new(16);
+  self->super.clone = _clone;
+  self->super.free_fn = _free;
+}
+
+void
+varbindlist_scanner_deinit(VarBindListScanner *self)
+{
+  kv_scanner_free_method(&self->super);
+  g_string_free(self->varbind_type, TRUE);
+}
+
+gboolean
+varbindlist_scanner_scan_next(VarBindListScanner *self)
+{
+  return kv_scanner_scan_next(&self->super);
+}
+
+VarBindListScanner *
+varbindlist_scanner_new(void)
+{
+  VarBindListScanner *self = g_new(VarBindListScanner, 1);
+  varbindlist_scanner_init(self);
+  return self;
+}

--- a/modules/snmptrapd-parser/varbindlist-scanner.c
+++ b/modules/snmptrapd-parser/varbindlist-scanner.c
@@ -89,6 +89,7 @@ varbindlist_scanner_init(VarBindListScanner *self)
   kv_scanner_init_instance(&self->super, '=', "\t", FALSE);
   kv_scanner_set_extract_annotation_func(&self->super, _extract_type);
   kv_scanner_set_valid_key_character_func(&self->super, _is_valid_key_character);
+  kv_scanner_set_stop_character(&self->super, '\n');
 
   self->varbind_type = g_string_sized_new(16);
   self->super.clone = _clone;

--- a/modules/snmptrapd-parser/varbindlist-scanner.h
+++ b/modules/snmptrapd-parser/varbindlist-scanner.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef VARBINDLIST_SCANNER_H_INCLUDED
+#define VARBINDLIST_SCANNER_H_INCLUDED
+
+#include "scanner/kv-scanner/kv-scanner.h"
+
+typedef struct _VarBindListScanner VarBindListScanner;
+
+struct _VarBindListScanner
+{
+  KVScanner super;
+  GString *varbind_type;
+};
+
+static inline void
+varbindlist_scanner_input(VarBindListScanner *self, const gchar *input)
+{
+  kv_scanner_input(&self->super, input);
+}
+
+static inline VarBindListScanner *
+varbindlist_scanner_clone(VarBindListScanner *self)
+{
+  return (VarBindListScanner *)kv_scanner_clone(&self->super);
+}
+
+static inline void
+varbindlist_scanner_free(VarBindListScanner *self)
+{
+  if (self)
+    kv_scanner_free(&self->super);
+}
+
+static inline const gchar *
+varbindlist_scanner_get_current_key(VarBindListScanner *self)
+{
+  return kv_scanner_get_current_key(&self->super);
+}
+
+static inline const gchar *
+varbindlist_scanner_get_current_type(VarBindListScanner *self)
+{
+  return self->varbind_type->str;
+}
+
+static inline const gchar *
+varbindlist_scanner_get_current_value(VarBindListScanner *self)
+{
+  return kv_scanner_get_current_value(&self->super);
+}
+
+gboolean varbindlist_scanner_scan_next(VarBindListScanner *self);
+VarBindListScanner *varbindlist_scanner_new(void);
+
+void varbindlist_scanner_init(VarBindListScanner *self);
+void varbindlist_scanner_deinit(VarBindListScanner *self);
+
+#endif

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -13,7 +13,8 @@ SCL_SUBDIRS	= \
 	hdfs		\
 	apache		\
 	loggly		\
-	logmatic
+	logmatic	\
+	snmptrap
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -1,0 +1,40 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block source snmptrap(
+  filename("")
+  prefix(".snmp.")
+  generate-message(yes)
+)
+{
+  channel {
+    source {
+      file("`filename`"
+          multi-line-mode("prefix-garbage")
+          # prefix: <date><separator><time>
+          multi-line-prefix('^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}[ T]([0-9]{1,2}:){2}[0-9]{2}')
+          flags(no-parse)
+      );
+    };
+    parser { snmptrapd-parser( prefix(`prefix`) generate-message(`generate-message`) ); };
+  };
+};

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -32,6 +32,7 @@ block source snmptrap(
           multi-line-mode("prefix-garbage")
           # prefix: <date><separator><time>
           multi-line-prefix('^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}[ T]([0-9]{1,2}:){2}[0-9]{2}')
+          `__VARARGS__`
           flags(no-parse)
       );
     };

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -23,7 +23,7 @@
 block source snmptrap(
   filename("")
   prefix(".snmp.")
-  generate-message(yes)
+  set-message-macro(yes)
 )
 {
   channel {
@@ -36,6 +36,6 @@ block source snmptrap(
           flags(no-parse)
       );
     };
-    parser { snmptrapd-parser( prefix("`prefix`") generate-message(`generate-message`) ); };
+    parser { snmptrapd-parser( prefix("`prefix`") set-message-macro(`set-message-macro`) ); };
   };
 };

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -36,6 +36,6 @@ block source snmptrap(
           flags(no-parse)
       );
     };
-    parser { snmptrapd-parser( prefix(`prefix`) generate-message(`generate-message`) ); };
+    parser { snmptrapd-parser( prefix("`prefix`") generate-message(`generate-message`) ); };
   };
 };

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -53,7 +53,7 @@ dev-utils/plugin_skeleton_creator/create_plugin.sh
 tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
-modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|[^/]*$)
+modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|snmptrapd-parser|[^/]*$)
 modules/(add-contextual-data|map-value-pairs|[^/]*$)
 scl
 scripts


### PR DESCRIPTION
This PR contains the snmptrapd parser plugin and a filesource-based snmptrapd SCL source block.


![snmptrapd-parser](https://cloud.githubusercontent.com/assets/3130044/26317782/f20309a2-3f18-11e7-9168-ae09fe359c04.png)


snmptrapd-parser can be used to parse the default output of Net-SNMP's snmptrapd.

The parsed information is available as key-value pairs, which can be used/serialized (macros, format-json, etc.) in the log path.

Because the `:` character is not accepted as a macro name in the configuration language of syslog-ng, all consecutive `:` characters are replaced with a single `_`.
For example, the value of the `NET-SNMP-EXAMPLES-MIB::netSnmpExampleString` key can be accessed with `${NET-SNMP-EXAMPLES-MIB_netSnmpExampleString}`.

If you want to forward the message in a structured way, you can disable the default message generation with the `set-message-macro(no)` option.


Currently, the default V2 output format is supported.
Since there is no explicit V1 format in the code base of snmptrapd, we had to specify it:
`%.4y-%.2m-%.2l %.2h:%.2j:%.2k %B [%b]: %N\n\t%W Trap (%q) Uptime: %#T\n%v\n`


Example usage:

```
log {
  source {
    snmptrap(filename("/var/log/snmptrapd.log"));
  };

  /* additional parsers, filters, rewrite rules */

  destination {
    file("/var/log/example.log");
  };
};
```

```
log {
  source {
    snmptrap(
      filename("/var/log/snmptrapd.log")
      set-message-macro(no)
      prefix(".custom.snmp.")
    );
  };

  destination {
    file("/var/log/example.log" template("$(format-json --scope dot-nv-pairs)\n"));
  };
};
```
------------------------------

snmptrapd should be configured with the following restrictions:
- snmptrapd should log into file
- for V1 traps, the following format must be used (there is no explicit default):

```
format1 %.4y-%.2m-%.2l %.2h:%.2j:%.2k %B [%b]: %N\n\t%W Trap (%q) Uptime: %#T\n%v\n
```

- for V2 traps, the default format is expected, so this line is **optional**:

```
format2 %.4y-%.2m-%.2l %.2h:%.2j:%.2k %B [%b]:\n%v\n
```

Example snmptrapd.conf:
```
authCommunity log,execute,net public
format1 %.4y-%.2m-%.2l %.2h:%.2j:%.2k %B [%b]: %N\n\t%W Trap (%q) Uptime: %#T\n%v\n
outputOption s
```

```
$ snmptrapd -Lf /var/log/snmptrapd.log
```

NOTE 1: Due to a bug in snmptrapd, if you specify the filename in the configuration file with 'logOption',
the trap format won't be applied unless you also specify another output as a command line argument (-Lf, -Ls).

NOTE 2: There is another bug in which snmptrapd doesn't quote STRING values in the VarBindList.
This only happens if the given OID is resolved to a symbolic name.

------------------------------

Further development ideas:
- kv-parser and kv-scanner should also use scratch buffers
- clarify the null-terminated-string vs input_len confusion in log_parser_process() (currently, we used `APPEND_ZERO`, but also updated the input_len during the parsing process)
- add debug messages to show the exact position where the parser detected a problem