### PR TITLE
diskq: cover case disk-buf-size(0)

### DIFF
--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -43,11 +43,7 @@ disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size)
 void
 disk_queue_options_disk_buf_size_set(DiskQueueOptions *self, gint64 disk_buf_size)
 {
-  if (disk_buf_size == 0)
-    {
-      msg_warning("WARNING: The configured disk buffer size is zero. No disk queue file will be created.");
-    }
-  else if (disk_buf_size < MIN_DISK_BUF_SIZE)
+  if (disk_buf_size < MIN_DISK_BUF_SIZE)
     {
       msg_warning("WARNING: The configured disk buffer size is smaller than the minimum allowed",
                   evt_tag_int("configured size", disk_buf_size),


### PR DESCRIPTION
Grammar allows disk-buf-size to be 0.
However in that case syslog-ng exits on the first incoming message due to SEGFAULT.

The code detects that the disk-buf-size is not correct, but allows it.
"[2017-05-31T09:46:05.408827] WARNING: The configured disk buffer size is zero. No disk queue file will be created.;"