### PR TITLE
Invalid read in system source/nvtable and in file destination

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1357,6 +1357,9 @@ log_writer_deinit(LogPipe *s)
   log_writer_stop_watches(self);
   iv_event_unregister(&self->queue_filled);
 
+  if (iv_timer_registered(&self->reopen_timer))
+    iv_timer_unregister(&self->reopen_timer);
+
   ml_batched_timer_unregister(&self->suppress_timer);
   ml_batched_timer_unregister(&self->mark_timer);
 

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -224,7 +224,8 @@ static void
 _set_program(JournalReaderOptions *options, LogMessage *msg)
 {
   gssize value_length = 0;
-  const gchar *value = _get_value_from_message(options, msg, "SYSLOG_IDENTIFIER", &value_length);
+  /* g_strdup: referred value can change during log_msg_set_value if nvtable realloc needed */
+  gchar *value = g_strdup(_get_value_from_message(options, msg, "SYSLOG_IDENTIFIER", &value_length));
 
   if (value_length > 0)
     {
@@ -232,9 +233,12 @@ _set_program(JournalReaderOptions *options, LogMessage *msg)
     }
   else
     {
-      value = _get_value_from_message(options, msg, "_COMM", &value_length);
+      value = g_strdup(_get_value_from_message(options, msg, "_COMM", &value_length));
       log_msg_set_value(msg, LM_V_PROGRAM, value, value_length);
     }
+
+  g_free(value);
+
 }
 
 static void


### PR DESCRIPTION
This patchset contains fixes for two invalid read issues:
- System source: a value (program name) that needs to be added to nvtable is invalidated due to nvtable realloc.
- File destination: in case target file cannot be created, reopen_timer goes on infinitely, not stopped even after syslog-ng stops. Thus the scheduled timer has invalid cookie, thus an invalid read occurs during syslog-ng stop.

A little more verbose description can be found in commit messages.