### PR TITLE
MainLoop: crash due to async calls might be held back without limit

### DIFF
--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -54,6 +54,7 @@ struct _LogThrDestDriver
   StatsCounterItem *memory_usage;
 
   gboolean suspended;
+  gboolean under_termination;
   time_t time_reopen;
 
   LogQueue *queue;

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -84,6 +84,7 @@ void main_loop_worker_init(void);
 void main_loop_worker_deinit(void);
 
 extern volatile gboolean main_loop_workers_quit;
+extern volatile gboolean is_reloading_scheduled;
 
 static inline gboolean
 main_loop_worker_job_quit(void)


### PR DESCRIPTION
Reload and stop commands are implemented as an async calls. These async calls only executed when there are no workers running.

In case of slow workers or high load, workers might not be exited for a long time, possibly infinitely in case sources are faster than the destinations. This results in such async calls held back.

The original implementation g_asserts that only one async call is running at a given time, though it is possible in the scenarios above that the 100ms is not enough for the previous async call to exit, resulting in crash.
See: https://github.com/balabit/syslog-ng/issues/1506

This patch collects the commands to be executed in a queue. When all workers exited, we iterate through the queue and call all such actions.

This fixes the crash part.

But certainly it is also an issue that workers may not exit for a long period of time. The fact that workers need to exit is registered inside MainLoop. This patch adds a check for this flag in logthrdestdriver, when messages are fetched from the queues.

Test/Reproduce:
I could test/reproduce these issues by the following way:
One needs an nginx with echo module installed. (On ubuntu16.04, nginx-full package contains echo module, while the standard nginx package does not).
Add the following location to nginx:
```
	location = /slow-reply {
	   echo_sleep 5.0;
	   #return 200 'this response would NOT be delayed!';
	   echo 'Slooow motion';
	}
````
This will ensure nginx will send responses only after 5 seconds, so one have time to play around syslog-ng.
Inside syslog-ng config:
`destination d_https { http(url("http://localhost:80/slow-reply"));};`

Push some messages to the destination: (I have a network source with port 5555)
`loggen -n 10 -s 130 -i 127.0.0.1 5555`

Then try to stop syslog-ng: ctrl-c or /syslog-ng-ctl stop
After this patch syslog-ng exits after 5 seconds, otherwise 50 seconds.