### PR TITLE
Add template() option to apache-accesslog-parser(). 

### DIFF
--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -19,7 +19,7 @@
 # COPYING for details.
 #
 #############################################################################
-block parser apache-accesslog-parser(prefix(".apache.")) {
+block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
 
 
     channel {
@@ -29,6 +29,7 @@ block parser apache-accesslog-parser(prefix(".apache.")) {
                 dialect(escape-double-char)
                 flags(strip-whitespace)
                 delimiters(" ")
+                template(`template`)
                 quote-pairs('""[]')
                 # field names match of that of Logstash
                 columns("clientip", "ident", "auth",


### PR DESCRIPTION
This way it can parse any templates, not just MESSAGE. To retain
backwards compatibility, MESSAGE is parsed by default.

Signed-off-by: Peter Czanik <peter@czanik.hu>