### PR TITLE
diskq: remove an always TRUE condition in _acquire_queue

### DIFF
--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -44,22 +44,16 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name, gpointer user_data)
 
   if (queue)
     {
-      if (queue->type != log_queue_disk_type || self->options.reliable != log_queue_disk_is_reliable(queue))
-        {
-          log_queue_unref(queue);
-          queue = NULL;
-        }
+      log_queue_unref(queue);
+      queue = NULL;
     }
 
-  if (!queue)
-    {
-      if (self->options.reliable)
-        queue = log_queue_disk_reliable_new(&self->options);
-      else
-        queue = log_queue_disk_non_reliable_new(&self->options);
-      log_queue_set_throttle(queue, dd->throttle);
-      queue->persist_name = g_strdup(persist_name);
-    }
+  if (self->options.reliable)
+    queue = log_queue_disk_reliable_new(&self->options);
+  else
+    queue = log_queue_disk_non_reliable_new(&self->options);
+  log_queue_set_throttle(queue, dd->throttle);
+  queue->persist_name = g_strdup(persist_name);
 
   qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
   success = log_queue_disk_load_queue(queue, qfile_name);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -418,7 +418,6 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options)
   self->qoverflow = g_queue_new ();
   self->qout_size = options->qout_size;
   self->qoverflow_size = options->mem_buf_length;
-  self->super.super.type = log_queue_disk_type;
   _set_virtual_functions (&self->super);
   return &self->super.super;
 }

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -349,7 +349,6 @@ log_queue_disk_reliable_new(DiskQueueOptions *options)
   qdisk_init(self->super.qdisk, options);
   self->qreliable = g_queue_new();
   self->qbacklog = g_queue_new();
-  self->super.super.type = log_queue_disk_type;
   _set_virtual_functions(&self->super);
   return &self->super.super;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -336,6 +336,7 @@ log_queue_disk_init_instance(LogQueueDisk *self)
   log_queue_init_instance(&self->super,NULL);
   self->qdisk = qdisk_new();
 
+  self->super.type = log_queue_disk_type;
   self->super.get_length = _get_length;
   self->super.push_tail = _push_tail;
   self->super.push_head = _push_head;


### PR DESCRIPTION
Previously, `queue->type` was not initialized correctly at all (fixed in #1539), so `_acquire_queue` created a new queue in every case.

NOTE: The removed logic is reasonable and valuable, so we should consider reverting this patch after log_queue_disk_load_queue() is fixed.