### PR TITLE
Fillup rate counter I.

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <iv_thread.h>
 
-const QueueType log_queue_fifo_type = "FIFO";
+const gchar *log_queue_fifo_type = "FIFO";
 
 /*
  * LogFifo is a scalable first-in-first-output queue implementation, that:
@@ -549,7 +549,7 @@ log_queue_fifo_new(gint qoverflow_size, const gchar *persist_name)
   self = g_malloc0(sizeof(LogQueueFifo) + log_queue_max_threads * sizeof(self->qoverflow_input[0]));
 
   log_queue_init_instance(&self->super, persist_name);
-  self->super.type = log_queue_fifo_type;
+  self->super.queue_type = log_queue_fifo_type;
   self->super.use_backlog = FALSE;
   self->super.get_length = log_queue_fifo_get_length;
   self->super.is_empty_racy = log_queue_fifo_is_empty_racy;

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -27,6 +27,8 @@
 #include "messages.h"
 #include "serialize.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-views.h"
 #include "mainloop-worker.h"
 
 #include <sys/types.h>
@@ -112,7 +114,7 @@ iv_list_update_msg_size(LogQueueFifo *self, struct iv_list_head *head)
   iv_list_for_each_safe(ilh, ilh2, head)
   {
     msg = iv_list_entry(ilh, LogMessageQueueNode, list)->msg;
-    stats_counter_add(self->super.memory_usage, log_msg_get_size(msg));
+    stats_counter_add(self->super.counters.external.memory_usage, log_msg_get_size(msg));
   }
 }
 
@@ -195,7 +197,7 @@ log_queue_fifo_move_input_unlocked(LogQueueFifo *self, gint thread_id)
           self->qoverflow_input[thread_id].len--;
           path_options.ack_needed = node->ack_needed;
           path_options.flow_control_requested = node->flow_control_requested;
-          stats_counter_inc(self->super.dropped_messages);
+          stats_counter_inc(self->super.counters.external.dropped_messages);
           log_msg_free_queue_node(node);
           if (path_options.flow_control_requested)
             log_msg_drop(msg, &path_options, AT_SUSPENDED);
@@ -208,7 +210,7 @@ log_queue_fifo_move_input_unlocked(LogQueueFifo *self, gint thread_id)
                 evt_tag_int("count", n),
                 evt_tag_str("persist_name", self->super.persist_name));
     }
-  stats_counter_add(self->super.queued_messages, self->qoverflow_input[thread_id].len);
+  stats_counter_add(self->super.counters.external.queued_messages, self->qoverflow_input[thread_id].len);
   iv_list_update_msg_size(self, &self->qoverflow_input[thread_id].items);
 
   iv_list_splice_tail_init(&self->qoverflow_input[thread_id].items, &self->qoverflow_wait);
@@ -311,15 +313,15 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
       iv_list_add_tail(&node->list, &self->qoverflow_wait);
       self->qoverflow_wait_len++;
       log_queue_push_notify(&self->super);
-      stats_counter_inc(self->super.queued_messages);
-      stats_counter_add(self->super.memory_usage, log_msg_get_size(msg));
+      stats_counter_inc(self->super.counters.external.queued_messages);
+      stats_counter_add(self->super.counters.external.memory_usage, log_msg_get_size(msg));
       g_static_mutex_unlock(&self->super.lock);
 
       log_msg_unref(msg);
     }
   else
     {
-      stats_counter_inc(self->super.dropped_messages);
+      stats_counter_inc(self->super.counters.external.dropped_messages);
       g_static_mutex_unlock(&self->super.lock);
 
       if (path_options->flow_control_requested)
@@ -357,8 +359,8 @@ log_queue_fifo_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
   self->qoverflow_output_len++;
   log_msg_unref(msg);
 
-  stats_counter_inc(self->super.queued_messages);
-  stats_counter_add(self->super.memory_usage, log_msg_get_size(msg));
+  stats_counter_inc(self->super.counters.external.queued_messages);
+  stats_counter_add(self->super.counters.external.memory_usage, log_msg_get_size(msg));
 }
 
 /*
@@ -412,8 +414,8 @@ log_queue_fifo_pop_head(LogQueue *s, LogPathOptions *path_options)
        */
       return NULL;
     }
-  stats_counter_dec(self->super.queued_messages);
-  stats_counter_sub(self->super.memory_usage, log_msg_get_size(msg));
+  stats_counter_dec(self->super.counters.external.queued_messages);
+  stats_counter_sub(self->super.counters.external.memory_usage, log_msg_get_size(msg));
 
   if (self->super.use_backlog)
     {
@@ -471,7 +473,7 @@ log_queue_fifo_rewind_backlog_all(LogQueue *s)
   iv_list_update_msg_size(self, &self->qbacklog);
 
   self->qoverflow_output_len += self->qbacklog_len;
-  stats_counter_add(self->super.queued_messages, self->qbacklog_len);
+  stats_counter_add(self->super.counters.external.queued_messages, self->qbacklog_len);
   self->qbacklog_len = 0;
 }
 
@@ -497,8 +499,8 @@ log_queue_fifo_rewind_backlog(LogQueue *s, guint rewind_count)
 
       self->qbacklog_len--;
       self->qoverflow_output_len++;
-      stats_counter_inc(self->super.queued_messages);
-      stats_counter_add(self->super.memory_usage, log_msg_get_size(node->msg));
+      stats_counter_inc(self->super.counters.external.queued_messages);
+      stats_counter_add(self->super.counters.external.memory_usage, log_msg_get_size(node->msg));
     }
 }
 
@@ -540,6 +542,38 @@ log_queue_fifo_free(LogQueue *s)
   log_queue_free_method(s);
 }
 
+static void
+_register_internal_counters(LogQueue *s, StatsClusterKey *sc_key, gint stats_level)
+{
+  LogQueueFifo *self = (LogQueueFifo *)s;
+  StatsClusterKey sc_key_internal;
+  StatsCluster *capacity_cluster, *queued_cluster;
+
+  stats_cluster_single_key_set_with_name(&sc_key_internal, sc_key->component, sc_key->id, sc_key->instance,
+                                         "mem_capacity_count");
+  capacity_cluster = stats_register_counter(stats_level, &sc_key_internal, SC_TYPE_SINGLE_VALUE,
+                                            &self->super.counters.internal.memory_capacity);
+  queued_cluster = stats_registry_lookup_cluster(sc_key);
+  if (capacity_cluster != NULL && queued_cluster != NULL)
+    {
+      stats_register_fifo_fillup_rate(queued_cluster, capacity_cluster, self->super.counters.external.queued_messages,
+                                      self->super.counters.internal.memory_capacity);
+    }
+
+  stats_counter_set(self->super.counters.internal.memory_capacity, self->qoverflow_size);
+}
+
+static void
+_unregister_internal_counters(LogQueue *s, StatsClusterKey *sc_key)
+{
+  LogQueueFifo *self = (LogQueueFifo *)s;
+  StatsClusterKey sc_key_internal;
+
+  stats_cluster_single_key_set_with_name(&sc_key_internal, sc_key->component, sc_key->id, sc_key->instance,
+                                         "mem_capacity_count");
+  stats_unregister_counter(&sc_key_internal, SC_TYPE_SINGLE_VALUE, &self->super.counters.internal.memory_capacity);
+}
+
 LogQueue *
 log_queue_fifo_new(gint qoverflow_size, const gchar *persist_name)
 {
@@ -560,6 +594,8 @@ log_queue_fifo_new(gint qoverflow_size, const gchar *persist_name)
   self->super.ack_backlog = log_queue_fifo_ack_backlog;
   self->super.rewind_backlog = log_queue_fifo_rewind_backlog;
   self->super.rewind_backlog_all = log_queue_fifo_rewind_backlog_all;
+  self->super.register_internal_counters = _register_internal_counters;
+  self->super.unregister_internal_counters = _unregister_internal_counters;
 
   self->super.free_fn = log_queue_fifo_free;
 

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -169,15 +169,12 @@ log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc para
 }
 
 void
-log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages,
-                       StatsCounterItem *memory_usage)
+log_queue_set_counters(LogQueue *self, LogQueueCountersExternal counters)
 {
-  self->queued_messages = queued_messages;
-  self->dropped_messages = dropped_messages;
-  self->memory_usage = memory_usage;
-  stats_counter_set(self->memory_usage,
+  self->counters.external = counters;
+  stats_counter_set(self->counters.external.queued_messages, log_queue_get_length(self));
+  stats_counter_set(self->external.memory_usage,
                     self->memory_usage_qout_initial_value + self->memory_usage_overflow_initial_value);
-  stats_counter_set(self->queued_messages, log_queue_get_length(self));
 }
 
 void

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -68,6 +68,7 @@ struct _LogQueue
   void (*ack_backlog)(LogQueue *self, gint n);
   void (*rewind_backlog)(LogQueue *self, guint rewind_count);
   void (*rewind_backlog_all)(LogQueue *self);
+  gint (*capacity_fn)(LogQueue *self);
 
   void (*free_fn)(LogQueue *self);
 };
@@ -192,6 +193,14 @@ log_queue_set_use_backlog(LogQueue *self, gboolean use_backlog)
 {
   if (self)
     self->use_backlog = use_backlog;
+}
+
+static inline gint
+log_queue_get_capacity(LogQueue *self)
+{
+  if (self->capacity_fn)
+    return self->capacity_fn(self);
+  return 0;
 }
 
 void log_queue_push_notify(LogQueue *self);

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -34,11 +34,10 @@ typedef void (*LogQueuePushNotifyFunc)(gpointer user_data);
 
 typedef struct _LogQueue LogQueue;
 
-typedef char *QueueType;
 
 struct _LogQueue
 {
-  QueueType type;
+  const gchar *queue_type;
   GAtomicCounter ref_cnt;
   gboolean use_backlog;
 
@@ -201,6 +200,14 @@ log_queue_get_capacity(LogQueue *self)
   if (self->capacity_fn)
     return self->capacity_fn(self);
   return 0;
+}
+
+static inline const gchar *
+log_queue_get_type(LogQueue *self)
+{
+  if (self->queue_type)
+    return self->queue_type;
+  return NULL;
 }
 
 void log_queue_push_notify(LogQueue *self);

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -24,6 +24,7 @@
 
 #include "stats/stats-views.h"
 #include "logthrdestdrv.h"
+#include "logqueue.h"
 #include "seqnum.h"
 
 #define MAX_RETRIES_OF_FAILED_INSERT_DEFAULT 3
@@ -321,9 +322,9 @@ log_threaded_dest_driver_start_thread(LogThrDestDriver *self)
 static void
 _update_processed_message_counter_when_diskq_is_used(LogThrDestDriver *self)
 {
-  if (!g_strcmp0(self->queue->type, LOG_QUEUE_DISK_TYPE))
+  if (!g_strcmp0(log_queue_get_type(self->queue), "DISK"))
     {
-      stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
+      stats_counter_add(self->counters.processed_messages, stats_counter_get(self->counters.queued_messages));
     }
 }
 

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -321,7 +321,7 @@ log_threaded_dest_driver_start_thread(LogThrDestDriver *self)
 static void
 _update_processed_message_counter_when_diskq_is_used(LogThrDestDriver *self)
 {
-  if (!g_strcmp0(self->queue->type, "DISK"))
+  if (!g_strcmp0(self->queue->type, LOG_QUEUE_DISK_TYPE))
     {
       stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
     }

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -47,10 +47,14 @@ struct _LogThrDestDriver
 {
   LogDestDriver super;
 
-  StatsCounterItem *dropped_messages;
-  StatsCounterItem *queued_messages;
-  StatsCounterItem *processed_messages;
-  StatsCounterItem *memory_usage;
+  struct
+  {
+    StatsCounterItem *dropped_messages;
+    StatsCounterItem *queued_messages;
+    StatsCounterItem *processed_messages;
+    StatsCounterItem *memory_usage;
+    StatsCounterItem *log_queue_max_size;
+  } counters;
 
   gboolean suspended;
   time_t time_reopen;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -26,6 +26,7 @@
 #include "messages.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-views.h"
+#include "stats/stats-cluster-single.h"
 #include "hostname.h"
 #include "host-resolve.h"
 #include "seqnum.h"
@@ -37,6 +38,7 @@
 #include "ml-batched-timer.h"
 #include "str-format.h"
 #include "scratch-buffers.h"
+#include "logqueue.h"
 
 #include <unistd.h>
 #include <assert.h>
@@ -1304,7 +1306,7 @@ _register_counters(LogWriter *self)
 static void
 _update_processed_message_counter_when_diskq_is_used(LogWriter *self)
 {
-  if (!g_strcmp0(self->queue->type, LOG_QUEUE_DISK_TYPE))
+  if (!g_strcmp0(log_queue_get_type(self->queue), "DISK"))
     {
       stats_counter_add(self->counters.processed_messages, stats_counter_get(self->counters.queued_messages));
     }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1289,7 +1289,7 @@ _register_counters(LogWriter *self)
 static void
 _update_processed_message_counter_when_diskq_is_used(LogWriter *self)
 {
-  if (!g_strcmp0(self->queue->type, "DISK"))
+  if (!g_strcmp0(self->queue->type, LOG_QUEUE_DISK_TYPE))
     {
       stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
     }

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -48,6 +48,12 @@ stats_unlock(void)
   g_static_mutex_unlock(&stats_mutex);
 }
 
+StatsCluster *
+stats_registry_lookup_cluster(const StatsClusterKey *sc_key)
+{
+  return g_hash_table_lookup(stats_cluster_container, sc_key);
+}
+
 static StatsCluster *
 _grab_cluster(gint stats_level, const StatsClusterKey *sc_key, gboolean dynamic)
 {

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -35,6 +35,7 @@ void stats_unlock(void);
 gboolean stats_check_level(gint level);
 StatsCluster *stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+StatsCluster *stats_registry_lookup_cluster(const StatsClusterKey *sc_key);
 void stats_register_and_increment_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 void stats_unregister_counter(const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);

--- a/lib/stats/stats-views.h
+++ b/lib/stats/stats-views.h
@@ -27,6 +27,7 @@
 #include "stats/stats-query.h"
 
 void stats_register_written_view(StatsCluster *cluster, StatsCounterItem *processed, StatsCounterItem *dropped, StatsCounterItem *queued);
+void stats_register_fifo_fillup_rate(StatsCluster *cluster_of_actual, StatsCluster *cluster_of_max, StatsCounterItem *actual, StatsCounterItem *max);
 
 #endif
 

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -96,9 +96,12 @@ typedef struct _AFSqlDestDriver
 
   LogTemplateOptions template_options;
 
-  StatsCounterItem *dropped_messages;
-  StatsCounterItem *queued_messages;
-  StatsCounterItem *memory_usage;
+  struct 
+  {
+    StatsCounterItem *dropped_messages;
+    StatsCounterItem *queued_messages;
+    StatsCounterItem *memory_usage;
+  } counters;
 
   GHashTable *dbd_options;
   GHashTable *dbd_options_numeric;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -150,7 +150,7 @@ _move_message_from_qbacklog_to_qreliable(LogQueueDiskReliable *self)
   g_queue_push_head(self->qreliable, ptr_msg);
   g_queue_push_head(self->qreliable, ptr_pos);
 
-  stats_counter_add(self->super.super.memory_usage, log_msg_get_size(ptr_msg));
+  stats_counter_add(self->super.super.counters.external.memory_usage, log_msg_get_size(ptr_msg));
 }
 
 static void
@@ -188,7 +188,7 @@ _rewind_backlog(LogQueueDisk *s, guint rewind_count)
   qdisk_set_reader_head (self->super.qdisk, new_read_head);
   qdisk_set_length (self->super.qdisk, qdisk_get_length (self->super.qdisk) + rewind_count);
 
-  stats_counter_add (self->super.super.queued_messages, rewind_count);
+  stats_counter_add (self->super.super.counters.external.queued_messages, rewind_count);
 }
 
 static LogMessage *
@@ -203,7 +203,7 @@ _pop_head(LogQueueDisk *s, LogPathOptions *path_options)
       if (pos == qdisk_get_reader_head (self->super.qdisk))
         {
           msg = g_queue_pop_head (self->qreliable);
-          stats_counter_sub(self->super.super.memory_usage, log_msg_get_size(msg));
+          stats_counter_sub(self->super.super.counters.external.memory_usage, log_msg_get_size(msg));
 
           POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qreliable), path_options);
           _skip_message (s);
@@ -290,7 +290,7 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
       g_queue_push_tail (self->qreliable, LOG_PATH_OPTIONS_TO_POINTER(path_options));
       log_msg_ref (msg);
 
-      stats_counter_add(self->super.super.memory_usage, log_msg_get_size(msg));
+      stats_counter_add(self->super.super.counters.external.memory_usage, log_msg_get_size(msg));
       local_options->ack_needed = FALSE;
     }
 
@@ -338,6 +338,8 @@ _set_virtual_functions(LogQueueDisk *self)
   self->load_queue = _load_queue;
   self->start = _start;
   self->save_queue = _save_queue;
+  self->register_internal_counters = NULL;
+  self->unregister_internal_counters = NULL;
 }
 
 LogQueue *

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -55,6 +55,13 @@ _get_length(LogQueue *s)
   return qdisk_length;
 }
 
+static gint
+_get_capacity(LogQueue *s)
+{
+  LogQueueDisk *self = (LogQueueDisk *) s;
+  return qdisk_get_capacity(self->qdisk);
+}
+
 static void
 _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 {
@@ -345,6 +352,7 @@ log_queue_disk_init_instance(LogQueueDisk *self)
   self->super.rewind_backlog = _rewind_backlog;
   self->super.rewind_backlog_all = _backlog_all;
   self->super.free_fn = _free;
+  self->super.capacity_fn = _get_capacity;
 
   self->read_message = _read_message;
   self->write_message = _write_message;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-const QueueType log_queue_disk_type = "DISK";
+const gchar *LOG_QUEUE_DISK_TYPE = "DISK";
 
 static gint64
 _get_length(LogQueue *s)
@@ -343,7 +343,7 @@ log_queue_disk_init_instance(LogQueueDisk *self)
   log_queue_init_instance(&self->super,NULL);
   self->qdisk = qdisk_new();
 
-  self->super.type = log_queue_disk_type;
+  self->super.queue_type = LOG_QUEUE_DISK_TYPE;
   self->super.get_length = _get_length;
   self->super.push_tail = _push_tail;
   self->super.push_head = _push_head;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -27,6 +27,8 @@
 #include "serialize.h"
 #include "logmsg/logmsg-serialize.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-views.h"
 #include "reloc.h"
 #include "qdisk.h"
 
@@ -73,14 +75,14 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
       if (self->push_tail(self, msg, &local_options, path_options))
         {
           log_queue_push_notify (&self->super);
-          stats_counter_inc(self->super.queued_messages);
+          stats_counter_inc(self->super.counters.external.queued_messages);
           log_msg_ack(msg, &local_options, AT_PROCESSED);
           log_msg_unref(msg);
           g_static_mutex_unlock(&self->super.lock);
           return;
         }
     }
-  stats_counter_inc (self->super.dropped_messages);
+  stats_counter_inc (self->super.counters.external.dropped_messages);
 
   if (path_options->flow_control_requested)
     log_msg_ack(msg, path_options, AT_SUSPENDED);
@@ -117,7 +119,7 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
     }
   if (msg != NULL)
     {
-      stats_counter_dec(self->super.queued_messages);
+      stats_counter_dec(self->super.counters.external.queued_messages);
     }
   g_static_mutex_unlock(&self->super.lock);
   return msg;
@@ -210,6 +212,45 @@ log_queue_disk_get_filename(LogQueue *s)
 {
   LogQueueDisk *self = (LogQueueDisk *) s;
   return qdisk_get_filename(self->qdisk);
+}
+
+void
+log_queue_disk_register_internal_counters(LogQueueDisk *self, StatsClusterKey *sc_key, gint stats_level)
+{
+  if (self && self->register_internal_counters)
+    self->register_internal_counters(self, sc_key, stats_level);
+}
+
+void
+log_queue_disk_unregister_internal_counters(LogQueueDisk *self, StatsClusterKey *sc_key)
+{
+  if (self && self->unregister_internal_counters)
+    self->unregister_internal_counters(self, sc_key);
+}
+
+static void
+_register_internal_counters(LogQueue *s, StatsClusterKey *sc_key, gint stats_level)
+{
+  LogQueueDisk *self = (LogQueueDisk *)s;
+  StatsClusterKey sc_key_internal;
+
+  stats_cluster_single_key_set_with_name(&sc_key_internal, sc_key->component, sc_key->id, sc_key->instance,
+                                         "disk_capacity_byte");
+  stats_register_counter(stats_level, &sc_key_internal, SC_TYPE_SINGLE_VALUE,
+                         &self->super.counters.internal.disk_capacity);
+
+  stats_counter_set(self->super.counters.internal.disk_capacity, qdisk_get_capacity(self->qdisk));
+}
+
+static void
+_unregister_internal_counters(LogQueue *s, StatsClusterKey *sc_key)
+{
+  LogQueueDisk *self = (LogQueueDisk *)s;
+  StatsClusterKey sc_key_internal;
+
+  stats_cluster_single_key_set_with_name(&sc_key_internal, sc_key->component, sc_key->id, sc_key->instance,
+                                         "disk_capacity_byte");
+  stats_unregister_counter(&sc_key_internal, SC_TYPE_SINGLE_VALUE, &self->super.counters.internal.disk_capacity);
 }
 
 static void
@@ -358,4 +399,6 @@ log_queue_disk_init_instance(LogQueueDisk *self)
   self->write_message = _write_message;
   self->restart = _restart;
   self->restart_corrupted = _restart_corrupted;
+  self->super.register_internal_counters = _register_internal_counters;
+  self->super.unregister_internal_counters = _unregister_internal_counters;
 }

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -52,7 +52,7 @@ struct _LogQueueDisk
   void (*restart_corrupted)(LogQueueDisk *self);
 };
 
-extern const QueueType log_queue_disk_type;
+extern const gchar *LOG_QUEUE_DISK_TYPE;
 
 gboolean log_queue_disk_is_reliable(LogQueue *s);
 const gchar *log_queue_disk_get_filename(LogQueue *self);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -50,6 +50,8 @@ struct _LogQueueDisk
   gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
   void (*restart)(LogQueueDisk *self);
   void (*restart_corrupted)(LogQueueDisk *self);
+  void (*register_internal_counters)(LogQueueDisk *self, StatsClusterKey *sc_key, gint stats_level);
+  void (*unregister_internal_counters)(LogQueueDisk *self, StatsClusterKey *sc_key);
 };
 
 extern const gchar *LOG_QUEUE_DISK_TYPE;
@@ -59,5 +61,7 @@ const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
 void log_queue_disk_init_instance(LogQueueDisk *self);
+void log_queue_disk_register_internal_counters(LogQueueDisk *self, StatsClusterKey *sc_key, gint stats_level);
+void log_queue_disk_unregister_internal_counters(LogQueueDisk *self, StatsClusterKey *sc_key);
 
 #endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1015,3 +1015,9 @@ qdisk_new()
   QDisk *self = g_new0(QDisk, 1);
   return self;
 }
+
+gint64
+qdisk_get_capacity(QDisk *self)
+{
+  return self->options->disk_buf_size;
+}

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -54,6 +54,7 @@ void qdisk_free(QDisk *self);
 gboolean qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 
 gint64 qdisk_get_length(QDisk *self);
+gint64 qdisk_get_capacity(QDisk *self);
 void qdisk_set_length(QDisk *self, gint64 new_value);
 gint64 qdisk_get_size(QDisk *self);
 gint64 qdisk_get_writer_head(QDisk *self);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -136,10 +136,10 @@ testcase_ack_and_rewind_messages()
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, "queued messages", NULL );
   stats_lock();
-  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->counters.external.queued_messages);
   stats_unlock();
 
-  assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 0, "queued messages: %d", __LINE__);
 
   filename = g_string_sized_new(32);
   g_string_sprintf(filename,"test-rewind_and_acks.qf");
@@ -149,22 +149,23 @@ testcase_ack_and_rewind_messages()
   fed_messages = 0;
   acked_messages = 0;
   feed_some_messages(q, 1000, &parse_options);
-  assert_gint(stats_counter_get(q->queued_messages), 1000, "queued messages: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 1000, "queued messages: %d", __LINE__);
 
   for(i = 0; i < 10; i++)
     {
       send_some_messages(q,1);
-      assert_gint(stats_counter_get(q->queued_messages), 999, "queued messages wrong number %d", __LINE__);
+      assert_gint(stats_counter_get(q->counters.external.queued_messages), 999, "queued messages wrong number %d", __LINE__);
       app_rewind_some_messages(q,1);
-      assert_gint(stats_counter_get(q->queued_messages), 1000, "queued messages wrong number: %d", __LINE__);
+      assert_gint(stats_counter_get(q->counters.external.queued_messages), 1000, "queued messages wrong number: %d",
+                  __LINE__);
     }
   send_some_messages(q,1000);
-  assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 0, "queued messages: %d", __LINE__);
   app_ack_some_messages(q,500);
   app_rewind_some_messages(q,500);
-  assert_gint(stats_counter_get(q->queued_messages), 500, "queued messages: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 500, "queued messages: %d", __LINE__);
   send_some_messages(q,500);
-  assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 0, "queued messages: %d", __LINE__);
   app_ack_some_messages(q,500);
   log_queue_unref(q);
   unlink(filename->str);
@@ -354,32 +355,32 @@ init_statistics(LogQueue *q)
   StatsClusterKey sc_key1, sc_key2;
   stats_lock();
   stats_cluster_logpipe_key_set(&sc_key1, SCS_DESTINATION, "queued messages", NULL );
-  stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->queued_messages);
+  stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->counters.external.queued_messages);
   stats_cluster_logpipe_key_set(&sc_key2, SCS_DESTINATION, "memory usage", NULL );
-  stats_register_counter(1, &sc_key2, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
+  stats_register_counter(1, &sc_key2, SC_TYPE_MEMORY_USAGE, &q->counters.external.memory_usage);
   stats_unlock();
-  stats_counter_set(q->queued_messages, 0);
-  stats_counter_set(q->memory_usage, 0);
+  stats_counter_set(q->counters.external.queued_messages, 0);
+  stats_counter_set(q->counters.external.memory_usage, 0);
 }
 
 static void
 assert_general_message_flow(LogQueue *q, gssize one_msg_size)
 {
   send_some_messages(q,1);
-  assert_gint(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), one_msg_size, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 1, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), one_msg_size, "memory_usage: line: %d", __LINE__);
 
   send_some_messages(q,1);
-  assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), 0, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 0, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), 0, "memory_usage: line: %d", __LINE__);
 
   feed_some_messages(q, 10, &parse_options);
-  assert_gint(stats_counter_get(q->queued_messages), 10, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), one_msg_size*10, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 10, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), one_msg_size*10, "memory_usage: line: %d", __LINE__);
 
   send_some_messages(q,5);
-  assert_gint(stats_counter_get(q->queued_messages), 5, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), one_msg_size*5, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 5, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), one_msg_size*5, "memory_usage: line: %d", __LINE__);
 }
 
 static LogQueue *
@@ -393,8 +394,8 @@ testcase_diskq_prepare(DiskQueueOptions *options, diskq_tester_parameters_t *par
   q = parameters->constructor(options);
 
   init_statistics(q);
-  assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), 0, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 0, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), 0, "memory_usage: line: %d", __LINE__);
 
   g_string_sprintf(filename,"file.qf");
   unlink(filename->str);
@@ -407,7 +408,7 @@ static void
 assert_first_message_reliable(LogQueue *q, diskq_tester_parameters_t *parameters)
 {
   feed_some_messages(q, 1, &parse_options);
-  assert_gint(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 1, "queued messages: line: %d", __LINE__);
   /* For reliable queue we have qout = 0, so messages go to the overflow area.
      But qreliable pushes 3 elements per message: msg, options, position */
   if (parameters->overflow_expected)
@@ -419,7 +420,7 @@ assert_first_message_non_reliable(LogQueue *q, diskq_tester_parameters_t *parame
 {
   LogQueueDiskNonReliable *queue = (LogQueueDiskNonReliable *)q;
   feed_some_messages(q, 1, &parse_options);
-  assert_gint(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 1, "queued messages: line: %d", __LINE__);
   assert_gint(queue->qoverflow->length, 0, "one message on overflow area: line: %d", __LINE__);
 }
 
@@ -428,8 +429,8 @@ assert_second_message_reliable(LogQueue *q, diskq_tester_parameters_t *parameter
 {
   LogQueueDiskReliable *queue = (LogQueueDiskReliable *)q;
   feed_some_messages(q, 1, &parse_options);
-  assert_gint(stats_counter_get(q->queued_messages), 2, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 2, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
 
   if (parameters->overflow_expected)
     assert_gint(queue->qreliable->length, 6, "one message on overflow area: line: %d", __LINE__);
@@ -439,8 +440,8 @@ static void
 assert_second_message_non_reliable(LogQueue *q, diskq_tester_parameters_t *parameters, gssize one_msg_size)
 {
   feed_some_messages(q, 1, &parse_options);
-  assert_gint(stats_counter_get(q->queued_messages), 2, "queued messages: line: %d", __LINE__);
-  assert_gint(stats_counter_get(q->memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.queued_messages), 2, "queued messages: line: %d", __LINE__);
+  assert_gint(stats_counter_get(q->counters.external.memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
 
   /* qout must be 1 for nonreliable case so we have only one message. But nonreliable pushes two elements: msg + options */
   assert_gint(((LogQueueDiskNonReliable *)q)->qoverflow->length, 2, "one message on overflow area: line: %d", __LINE__);
@@ -458,13 +459,13 @@ testcase_diskq_statistics(diskq_tester_parameters_t parameters)
 
   parameters.first_msg_asserter(q, &parameters);
 
-  guint32 one_msg_size = stats_counter_get(q->memory_usage);
+  guint32 one_msg_size = stats_counter_get(q->counters.external.memory_usage);
   if (parameters.overflow_expected)
     /* Only when overflow. If there is no overflow, the first
        msg is put to the output queue so statistics is not increased: one_msg_size == 0 */
     assert_true(is_valid_msg_size(one_msg_size), "one_msg_size %d: line: %d", one_msg_size, __LINE__);
   else
-    assert_gint(stats_counter_get(q->memory_usage), 0, "queued messages: line: %d", __LINE__);
+    assert_gint(stats_counter_get(q->counters.external.memory_usage), 0, "queued messages: line: %d", __LINE__);
 
   parameters.second_msg_asserter(q, &parameters, one_msg_size);
 

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -72,14 +72,15 @@ test_diskq_become_full(gboolean reliable)
   stats_lock();
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
-  stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
-  stats_counter_set(q->dropped_messages, 0);
+  stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->counters.external.dropped_messages);
+  stats_counter_set(q->counters.external.dropped_messages, 0);
   stats_unlock();
   unlink(DISKQ_FILENAME);
   log_queue_disk_load_queue(q, DISKQ_FILENAME);
   feed_some_messages(q, 1000, &parse_options);
 
-  assert_gint(q->dropped_messages->value, 1000, "Bad dropped message number (reliable: %s)", reliable ? "TRUE" : "FALSE");
+  assert_gint(q->counters.external.dropped_messages->value, 1000, "Bad dropped message number (reliable: %s)",
+              reliable ? "TRUE" : "FALSE");
 
   log_queue_unref(q);
   disk_queue_options_destroy(&options);

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -196,26 +196,26 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
   StatsClusterKey sc_key;
   stats_lock();
   stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
-  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
-  stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->counters.external.queued_messages);
+  stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->counters.external.memory_usage);
   stats_unlock();
 
   log_queue_set_use_backlog(q, TRUE);
 
-  cr_assert_eq(q->queued_messages->value, 0);
+  cr_assert_eq(q->counters.external.queued_messages->value, 0);
 
   fed_messages = 0;
   acked_messages = 0;
   feed_some_messages(q, 1, &parse_options);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 1);
-  cr_assert_neq(stats_counter_get(q->memory_usage), 0);
-  gint size_when_single_msg = stats_counter_get(q->memory_usage);
+  cr_assert_eq(stats_counter_get(q->counters.external.queued_messages), 1);
+  cr_assert_neq(stats_counter_get(q->counters.external.memory_usage), 0);
+  gint size_when_single_msg = stats_counter_get(q->counters.external.memory_usage);
 
   for (i = 0; i < 10; i++)
     feed_some_messages(q, 10, &parse_options);
 
-  cr_assert_eq(stats_counter_get(q->queued_messages), 101);
-  cr_assert_eq(stats_counter_get(q->memory_usage), 101*size_when_single_msg);
+  cr_assert_eq(stats_counter_get(q->counters.external.queued_messages), 101);
+  cr_assert_eq(stats_counter_get(q->counters.external.memory_usage), 101*size_when_single_msg);
 
   send_some_messages(q, fed_messages);
   app_ack_some_messages(q, fed_messages);


### PR DESCRIPTION
This PR includes:
* refactors:
    * external and internal counter grouping for log queues
    * generalize functions of views
* new counters
    * `disk_capacity_count`: `log_fifo_size` set by users
    * `mem_capacity_byte`: `disk_buf_size` set by users
    * `disk_fillup_rate`: ratio of `queued` and `log_fifo_size` in percent