### PR TITLE
contrib: install syslog-debun

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,7 @@ check_PROGRAMS		=
 check_SCRIPTS		=
 TESTS			= $(check_PROGRAMS) $(check_SCRIPTS)
 bin_SCRIPTS		=
+dist_sbin_SCRIPTS	=
 bin_PROGRAMS		=
 sbin_PROGRAMS		=
 libexec_PROGRAMS	=

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,3 +1,6 @@
+dist_sbin_SCRIPTS += \
+	contrib/syslog-debun
+
 EXTRA_DIST += \
 	contrib/README \
 	\

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,11 +1,11 @@
 dist_sbin_SCRIPTS += \
-	contrib/syslog-debun
+	contrib/syslog-ng-debun
 
 EXTRA_DIST += \
 	contrib/README \
 	\
-	contrib/README.syslog-debun \
-	contrib/syslog-debun \
+	contrib/README.syslog-ng-debun \
+	contrib/syslog-ng-debun \
 	\
 	contrib/init.d.solaris \
 	contrib/init.d.HP-UX \

--- a/contrib/README.syslog-ng-debun
+++ b/contrib/README.syslog-ng-debun
@@ -1,43 +1,43 @@
-README for syslog-debun, the Syslog-ng DEBUg buNdle generator
+README for syslog-ng-debun, the Syslog-ng DEBUg buNdle generator
 
 The main purpose of this software is to collect and save information about
 your syslog-ng installation / implementation for that case, if you want to
 ask help about your syslog-ng related problem.
 
 usage examples:
-# syslog-debun
+# syslog-ng-debun
 	Create a simple debug bundle, collecting about your environmental
 	information. eg. list of packages, which contains the word: syslog
 	ldd of your syslog-binary, etc.
 
-# syslog-debun -l
+# syslog-ng-debun -l
 	Like previuos, but left out some information, which may you think
 	harm your privacy. Eg fstab, df's output, mount info, ip / network
 	interface configuration, DNS resolv info, and process tree is NOT
 	collected.
 
-# syslog-debun -d
+# syslog-ng-debun -d
 	Besides collecting information, it stops system's syslog-ng, then
 	start in debug mode with -Fedv --enable-core, and until you do not
 	press enter, it stays in that mode. Debug's output is collected into
 	a separate file, and also collected.
 
-# syslog-debun -p
+# syslog-ng-debun -p
 	Will run packet capture with filter: "port 514 or port 601 or port 53"
 	Also wait for pressing enter, like debug mode.
 
-# syslog-debun -p -t 10
+# syslog-ng-debun -p -t 10
 	Like the previous one, but do not wait for pressing enter, it will
 	exit from tcpdump mode after 10 seconds. (noninteractive debug mode)
 
-# syslog-debun -P "host 1.2.3.4" -D "-Fev --enable-core"
+# syslog-ng-debun -P "host 1.2.3.4" -D "-Fev --enable-core"
 	packet capturing's filter will be changed from default to
 		host 1.2.3.4
 	Debugging paramters will be changed from default to
 		-Fev --enable-core
 	And, since a timout is not given, it will wait for pressing enter.
 
-# syslog-debun -p -d -w 5 -t 10
+# syslog-ng-debun -p -d -w 5 -t 10
 	Collect pcap and debug mode output following this scenario:
 	* start packet capture with default params
 	* wait 5 seconds
@@ -49,10 +49,10 @@ usage examples:
 	* start system's syslog-ng
 	* stops packet capturing
 
-# syslog-debun -W /var/tmp -P /usr/local
+# syslog-ng-debun -W /var/tmp -P /usr/local
 	Collect debug info, but the temporary files, and the result will be
 	in /var/tmp instead of /tmp and don't try to search syslog-ng in
 	/opt/syslog-ng, it will search in /usr/local
 
-# syslog-debun -s -t 10
+# syslog-ng-debun -s -t 10
 	Collect debug info, start tracing, and exit tracing after 10 seconds

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -1,7 +1,7 @@
 #!/bin/sh
 #!/bin/bash
 
-### syslog-debun: syslog debug bundle generator
+### syslog-ng-debun: syslog debug bundle generator
 ### Written/Copyright: Gyorgy Pasztor <pasztor@linux.gyakg.u-szeged.hu>, (c) 2014-2016.
 ### Further enhancements: Janos Szigetvari - jszigetvari at gmail dot com, (c) 2016-2017.
 ### This software may be used and distributed according to the terms of GNU GPLv2
@@ -90,7 +90,7 @@ distpkgoffile_cleanup () { : ; }
 ###
 debun_usage () {
 cat <<END
-Usage: syslog-debun [OPTIONS]
+Usage: syslog-ng-debun [OPTIONS]
 
 General Options:
   -h		Show this help page


### PR DESCRIPTION
This PR 
- renames syslog-debun to syslog-ng-debun
- installs syslog-debun, so it can be included easily in .rpm, .deb packages

@lbudai @jszigetvari @czanik