### PR TITLE
Fix memory usage counter bug #2: disk-buffer, overflow buffer and reload

### DIFF
--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -175,7 +175,8 @@ log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsC
   self->queued_messages = queued_messages;
   self->dropped_messages = dropped_messages;
   self->memory_usage = memory_usage;
-  stats_counter_set(self->memory_usage, self->memory_usage_initial_value);
+  stats_counter_set(self->memory_usage, self->memory_usage_qout_initial_value);
+  stats_counter_add(self->memory_usage, self->memory_usage_overflow_initial_value);
   stats_counter_set(self->queued_messages, log_queue_get_length(self));
 }
 

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -175,8 +175,8 @@ log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsC
   self->queued_messages = queued_messages;
   self->dropped_messages = dropped_messages;
   self->memory_usage = memory_usage;
-  stats_counter_set(self->memory_usage, self->memory_usage_qout_initial_value);
-  stats_counter_add(self->memory_usage, self->memory_usage_overflow_initial_value);
+  stats_counter_set(self->memory_usage,
+                    self->memory_usage_qout_initial_value + self->memory_usage_overflow_initial_value);
   stats_counter_set(self->queued_messages, log_queue_get_length(self));
 }
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -50,7 +50,8 @@ struct _LogQueue
   StatsCounterItem *queued_messages;
   StatsCounterItem *dropped_messages;
   StatsCounterItem *memory_usage;
-  gssize memory_usage_initial_value;
+  gssize memory_usage_qout_initial_value;
+  gssize memory_usage_overflow_initial_value;
 
   GStaticMutex lock;
   LogQueuePushNotifyFunc parallel_push_notify;

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -32,7 +32,7 @@ typedef struct
 {
   guint index_in_queue;
   guint item_number_per_message;
-  gssize *memory_usage_initial_value;
+  gssize *value_accumulator;
 } DiskqMemusageLoaderState;
 
 static gboolean
@@ -49,7 +49,7 @@ _update_memory_usage_during_load(gpointer data, gpointer s)
   if (_object_is_message_in_position(state->index_in_queue, state->item_number_per_message))
     {
       LogMessage *msg = (LogMessage *)data;
-      *state->memory_usage_initial_value += log_msg_get_size(msg);
+      *state->value_accumulator += log_msg_get_size(msg);
     }
   state->index_in_queue++;
 }
@@ -63,12 +63,12 @@ _start(LogQueueDisk *s, const gchar *filename)
 
   DiskqMemusageLoaderState qout_sum = { .index_in_queue = 0,
                                         .item_number_per_message = ITEM_NUMBER_PER_MESSAGE,
-                                        .memory_usage_initial_value = &self->super.super.memory_usage_qout_initial_value
+                                        .value_accumulator = &self->super.super.memory_usage_qout_initial_value
                                       };
 
   DiskqMemusageLoaderState overflow_sum = { .index_in_queue = 0,
                                             .item_number_per_message = ITEM_NUMBER_PER_MESSAGE,
-                                            .memory_usage_initial_value = &self->super.super.memory_usage_overflow_initial_value
+                                            .value_accumulator = &self->super.super.memory_usage_overflow_initial_value
                                           };
 
   g_queue_foreach(self->qout, _update_memory_usage_during_load, &qout_sum);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -61,12 +61,18 @@ _start(LogQueueDisk *s, const gchar *filename)
 
   gboolean retval = qdisk_start(s->qdisk, filename, self->qout, self->qbacklog, self->qoverflow);
 
-  DiskqMemusageLoaderState state = { .index_in_queue = 0,
-                                     .item_number_per_message = ITEM_NUMBER_PER_MESSAGE,
-                                     .memory_usage_initial_value = &self->super.super.memory_usage_initial_value
-                                   };
+  DiskqMemusageLoaderState qout_sum = { .index_in_queue = 0,
+                                        .item_number_per_message = ITEM_NUMBER_PER_MESSAGE,
+                                        .memory_usage_initial_value = &self->super.super.memory_usage_qout_initial_value
+                                      };
 
-  g_queue_foreach(self->qout, _update_memory_usage_during_load, &state);
+  DiskqMemusageLoaderState overflow_sum = { .index_in_queue = 0,
+                                            .item_number_per_message = ITEM_NUMBER_PER_MESSAGE,
+                                            .memory_usage_initial_value = &self->super.super.memory_usage_overflow_initial_value
+                                          };
+
+  g_queue_foreach(self->qout, _update_memory_usage_during_load, &qout_sum);
+  g_queue_foreach(self->qoverflow, _update_memory_usage_during_load, &overflow_sum);
 
   return retval;
 }


### PR DESCRIPTION
We have found an error around memory usage counter when non-reliable disk-buffer is used and syslog-ng is reloaded.

We have found that the problem is around the overflow buffer which was not re-initialized after reload.
It caused an underflow in memory usage counter when syslog-ng can successfully send the messages from the disk-buffer.

Using the same solution that was done for qout buffer.