### PR TITLE
geoip: legacy library - invalid database warning

### DIFF
--- a/modules/geoip/Makefile.am
+++ b/modules/geoip/Makefile.am
@@ -7,7 +7,10 @@ modules_geoip_libgeoip_plugin_la_SOURCES=	\
 	modules/geoip/geoip-parser-grammar.y	\
 	modules/geoip/geoip-parser-parser.c	\
 	modules/geoip/geoip-parser-parser.h	\
-	modules/geoip/geoip-plugin.c
+	modules/geoip/geoip-plugin.c		\
+	modules/geoip/geoip-helper.h		\
+	modules/geoip/geoip-helper.c
+
 modules_geoip_libgeoip_plugin_la_CPPFLAGS	=	\
 	$(AM_CPPFLAGS)					\
 	-I$(top_srcdir)/modules/geoip			\

--- a/modules/geoip/geoip-helper.c
+++ b/modules/geoip/geoip-helper.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "geoip-helper.h"
+
+#include <messages.h>
+
+gboolean
+is_country_type(GeoIPDBTypes database_type)
+{
+
+  switch (database_type)
+    {
+    case GEOIP_LARGE_COUNTRY_EDITION:
+    case GEOIP_COUNTRY_EDITION:
+    case GEOIP_PROXY_EDITION:
+    case GEOIP_NETSPEED_EDITION:
+      return TRUE;
+
+    case GEOIP_CITY_EDITION_REV0:
+    case GEOIP_CITY_EDITION_REV1:
+      return FALSE;
+
+    default:
+      g_assert_not_reached();
+      return FALSE;
+    }
+}

--- a/modules/geoip/geoip-helper.h
+++ b/modules/geoip/geoip-helper.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef GEOIP_HELPER_H_INCLUDED
+#define GEOIP_HELPER_H_INCLUDED
+
+#include <GeoIPCity.h>
+#include <GeoIP.h>
+
+#include <syslog-ng.h>
+
+gboolean is_country_type(GeoIPDBTypes database_type);
+#endif

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -24,24 +24,25 @@
 #include "geoip-parser.h"
 #include "parser/parser-expr.h"
 #include "scratch-buffers2.h"
+#include "geoip-helper.h"
 
-#include <GeoIPCity.h>
+typedef struct _GeoIPParser GeoIPParser;
 
-typedef struct
+struct _GeoIPParser
 {
   LogParser super;
   GeoIP *gi;
 
   gchar *database;
   gchar *prefix;
-
+  void (*add_geoip_result)(GeoIPParser *, LogMessage *, const gchar *);
   struct
   {
     gchar *country_code;
     gchar *longitude;
     gchar *latitude;
   } dest;
-} GeoIPParser;
+};
 
 void
 geoip_parser_set_prefix(LogParser *s, const gchar *prefix)
@@ -74,6 +75,51 @@ geoip_parser_set_database(LogParser *s, const gchar *database)
   self->database = g_strdup(database);
 }
 
+static void
+add_geoip_record(GeoIPParser *self, LogMessage *msg, const gchar *ip)
+{
+  GeoIPRecord *record;
+  GString *value;
+
+  record = GeoIP_record_by_name(self->gi, ip);
+  if (record)
+    {
+      if (record->country_code)
+        log_msg_set_value_by_name(msg, self->dest.country_code,
+                                  record->country_code,
+                                  strlen(record->country_code));
+
+      value = scratch_buffers2_alloc();
+
+      g_string_printf(value, "%f",
+                      record->latitude);
+      log_msg_set_value_by_name(msg, self->dest.latitude,
+                                value->str,
+                                value->len);
+
+      g_string_printf(value, "%f",
+                      record->longitude);
+      log_msg_set_value_by_name(msg, self->dest.longitude,
+                                value->str,
+                                value->len);
+
+      GeoIPRecord_delete(record);
+    }
+}
+
+static void
+add_geoip_country_code(GeoIPParser *self, LogMessage *msg, const gchar *ip)
+{
+  const char *country;
+
+  country = GeoIP_country_code_by_name(self->gi, ip);
+  if (country)
+    log_msg_set_value_by_name(msg, self->dest.country_code,
+                              country,
+                              strlen(country));
+}
+
+
 static gboolean
 geoip_parser_process(LogParser *s, LogMessage **pmsg,
                      const LogPathOptions *path_options,
@@ -81,49 +127,13 @@ geoip_parser_process(LogParser *s, LogMessage **pmsg,
 {
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  GeoIPRecord *record;
-  GString *value;
 
   if (!self->dest.country_code &&
       !self->dest.latitude &&
       !self->dest.longitude)
     return TRUE;
 
-  record = GeoIP_record_by_name(self->gi, input);
-
-  if (!record)
-    {
-      const char *country;
-
-      country = GeoIP_country_code_by_name(self->gi, input);
-      if (country)
-        log_msg_set_value_by_name(msg, self->dest.country_code,
-                                  country,
-                                  strlen(country));
-
-      return TRUE;
-    }
-
-  if (record->country_code)
-    log_msg_set_value_by_name(msg, self->dest.country_code,
-                              record->country_code,
-                              strlen(record->country_code));
-
-  value = scratch_buffers2_alloc();
-
-  g_string_printf(value, "%f",
-                  record->latitude);
-  log_msg_set_value_by_name(msg, self->dest.latitude,
-                            value->str,
-                            value->len);
-
-  g_string_printf(value, "%f",
-                  record->longitude);
-  log_msg_set_value_by_name(msg, self->dest.longitude,
-                            value->str,
-                            value->len);
-
-  GeoIPRecord_delete(record);
+  self->add_geoip_result(self, msg, input);
 
   return TRUE;
 }
@@ -174,6 +184,19 @@ geoip_parser_init(LogPipe *s)
 
   if (!self->gi)
     return FALSE;
+
+  if (is_country_type(self->gi->databaseType))
+    {
+      msg_debug("geoip: country type database detected",
+                evt_tag_int("database type", self->gi->databaseType));
+      self->add_geoip_result = add_geoip_country_code;
+    }
+  else
+    {
+      msg_debug("geoip: city type database detected",
+                evt_tag_int("database type", self->gi->databaseType));
+      self->add_geoip_result = add_geoip_record;
+    }
   return log_parser_init_method(s);
 }
 


### PR DESCRIPTION
Fixing: https://github.com/balabit/syslog-ng/issues/663
and https://github.com/balabit/syslog-ng/issues/1446

This patchset removes the invalid database warning that is written by geoip plugin in syslog-ng in certain circumstances.

There are two database types that operators can use: city and the country version. In the original behaviour, syslog-ng tried to interpret the database as if it was city version: GeoIP_record_by_name, and in case it fails, she falls back to the country version: GeoIP_country_code_by_name.
But in case of mismatch, libgeoip writes an unmaskable warning about invalid database. Hence the problem.

The resolution is the following: during init phase, syslog-ng detects the database type, and uses only the appropriate api call that is compatible with the detected database type. This fixes the geoip parser.

For the template function version there is one slight addition. 
When database is not provided, libgeoip will look for the database file in a hard coded path (set by package maintainers using a compiler option): GeoIP_new(GEOIP_MMAP_CACHE);
In the original implementation syslog-ng did not support to specify database location for template parameters. Only the "official" location provided by package maintainers was used. And the fallback mechanic that was included in the parser version was missing, so operators were forced to use the country version.

By this patchset operators can specify database location for geoip template function as well:
destination d_file {
   file("/tmp/output" flags(syslog-protocol)
   template("$(geoip --database GeoLiteCity.dat ${HOST})"));
};
