### PR TITLE
dbparser: Rework getenv dependency in unit test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,7 @@ xsddir='${datadir}/syslog-ng/xsd'
 
 config_includedir='${datadir}/syslog-ng/include'
 scldir="${config_includedir}/scl"
+abs_topsrcdir=`(cd $srcdir && pwd)`
 
 AC_CONFIG_HEADERS(config.h)
 
@@ -1575,7 +1576,7 @@ fi
 AC_DEFINE_UNQUOTED(PATH_MODULEDIR, "$moduledir", [module installation directory])
 AC_DEFINE_UNQUOTED(MODULE_PATH, "$module_path", [module search path])
 AC_DEFINE_UNQUOTED(JAVA_MODULE_PATH, "$java_module_path", [java module search path])
-
+AC_DEFINE_UNQUOTED(PATH_TOPSRC_DIR, "$abs_topsrcdir", [top_srcdir path])
 
 
 AC_DEFINE_UNQUOTED(WITH_COMPILE_DATE, $wcmp_date, [Include the compile date in the binary])

--- a/modules/dbparser/pdb-file.c
+++ b/modules/dbparser/pdb-file.c
@@ -84,14 +84,11 @@ exit:
 static const gchar *
 _get_xsddir_in_build(void)
 {
-#ifdef SYSLOG_NG_ENABLE_DEBUG
-  const gchar *srcdir;
+#ifdef SYSLOG_NG_PATH_TOPSRC_DIR
   static gchar path[256];
-
-  srcdir = getenv("top_srcdir");
-  if (srcdir)
+  if (strcmp(SYSLOG_NG_PATH_TOPSRC_DIR, ""))
     {
-      g_snprintf(path, sizeof(path), "%s/doc/xsd", srcdir);
+      g_snprintf(path, sizeof(path), "%s/doc/xsd", SYSLOG_NG_PATH_TOPSRC_DIR);
       return path;
     }
 #endif
@@ -104,20 +101,16 @@ _get_xsddir_in_production(void)
   return get_installation_path_for(SYSLOG_NG_PATH_XSDDIR);
 }
 
-static const gchar *
-_get_xsddir(void)
-{
-  return _get_xsddir_in_build() ? : _get_xsddir_in_production();
-}
+typedef const gchar *(*PdbGetXsdDirFunc) (void);
 
 static gchar *
-_get_xsd_file(gint version)
+_get_xsd_file(gint version, PdbGetXsdDirFunc get_xsd_dir)
 {
-  return g_strdup_printf("%s/patterndb-%d.xsd", _get_xsddir(), version);
+  return g_strdup_printf("%s/patterndb-%d.xsd", get_xsd_dir(), version);
 }
 
-gboolean
-pdb_file_validate(const gchar *filename, GError **error)
+static gboolean
+_pdb_file_validate(const gchar *filename, GError **error, PdbGetXsdDirFunc get_xsd_dir)
 {
   gchar *xmllint_cmdline;
   gint version;
@@ -131,7 +124,7 @@ pdb_file_validate(const gchar *filename, GError **error)
   if (!version)
     return FALSE;
 
-  xsd_file = _get_xsd_file(version);
+  xsd_file = _get_xsd_file(version, get_xsd_dir);
   if (!is_file_regular(xsd_file))
     {
       g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "XSD file is not available at %s", xsd_file);
@@ -164,4 +157,16 @@ pdb_file_validate(const gchar *filename, GError **error)
   g_free(xmllint_cmdline);
   g_free(stderr_content);
   return TRUE;
+}
+
+gboolean
+pdb_file_validate(const gchar *filename, GError **error)
+{
+  return _pdb_file_validate(filename, error, _get_xsddir_in_production);
+}
+
+gboolean
+pdb_file_validate_in_tests(const gchar *filename, GError **error)
+{
+  return _pdb_file_validate(filename, error, _get_xsddir_in_build);
 }

--- a/modules/dbparser/pdb-file.h
+++ b/modules/dbparser/pdb-file.h
@@ -28,5 +28,6 @@
 
 gint pdb_file_detect_version(const gchar *pdbfile, GError **error);
 gboolean pdb_file_validate(const gchar *filename, GError **error);
+gboolean pdb_file_validate_in_tests(const gchar *filename, GError **error);
 
 #endif

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -59,7 +59,7 @@ assert_pdb_file_valid(const gchar *filename_, const gchar *pdb)
   GError *error = NULL;
   gboolean success;
 
-  success = pdb_file_validate(filename_, &error);
+  success = pdb_file_validate_in_tests(filename_, &error);
   assert_true(success, "Error validating patterndb, error=%s\n>>>\n%s\n<<<", error ? error->message : "unknown", pdb);
   g_clear_error(&error);
 }


### PR DESCRIPTION
Some cases the test_patterndb unit test is not working, e.g. running the unit test binary itself natively (not with make check) without setting the "top_srcdir" environment variable.

Fixing the case when ENABLE_DEBUG option is not set and function used a possibly non-existing production-PATH): 
- the getenv "top_srcdir" dependency replaced by a configure set macro
(note: ifdef was not protecting, code-part always compiled, only worked in production because getenv failed)

Unit test can be run standalone.

Interface "pdb_file_validate" is split by use cases: production and tests.
No need to determine it in one function during runtime.