### PR TITLE
dbld: use automake.11 in debian environment

### DIFF
--- a/dbld/images/jessie/dev-dependencies.txt
+++ b/dbld/images/jessie/dev-dependencies.txt
@@ -1,7 +1,7 @@
 # required for autogen
 autoconf
 autoconf-archive
-automake
+automake1.11
 libtool
 pkg-config
 # required for configure


### PR DESCRIPTION
release tarball requires automake1.11

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>