### PR TITLE
Set the default time-zone to UTC for elasticsearch2

### DIFF
--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -76,6 +76,7 @@ block destination elasticsearch2(
   http_auth_type("none")
   http_auth_type_basic_username("")
   http_auth_type_basic_password("")
+  time_zone("UTC")
 )
 {
   java(
@@ -102,6 +103,7 @@ block destination elasticsearch2(
     option("http_auth_type", `http_auth_type`)
     option("http_auth_type_basic_username", `http_auth_type_basic_username`)
     option("http_auth_type_basic_password", `http_auth_type_basic_password`)
+    option("time_zone", `time_zone`)
     `__VARARGS__`
   );
 };

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -103,7 +103,7 @@ block destination elasticsearch2(
     option("http_auth_type", `http_auth_type`)
     option("http_auth_type_basic_username", `http_auth_type_basic_username`)
     option("http_auth_type_basic_password", `http_auth_type_basic_password`)
-    option("time_zone", `time_zone`)
+    time_zone(`time_zone`)
     `__VARARGS__`
   );
 };


### PR DESCRIPTION
Elasticsearch and Kibana use UTC internally. Sending logs with UTC,
they end up in the right index and show up at the right time in
Kibana. Helps to avoid surprises and long debugging sessions :)

Suggested by Fabien Wernli on the syslog-ng mailing list.

Signed-off-by: Peter Czanik <peter@czanik.hu>