### PR TITLE
Do not redefine modules_affile_tests_TESTS in Makefile

### DIFF
--- a/modules/affile/tests/Makefile.am
+++ b/modules/affile/tests/Makefile.am
@@ -11,7 +11,7 @@ modules_affile_tests_test_affile_open_file_LDFLAGS 	=   \
 	$(PREOPEN_CORE)
 
 if ENABLE_CRITERION
-modules_affile_tests_TESTS 				= \
+modules_affile_tests_TESTS 				+= \
   modules/affile/tests/test_wildcard_source \
 	modules/affile/tests/test_directory_monitor \
 	modules/affile/tests/test_collection_comporator


### PR DESCRIPTION
Previously, `modules_affile_tests_TESTS` were redefined if Criterion was found on the system. Because of this on my systems syslog-ng did not compile. On other systems `affile_open_file` unittest never ran.
 
Signed-off-by: Noémi Ványi <sitbackandwait@gmail.com>