### PR TITLE
dbparser: add drop-unmatched() option

### DIFF
--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -66,6 +66,7 @@ SyntheticMessage *last_message;
 %token KW_HAVING
 %token KW_AGGREGATE
 %token KW_VALUE
+%token KW_DROP_UNMATCHED
 
 %type <num> stateful_parser_inject_mode
 %type <ptr> synthetic_message
@@ -100,6 +101,7 @@ parser_db_opts
 /* NOTE: we don't support parser_opt as we don't want the user to specify a template */
 parser_db_opt
         : KW_FILE '(' string ')'                		{ log_db_parser_set_db_file(((LogDBParser *) last_parser), $3); free($3); }
+	| KW_DROP_UNMATCHED '(' yesno ')'			{ log_db_parser_set_drop_unmatched(((LogDBParser *) last_parser), $3); };
 	| stateful_parser_opt
         ;
 

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -36,6 +36,7 @@ static CfgLexerKeyword dbparser_keywords[] =
 
   /* correllate options */
   { "inject_mode",        KW_INJECT_MODE },
+  { "drop_unmatched",     KW_DROP_UNMATCHED },
   { "key",                KW_KEY },
   { "scope",              KW_SCOPE },
   { "timeout",            KW_TIMEOUT },

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -31,6 +31,7 @@
 
 typedef struct _LogDBParser LogDBParser;
 
+void log_db_parser_set_drop_unmatched(LogDBParser *self, gboolean setting);
 void log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file);
 LogParser *log_db_parser_new(GlobalConfig *cfg);
 


### PR DESCRIPTION
This patch adds a new drop-unmatched() option to db-parser() that causes
unmatched messages to be dropped, like this:

db-parser(drop-unmatched(yes));

If none of the rules match, the message would be dropped. If there's
a match the message goes "through".

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>