### PR TITLE
CfgTree: Improve error message when config can not initialized

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1123,7 +1123,8 @@ cfg_tree_start(CfgTree *self)
 
       if (!log_pipe_init(pipe))
         {
-          msg_error("Error initializing message pipeline");
+          msg_error("Error initializing message pipeline",
+                    log_pipe_location_tag(pipe));
           return FALSE;
         }
     }


### PR DESCRIPTION
Example:
Error initializing message pipeline; location='syslog-ng.conf:26:23'

This "location" can help to point which driver failing during the
config initializtion.

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>
Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>