### PR TITLE
logsource: add "source suspended/resumed" debug messages

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -41,7 +41,7 @@ log_source_wakeup(LogSource *self)
   if (self->wakeup)
     self->wakeup(self);
 
-  msg_debug("Source has been resumed", evt_tag_str("group_name", self->options->group_name));
+  msg_debug("Source has been resumed", log_pipe_location_tag(&self->super));
 }
 
 static inline void
@@ -143,7 +143,7 @@ log_source_msg_ack(LogMessage *msg, AckType ack_type)
 void
 log_source_flow_control_suspend(LogSource *self)
 {
-  msg_debug("Source has been suspended", evt_tag_str("group_name", self->options->group_name));
+  msg_debug("Source has been suspended", log_pipe_location_tag(&self->super));
 
   g_atomic_counter_set(&self->suspended_window_size, g_atomic_counter_get(&self->window_size));
   g_atomic_counter_set(&self->window_size, 0);
@@ -247,7 +247,7 @@ log_source_post(LogSource *self, LogMessage *msg)
   old_window_size = g_atomic_counter_exchange_and_add(&self->window_size, -1);
 
   if (G_UNLIKELY(old_window_size == 1))
-    msg_debug("Source has been suspended", evt_tag_str("group_name", self->options->group_name));
+    msg_debug("Source has been suspended", log_pipe_location_tag(&self->super));
 
   /*
    * NOTE: this assertion validates that the source is not overflowing its


### PR DESCRIPTION
This information can be useful when a user wants to find out why syslog-ng doesn't receive messages.
@jszigetvari 

Note that these are just debug messages; if you want to measure the "availability of sources", an `iw-size` related stat counter would be a better choice.
