### PR TITLE
stats: set processed counter to the value of queued

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -323,7 +323,7 @@ _update_processed_message_counter_when_diskq_is_used(LogThrDestDriver *self)
 {
   if (!g_strcmp0(self->queue->type, "DISK"))
     {
-      stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
+      stats_counter_set(self->processed_messages, stats_counter_get(self->queued_messages));
     }
 }
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1291,7 +1291,7 @@ _update_processed_message_counter_when_diskq_is_used(LogWriter *self)
 {
   if (!g_strcmp0(self->queue->type, "DISK"))
     {
-      stats_counter_add(self->processed_messages, stats_counter_get(self->queued_messages));
+      stats_counter_set(self->processed_messages, stats_counter_get(self->queued_messages));
     }
 }
 


### PR DESCRIPTION
Previously, it was added not set. This doubled the value and
led to bad written counter value.

Signed-off-by: Noémi Ványi <sitbackandwait@gmail.com>