### PR TITLE
diskq: fix crash when diskq is used with file destionation and file is reaped

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -427,8 +427,9 @@ affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw)
       g_static_mutex_unlock(&self->lock);
     }
 
-  log_dest_driver_release_queue(&self->super, log_writer_get_queue(writer));
+  LogQueue *queue = log_writer_get_queue(writer);
   log_pipe_deinit(&dw->super);
+  log_dest_driver_release_queue(&self->super, queue);
   log_pipe_unref(&dw->super);
 }
 


### PR DESCRIPTION
We allow using disk-buffer for file sources, nevertheless syslog-ng crashes.
It is crashing when the file destination is reaping and log_writer_flush is called during deinit.

The reason is that during reaping we deinitialized the diskq and then called log_writer_flush which tries to access the diskq, but its already a NULL pointer.

This patch checks if the diskq is deinitialized before trying to access the diskq.