### PR TITLE
Remove diskq option from file destinations

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1159,25 +1159,7 @@ dest_driver_option
 
 	: KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
 	| KW_THROTTLE '(' nonnegative_integer ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
-        | LL_IDENTIFIER
-          {
-            Plugin *p;
-            gint context = LL_CONTEXT_INNER_DEST;
-            gpointer value;
-
-            p = plugin_find(configuration, context, $1);
-            CHECK_ERROR(p, @1, "%s plugin %s not found", cfg_lexer_lookup_context_name_by_type(context), $1);
-
-            value = plugin_parse_config(p, configuration, &@1, last_driver);
-
-            free($1);
-            if (!value)
-              {
-                YYERROR;
-              }
-            log_driver_add_plugin(last_driver, (LogDriverPlugin *) value);
-          }
-    | driver_option
+	| driver_option
         ;
 
 dest_writer_options

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -159,6 +159,8 @@ extern struct _StatsOptions *last_stats_options;
 %token LL_CONTEXT_CLIENT_PROTO        17
 %token LL_CONTEXT_SERVER_PROTO        18
 %token LL_CONTEXT_SELECTOR            19
+%token LL_CONTEXT_DEST_PLUGIN_DISKQ   20
+
 
 
 /* statements */

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1091,6 +1091,7 @@ static const gchar *lexer_contexts[] =
   [LL_CONTEXT_CLIENT_PROTO] = "client-proto",
   [LL_CONTEXT_SERVER_PROTO] = "server-proto",
   [LL_CONTEXT_SELECTOR] = "selector",
+  [LL_CONTEXT_DEST_PLUGIN_DISKQ] = "dest-plugin-diskq",
 };
 
 gint

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -68,6 +68,7 @@ struct _ModuleInfo
 
 /* instantiate a new plugin */
 Plugin *plugin_find(GlobalConfig *cfg, gint plugin_type, const gchar *plugin_name);
+Plugin *plugin_find_multiple_types(GlobalConfig *cfg, const gint *plugin_types, gint num_of_plugin_types, const gchar *plugin_name);
 gpointer plugin_construct(Plugin *self, GlobalConfig *cfg, gint plugin_type, const gchar *plugin_name);
 gpointer plugin_parse_config(Plugin *plugin, GlobalConfig *cfg, YYLTYPE *yylloc, gpointer arg);
 

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -87,6 +87,7 @@ afamqp_option
 	| KW_PASSWORD '(' string ')'		{ afamqp_dd_set_password(last_driver, $3); free($3); }
 	| value_pair_option			{ afamqp_dd_set_value_pairs(last_driver, $1); }
 	| dest_driver_option
+  | dest_driver_basic_and_diskq_plugins
 	| threaded_dest_driver_option
 	| { last_template_options = afamqp_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -237,7 +237,7 @@ dest_afpipe_options
 dest_afpipe_option
 	: dest_writer_option
 	| dest_driver_option
-	| dest_driver_basic_plugins
+	| dest_driver_basic_and_diskq_plugins
 	| file_perm_option
 	;
 

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -211,6 +211,7 @@ dest_affile_options
 dest_affile_option
 	: dest_writer_option
 	| dest_driver_option
+	| dest_driver_basic_plugins
         | file_perm_option
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
@@ -236,6 +237,7 @@ dest_afpipe_options
 dest_afpipe_option
 	: dest_writer_option
 	| dest_driver_option
+	| dest_driver_basic_plugins
 	| file_perm_option
 	;
 

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -84,6 +84,7 @@ afmongodb_option
             afmongodb_dd_set_value_pairs(last_driver, $1);
         }
     | dest_driver_option
+    | dest_driver_basic_and_diskq_plugins
     | threaded_dest_driver_option
     | { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
     ;

--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -113,6 +113,7 @@ dest_afprogram_options
 dest_afprogram_option
 	: dest_writer_option
 	| dest_driver_option
+	| dest_driver_basic_and_diskq_plugins
 	| KW_KEEP_ALIVE '(' yesno ')' { afprogram_dd_set_keep_alive((AFProgramDestDriver *)last_driver, $3); }
 	| KW_INHERIT_ENVIRONMENT '(' yesno ')' { afprogram_set_inherit_environment(&((AFProgramDestDriver *)last_driver)->process_info, $3); }
 	;

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -163,6 +163,7 @@ afsmtp_option
           }
         | threaded_dest_driver_option
         | dest_driver_option
+        | dest_driver_basic_and_diskq_plugins
         | { last_template_options = afsmtp_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -491,6 +491,7 @@ dest_afunix_option
 	| dest_afsocket_option
 	| socket_option
 	| dest_driver_option
+	| dest_driver_basic_and_diskq_plugins
 	;
 
 dest_afinet
@@ -536,6 +537,7 @@ dest_afinet_option
 	| dest_writer_option
 	| dest_afsocket_option
 	| dest_driver_option
+	| dest_driver_basic_and_diskq_plugins
 	;
 
 

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -123,6 +123,7 @@ dest_afsql_option
 
 	| { last_template_options = &((AFSqlDestDriver *) last_driver)->template_options; } template_option
 	| dest_driver_option
+	| dest_driver_basic_and_diskq_plugins
         ;
 
 dest_afsql_values

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -80,6 +80,7 @@ afstomp_option
         | KW_PASSWORD '(' string ')'		{ afstomp_dd_set_password(last_driver, $3); free($3); }
         | value_pair_option			{ afstomp_dd_set_value_pairs(last_driver, $1); }
         | dest_driver_option
+        | dest_driver_basic_and_diskq_plugins
         | threaded_dest_driver_option
 	| { last_template_options = afstomp_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -68,7 +68,7 @@ DiskQueueOptions *last_options;
 %%
 
 start
-	: LL_CONTEXT_INNER_DEST dest_diskq { YYACCEPT; }
+	: LL_CONTEXT_DEST_PLUGIN_DISKQ dest_diskq { YYACCEPT; }
 	;
 
 dest_diskq

--- a/modules/diskq/diskq-plugin.c
+++ b/modules/diskq/diskq-plugin.c
@@ -30,7 +30,7 @@ extern CfgParser diskq_parser;
 static Plugin diskq_plugins[] =
 {
   {
-    .type = LL_CONTEXT_INNER_DEST,
+    .type = LL_CONTEXT_DEST_PLUGIN_DISKQ,
     .name = "disk_buffer",
     .parser = &diskq_parser,
   },

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -114,6 +114,7 @@ http_option
     | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
     | dest_driver_option
+    | dest_driver_basic_and_diskq_plugins
     | threaded_dest_driver_option
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option
     ;

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -80,6 +80,7 @@ java_dest_option
         | KW_OPTION '(' java_dest_custom_options ')'
         | threaded_dest_driver_option
         | dest_driver_option
+        | dest_driver_basic_and_diskq_plugins
         | { last_template_options = java_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -100,6 +100,7 @@ python_dd_option
             python_dd_set_value_pairs(last_driver, $1);
           }
         | dest_driver_option
+        | dest_driver_basic_and_diskq_plugins
         | { last_template_options = python_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -91,6 +91,7 @@ redis_option
             free($3);
           }
         | dest_driver_option
+        | dest_driver_basic_and_diskq_plugins
         | threaded_dest_driver_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -138,6 +138,7 @@ riemann_option
             riemann_dd_set_flush_lines(last_driver,  $3);
           }
         | dest_driver_option
+        | dest_driver_basic_and_diskq_plugins
         | threaded_dest_driver_option
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option
         ;


### PR DESCRIPTION
This pull request is created to disallow the usage of diskq plugin in some destinations (e.g file and pipe destinations). See SYSLOGDEV-3479
For this the diskq module's context in the grammar has to be changed so it will not be generally available for all destination drivers.

Some aspects considered:
- modules which can use the diskq module should be able to use general destination plugins too.
- we want to keep the possibility to have general destination plugins for modules that cannot use diskq.

What has been done:
-   create new context for diskq in lexer and grammar
-  add new plugin_find interface to be able to search with multiple contexts (therefore modules can access to general destination plugins and to diskq module)
- restructured grammar of destination driver options