### PR TITLE
Fix minor memory leaks in disk buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Makefile.in
 aclocal.m4
 config.h.in
 configure
+configure.gnu
 depcomp
 install-sh
 missing

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,3 +1,4 @@
+m4
 .arch-ids
 .arch-inventory
 *~

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -64,7 +64,6 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name, gpointer user_data)
           msg_error("Error opening disk-queue file, a new one started",
                     evt_tag_str("old_filename", qfile_name),
                     evt_tag_str("new_filename", log_queue_disk_get_filename(queue)));
-          g_free(qfile_name);
         }
       else
         {
@@ -73,6 +72,8 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name, gpointer user_data)
           return NULL;
         }
     }
+
+  g_free(qfile_name);
 
   if (persist_name)
     {

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -49,11 +49,10 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name, gpointer user_data)
     }
 
   if (self->options.reliable)
-    queue = log_queue_disk_reliable_new(&self->options);
+    queue = log_queue_disk_reliable_new(&self->options, persist_name);
   else
-    queue = log_queue_disk_non_reliable_new(&self->options);
+    queue = log_queue_disk_non_reliable_new(&self->options, persist_name);
   log_queue_set_throttle(queue, dd->throttle);
-  queue->persist_name = g_strdup(persist_name);
 
   qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
   success = log_queue_disk_load_queue(queue, qfile_name);

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -83,14 +83,14 @@ open_queue(char *filename, LogQueue **lq, DiskQueueOptions *options)
     {
       options->disk_buf_size = 128;
       options->mem_buf_size = 1024 * 1024;
-      *lq = log_queue_disk_reliable_new(options);
+      *lq = log_queue_disk_reliable_new(options, NULL);
     }
   else
     {
       options->disk_buf_size = 1;
       options->mem_buf_size = 128;
       options->qout_size = 128;
-      *lq = log_queue_disk_non_reliable_new(options);
+      *lq = log_queue_disk_non_reliable_new(options, NULL);
     }
 
   if (!log_queue_disk_load_queue(*lq, filename))

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -413,11 +413,11 @@ _set_virtual_functions (LogQueueDisk *self)
 }
 
 LogQueue *
-log_queue_disk_non_reliable_new(DiskQueueOptions *options)
+log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_name)
 {
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
-  log_queue_disk_init_instance (&self->super);
+  log_queue_disk_init_instance(&self->super, persist_name);
   qdisk_init (self->super.qdisk, options);
   self->qbacklog = g_queue_new ();
   self->qout = g_queue_new ();

--- a/modules/diskq/logqueue-disk-non-reliable.h
+++ b/modules/diskq/logqueue-disk-non-reliable.h
@@ -36,6 +36,6 @@ typedef struct _LogQueueDiskNonReliable
   gint qout_size;
 } LogQueueDiskNonReliable;
 
-LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options);
+LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_name);
 
 #endif /* LOG_QUEUE_DISK_NON_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -341,11 +341,11 @@ _set_virtual_functions(LogQueueDisk *self)
 }
 
 LogQueue *
-log_queue_disk_reliable_new(DiskQueueOptions *options)
+log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name)
 {
   g_assert(options->reliable == TRUE);
   LogQueueDiskReliable *self = g_new0(LogQueueDiskReliable, 1);
-  log_queue_disk_init_instance(&self->super);
+  log_queue_disk_init_instance(&self->super, persist_name);
   qdisk_init(self->super.qdisk, options);
   self->qreliable = g_queue_new();
   self->qbacklog = g_queue_new();

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -33,6 +33,6 @@ typedef struct _LogQueueDiskReliable
   GQueue *qbacklog;
 } LogQueueDiskReliable;
 
-LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options);
+LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name);
 
 #endif /* LOGQUEUE_DISK_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -215,7 +215,8 @@ _free(LogQueue *s)
 
   qdisk_deinit(self->qdisk);
   qdisk_free(self->qdisk);
-  g_free(self);
+
+  log_queue_free_method(s);
 }
 
 static gboolean

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -332,9 +332,9 @@ _restart_corrupted(LogQueueDisk *self)
 
 
 void
-log_queue_disk_init_instance(LogQueueDisk *self)
+log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
 {
-  log_queue_init_instance(&self->super,NULL);
+  log_queue_init_instance(&self->super, persist_name);
   self->qdisk = qdisk_new();
 
   self->super.type = log_queue_disk_type;

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -58,6 +58,6 @@ gboolean log_queue_disk_is_reliable(LogQueue *s);
 const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
-void log_queue_disk_init_instance(LogQueueDisk *self);
+void log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name);
 
 #endif

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -61,7 +61,7 @@ testcase_zero_diskbuf_and_normal_acks()
 
   _construct_options(&options, 10000000, 100000, TRUE);
 
-  q = log_queue_disk_reliable_new(&options);
+  q = log_queue_disk_reliable_new(&options, NULL);
   log_queue_set_use_backlog(q, TRUE);
 
   filename = g_string_sized_new(32);
@@ -95,7 +95,7 @@ testcase_zero_diskbuf_alternating_send_acks()
 
   _construct_options(&options, 10000000, 100000, TRUE);
 
-  q = log_queue_disk_reliable_new(&options);
+  q = log_queue_disk_reliable_new(&options, NULL);
   log_queue_set_use_backlog(q, TRUE);
 
   filename = g_string_sized_new(32);
@@ -130,7 +130,7 @@ testcase_ack_and_rewind_messages()
 
   _construct_options(&options, 10000000, 100000, TRUE);
 
-  q = log_queue_disk_reliable_new(&options);
+  q = log_queue_disk_reliable_new(&options, NULL);
   log_queue_set_use_backlog(q, TRUE);
 
   StatsClusterKey sc_key;
@@ -287,7 +287,7 @@ testcase_with_threads()
 
       _construct_options(&options, 10000000, 100000, TRUE);
 
-      q = log_queue_disk_reliable_new(&options);
+      q = log_queue_disk_reliable_new(&options, NULL);
       filename = g_string_sized_new(32);
       g_string_sprintf(filename,"test-%04d.qf",i);
       unlink(filename->str);
@@ -324,7 +324,7 @@ is_valid_msg_size(guint32 one_msg_size)
 
 struct diskq_tester_parameters;
 
-typedef LogQueue *(*queue_constructor_t)(DiskQueueOptions *);
+typedef LogQueue *(*queue_constructor_t)(DiskQueueOptions *, const gchar *);
 typedef void (*first_msg_asserter_t)(LogQueue *q, struct diskq_tester_parameters *parameters);
 typedef void (*second_msg_asserter_t)(LogQueue *q, struct diskq_tester_parameters *parameters, gssize one_msg_size);
 
@@ -390,7 +390,7 @@ testcase_diskq_prepare(DiskQueueOptions *options, diskq_tester_parameters_t *par
   _construct_options(options, parameters->disk_size, 100000, parameters->reliable);
   options->qout_size = parameters->qout_size;
 
-  q = parameters->constructor(options);
+  q = parameters->constructor(options, NULL);
 
   init_statistics(q);
   assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: line: %d", __LINE__);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -54,21 +54,22 @@ test_diskq_become_full(gboolean reliable)
   fed_messages = 0;
   DiskQueueOptions options = {0};
 
+  const gchar *persist_name = "test_diskq";
+
   options.reliable = reliable;
   if (reliable)
     {
       _construct_options(&options, 1000, 1000, reliable);
-      q = log_queue_disk_reliable_new(&options);
+      q = log_queue_disk_reliable_new(&options, persist_name);
     }
   else
     {
       _construct_options(&options, 1000, 0, reliable);
-      q = log_queue_disk_non_reliable_new(&options);
+      q = log_queue_disk_non_reliable_new(&options, persist_name);
     }
 
   log_queue_set_use_backlog(q, TRUE);
 
-  q->persist_name = "test_diskq";
   stats_lock();
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -61,7 +61,7 @@ _init_diskq_for_test(gint64 size, gint64 membuf_size)
   LogQueueDiskReliable *dq;
 
   _construct_options(&options, size, membuf_size, TRUE);
-  LogQueue *q = log_queue_disk_reliable_new(&options);
+  LogQueue *q = log_queue_disk_reliable_new(&options, NULL);
   struct stat st;
   num_of_ack = 0;
   gchar *filename = FILENAME;


### PR DESCRIPTION
This PR fixes 2 minor memory leaks in the disk buffer module.

```
41 bytes are definitely lost
  by g_strdup (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
  by _acquire_queue (diskq.c:56)

61 bytes are definitely lost
  by persist_state_lookup_string (persist-state.c:825)
  by _acquire_queue (diskq.c:58)

8 bytes are definitely lost
  by g_mutex_new (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
  by log_queue_reset_parallel_push (logqueue.c:69)
```

I've also added a refactor commit, which propagates `persist_name` through the constructor of `LogQueue`.

@furiel I'm dedicating this PR to you. :smile: 