### PR TITLE
TLS improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -960,6 +960,7 @@ AC_CHECK_DECLS([X509_STORE_CTX_get0_cert],[], [], [[#include <openssl/ssl.h>]])
 AC_CHECK_DECLS([X509_get_extension_flags], [], [], [[#include <openssl/x509v3.h>]])
 AC_CHECK_DECLS([EVP_MD_CTX_reset], [], [], [[#include <openssl/evp.h>]])
 AC_CHECK_DECLS([ASN1_STRING_get0_data], [], [], [[#include <openssl/asn1.h>]])
+AC_CHECK_DECLS([DH_set0_pqg], [], [], [[#include <openssl/dh.h>]])
 
 CPPFLAGS="$CPPFLAGS_SAVE"
 

--- a/lib/compat/openssl_support.c
+++ b/lib/compat/openssl_support.c
@@ -160,3 +160,29 @@ openssl_init(void)
   OpenSSL_add_all_algorithms();
 #endif
 }
+
+void openssl_ctx_setup_ecdh(SSL_CTX *ctx)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+
+  /* No need to setup as ECDH auto is the default */
+
+#elif OPENSSL_VERSION_NUMBER >= 0x10002000L
+
+  SSL_CTX_set_ecdh_auto(ctx, 1);
+
+#elif OPENSSL_VERSION_NUMBER >= 0x10001000L
+
+  int ecdh_nid = OBJ_sn2nid(SN_X9_62_prime256v1);
+  if (ecdh_nid == NID_undef)
+    return;
+
+  EC_KEY *ecdh = EC_KEY_new_by_curve_name(ecdh_nid);
+  if (!ecdh)
+    return;
+
+  SSL_CTX_set_tmp_ecdh(ctx, ecdh);
+  EC_KEY_free(ecdh);
+
+#endif
+}

--- a/lib/compat/openssl_support.c
+++ b/lib/compat/openssl_support.c
@@ -173,11 +173,7 @@ void openssl_ctx_setup_ecdh(SSL_CTX *ctx)
 
 #elif OPENSSL_VERSION_NUMBER >= 0x10001000L
 
-  int ecdh_nid = OBJ_sn2nid(SN_X9_62_prime256v1);
-  if (ecdh_nid == NID_undef)
-    return;
-
-  EC_KEY *ecdh = EC_KEY_new_by_curve_name(ecdh_nid);
+  EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
   if (!ecdh)
     return;
 

--- a/lib/compat/openssl_support.c
+++ b/lib/compat/openssl_support.c
@@ -182,3 +182,33 @@ void openssl_ctx_setup_ecdh(SSL_CTX *ctx)
 
 #endif
 }
+
+#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG
+int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+  if ((dh->p == NULL && p == NULL)
+      || (dh->g == NULL && g == NULL))
+    return 0;
+
+  if (p != NULL)
+    {
+      BN_free(dh->p);
+      dh->p = p;
+    }
+  if (q != NULL)
+    {
+      BN_free(dh->q);
+      dh->q = q;
+    }
+  if (g != NULL)
+    {
+      BN_free(dh->g);
+      dh->g = g;
+    }
+
+  if (q != NULL)
+    dh->length = BN_num_bits(q);
+
+  return 1;
+}
+#endif

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -26,6 +26,7 @@
 
 #include "compat/compat.h"
 #include <openssl/ssl.h>
+#include <openssl/dh.h>
 
 #if !SYSLOG_NG_HAVE_DECL_SSL_CTX_GET0_PARAM
 X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx);
@@ -51,6 +52,10 @@ uint32_t X509_get_extension_flags(X509 *x);
 
 #if !SYSLOG_NG_HAVE_DECL_ASN1_STRING_GET0_DATA
 #define ASN1_STRING_get0_data ASN1_STRING_data
+#endif
+
+#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG
+int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 #endif
 
 void openssl_ctx_setup_ecdh(SSL_CTX *ctx);

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -46,12 +46,14 @@ uint32_t X509_get_extension_flags(X509 *x);
 #define DECLARE_EVP_MD_CTX(md_ctx) EVP_MD_CTX * md_ctx = EVP_MD_CTX_create()
 #else
 #define DECLARE_EVP_MD_CTX(md_ctx) EVP_MD_CTX _##md_ctx; EVP_MD_CTX * md_ctx = & _##md_ctx
-#define EVP_MD_CTX_destroy(md_ctx) EVP_MD_CTX_cleanup(md_ctx) 
+#define EVP_MD_CTX_destroy(md_ctx) EVP_MD_CTX_cleanup(md_ctx)
 #endif
 
 #if !SYSLOG_NG_HAVE_DECL_ASN1_STRING_GET0_DATA
 #define ASN1_STRING_get0_data ASN1_STRING_data
 #endif
+
+void openssl_ctx_setup_ecdh(SSL_CTX *ctx);
 
 void openssl_init();
 void openssl_crypto_init_threading();

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -391,6 +391,36 @@ tls_context_setup_ssl_options(TLSContext *self)
     }
 }
 
+static void
+tls_context_setup_ecdh(TLSContext *self)
+{
+  if (self->mode != TM_SERVER)
+    return;
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+
+  /* No need to setup as ECDH auto is the default */
+
+#elif OPENSSL_VERSION_NUMBER >= 0x10002000L
+
+  SSL_CTX_set_ecdh_auto(self->ssl_ctx, 1);
+
+#elif OPENSSL_VERSION_NUMBER >= 0x10001000L
+
+  int ecdh_nid = OBJ_sn2nid(SN_X9_62_prime256v1);
+  if (ecdh_nid == NID_undef)
+    return;
+
+  EC_KEY *ecdh = EC_KEY_new_by_curve_name(ecdh_nid);
+  if (!ecdh)
+    return;
+
+  SSL_CTX_set_tmp_ecdh(self->ssl_ctx, ecdh);
+  EC_KEY_free(ecdh);
+
+#endif
+}
+
 gboolean
 tls_context_setup_context(TLSContext *self)
 {
@@ -419,6 +449,7 @@ tls_context_setup_context(TLSContext *self)
 
   tls_context_setup_verify_mode(self);
   tls_context_setup_ssl_options(self);
+  tls_context_setup_ecdh(self);
 
   if (self->cipher_suite)
     {

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -308,11 +308,6 @@ file_exists(const gchar *fname)
 TLSSession *
 tls_context_setup_session(TLSContext *self)
 {
-  SSL *ssl;
-  TLSSession *session;
-  gulong ssl_error;
-  long ssl_options;
-
   if (!self->ssl_ctx)
     {
       gint verify_mode = 0;
@@ -369,7 +364,7 @@ tls_context_setup_session(TLSContext *self)
 
       if (self->ssl_options != TSO_NONE)
         {
-          ssl_options=0;
+          glong ssl_options = 0;
           if(self->ssl_options & TSO_NOSSLv2)
             ssl_options |= SSL_OP_NO_SSLv2;
           if(self->ssl_options & TSO_NOSSLv3)
@@ -397,19 +392,19 @@ tls_context_setup_session(TLSContext *self)
         }
     }
 
-  ssl = SSL_new(self->ssl_ctx);
+  SSL *ssl = SSL_new(self->ssl_ctx);
 
   if (self->mode == TM_CLIENT)
     SSL_set_connect_state(ssl);
   else
     SSL_set_accept_state(ssl);
 
-  session = tls_session_new(ssl, self);
+  TLSSession *session = tls_session_new(ssl, self);
   SSL_set_app_data(ssl, session);
   return session;
 
-error:
-  ssl_error = ERR_get_error();
+error:;
+  gulong ssl_error = ERR_get_error();
   msg_error("Error setting up TLS session context",
             evt_tag_printf("tls_error", "%s:%s:%s", ERR_lib_error_string(ssl_error), ERR_func_error_string(ssl_error),
                            ERR_reason_error_string(ssl_error)));

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -310,7 +310,7 @@ tls_context_setup_session(TLSContext *self)
 {
   SSL *ssl;
   TLSSession *session;
-  gint ssl_error;
+  gulong ssl_error;
   long ssl_options;
 
   if (!self->ssl_ctx)

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -396,11 +396,6 @@ tls_context_setup_context(TLSContext *self)
 {
   gint verify_flags = X509_V_FLAG_POLICY_CHECK;
 
-  if (self->mode == TM_CLIENT)
-    self->ssl_ctx = SSL_CTX_new(SSLv23_client_method());
-  else
-    self->ssl_ctx = SSL_CTX_new(SSLv23_server_method());
-
   if (!self->ssl_ctx)
     goto error;
   if (file_exists(self->key_file) && !SSL_CTX_use_PrivateKey_file(self->ssl_ctx, self->key_file, SSL_FILETYPE_PEM))
@@ -469,6 +464,12 @@ tls_context_new(TLSMode mode)
   self->mode = mode;
   self->verify_mode = TVM_REQUIRED | TVM_TRUSTED;
   self->ssl_options = TSO_NOSSLv2;
+
+  if (self->mode == TM_CLIENT)
+    self->ssl_ctx = SSL_CTX_new(SSLv23_client_method());
+  else
+    self->ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+
   return self;
 }
 

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -391,7 +391,7 @@ tls_context_setup_ssl_options(TLSContext *self)
     }
 }
 
-static gboolean
+gboolean
 tls_context_setup_context(TLSContext *self)
 {
   gint verify_flags = X509_V_FLAG_POLICY_CHECK;

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -447,10 +447,7 @@ TLSSession *
 tls_context_setup_session(TLSContext *self)
 {
   if (!self->ssl_ctx)
-    {
-      if (!tls_context_setup_context(self))
-        return NULL;
-    }
+    return NULL;
 
   SSL *ssl = SSL_new(self->ssl_ctx);
 

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -32,6 +32,8 @@
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <openssl/dh.h>
+#include <openssl/bn.h>
 
 struct _TLSContext
 {
@@ -469,11 +471,12 @@ _load_dh_fallback(void)
    * RFC3526 specifies a generator of 2.
    */
 
-  dh->p = get_rfc3526_prime_2048(NULL);
-  BN_dec2bn(&dh->g, "2");
+  BIGNUM *g = NULL;
+  BN_dec2bn(&g, "2");
 
-  if (!dh->p || !dh->g)
+  if (!DH_set0_pqg(dh, get_rfc3526_prime_2048(NULL), NULL, g))
     {
+      BN_free(g);
       DH_free(dh);
       return NULL;
     }

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -39,6 +39,7 @@ struct _TLSContext
   gint verify_mode;
   gchar *key_file;
   gchar *cert_file;
+  gchar *dhparam_file;
   gchar *ca_dir;
   gchar *crl_dir;
   gchar *cipher_suite;
@@ -408,6 +409,79 @@ _set_optional_ecdh_curve_list(SSL_CTX *ctx, const gchar *ecdh_curve_list)
 }
 
 static gboolean
+_is_dh_valid(DH *dh)
+{
+  if (!dh)
+    return FALSE;
+
+  gint check_flags;
+  if (!DH_check(dh, &check_flags))
+    return FALSE;
+
+  gboolean error_flag_is_set = check_flags &
+                               (DH_CHECK_P_NOT_PRIME
+                                | DH_UNABLE_TO_CHECK_GENERATOR
+                                | DH_CHECK_P_NOT_SAFE_PRIME
+                                | DH_NOT_SUITABLE_GENERATOR);
+
+  return !error_flag_is_set;
+}
+
+static DH *
+_load_dh_from_file(const gchar *dhparam_file)
+{
+  if (!file_exists(dhparam_file))
+    return NULL;
+
+  BIO *bio = BIO_new_file(dhparam_file, "r");
+  if (!bio)
+    return NULL;
+
+  DH *dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
+  BIO_free(bio);
+
+  if (!_is_dh_valid(dh))
+    {
+      msg_error("Error setting up TLS session context, invalid DH parameters",
+                evt_tag_str("dhparam_file", dhparam_file),
+                NULL);
+
+      DH_free(dh);
+      return NULL;
+    }
+
+  return dh;
+}
+
+static DH *
+_load_dh_fallback(void)
+{
+  DH *dh = DH_new();
+
+  if (!dh)
+    return NULL;
+
+  /*
+   * "2048-bit MODP Group" from RFC3526, Section 3.
+   *
+   * The prime is: 2^2048 - 2^1984 - 1 + 2^64 * { [2^1918 pi] + 124476 }
+   *
+   * RFC3526 specifies a generator of 2.
+   */
+
+  dh->p = get_rfc3526_prime_2048(NULL);
+  BN_dec2bn(&dh->g, "2");
+
+  if (!dh->p || !dh->g)
+    {
+      DH_free(dh);
+      return NULL;
+    }
+
+  return dh;
+}
+
+static gboolean
 tls_context_setup_ecdh(TLSContext *self)
 {
   /* server only */
@@ -420,6 +494,20 @@ tls_context_setup_ecdh(TLSContext *self)
   openssl_ctx_setup_ecdh(self->ssl_ctx);
 
   return TRUE;
+}
+
+static gboolean
+tls_context_setup_dh(TLSContext *self)
+{
+  DH *dh = self->dhparam_file ? _load_dh_from_file(self->dhparam_file) : _load_dh_fallback();
+
+  if (!dh)
+    return FALSE;
+
+  gboolean ctx_dh_success = SSL_CTX_set_tmp_dh(self->ssl_ctx, dh);
+
+  DH_free(dh);
+  return ctx_dh_success;
 }
 
 gboolean
@@ -457,6 +545,8 @@ tls_context_setup_context(TLSContext *self)
       return FALSE;
     }
 
+  if (!tls_context_setup_dh(self))
+    goto error;
 
   if (self->cipher_suite)
     {
@@ -519,6 +609,7 @@ tls_context_free(TLSContext *self)
   g_list_foreach(self->trusted_dn_list, (GFunc) g_free, NULL);
   g_free(self->key_file);
   g_free(self->cert_file);
+  g_free(self->dhparam_file);
   g_free(self->ca_dir);
   g_free(self->crl_dir);
   g_free(self->cipher_suite);
@@ -623,6 +714,13 @@ tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list)
 {
   g_free(self->ecdh_curve_list);
   self->ecdh_curve_list = g_strdup(ecdh_curve_list);
+}
+
+void
+tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file)
+{
+  g_free(self->dhparam_file);
+  self->dhparam_file = g_strdup(dhparam_file);
 }
 
 void

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -520,6 +520,52 @@ tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
   return TRUE;
 }
 
+gint
+tls_context_get_verify_mode(const TLSContext *self)
+{
+  return self->verify_mode;
+}
+
+void tls_context_set_verify_mode(TLSContext *self, gint verify_mode)
+{
+  self->verify_mode = verify_mode;
+}
+
+void
+tls_context_set_key_file(TLSContext *self, const gchar *key_file)
+{
+  g_free(self->key_file);
+  self->key_file = g_strdup(key_file);
+}
+
+void
+tls_context_set_cert_file(TLSContext *self, const gchar *cert_file)
+{
+  g_free(self->cert_file);
+  self->cert_file = g_strdup(cert_file);
+}
+
+void
+tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir)
+{
+  g_free(self->ca_dir);
+  self->ca_dir = g_strdup(ca_dir);
+}
+
+void
+tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir)
+{
+  g_free(self->crl_dir);
+  self->crl_dir = g_strdup(crl_dir);
+}
+
+void
+tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite)
+{
+  g_free(self->cipher_suite);
+  self->cipher_suite = g_strdup(cipher_suite);
+}
+
 void
 tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx)
 {

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -306,6 +306,18 @@ file_exists(const gchar *fname)
 }
 
 static void
+_print_and_clear_tls_session_error(void)
+{
+  gulong ssl_error = ERR_get_error();
+  msg_error("Error setting up TLS session context",
+            evt_tag_printf("tls_error", "%s:%s:%s",
+                           ERR_lib_error_string(ssl_error),
+                           ERR_func_error_string(ssl_error),
+                           ERR_reason_error_string(ssl_error)));
+  ERR_clear_error();
+}
+
+static void
 tls_context_setup_verify_mode(TLSContext *self)
 {
   gint verify_mode = 0;
@@ -406,12 +418,8 @@ tls_context_setup_context(TLSContext *self)
 
   return TRUE;
 
-error:;
-  gulong ssl_error = ERR_get_error();
-  msg_error("Error setting up TLS session context",
-            evt_tag_printf("tls_error", "%s:%s:%s", ERR_lib_error_string(ssl_error), ERR_func_error_string(ssl_error),
-                           ERR_reason_error_string(ssl_error)));
-  ERR_clear_error();
+error:
+  _print_and_clear_tls_session_error();
   if (self->ssl_ctx)
     {
       SSL_CTX_free(self->ssl_ctx);

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -33,6 +33,21 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
+struct _TLSContext
+{
+  TLSMode mode;
+  gint verify_mode;
+  gchar *key_file;
+  gchar *cert_file;
+  gchar *ca_dir;
+  gchar *crl_dir;
+  gchar *cipher_suite;
+  SSL_CTX *ssl_ctx;
+  GList *trusted_fingerpint_list;
+  GList *trusted_dn_list;
+  gint ssl_options;
+};
+
 gboolean
 tls_get_x509_digest(X509 *x, GString *hash_string)
 {

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -397,28 +397,7 @@ tls_context_setup_ecdh(TLSContext *self)
   if (self->mode != TM_SERVER)
     return;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-
-  /* No need to setup as ECDH auto is the default */
-
-#elif OPENSSL_VERSION_NUMBER >= 0x10002000L
-
-  SSL_CTX_set_ecdh_auto(self->ssl_ctx, 1);
-
-#elif OPENSSL_VERSION_NUMBER >= 0x10001000L
-
-  int ecdh_nid = OBJ_sn2nid(SN_X9_62_prime256v1);
-  if (ecdh_nid == NID_undef)
-    return;
-
-  EC_KEY *ecdh = EC_KEY_new_by_curve_name(ecdh_nid);
-  if (!ecdh)
-    return;
-
-  SSL_CTX_set_tmp_ecdh(self->ssl_ctx, ecdh);
-  EC_KEY_free(ecdh);
-
-#endif
+  openssl_ctx_setup_ecdh(self->ssl_ctx);
 }
 
 gboolean

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -474,48 +474,50 @@ tls_context_free(TLSContext *self)
   g_free(self);
 }
 
-TLSVerifyMode
-tls_lookup_verify_mode(const gchar *mode_str)
+gboolean
+tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode_str)
 {
   if (strcasecmp(mode_str, "none") == 0)
-    return TVM_NONE;
+    self->verify_mode = TVM_NONE;
   else if (strcasecmp(mode_str, "optional-trusted") == 0 || strcasecmp(mode_str, "optional_trusted") == 0)
-    return TVM_OPTIONAL | TVM_TRUSTED;
+    self->verify_mode = TVM_OPTIONAL | TVM_TRUSTED;
   else if (strcasecmp(mode_str, "optional-untrusted") == 0 || strcasecmp(mode_str, "optional_untrusted") == 0)
-    return TVM_OPTIONAL | TVM_UNTRUSTED;
+    self->verify_mode = TVM_OPTIONAL | TVM_UNTRUSTED;
   else if (strcasecmp(mode_str, "required-trusted") == 0 || strcasecmp(mode_str, "required_trusted") == 0)
-    return TVM_REQUIRED | TVM_TRUSTED;
+    self->verify_mode = TVM_REQUIRED | TVM_TRUSTED;
   else if (strcasecmp(mode_str, "required-untrusted") == 0 || strcasecmp(mode_str, "required_untrusted") == 0)
-    return TVM_REQUIRED | TVM_UNTRUSTED;
+    self->verify_mode = TVM_REQUIRED | TVM_UNTRUSTED;
+  else
+    return FALSE;
 
-  return TVM_REQUIRED | TVM_TRUSTED;
+  return TRUE;
 }
 
-gint
-tls_lookup_options(GList *options)
+gboolean
+tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
 {
-  gint ret=TSO_NONE;
+  self->ssl_options = TSO_NONE;
+
   GList *l;
   for (l=options; l != NULL; l=l->next)
     {
-      msg_debug("ssl-option", evt_tag_str("opt", l->data));
       if (strcasecmp(l->data, "no-sslv2") == 0 || strcasecmp(l->data, "no_sslv2") == 0)
-        ret|=TSO_NOSSLv2;
+        self->ssl_options |= TSO_NOSSLv2;
       else if (strcasecmp(l->data, "no-sslv3") == 0 || strcasecmp(l->data, "no_sslv3") == 0)
-        ret|=TSO_NOSSLv3;
+        self->ssl_options |= TSO_NOSSLv3;
       else if (strcasecmp(l->data, "no-tlsv1") == 0 || strcasecmp(l->data, "no_tlsv1") == 0)
-        ret|=TSO_NOTLSv1;
+        self->ssl_options |= TSO_NOTLSv1;
 #ifdef SSL_OP_NO_TLSv1_2
       else if (strcasecmp(l->data, "no-tlsv11") == 0 || strcasecmp(l->data, "no_tlsv11") == 0)
-        ret|=TSO_NOTLSv11;
+        self->ssl_options |= TSO_NOTLSv11;
       else if (strcasecmp(l->data, "no-tlsv12") == 0 || strcasecmp(l->data, "no_tlsv12") == 0)
-        ret|=TSO_NOTLSv12;
+        self->ssl_options |= TSO_NOTLSv12;
 #endif
       else
-        msg_error("Unknown ssl-option", evt_tag_str("option", l->data));
+        return FALSE;
     }
-  msg_debug("ssl-options parsed", evt_tag_printf("parsed value", "%d", ret));
-  return ret;
+
+  return TRUE;
 }
 
 void

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -80,7 +80,7 @@ typedef struct _TLSSession
 void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, gpointer verify_data, GDestroyNotify verify_destroy);
 void tls_session_free(TLSSession *self);
 
-
+gboolean tls_context_setup_context(TLSContext *self);
 TLSSession *tls_context_setup_session(TLSContext *self);
 void tls_session_set_trusted_fingerprints(TLSContext *self, GList *fingerprints);
 void tls_session_set_trusted_dn(TLSContext *self, GList *dns);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -80,21 +80,6 @@ typedef struct _TLSSession
 void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, gpointer verify_data, GDestroyNotify verify_destroy);
 void tls_session_free(TLSSession *self);
 
-struct _TLSContext
-{
-  TLSMode mode;
-  gint verify_mode;
-  gchar *key_file;
-  gchar *cert_file;
-  gchar *ca_dir;
-  gchar *crl_dir;
-  gchar *cipher_suite;
-  SSL_CTX *ssl_ctx;
-  GList *trusted_fingerpint_list;
-  GList *trusted_dn_list;
-  gint ssl_options;
-};
-
 
 TLSSession *tls_context_setup_session(TLSContext *self);
 void tls_session_set_trusted_fingerprints(TLSContext *self, GList *fingerprints);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -102,8 +102,8 @@ void tls_session_set_trusted_dn(TLSContext *self, GList *dns);
 TLSContext *tls_context_new(TLSMode mode);
 void tls_context_free(TLSContext *s);
 
-TLSVerifyMode tls_lookup_verify_mode(const gchar *mode_str);
-gint tls_lookup_options(GList *options);
+gboolean tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode_str);
+gboolean tls_context_set_ssl_options_by_name(TLSContext *self, GList *options);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -99,11 +99,19 @@ struct _TLSContext
 TLSSession *tls_context_setup_session(TLSContext *self);
 void tls_session_set_trusted_fingerprints(TLSContext *self, GList *fingerprints);
 void tls_session_set_trusted_dn(TLSContext *self, GList *dns);
+
 TLSContext *tls_context_new(TLSMode mode);
 void tls_context_free(TLSContext *s);
 
 gboolean tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode_str);
 gboolean tls_context_set_ssl_options_by_name(TLSContext *self, GList *options);
+gint tls_context_get_verify_mode(const TLSContext *self);
+void tls_context_set_verify_mode(TLSContext *self, gint verify_mode);
+void tls_context_set_key_file(TLSContext *self, const gchar *key_file);
+void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
+void tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir);
+void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
+void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -98,6 +98,7 @@ void tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir);
 void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
+void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -97,6 +97,7 @@ void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
 void tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir);
 void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
+void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -102,7 +102,7 @@ afinet_dd_verify_callback(gint ok, X509_STORE_CTX *ctx, gpointer user_data)
   X509 *cert = X509_STORE_CTX_get0_cert(ctx);
 
   if (ok && current_cert == cert && self->hostname
-      && (transport_mapper_inet->tls_context->verify_mode & TVM_TRUSTED))
+      && (tls_context_get_verify_mode(transport_mapper_inet->tls_context) & TVM_TRUSTED))
     {
       ok = tls_verify_certificate_name(cert, self->hostname);
     }

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -464,6 +464,9 @@ afsocket_dd_init(LogPipe *s)
       return FALSE;
     }
 
+  if (!transport_mapper_init(self->transport_mapper))
+    return FALSE;
+
   if (!afsocket_dd_setup_writer(self))
     return FALSE;
 

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -163,6 +163,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_PEER_VERIFY
 %token KW_KEY_FILE
 %token KW_CERT_FILE
+%token KW_DHPARAM_FILE
 %token KW_CA_DIR
 %token KW_CRL_DIR
 %token KW_TRUSTED_KEYS
@@ -685,6 +686,11 @@ tls_option
 	| KW_CERT_FILE '(' string ')'
 	  {
 	    tls_context_set_cert_file(last_tls_context, $3);
+            free($3);
+          }
+        | KW_DHPARAM_FILE '(' string ')'
+          {
+            tls_context_set_dhparam_file(last_tls_context, $3);
             free($3);
           }
 	| KW_CA_DIR '(' string ')'

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -168,6 +168,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_TRUSTED_KEYS
 %token KW_TRUSTED_DN
 %token KW_CIPHER_SUITE
+%token KW_ECDH_CURVE_LIST
 %token KW_SSL_OPTIONS
 
 /* INCLUDE_DECLS */
@@ -709,6 +710,11 @@ tls_option
             tls_context_set_cipher_suite(last_tls_context, $3);
             free($3);
 	  }
+        | KW_ECDH_CURVE_LIST '(' string ')'
+          {
+            tls_context_set_ecdh_curve_list(last_tls_context, $3);
+            free($3);
+          }
 	| KW_SSL_OPTIONS '(' string_list ')'
 	  {
             CHECK_ERROR(tls_context_set_ssl_options_by_name(last_tls_context, $3), @3,

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -228,7 +228,7 @@ driver
         | LL_CONTEXT_DESTINATION dest_afnetwork               { $$ = $2; }
         ;
 
-        
+
 source_afunix
         : KW_UNIX_DGRAM '(' source_afunix_dgram_params ')'	                                { $$ = $3; }
 	| KW_UNIX_STREAM '(' source_afunix_stream_params ')' 	                                { $$ = $3; }
@@ -455,7 +455,7 @@ source_systemd_syslog_option
         : source_reader_option
         | socket_option
         ;
-        
+
 dest_afunix
 	: KW_UNIX_DGRAM '(' dest_afunix_dgram_params ')'	{ $$ = $3; }
 	| KW_UNIX_STREAM '(' dest_afunix_stream_params ')'	{ $$ = $3; }
@@ -673,7 +673,7 @@ tls_option
           }
 	| KW_PEER_VERIFY '(' string ')'
 	  {
-	    last_tls_context->verify_mode = tls_lookup_verify_mode($3);
+	    tls_context_set_verify_mode_by_name(last_tls_context, $3);
             free($3);
           }
 	| KW_KEY_FILE '(' string ')'
@@ -711,7 +711,7 @@ tls_option
 	  }
 	| KW_SSL_OPTIONS '(' string_list ')'
 	  {
-            last_tls_context->ssl_options = tls_lookup_options($3);
+            tls_context_set_ssl_options_by_name(last_tls_context, $3);
 	  }
         | KW_ENDIF {
 }

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -667,33 +667,33 @@ tls_option
 
 	| KW_PEER_VERIFY '(' yesno ')'
 	  {
-	    last_tls_context->verify_mode = $3
-		? (TVM_REQUIRED | TVM_TRUSTED)
-		: (TVM_OPTIONAL | TVM_UNTRUSTED);
+	    gint verify_mode = $3 ? (TVM_REQUIRED | TVM_TRUSTED) : (TVM_OPTIONAL | TVM_UNTRUSTED);
+	    tls_context_set_verify_mode(last_tls_context, verify_mode);
           }
 	| KW_PEER_VERIFY '(' string ')'
 	  {
-	    tls_context_set_verify_mode_by_name(last_tls_context, $3);
+	    CHECK_ERROR(tls_context_set_verify_mode_by_name(last_tls_context, $3), @3,
+	                "unknown peer-verify() argument");
             free($3);
           }
 	| KW_KEY_FILE '(' string ')'
 	  {
-	    last_tls_context->key_file = g_strdup($3);
+	    tls_context_set_key_file(last_tls_context, $3);
             free($3);
           }
 	| KW_CERT_FILE '(' string ')'
 	  {
-	    last_tls_context->cert_file = g_strdup($3);
+	    tls_context_set_cert_file(last_tls_context, $3);
             free($3);
           }
 	| KW_CA_DIR '(' string ')'
 	  {
-	    last_tls_context->ca_dir = g_strdup($3);
+	    tls_context_set_ca_dir(last_tls_context, $3);
             free($3);
           }
 	| KW_CRL_DIR '(' string ')'
 	  {
-	    last_tls_context->crl_dir = g_strdup($3);
+	    tls_context_set_crl_dir(last_tls_context, $3);
             free($3);
           }
         | KW_TRUSTED_KEYS '(' string_list ')'
@@ -706,12 +706,13 @@ tls_option
           }
 	| KW_CIPHER_SUITE '(' string ')'
 	  {
-            last_tls_context->cipher_suite = g_strdup($3);
+            tls_context_set_cipher_suite(last_tls_context, $3);
             free($3);
 	  }
 	| KW_SSL_OPTIONS '(' string_list ')'
 	  {
-            tls_context_set_ssl_options_by_name(last_tls_context, $3);
+            CHECK_ERROR(tls_context_set_ssl_options_by_name(last_tls_context, $3), @3,
+                        "unknown ssl-options() argument");
 	  }
         | KW_ENDIF {
 }

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -47,6 +47,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "peer_verify",        KW_PEER_VERIFY },
   { "key_file",           KW_KEY_FILE },
   { "cert_file",          KW_CERT_FILE },
+  { "dhparam_file",       KW_DHPARAM_FILE },
   { "ca_dir",             KW_CA_DIR },
   { "crl_dir",            KW_CRL_DIR },
   { "trusted_keys",       KW_TRUSTED_KEYS },

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -52,6 +52,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "trusted_keys",       KW_TRUSTED_KEYS },
   { "trusted_dn",         KW_TRUSTED_DN },
   { "cipher_suite",       KW_CIPHER_SUITE },
+  { "ecdh_curve_list",    KW_ECDH_CURVE_LIST },
   { "ssl_options",        KW_SSL_OPTIONS },
 
   { "localip",            KW_LOCALIP },

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -54,6 +54,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "trusted_dn",         KW_TRUSTED_DN },
   { "cipher_suite",       KW_CIPHER_SUITE },
   { "ecdh_curve_list",    KW_ECDH_CURVE_LIST },
+  { "curve_list",         KW_ECDH_CURVE_LIST, KWS_OBSOLETE, "ecdh_curve_list"},
   { "ssl_options",        KW_SSL_OPTIONS },
 
   { "localip",            KW_LOCALIP },

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -674,7 +674,8 @@ afsocket_sd_init_method(LogPipe *s)
          afsocket_sd_setup_transport(self) &&
          afsocket_sd_setup_addresses(self) &&
          afsocket_sd_restore_kept_alive_connections(self) &&
-         afsocket_sd_open_listener(self);
+         afsocket_sd_open_listener(self) &&
+         transport_mapper_init(self->transport_mapper);
 }
 
 gboolean

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -102,6 +102,17 @@ transport_mapper_inet_construct_log_transport(TransportMapper *s, gint fd)
     return transport_mapper_construct_log_transport_method(s, fd);
 }
 
+static gboolean
+transport_mapper_inet_init(TransportMapper *s)
+{
+  TransportMapperInet *self = (TransportMapperInet *) s;
+
+  if (self->tls_context && !tls_context_setup_context(self->tls_context))
+    return FALSE;
+
+  return TRUE;
+}
+
 void
 transport_mapper_inet_free_method(TransportMapper *s)
 {
@@ -118,6 +129,7 @@ transport_mapper_inet_init_instance(TransportMapperInet *self, const gchar *tran
   transport_mapper_init_instance(&self->super, transport);
   self->super.apply_transport = transport_mapper_inet_apply_transport_method;
   self->super.construct_log_transport = transport_mapper_inet_construct_log_transport;
+  self->super.init = transport_mapper_inet_init;
   self->super.free_fn = transport_mapper_inet_free_method;
   self->super.address_family = AF_INET;
 }

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -47,6 +47,7 @@ struct _TransportMapper
 
   gboolean (*apply_transport)(TransportMapper *self, GlobalConfig *cfg);
   LogTransport *(*construct_log_transport)(TransportMapper *self, gint fd);
+  gboolean (*init)(TransportMapper *self);
   void (*free_fn)(TransportMapper *self);
 };
 
@@ -76,6 +77,15 @@ static inline LogTransport *
 transport_mapper_construct_log_transport(TransportMapper *self, gint fd)
 {
   return self->construct_log_transport(self, fd);
+}
+
+static inline gboolean
+transport_mapper_init(TransportMapper *self)
+{
+  if (self->init)
+    return self->init(self);
+
+  return TRUE;
 }
 
 #endif


### PR DESCRIPTION
This PR contains

- a medium-sized refactor in tlscontext
- minor fixes
- TLS features:
    - startup time `ssl-options()` and `peer-verify()` check
    - startup time `key_file`, `cert_file`, `ca_dir`, `crl_dir` and `cipher_suite` check
    - **ECDH  cipher support** (OpenSSL 1.0.1, 1.0.2, 1.1.0) with the `ecdh-curve-list()` option (only available >= 1.0.2)
        - for < 1.0.2, a hard-coded curve is used
        - for >= 1.0.2, automatic curve selection is used (the `ecdh-curve-list()` option can restrict this list)
    - **DH cipher support** with the `dhparam-file()` option
        - if the option is not specified, fallback RFC 3526 parameters are used

Example usage:
```
$ openssl dhparam -out /dh/dh2048.pem 2048

syslog(
  port(4444)
  transport(tls)
  tls(
    ecdh-curve-list("prime256v1:secp384r1") # <---- new
    dhparam-file("/dh/dh2048.pem") # <---- new
    ca-dir("/ca-dir")
    key-file("/key/key.pem")
    cert-file("/cert/cert.pem")
    cipher-suite("ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256") # <-- finally works
    peer-verify("required-trusted")
    ssl-options(no-sslv2, no-sslv3, no-tlsv1)
  )
);
```

This PR includes #1450 with minor modifications.

Important question:
**Should I remove the DH fallback mechanism?**
I'm using RFC 3526 parameters, but the `get_rfc3526_prime_2048()` function of OpenSSL is not officially documented.

TODO:
- [x] Write tests for Kira
- [x] Test manually with OpenSSL 1.0.1 (CentOS 7)
  - `ecdh-curve-list()` is ignored here
- [x] Test manually with OpenSSL 1.0.2 (Ubuntu 16.04)
- [x] Test manually with OpenSSL 1.1.0 (Arch Linux)

Fixes #942
@Viaguld @ouarak

--------------------------------------------------------------------------------------

### Commit categories
#### Medium-sized refactor in tlscontext
  - tlscontext: move the declarations of variables to their initialization point
  - tlscontext: extract TLS context setup from setup_session()
  - tlscontext: refactor TLS peer certificate verification setup
  - tlscontext: extract TLS option setup from setup_context()
  - tlscontext: extract _print_tls_session_error() from setup_context()
  - tlscontext: make internal fields and methods private
  - tlscontext: move SSL context creation to tls_context_new()

#### Minor fixes
  - tlscontext: fix the type of ssl_error

#### Startup time option check
  - tlscontext: change the interface of lookup_verify_mode and lookup_options
  - tlscontext: add setters
  - afsocket: use the setters of TLSContext with parse-time error check
  - transport-mapper: add virtual init() function
  - tlscontext: make setup_context() public
  - afsocket: validate TLS options at init time

#### ECDH and DH support
  - tlscontext: add ECDH support
  - tlscontext: add optional curve_list
  - afsocket: add curve-list() option to grammar
  - tlscontext: add optional dhparam_file field
  - afsocket: add dhparam-file() option to grammar