### PR TITLE
Add function to load config snippet

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -946,7 +946,6 @@ relex:
           msg_warning("WARNING: Configuration file has no version number, assuming syslog-ng 2.1 format. Please add @version: maj.min to the beginning of the file to indicate this explicitly");
           cfg_set_version(configuration, 0x0201);
         }
-      cfg_load_candidate_modules(configuration);
       self->non_pragma_seen = TRUE;
     }
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -286,7 +286,7 @@ cfg_register_builtin_plugins(GlobalConfig *self)
 }
 
 GlobalConfig *
-cfg_new(gint version)
+cfg_new_snippet(gint version)
 {
   GlobalConfig *self = g_new0(GlobalConfig, 1);
 
@@ -326,6 +326,13 @@ cfg_new(gint version)
 
   cfg_tree_init_instance(&self->tree, self);
   cfg_register_builtin_plugins(self);
+  return self;
+}
+
+GlobalConfig *
+cfg_new(gint version)
+{
+  GlobalConfig *self = cfg_new_snippet(version);
   cfg_load_candidate_modules(self);
   return self;
 }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -339,7 +339,6 @@ cfg_set_global_paths(GlobalConfig *self)
   cfg_args_set(self->lexer->globals, "syslog-ng-include", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
   cfg_args_set(self->lexer->globals, "scl-root", get_installation_path_for(SYSLOG_NG_PATH_SCLDIR));
   cfg_args_set(self->lexer->globals, "module-path", resolvedConfigurablePaths.initial_module_path);
-  cfg_args_set(self->lexer->globals, "autoload-compiled-modules", "1");
 
   include_path = g_strdup_printf("%s:%s",
                                  get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR),
@@ -374,11 +373,7 @@ cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer 
 void
 cfg_load_candidate_modules(GlobalConfig *self)
 {
-  /* we enable autoload for pre-3.1 configs or when the user requested
-   * auto-load (the default) */
-
-  if ((cfg_is_config_version_older(self, 0x0302) ||
-       atoi(cfg_args_get(self->lexer->globals, "autoload-compiled-modules"))) && !self->candidate_plugins)
+  if (!self->candidate_plugins)
     {
       plugin_load_candidate_modules(self);
     }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -326,6 +326,7 @@ cfg_new(gint version)
 
   cfg_tree_init_instance(&self->tree, self);
   cfg_register_builtin_plugins(self);
+  cfg_load_candidate_modules(self);
   return self;
 }
 
@@ -373,10 +374,7 @@ cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer 
 void
 cfg_load_candidate_modules(GlobalConfig *self)
 {
-  if (!self->candidate_plugins)
-    {
-      plugin_load_candidate_modules(self);
-    }
+  plugin_load_candidate_modules(self);
 
 #if (!SYSLOG_NG_ENABLE_FORCED_SERVER_MODE)
   if (!plugin_load_module("license", self, NULL))

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -133,6 +133,7 @@ void cfg_load_candidate_modules(GlobalConfig *self);
 void cfg_set_global_paths(GlobalConfig *self);
 
 GlobalConfig *cfg_new(gint version);
+GlobalConfig *cfg_new_snippet(gint version);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
 gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gboolean syntax_only, gchar *preprocess_into);
 gboolean cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, gchar *preprocess_into);


### PR DESCRIPTION
## Rationale

With these patches, the syslog-ng's configuration mechanism can be used to parse syslog-ng config file snippets.

## Usage

```c
GlobalConfig *cfg_snippet = cfg_new_snippet(configuration->user_version);
cfg_read_config(cfg_snippet, file_path, FALSE, NULL);
GList *objects_in_cfg_snippet = cfg_tree_get_objects(&cfg->tree);
for (GList *cfg_object = objects_in_cfg_snippet; cfg_object != NULL; cfg_object = cfg_object->next)
  {
    LogExprNode *node = (LogExprNode *) cfg_object->data;
    /* work with `node` */
  }
```

## Note

We are already do this, and there were a bug report that some modules were loaded multiple times. This is an alternative implementation of #1568.