### PR TITLE
Scratchbuffers optimization

### DIFF
--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -1441,6 +1441,18 @@ g_process_startup_ok(void)
 void
 g_process_finish(void)
 {
+
+#ifdef SYSLOG_NG_HAVE_ENVIRON
+
+  for (gint i = 0; environ[i] != NULL; i++)
+    g_free(environ[i]);
+
+  g_free(environ);
+
+  if (process_opts.argv_orig)
+    free(process_opts.argv_orig);
+#endif
+
   g_process_remove_pidfile();
 }
 
@@ -1502,4 +1514,3 @@ g_process_add_option_group(GOptionContext *ctx)
   g_option_group_add_entries(group, g_process_option_entries);
   g_option_context_add_group(ctx, group);
 }
-

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -26,6 +26,7 @@
 #include "mainloop-io-worker.h"
 #include "mainloop-call.h"
 #include "ack_tracker.h"
+#include "scratch-buffers2.h"
 
 #include <iv_event.h>
 
@@ -378,11 +379,15 @@ log_reader_fetch_log(LogReader *self)
         {
           msg_count++;
 
+          ScratchBuffersMarker mark;
+          scratch_buffers2_mark(&mark);
           if (!log_reader_handle_line(self, msg, msg_len, &aux))
             {
+              scratch_buffers2_reclaim_marked(mark);
               /* window is full, don't generate further messages */
               break;
             }
+          scratch_buffers2_reclaim_marked(mark);
         }
     }
   log_transport_aux_data_destroy(&aux);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -36,6 +36,7 @@
 #include "mainloop-call.h"
 #include "ml-batched-timer.h"
 #include "str-format.h"
+#include "scratch-buffers2.h"
 
 #include <unistd.h>
 #include <assert.h>
@@ -1202,8 +1203,14 @@ log_writer_flush(LogWriter *self, LogWriterFlushMode flush_mode)
       if (!msg)
         break;
 
+      ScratchBuffersMarker mark;
+      scratch_buffers2_mark(&mark);
       if (!log_writer_write_message(self, msg, &path_options, &write_error))
-        break;
+        {
+          scratch_buffers2_reclaim_marked(mark);
+          break;
+        }
+      scratch_buffers2_reclaim_marked(mark);
     }
 
   if (write_error)

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -25,6 +25,7 @@
 #include "mainloop-worker.h"
 #include "mainloop-call.h"
 #include "logqueue.h"
+#include "scratch-buffers2.h"
 
 /************************************************************************************
  * I/O worker threads
@@ -51,6 +52,7 @@ _work(MainLoopIOWorkerJob *self)
 {
   self->work(self->user_data);
   main_loop_worker_invoke_batch_callbacks();
+  scratch_buffers2_explicit_gc();
 }
 
 /* NOTE: runs in the main thread */

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -177,14 +177,12 @@ main_loop_worker_thread_start(void *cookie)
   _allocate_thread_id();
   INIT_IV_LIST_HEAD(&batch_callbacks);
   app_thread_start();
-  scratch_buffers2_automatic_gc_init();
 }
 
 /* Call this function from worker threads, when you stop */
 void
 main_loop_worker_thread_stop(void)
 {
-  scratch_buffers2_automatic_gc_deinit();
   app_thread_stop();
   _release_thread_id();
 }


### PR DESCRIPTION
Prior this patch, in case of high load scratchbuffers garbage
collection might not be executed for a very long time, because ivykis
worker thread is optimized to exhaust the main thread.
This patch explicitely calls scratchbuffers garbage collection during
fetching and flushing messages.

@bazsi @MrAnno 