### PR TITLE
cisco-parser: Added prefix option

### DIFF
--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -71,7 +71,7 @@ block parser cisco-timestamp-parser(template()) {
     };
 };
 
-block parser cisco-parser() {
+block parser cisco-parser(prefix(".cisco.")) {
     channel {
         parser {
             # split msg and header right before the '%', Cisco messages may
@@ -81,7 +81,7 @@ block parser cisco-parser() {
 
             csv-parser(delimiters(chars(':')) template("$2") columns('3'));
             csv-parser(delimiters(chars('-')) template("$3")
-                       columns('.cisco.facility', '.cisco.severity', '.cisco.mnemonic'));
+                       columns('`prefix`facility', '`prefix`severity', '`prefix`mnemonic'));
         };
         rewrite {
             set('%$2', value("MSG"));


### PR DESCRIPTION
With this option a user can change the prefix for cisco specific fields
and for example add it to SDATA. Just change prefix to ".SDATA.cisco."