### PR TITLE
afamqp: layer violation in suspending thrdestdrv results in crash

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -39,7 +39,7 @@ log_threaded_dest_driver_format_seqnum_for_persist(LogThrDestDriver *self)
   return persist_name;
 }
 
-void
+static void
 log_threaded_dest_driver_suspend(LogThrDestDriver *self)
 {
   iv_validate_now();

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -103,8 +103,6 @@ gboolean log_threaded_dest_driver_start(LogPipe *s);
 void log_threaded_dest_driver_init_instance(LogThrDestDriver *self, GlobalConfig *cfg);
 void log_threaded_dest_driver_free(LogPipe *s);
 
-void log_threaded_dest_driver_suspend(LogThrDestDriver *self);
-
 void log_threaded_dest_driver_message_accept(LogThrDestDriver *self,
                                              LogMessage *msg);
 void log_threaded_dest_driver_message_drop(LogThrDestDriver *self,


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/1513

There were two issues with afamqp that lead to crashing when
timer_reopen registered.

Afamqp did not virtualize connect function, even though it
should have done. As a result, connect/reconnect logic did not work
inside LogThrDestDrv, essentially logthrdestdrv marked the destination
as connected even though connection failed. Therefore, logthrdestdrv
pushed message to afamqp. Afamqp knew well that she was not connected,
so she tried to reconnect. Though the connection failed again, so
WORKER_INSERT_RESULT_NOT_CONNECTED was sent back to
logthrdestdrv. Receiving this error code, logthrdestdrv start the
suspend logic.

Afamqp, as the the connect function was not virtualized, tried to
execute the suspend logic during connect as well.

In the end, suspend logic started two times, both by afamqp and
logthrdestdrv, resulting timer_reopen registered two times, hence the
crash.

This patch virtualizes connect function of afamqp, removes the suspend
logic triggered inside afamqp, and removes
log_threaded_dest_driver_suspend from header because destination
drivers should not call it at all.
Signed-off-by: Antal Nemes <antal.nemes@balabit.com>