### PR TITLE
http destination: improvements

### DIFF
--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -63,6 +63,7 @@
 %token KW_CIPHER_SUITE
 %token KW_SSL_VERSION
 %token KW_PEER_VERIFY
+%token KW_TIMEOUT
 
 %type   <ptr> driver
 %type   <ptr> http_destination
@@ -113,6 +114,7 @@ http_option
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
     | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
+    | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | dest_driver_option
     | threaded_dest_driver_option
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -103,7 +103,7 @@ http_option
     | KW_USER       '(' string ')'            { http_dd_set_user(last_driver, $3); free($3); }
     | KW_PASSWORD   '(' string ')'            { http_dd_set_password(last_driver, $3); free($3); }
     | KW_USER_AGENT '(' string ')'            { http_dd_set_user_agent(last_driver, $3); free($3); }
-    | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free($3); }
+    | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free_full($3, free); }
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
     | KW_CA_DIR     '(' string ')'            { http_dd_set_ca_dir(last_driver, $3); free($3); }
@@ -121,4 +121,3 @@ http_option
 /* INCLUDE_RULES */
 
 %%
-

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -45,6 +45,7 @@ static CfgLexerKeyword http_keywords[] =
   { "cipher_suite", KW_CIPHER_SUITE },
   { "ssl_version",  KW_SSL_VERSION },
   { "peer_verify",  KW_PEER_VERIFY },
+  { "timeout",      KW_TIMEOUT },
   { NULL }
 };
 

--- a/modules/http/http-plugin.h
+++ b/modules/http/http-plugin.h
@@ -46,6 +46,7 @@ typedef struct
   int ssl_version;
   gboolean peer_verify;
   short int method_type;
+  glong timeout;
   LogTemplate *body_template;
   LogTemplateOptions template_options;
 } HTTPDestinationDriver;
@@ -67,6 +68,7 @@ void http_dd_set_key_file(LogDriver *d, const gchar *key_file);
 void http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers);
 void http_dd_set_ssl_version(LogDriver *d, const gchar *value);
 void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
+void http_dd_set_timeout(LogDriver *d, glong timeout);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 
 #endif

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -175,6 +175,8 @@ _set_curl_opt(HTTPDestinationDriver *self)
   curl_easy_setopt(self->curl, CURLOPT_SSL_VERIFYHOST, self->peer_verify ? 2L : 0L);
   curl_easy_setopt(self->curl, CURLOPT_SSL_VERIFYPEER, self->peer_verify ? 1L : 0L);
 
+  curl_easy_setopt(self->curl, CURLOPT_TIMEOUT, self->timeout);
+
   if (self->method_type == METHOD_TYPE_PUT)
     curl_easy_setopt(self->curl, CURLOPT_CUSTOMREQUEST, "PUT");
 }
@@ -408,6 +410,14 @@ http_dd_set_peer_verify(LogDriver *d, gboolean verify)
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
   self->peer_verify = verify;
+}
+
+void
+http_dd_set_timeout(LogDriver *d, glong timeout)
+{
+  HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
+
+  self->timeout = timeout;
 }
 
 gboolean

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -204,7 +204,7 @@ _insert(LogThrDestDriver *s, LogMessage *msg)
 
       curl_slist_free_all(curl_headers);
 
-      return WORKER_INSERT_RESULT_ERROR;
+      return WORKER_INSERT_RESULT_NOT_CONNECTED;
     }
 
   if (body_rendered)

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -443,6 +443,8 @@ http_dd_free(LogPipe *s)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *)s;
 
+  log_template_options_destroy(&self->template_options);
+
   curl_easy_cleanup(self->curl);
   curl_global_cleanup();
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -230,7 +230,8 @@ _insert(LogThrDestDriver *s, LogMessage *msg)
   if ((ret = curl_easy_perform(self->curl)) != CURLE_OK)
     {
       msg_error("curl: error sending HTTP request",
-                evt_tag_str("error", curl_easy_strerror(ret)));
+                evt_tag_str("error", curl_easy_strerror(ret)),
+                log_pipe_location_tag(&s->super.super.super));
 
       curl_slist_free_all(curl_headers);
 
@@ -465,7 +466,8 @@ http_dd_init(LogPipe *s)
 
   if (!(self->curl = curl_easy_init()))
     {
-      msg_error("curl: cannot initialize libcurl", NULL);
+      msg_error("curl: cannot initialize libcurl",
+                log_pipe_location_tag(s));
       return FALSE;
     }
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -193,8 +193,6 @@ _insert(LogThrDestDriver *s, LogMessage *msg)
 
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) s;
 
-  _set_curl_opt(self);
-
   struct curl_slist *curl_headers = _get_curl_headers(self, msg);
   const gchar *body = _get_body(self, msg);
   _set_payload(self, curl_headers, body);
@@ -433,6 +431,8 @@ http_dd_init(LogPipe *s)
     {
       self->url = g_strdup(HTTP_DEFAULT_URL);
     }
+
+  _set_curl_opt(self);
 
   return log_threaded_dest_driver_start(s);
 }

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -85,10 +85,15 @@ _disconnect(LogThrDestDriver *s)
 {
 }
 
+static void
+_add_custom_curl_header(gpointer data, gpointer curl_headers)
+{
+  curl_headers = curl_slist_append((struct curl_slist *)curl_headers, data);
+}
+
 static struct curl_slist *
 _get_curl_headers(HTTPDestinationDriver *self, LogMessage *msg)
 {
-  GList *header = NULL;
   struct curl_slist *curl_headers = NULL;
   gchar header_host[128] = {0};
   gchar header_program[32] = {0};
@@ -111,12 +116,7 @@ _get_curl_headers(HTTPDestinationDriver *self, LogMessage *msg)
              "X-Syslog-Level: %s", syslog_name_lookup_name_by_value(msg->pri & LOG_PRIMASK, sl_levels));
   curl_headers = curl_slist_append(curl_headers, header_level);
 
-  header = self->headers;
-  while (header != NULL)
-    {
-      curl_headers = curl_slist_append(curl_headers, (gchar *)header->data);
-      header = g_list_next(header);
-    }
+  g_list_foreach(self->headers, _add_custom_curl_header, curl_headers);
 
   return curl_headers;
 }


### PR DESCRIPTION
- Memory leak during reload/stop
- Invalid handling of retry-send when remote is down.
See: https://github.com/balabit/syslog-ng/issues/1500
- Replacing some loops with foreach
- Using scratchbuffers to store body of the http request
- Curl options are set only once during init
- Timeout is configurable for http request
- HTTP responses handled correcty: 2XX ack, 4XX drop, 5XX retry.

Please wait @mitzkia or @pzoleex with the merge.