### PR TITLE
Fix subst() on non-existing macro

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -622,7 +622,15 @@ log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handl
       log_msg_set_flag(self, LF_STATE_OWN_PAYLOAD);
     }
 
-  while (!nv_table_add_value_indirect(self->payload, handle, name, name_len, ref_handle, type, ofs, len, &new_entry))
+  NVReferencedSlice referenced_slice =
+  {
+    .handle = ref_handle,
+    .ofs = ofs,
+    .len = len,
+    .type = type
+  };
+
+  while (!nv_table_add_value_indirect(self->payload, handle, name, name_len, &referenced_slice, &new_entry))
     {
       /* error allocating string in payload, reallocate */
       if (!nv_table_realloc(self->payload, &self->payload))

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -460,9 +460,8 @@ nv_table_unset_value(NVTable *self, NVHandle handle)
 
 static void
 nv_table_set_indirect_entry(NVTable *self, NVHandle handle, NVEntry *entry, const gchar *name, gsize name_len,
-                            NVEntry *ref_entry, const NVReferencedSlice *referenced_slice)
+                            const NVReferencedSlice *referenced_slice)
 {
-  ref_entry->referenced = TRUE;
   entry->vindirect.handle = referenced_slice->handle;
   entry->vindirect.ofs = referenced_slice->ofs;
   entry->vindirect.len = referenced_slice->len;
@@ -548,7 +547,8 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
   if (entry && (((guint) entry->alloc_len) >= NV_ENTRY_INDIRECT_HDR + name_len + 1))
     {
       /* this value already exists and the new reference fits in the old space */
-      nv_table_set_indirect_entry(self, handle, entry, name, name_len, ref_entry, referenced_slice);
+      nv_table_set_indirect_entry(self, handle, entry, name, name_len, referenced_slice);
+      ref_entry->referenced = TRUE;
       return TRUE;
     }
   else if (!entry && new_entry)
@@ -566,7 +566,8 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
 
   ofs = nv_table_get_ofs_for_an_entry(self, entry);
 
-  nv_table_set_indirect_entry(self, handle, entry, name, name_len, ref_entry, referenced_slice);
+  nv_table_set_indirect_entry(self, handle, entry, name, name_len, referenced_slice);
+  ref_entry->referenced = TRUE;
 
   nv_table_set_table_entry(self, handle, ofs, index_entry);
 

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -526,7 +526,7 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
 
 
   entry = nv_table_get_entry(self, handle, &index_entry);
-  if (!entry && !new_entry && (rlen == 0 || !ref_entry))
+  if ((!entry && !new_entry && rlen == 0) || !ref_entry)
     {
       /* we don't store zero length matches unless the caller is
        * interested in whether a new entry was created. It is used by

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -112,6 +112,16 @@ nv_registry_get_handle_name(NVRegistry *self, NVHandle handle, gssize *length)
   return stored->name;
 }
 
+typedef struct _NVReferencedSlice
+{
+  NVHandle handle;
+  guint32 ofs;
+  guint32 len;
+  guint8 type;
+
+  gchar name[0];
+} NVReferencedSlice;
+
 /*
  * Contains a name-value pair.
  */
@@ -139,14 +149,8 @@ struct _NVEntry
       /* variable data, first the name of this entry, then the value, both are NUL terminated */
       gchar data[0];
     } vdirect;
-    struct
-    {
-      NVHandle handle;
-      guint32 ofs;
-      guint32 len;
-      guint8 type;
-      gchar name[0];
-    } vindirect;
+
+    NVReferencedSlice vindirect;
   };
 };
 
@@ -255,7 +259,8 @@ struct _NVTable
 
 gboolean nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name_len, const gchar *value, gsize value_len, gboolean *new_entry);
 void nv_table_unset_value(NVTable *self, NVHandle handle);
-gboolean nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, gsize name_len, NVHandle ref_handle, guint8 type, guint32 ofs, guint32 len, gboolean *new_entry);
+gboolean nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, gsize name_len,
+                                     NVReferencedSlice *referenced_slice, gboolean *new_entry);
 
 gboolean nv_table_foreach(NVTable *self, NVRegistry *registry, NVTableForeachFunc func, gpointer user_data);
 gboolean nv_table_foreach_entry(NVTable *self, NVTableForeachEntryFunc func, gpointer user_data);

--- a/lib/logmsg/tests/test_nvtable.c
+++ b/lib/logmsg/tests/test_nvtable.c
@@ -250,7 +250,11 @@ Test(nvtable, test_nvtable_direct)
           tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
           success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
           cr_assert(success);
-          success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+          success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                                &(NVReferencedSlice)
+          {
+            STATIC_HANDLE, 1, 126, 0
+          }, NULL);
           cr_assert(success);
           used = tab->used;
 
@@ -267,7 +271,11 @@ Test(nvtable, test_nvtable_direct)
           tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
           success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 64, NULL);
           cr_assert(success);
-          success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 63, NULL);
+          success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                                &(NVReferencedSlice)
+          {
+            STATIC_HANDLE, 1, 63, 0
+          }, NULL);
           cr_assert(success);
 
           used = tab->used;
@@ -285,7 +293,11 @@ Test(nvtable, test_nvtable_direct)
           tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
           success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 64, NULL);
           cr_assert(success);
-          success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 62, NULL);
+          success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                                &(NVReferencedSlice)
+          {
+            STATIC_HANDLE, 1, 62, 0
+          }, NULL);
           cr_assert(success);
           used = tab->used;
 
@@ -363,7 +375,11 @@ Test(nvtable, test_nvtable_indirect)
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, handle, value + 1, 126);
@@ -378,7 +394,11 @@ Test(nvtable, test_nvtable_indirect)
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert_not(success);
 
   nv_table_unref(tab);
@@ -390,11 +410,19 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 62, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 62, 0
+  }, NULL);
 
   cr_assert(success);
   cr_assert_eq(used, tab->used);
@@ -417,7 +445,11 @@ Test(nvtable, test_nvtable_indirect)
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   cr_assert_eq(tab->used, used);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
@@ -435,7 +467,11 @@ Test(nvtable, test_nvtable_indirect)
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   cr_assert_gt(tab->used, used);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
@@ -452,7 +488,11 @@ Test(nvtable, test_nvtable_indirect)
   success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert_not(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, handle, value, 1);
@@ -474,10 +514,18 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 122, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 122, 0
+  }, NULL);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, DYN_HANDLE, value + 1, 126);
@@ -488,10 +536,18 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 122, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 122, 0
+  }, NULL);
   cr_assert_not(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, DYN_HANDLE, value + 1, 126);
@@ -507,13 +563,25 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 1, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 1, 0
+  }, NULL);
   cr_assert(success);
 
   cr_assert_eq(tab->used, used);
@@ -527,13 +595,25 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 16, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 16, 0
+  }, NULL);
   cr_assert(success);
 
   cr_assert_gt(tab->used, used);
@@ -547,13 +627,25 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, 4, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 124, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 124, 0
+  }, NULL);
   cr_assert_not(success);
 
   cr_assert_eq(tab->used, used);
@@ -571,13 +663,21 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 16, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 16, 0
+  }, NULL);
   cr_assert(success);
 
   cr_assert_eq(tab->used, used);
@@ -592,13 +692,21 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   success = nv_table_add_value(tab, handle, name, strlen(name), value, 16, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 32, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 32, 0
+  }, NULL);
   cr_assert(success);
 
   cr_assert_gt(tab->used, used);
@@ -612,13 +720,21 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, 4, 256);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
-  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   success = nv_table_add_value(tab, handle, name, strlen(name), value, 16, NULL);
   cr_assert(success);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), DYN_HANDLE, 0, 1, 124, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    DYN_HANDLE, 1, 124, 0
+  }, NULL);
   cr_assert_not(success);
 
   cr_assert_eq(tab->used, used);
@@ -634,7 +750,11 @@ Test(nvtable, test_nvtable_indirect)
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
   used = tab->used;
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   cr_assert_eq(used, tab->used);
   assert_nvtable(tab, STATIC_HANDLE, "", 0);
@@ -673,7 +793,11 @@ Test(nvtable, test_nvtable_others)
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value + 32, 32, NULL);
   cr_assert(success);
@@ -687,7 +811,11 @@ Test(nvtable, test_nvtable_others)
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, NULL);
   cr_assert(success);
 
-  success = nv_table_add_value_indirect(tab, handle, name, strlen(name), STATIC_HANDLE, 0, 1, 126, NULL);
+  success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
+                                        &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 126, 0
+  }, NULL);
   cr_assert(success);
   success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value + 32, 32, NULL);
   cr_assert_not(success);


### PR DESCRIPTION
This PR contains multiple refactor steps in NVTable and a fix for #1514.
These are equivalent transformations except for a37a042f785cd105c6fe2840512626421a6ccb35.

Example config (to reproduce the bug):
```
log {
    source { program("/usr/bin/yes"); };

    rewrite {
        subst(".*", "nope", value(".SDATA.missing.value"));
    };

    destination { file("/tmp/out.txt"); };
};
```

Fixes #1514 