### PR TITLE
LogQueueFifo memory usage underflow and cfg object corruption during reload

### DIFF
--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -34,11 +34,14 @@ void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
 StatsCluster *stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+StatsCluster *stats_register_counter_and_index(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 void stats_register_and_increment_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 void stats_unregister_counter(const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
+
+void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);
 void stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data);
@@ -48,5 +51,8 @@ void stats_registry_init(void);
 void stats_registry_deinit(void);
 
 GHashTable* stats_registry_get_container(void);
+
+void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
+void load_counter_from_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 
 #endif

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -419,6 +419,7 @@ afsocket_dd_setup_writer(AFSocketDestDriver *self)
 
       self->writer = afsocket_dd_construct_writer(self);
     }
+  log_pipe_set_config((LogPipe *)self->writer, log_pipe_get_config(&self->super.super.super));
   log_writer_set_options(self->writer, &self->super.super.super,
                          &self->writer_options,
                          STATS_LEVEL0,


### PR DESCRIPTION
During reload, memory_usage counter is reset, but the queue might be maintained, for example when it contains messages. This leads counter value inconsistency during reload. After opening the destination, memory_usage will underflow.

To prevent this, memory_usage counter is saved to the persistent storage inside GlobalConfig, so that its value can be reloaded together with the queue.

During the implementation we run into another bug: after reload the reference to the cfg object of writer is corrupted, because when we fetch the writer object from persistent config, the writer object will refer to the already destroyed config object. This needed to be fixed by this patchset as well.