### PR TITLE
stats: set processed counter to the value of queued counter in init-time

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -351,6 +351,7 @@ log_threaded_dest_driver_start(LogPipe *s)
 
   log_queue_set_counters(self->queue, self->queued_messages,
                          self->dropped_messages, self->memory_usage);
+  stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
 
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
                                                            log_threaded_dest_driver_format_seqnum_for_persist(self)));

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1303,6 +1303,7 @@ log_writer_init(LogPipe *s)
     _register_counters(self);
 
   log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages, self->memory_usage);
+  stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
   if (self->proto)
     {
       LogProtoClient *proto;


### PR DESCRIPTION
Otherwise value of written counter could underflow when diskq is used
and the diskq contains some messages after restart.
written = processed - (queued+dropped)

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>