### PR TITLE
Logwriter: memory_usage underflow in case of non-reliable queue

### DIFF
--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -175,6 +175,7 @@ log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsC
   self->queued_messages = queued_messages;
   self->dropped_messages = dropped_messages;
   self->memory_usage = memory_usage;
+  stats_counter_set(self->memory_usage, self->memory_usage_initial_value);
   stats_counter_set(self->queued_messages, log_queue_get_length(self));
 }
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -50,6 +50,7 @@ struct _LogQueue
   StatsCounterItem *queued_messages;
   StatsCounterItem *dropped_messages;
   StatsCounterItem *memory_usage;
+  gssize memory_usage_initial_value;
 
   GStaticMutex lock;
   LogQueuePushNotifyFunc parallel_push_notify;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -170,10 +170,8 @@ log_writer_get_queue(LogWriter *s)
 
 /* consumes the reference */
 void
-log_writer_set_queue(LogWriter *s, LogQueue *queue)
+log_writer_set_queue(LogWriter *self, LogQueue *queue)
 {
-  LogWriter *self = (LogWriter *)s;
-
   log_queue_unref(self->queue);
   self->queue = log_queue_ref(queue);
   log_queue_set_use_backlog(self->queue, TRUE);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -31,8 +31,6 @@
 
 typedef struct _LogQueueDisk LogQueueDisk;
 
-#define LOG_PATH_OPTIONS_FOR_BACKLOG GINT_TO_POINTER(0x80000000)
-
 struct _LogQueueDisk
 {
   LogQueue super;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -408,7 +408,7 @@ _load_queue(QDisk *self, GQueue *q, gint64 q_ofs, gint32 q_len, gint32 q_count)
             {
               g_queue_push_tail(q, msg);
               /* we restore the queue without ACKs */
-              g_queue_push_tail(q, GINT_TO_POINTER(0x80000000));
+              g_queue_push_tail(q, LOG_PATH_OPTIONS_FOR_BACKLOG);
             }
           else
             {
@@ -1015,4 +1015,3 @@ qdisk_new()
   QDisk *self = g_new0(QDisk, 1);
   return self;
 }
-

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -27,6 +27,7 @@
 #include "syslog-ng.h"
 #include "diskq-options.h"
 
+#define LOG_PATH_OPTIONS_FOR_BACKLOG GINT_TO_POINTER(0x80000000)
 #define QDISK_RESERVED_SPACE 4096
 #define LOG_PATH_OPTIONS_TO_POINTER(lpo) GUINT_TO_POINTER(0x80000000 | (lpo)->ack_needed)
 


### PR DESCRIPTION
In case syslog-ng stopped with messages in a non reliable queue,
after next start non-reliable queue restores the qout queue. This
restoration should be visible in memory_usage, otherwise when the
destination becomes writable, memory_usage will underflow.
Signed-off-by: Antal Nemes <antal.nemes@balabit.com>