### PR TITLE
Riemann destination: various bugfixes including heap corruption

### DIFF
--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -496,7 +496,7 @@ static worker_insert_result_t
 riemann_worker_insert_one(RiemannDestDriver *self, LogMessage *msg)
 {
   riemann_event_t *event;
-  gboolean success = TRUE, need_drop = FALSE;
+  gboolean need_drop = FALSE;
   GString *str;
 
   event = riemann_event_new();
@@ -550,11 +550,8 @@ riemann_worker_insert_one(RiemannDestDriver *self, LogMessage *msg)
 
   if (need_drop)
     return WORKER_INSERT_RESULT_DROP;
-
-  if (success)
-    return WORKER_INSERT_RESULT_SUCCESS;
   else
-    return WORKER_INSERT_RESULT_ERROR;
+    return WORKER_INSERT_RESULT_SUCCESS;
 }
 
 static worker_insert_result_t
@@ -564,7 +561,7 @@ riemann_worker_batch_flush(RiemannDestDriver *self)
   int r;
 
   if (!riemann_dd_connect(self, TRUE))
-    return WORKER_INSERT_RESULT_ERROR;
+    return WORKER_INSERT_RESULT_NOT_CONNECTED;
 
   message = riemann_message_new();
 

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -577,7 +577,7 @@ riemann_worker_batch_flush(RiemannDestDriver *self)
   self->event.list = (riemann_event_t **)malloc (sizeof (riemann_event_t *) *
                                                  self->event.batch_size_max);
   if (r != 0)
-    return WORKER_INSERT_RESULT_DROP;
+    return WORKER_INSERT_RESULT_ERROR;
   else
     return WORKER_INSERT_RESULT_SUCCESS;
 }

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -588,12 +588,16 @@ riemann_worker_insert(LogThrDestDriver *s, LogMessage *msg)
   RiemannDestDriver *self = (RiemannDestDriver *)s;
   worker_insert_result_t result;
 
+  if (self->event.n == self->event.batch_size_max)
+    {
+      result = riemann_worker_batch_flush(self);
+      if (result != WORKER_INSERT_RESULT_SUCCESS)
+        return result;
+    }
+
   result = riemann_worker_insert_one(self, msg);
 
   if (self->event.n < self->event.batch_size_max)
-    return result;
-
-  if (result != WORKER_INSERT_RESULT_SUCCESS)
     return result;
 
   return riemann_worker_batch_flush(self);


### PR DESCRIPTION
This patchset contains various bugfixes/improvements for Riemann destination.

A little comment for one of these issues: in case flush-lines is configured, messages can get stuck in the internal queue of Riemann destination. 

The optimistic path when Riemann server is connected is covered by this patchset. But the failure path when Riemann server is not connected is not covered. In the latter case syslog-ng will try to send batch once, but will not retry again, until the new messages arrived, or the batch filled suddenly completely, which latter case is again covered by this patch.
Also, for now in case flush-lines is used and unaccessible Riemann server, all events except the latest in the batch will be lost, because LogThrDestDriver do not support such message bulk rewind support. Only the last message can be rewind.

Any such issues do not occur when flush-lines is not used.

These issues will be resolved later in another changeset.