### PR TITLE
travis: install libmaxminddb-dev in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
       sqlite3
       xsltproc
       criterion-dev
+      libmaxminddb-dev
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh


### PR DESCRIPTION
I've released it in my OBS repository for Travis.
https://build.opensuse.org/package/show/home:laszlo_budai:syslog-ng/libmaxminddb