### PR TITLE
bugfix (fixes #1635): use sd_journald_test_cursor() from systemd-jour…

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -322,8 +322,9 @@ _seek_to_saved_state(JournalReader *self)
 {
   JournalReaderState *state = persist_state_map_entry(self->persist_state, self->persist_handle);
   gint rc = journald_seek_cursor(self->journal, state->cursor);
+  gint tc = journald_test_cursor(self->journal, state->cursor);
   persist_state_unmap_entry(self->persist_state, self->persist_handle);
-  if (rc != 0)
+  if (rc != 0 || tc != 0)
     {
       msg_warning("Failed to seek journal to the saved cursor position",
                   evt_tag_str("cursor", state->cursor),

--- a/modules/systemd-journal/journald-subsystem.c
+++ b/modules/systemd-journal/journald-subsystem.c
@@ -225,6 +225,12 @@ journald_seek_cursor(Journald *self, const gchar *cursor)
 }
 
 int
+journald_test_cursor(Journald *self, const gchar *cursor)
+{
+  return sd_journal_test_cursor(self->journal, cursor);
+}
+
+int
 journald_get_fd(Journald *self)
 {
   return sd_journal_get_fd(self->journal);


### PR DESCRIPTION
…nal API for additional cursor test in syslog-ng.presit file

short bug description: when syslog-ng checks cursor position from
syslog-ng.persist file it does not check if cursor is "in the future" with
respect to the system.  This causes logging glitch when syslog-ng is started
(syslog-ng waits for the "time to come" to continue logging) when there is no
systemd journal entries with the "future time". This is because
sd_journald_seek_cursor() seeks to the next closest entry (in terms of time)
if no entry matches.