### PR TITLE
Grammar: allow flush-lines to be 0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -536,6 +536,7 @@ AC_CHECK_HEADERS(strings.h	\
 AC_CHECK_HEADERS(tcpd.h)
 
 AC_CHECK_TYPES([struct ucred, struct cmsgcred], [], [], [#define _GNU_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #include <sys/types.h>
 #include <sys/socket.h>])
 
@@ -579,7 +580,7 @@ I_CONSLOG
   blb_cv_c_i_conslog=no, blb_cv_c_i_conslog=yes)])
 
 old_CPPFLAGS=$CPPFLAGS
-CPPFLAGS=-D_GNU_SOURCE
+CPPFLAGS="-D_GNU_SOURCE -D_DEFAULT_SOURCE"
 AC_CACHE_CHECK(for O_LARGEFILE, blb_cv_c_o_largefile,
   [AC_EGREP_CPP(O_LARGEFILE,
 [
@@ -1430,7 +1431,7 @@ if test "x$module_path" = "x"; then
 	java_module_path="$moduledir"/java-modules
 fi
 
-CPPFLAGS="$CPPFLAGS $GLIB_CFLAGS $EVTLOG_CFLAGS $PCRE_CFLAGS $OPENSSL_CFLAGS $LIBNET_CFLAGS $LIBDBI_CFLAGS $IVYKIS_CFLAGS -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+CPPFLAGS="$CPPFLAGS $GLIB_CFLAGS $EVTLOG_CFLAGS $PCRE_CFLAGS $OPENSSL_CFLAGS $LIBNET_CFLAGS $LIBDBI_CFLAGS $IVYKIS_CFLAGS -D_GNU_SOURCE -D_DEFAULT_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
 
 ########################################################
 ## NOTES: on how syslog-ng is linked

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -885,7 +885,7 @@ options_items
 
 options_item
 	: KW_MARK_FREQ '(' nonnegative_integer ')'		{ configuration->mark_freq = $3; }
-	| KW_FLUSH_LINES '(' positive_integer ')'		{ configuration->flush_lines = $3; }
+	| KW_FLUSH_LINES '(' nonnegative_integer ')'		{ configuration->flush_lines = $3; }
         | KW_MARK_MODE '(' KW_INTERNAL ')'         { cfg_set_mark_mode(configuration, "internal"); }
         | KW_MARK_MODE '(' string ')'
           {
@@ -1144,7 +1144,7 @@ dest_writer_option
         /* NOTE: plugins need to set "last_writer_options" in order to incorporate this rule in their grammar */
 
 	: KW_FLAGS '(' dest_writer_options_flags ')' { last_writer_options->options = $3; }
-	| KW_FLUSH_LINES '(' positive_integer ')'		{ last_writer_options->flush_lines = $3; }
+	| KW_FLUSH_LINES '(' nonnegative_integer ')'		{ last_writer_options->flush_lines = $3; }
 	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ last_writer_options->flush_timeout = $3; }
         | KW_SUPPRESS '(' nonnegative_integer ')'            { last_writer_options->suppress = $3; }
 	| KW_TEMPLATE '(' string ')'       	{

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -115,7 +115,7 @@ dest_afsql_option
         | KW_VALUES '(' dest_afsql_values ')'		{ afsql_dd_set_values(last_driver, $3); }
         | KW_NULL '(' string ')'                { afsql_dd_set_null_value(last_driver, $3); free($3); }
         | KW_RETRIES '(' nonnegative_integer ')'          { afsql_dd_set_retries(last_driver, $3); }
-        | KW_FLUSH_LINES '(' positive_integer ')'      { afsql_dd_set_flush_lines(last_driver, $3); }
+        | KW_FLUSH_LINES '(' nonnegative_integer ')'      { afsql_dd_set_flush_lines(last_driver, $3); }
         | KW_FLUSH_TIMEOUT '(' positive_integer ')'    { afsql_dd_set_flush_timeout(last_driver, $3); }
         | KW_SESSION_STATEMENTS '(' string_list ')' { afsql_dd_set_session_statements(last_driver, $3); }
         | KW_FLAGS '(' dest_afsql_flags ')'     { afsql_dd_set_flags(last_driver, $3); }

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -133,7 +133,7 @@ riemann_option
           {
             riemann_dd_set_field_attributes(last_driver, last_value_pairs);
           }
-        | KW_FLUSH_LINES '(' positive_integer ')'
+        | KW_FLUSH_LINES '(' nonnegative_integer ')'
           {
             riemann_dd_set_flush_lines(last_driver,  $3);
           }


### PR DESCRIPTION
It is logically incorrect, but it was the default value in some distributions.

Fixes #1411, relates to #1354.