### PR TITLE
Allow to reuse GlobalConfig for local config

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -946,7 +946,13 @@ relex:
           msg_warning("WARNING: Configuration file has no version number, assuming syslog-ng 2.1 format. Please add @version: maj.min to the beginning of the file to indicate this explicitly");
           cfg_set_version(configuration, 0x0201);
         }
-      cfg_load_candidate_modules(configuration);
+
+      /* Negative would mean that this "GlobalConfig" is a partial, local config... */
+      if (self->user_version > 0) 
+        {
+          cfg_load_candidate_modules(configuration);
+        }
+
       self->non_pragma_seen = TRUE;
     }
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -59,6 +59,7 @@ struct _GlobalConfig
 {
   /* version number specified by the user, set _after_ parsing is complete */
   /* hex-encoded syslog-ng major/minor, e.g. 0x0201 is syslog-ng 2.1 format */
+  /* it can be < 0, which means that the parsed file is a partial, local config */
   gint user_version;
   
   /* version number as parsed from the configuration file, it can be set


### PR DESCRIPTION
## Rationale

With these patches, the syslog-ng's configuration mechanism can be used to parse syslog-ng configuration files for local configurations.

## Usage

```c
GlobalConfig *cfg = cfg_new(-1);
cfg_read_config(cfg, file_path, FALSE, NULL);
GList *objects_in_cfg = cfg_tree_get_objects(&cfg->tree);
for (GList *cfg_object = objects_in_cfg; cfg_object != NULL; cfg_object = cfg_object->next)
  {
    LogExprNode *node = (LogExprNode *) cfg_object->data;
    /* work with `node` */
  }
```

## Note

We are already do this, and there were a bug report that some modules were loaded multiple times.