### PR TITLE
bugfix (fixes #1570): use sd_journald_test_cursor() from systemd-jour…

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -322,8 +322,9 @@ _seek_to_saved_state(JournalReader *self)
 {
   JournalReaderState *state = persist_state_map_entry(self->persist_state, self->persist_handle);
   gint rc = journald_seek_cursor(self->journal, state->cursor);
+  gint tc = journald_test_cursor(self->journal, state->cursor);
   persist_state_unmap_entry(self->persist_state, self->persist_handle);
-  if (rc != 0)
+  if (rc != 0 || tc != 0)
     {
       msg_warning("Failed to seek journal to the saved cursor position",
                   evt_tag_str("cursor", state->cursor),

--- a/modules/systemd-journal/journald-subsystem.c
+++ b/modules/systemd-journal/journald-subsystem.c
@@ -76,6 +76,8 @@ typedef int
 typedef int
 (*SD_JOURNAL_SEEK_CURSOR)(sd_journal *j, const char *cursor);
 typedef int
+(*SD_JOURNAL_TEST_CURSOR)(sd_journal *j, const char *cursor);
+typedef int
 (*SD_JOURNAL_GET_FD)(sd_journal *j);
 typedef int
 (*SD_JOURNAL_PROCESS)(sd_journal *j);
@@ -91,6 +93,7 @@ static SD_JOURNAL_NEXT sd_journal_next;
 static SD_JOURNAL_RESTART_DATA sd_journal_restart_data;
 static SD_JOURNAL_ENUMERATE_DATA sd_journal_enumerate_data;
 static SD_JOURNAL_SEEK_CURSOR sd_journal_seek_cursor;
+static SD_JOURNAL_TEST_CURSOR sd_journal_test_cursor;
 static SD_JOURNAL_GET_FD sd_journal_get_fd;
 static SD_JOURNAL_PROCESS sd_journal_process;
 static SD_JOURNAL_GET_REALTIME_USEC sd_journal_get_realtime_usec;
@@ -222,6 +225,12 @@ int
 journald_seek_cursor(Journald *self, const gchar *cursor)
 {
   return sd_journal_seek_cursor(self->journal, cursor);
+}
+
+int
+journald_test_cursor(Journald *self, const gchar *cursor)
+{
+  return sd_journal_test_cursor(self->journal, cursor);
 }
 
 int

--- a/modules/systemd-journal/journald-subsystem.h
+++ b/modules/systemd-journal/journald-subsystem.h
@@ -60,6 +60,7 @@ int journald_next(Journald *self);
 void journald_restart_data(Journald *self);
 int journald_enumerate_data(Journald *self, const void **data, gsize *length);
 int journald_seek_cursor(Journald *self, const gchar *cursor);
+int journald_test_cursor(Journald *self, const gchar *cursor);
 int journald_get_fd(Journald *self);
 int journald_process(Journald *self);
 int journald_get_realtime_usec(Journald *self, guint64 *usec);

--- a/modules/systemd-journal/tests/journald-mock.c
+++ b/modules/systemd-journal/tests/journald-mock.c
@@ -148,6 +148,12 @@ journald_seek_cursor(Journald *self, const gchar *cursor)
 }
 
 int
+journald_test_cursor(Journald *self, const gchar *cursor)
+{
+  return 0;
+}
+
+int
 journald_get_fd(Journald *self)
 {
   g_assert(self->opened);


### PR DESCRIPTION
…nal API for additional cursor test in syslog-ng.presit file

short bug description: when syslog-ng checks cursor position from
syslog-ng.persist file it does not check if cursor is "in the future" with
respect to the system.  This causes logging glitch when syslog-ng is started
(syslog-ng waits for the "time to come" to continue logging) when there is no
systemd journal entries with the "future time". This is because
sd_journald_seek_cursor() seeks to the next closest entry (in terms of time)
if no entry matches.