### PR TITLE
affile: Add possibility to only signal re-open of file handles

### DIFF
--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -35,6 +35,7 @@ enum
   AH_PRE_CONFIG_LOADED,
   AH_POST_CONFIG_LOADED,
   AH_SHUTDOWN,
+  AH_REOPEN,
 };
 
 typedef void (*ApplicationHookFunc)(gint type, gpointer user_data);
@@ -48,5 +49,6 @@ void app_post_config_loaded();
 void app_thread_start(void);
 void app_thread_stop(void);
 void app_shutdown();
+void app_reopen(void);
 
 #endif

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -25,6 +25,7 @@
 #include "control/control-main.h"
 #include "mainloop.h"
 #include "messages.h"
+#include "apphook.h"
 #include "stats/stats-query-commands.h"
 
 static GList *command_list = NULL;
@@ -120,11 +121,20 @@ control_connection_reload(GString *command, gpointer user_data)
   return result;
 }
 
+static GString *
+control_connection_reopen(GString *command, gpointer user_data)
+{
+  GString *result = g_string_new("OK Re-open of log destination files initiated");
+  app_reopen();
+  return result;
+}
+
 ControlCommand default_commands[] =
 {
   { "LOG", NULL, control_connection_message_log },
   { "STOP", NULL, control_connection_stop_process },
   { "RELOAD", NULL, control_connection_reload },
+  { "REOPEN", NULL, control_connection_reopen },
   { "QUERY", NULL, process_query_command },
   { NULL, NULL, NULL },
 };

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -130,6 +130,7 @@ struct _MainLoop
   struct iv_signal sigterm_poll;
   struct iv_signal sigint_poll;
   struct iv_signal sigchild_poll;
+  struct iv_signal sigusr1_poll;
 
   struct iv_event exit_requested;
   struct iv_event reload_config_requested;
@@ -382,6 +383,12 @@ sig_child_handler(gpointer user_data)
 }
 
 static void
+sig_usr1_handler(gpointer user_data)
+{
+  app_reopen();
+}
+
+static void
 _ignore_signal(gint signum)
 {
   struct sigaction sa;
@@ -410,6 +417,7 @@ setup_signals(MainLoop *self)
   _register_signal_handler(&self->sigchild_poll, SIGCHLD, sig_child_handler, self);
   _register_signal_handler(&self->sigterm_poll, SIGTERM, sig_term_handler, self);
   _register_signal_handler(&self->sigint_poll, SIGINT, sig_term_handler, self);
+  _register_signal_handler(&self->sigusr1_poll, SIGUSR1, sig_usr1_handler, self);
 }
 
 /************************************************************************************

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -35,6 +35,7 @@
 #include "logwriter.h"
 #include "affile-dest-internal-queue-filter.h"
 #include "file-specializations.h"
+#include "apphook.h"
 
 #include <iv.h>
 #include <sys/types.h>
@@ -82,6 +83,8 @@
  * protection of the lock, keeping a the next pipe alive, even if that would
  * go away in a parallel reaper process.
  */
+
+static GList *affile_dest_drivers = NULL;
 
 struct _AFFileDestWriter
 {
@@ -179,7 +182,8 @@ affile_dw_reopen(AFFileDestWriter *self)
       proto = file_opener_construct_dst_proto(self->owner->file_opener, transport,
                                               &self->owner->writer_options.proto_options.super);
 
-      main_loop_call((void *(*)(void *)) affile_dw_arm_reaper, self, TRUE);
+      if (!iv_timer_registered(&self->reap_timer))
+        main_loop_call((void *(*)(void *)) affile_dw_arm_reaper, self, TRUE);
     }
   else
     {
@@ -352,6 +356,29 @@ affile_dw_new(const gchar *filename, GlobalConfig *cfg)
   self->filename = g_strdup(filename);
   g_static_mutex_init(&self->lock);
   return self;
+}
+
+static void
+affile_dw_reopen_writer(gpointer key, gpointer value, gpointer user_data)
+{
+  AFFileDestWriter *writer = (AFFileDestWriter *) value;
+  affile_dw_reopen(writer);
+}
+
+static void
+affile_dd_reopen_all_writers(gpointer data, gpointer user_data)
+{
+  AFFileDestDriver *driver = (AFFileDestDriver *) data;
+  if (driver->single_writer)
+    affile_dw_reopen(driver->single_writer);
+  else
+    g_hash_table_foreach(driver->writer_hash, affile_dw_reopen_writer, NULL);
+}
+
+static void
+affile_dd_register_reopen_hook(gint hook_type, gpointer user_data)
+{
+  g_list_foreach(affile_dest_drivers, affile_dd_reopen_all_writers, NULL);
 }
 
 void
@@ -723,6 +750,7 @@ affile_dd_free(LogPipe *s)
   AFFileDestDriver *self = (AFFileDestDriver *) s;
 
   g_static_mutex_free(&self->lock);
+  affile_dest_drivers = g_list_remove(affile_dest_drivers, self);
 
   /* NOTE: this must be NULL as deinit has freed it, otherwise we'd have circular references */
   g_assert(self->single_writer == NULL && self->writer_hash == NULL);
@@ -759,6 +787,9 @@ affile_dd_new_instance(gchar *filename, GlobalConfig *cfg)
 
   self->time_reap = -1;
   g_static_mutex_init(&self->lock);
+
+  affile_dest_drivers = g_list_append(affile_dest_drivers, self);
+
   return self;
 }
 
@@ -771,4 +802,10 @@ affile_dd_new(gchar *filename, GlobalConfig *cfg)
   self->writer_options.stats_source = SCS_FILE;
   self->file_opener = file_opener_for_regular_dest_files_new(&self->writer_options, &self->use_fsync);
   return &self->super.super;
+}
+
+void
+affile_dd_global_init(void)
+{
+  register_application_hook(AH_REOPEN, affile_dd_register_reopen_hook, NULL);
 }

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -58,5 +58,6 @@ void affile_dd_set_create_dirs(LogDriver *s, gboolean create_dirs);
 void affile_dd_set_fsync(LogDriver *s, gboolean enable);
 void affile_dd_set_overwrite_if_older(LogDriver *s, gint overwrite_if_older);
 void affile_dd_set_local_time_zone(LogDriver *s, const gchar *local_time_zone);
+void affile_dd_global_init(void);
 
 #endif

--- a/modules/affile/affile-plugin.c
+++ b/modules/affile/affile-plugin.c
@@ -24,6 +24,7 @@
 #include "cfg-parser.h"
 #include "plugin.h"
 #include "plugin-types.h"
+#include "affile-dest.h"
 
 extern CfgParser affile_parser;
 
@@ -65,6 +66,7 @@ gboolean
 affile_module_init(GlobalConfig *cfg, CfgArgs *args)
 {
   plugin_register(cfg, affile_plugins, G_N_ELEMENTS(affile_plugins));
+  affile_dd_global_init();
   return TRUE;
 }
 

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -160,6 +160,12 @@ slng_reload(int argc, char *argv[], const gchar *mode)
   return _dispatch_command("RELOAD");
 }
 
+static gint
+slng_reopen(int argc, char *argv[], const gchar *mode)
+{
+  return _dispatch_command("REOPEN");
+}
+
 const static gint QUERY_COMMAND = 0;
 static gboolean query_is_get_sum = FALSE;
 static gboolean query_reset = FALSE;
@@ -383,6 +389,7 @@ static struct
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose },
   { "stop", no_options, "Stop syslog-ng process", slng_stop },
   { "reload", no_options, "Reload syslog-ng", slng_reload },
+  { "reopen", no_options, "Re-open of log destination files", slng_reopen },
   { "query", query_options, "Query syslog-ng statistics. Possible commands: list, get, get --sum", slng_query },
   { "show-license-info", license_options, "Show information about the license", slng_license },
   { NULL, NULL },


### PR DESCRIPTION
I'm not sure it is feasible to solve issue #1423 in a good way without any penalty in performance given if it is related to race between multiple threads (which I suspect is the problem). So I tackled this from another point of view by avoiding a reload the configuration all together as it is not needed from the problem scenario stated in the issue and adding a new signal handler to only trigger a re-opening of log files instead.