### PR TITLE
diskq: allow reusing the previous queue instance on reload

### DIFF
--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -193,9 +193,7 @@ gboolean
 log_queue_disk_is_reliable(LogQueue *s)
 {
   LogQueueDisk *self = (LogQueueDisk *) s;
-  if (self->is_reliable)
-    return self->is_reliable(self);
-  return FALSE;
+  return qdisk_is_reliable(self->qdisk);
 }
 
 const gchar *

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -45,7 +45,6 @@ struct _LogQueueDisk
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);
   void (*free_fn)(LogQueueDisk *s);
-  gboolean (*is_reliable)(LogQueueDisk *s);
   LogMessage * (*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
   gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
   void (*restart)(LogQueueDisk *self);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -845,8 +845,6 @@ qdisk_deinit(QDisk *self)
       close(self->fd);
       self->fd = -1;
     }
-
-  self->options = NULL;
 }
 
 gssize

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1003,6 +1003,12 @@ qdisk_is_read_only(QDisk *self)
   return self->options->read_only;
 }
 
+gboolean
+qdisk_is_reliable(QDisk *self)
+{
+  return self->options->reliable;
+}
+
 void
 qdisk_free(QDisk *self)
 {

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -68,6 +68,7 @@ void qdisk_set_backlog_count(QDisk *self, gint64 new_value);
 gint qdisk_get_memory_size(QDisk *self);
 gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
+gboolean qdisk_is_reliable(QDisk *self);
 
 gssize qdisk_read_from_backlog(QDisk *self, gpointer buffer, gsize bytes_to_read);
 gssize qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position);


### PR DESCRIPTION
In DiskQ's `acquire_queue`, the reuse of a previous queue is possible, but
the implementation relies on the fact that DiskQueueOptions must be
available.

WARNING: New queue sizes will not be taken into account on reload.