### PR TITLE
Rework of Solaris SMF multi-instance support, to support unified-style default files

### DIFF
--- a/contrib/solaris-packaging/solaris10_install.txt
+++ b/contrib/solaris-packaging/solaris10_install.txt
@@ -91,7 +91,7 @@ Procedure 4.5. Installing syslog-ng on Sun Solaris 10
                   
    6.
 
-      Modify the syslog-ng.conf.to suit your needs. For details on how to configure syslog-ng, see The syslog-ng Administrator Guide, Chapter 3, Configuring syslog-ng.
+      Modify the syslog-ng.conf to suit your needs. For details on how to configure syslog-ng, see The syslog-ng Administrator Guide, Chapter 3, Configuring syslog-ng.
    7.
 
       Disable the original syslogd application.
@@ -104,8 +104,9 @@ Procedure 4.5. Installing syslog-ng on Sun Solaris 10
       Copy the following files to their proper places by issuing the following commands and modify them if needed.
 
 
-      # cp /opt/syslog-ng/doc/syslog-ng.example.xml /var/svc/manifest/system/syslog-ng.xml
-      # cp /opt/syslog-ng/doc/syslog-ng.method /lib/svc/method/syslog-ng
+      # cp <sourcedir>/contrib/solaris-packaging/syslog-ng.example.xml /var/svc/manifest/system/syslog-ng.xml
+      # cp <sourcedir>/contrib/solaris-packaging/syslog-ng.method /lib/svc/method/syslog-ng
+      # cp <sourcedir>/contrib/solaris-packaging/syslog-ng@default /etc/default/syslog-ng@default
                   
    9.
 
@@ -122,7 +123,7 @@ Procedure 4.5. Installing syslog-ng on Sun Solaris 10
       Enable and start syslog-ng.
 
 
-      # svcadm enable -t svc:/system/syslog-ng
+      # svcadm enable -t svc:/system/syslog-ng:default
                   
   11.
 

--- a/contrib/solaris-packaging/syslog-ng.method
+++ b/contrib/solaris-packaging/syslog-ng.method
@@ -8,7 +8,7 @@
 #   added nicer options field
 # Modified for BalaBit Ltd's syslog-ng package by Tamas Pal Mar, 1st 2006
 # Modified for BalaBit's syslog-ng package to make it multi-instance-able by György Pásztor Mar, 21th 2016
-# Minor modifications for Syslog-ng OSE by Janos Szigetvari Jul, 10th 2017
+# Minor modifications for Syslog-ng OSE by Janos Szigetvari Jul, 19th 2017
 
 . /lib/svc/share/smf_include.sh
 
@@ -16,47 +16,50 @@ result=${SMF_EXIT_OK}
 
 # Read command line arguments
 method="$1"		# %m
-instance="$2" 		# %i
+instance="$2"		# %i
 
 # Set defaults; SMF_FMRI should have been set, but just in case.
 if [ -z "$SMF_FMRI" ]; then
     SMF_FMRI="svc:/system/syslog-ng:${instance}"
 fi
 
-OPTIONS=
+SYSLOGPID_FILE=/var/run/syslog.pid
+OTHER_OPTIONS="--enable-core"
 MAXWAIT=30
 
 DEFAULTFILE=/etc/default/syslog-ng
 [ -f ${DEFAULTFILE} ] && . ${DEFAULTFILE}
 
-[ -f ${DEFAULTFILE}:${instance} ] && . ${DEFAULTFILE}:${instance}
+[ -f ${DEFAULTFILE}@${instance} ] && . ${DEFAULTFILE}@${instance}
 
-SYSLOGNG_PREFIX=${SYSLOGNG_PE_PREFIX:-/opt/syslog-ng}
-SYSLOGNG="$SYSLOGNG_PREFIX/sbin/syslog-ng"
+SYSLOGNG_PREFIX=${SYSLOGNG_PREFIX:-/usr/local}
+SYSLOGNG="${SYSLOGNG_PREFIX}/sbin/syslog-ng"
+VAR_DIR=${VAR_DIR:-${SYSLOGNG_PREFIX}/var}
 
 if [ "$instance" = "default" ];
 then
-        CONFFILE=${CONFFILE:-${SYSLOGNG_PREFIX}/etc/syslog-ng.conf}
-        PIDFILE=$SYSLOGNG_PREFIX/var/run/syslog-ng.pid
-        SYSLOGPIDFILE=/var/run/syslog.pid
-        METHOD_OPTIONS=
+        CONFIG_FILE=${CONFIG_FILE:-${SYSLOGNG_PREFIX}/etc/syslog-ng.conf}
+        PID_FILE=${PID_FILE:-${SYSLOGPID_FILE}}
 else
-        CONFFILE=${CONFFILE:-${SYSLOGNG_PREFIX}/etc/syslog-ng:${instance}.conf}
-        SYSLOGPIDFILE=/var/run/syslog:${instance}.pid
-        VARDIR="${SYSLOGNG_PREFIX}/var:${instance}"
-        PIDFILE=${VARDIR}/run/syslog-ng.pid
-        [ -d "$VARDIR" ] || mkdir "$VARDIR"
-        [ -d "$VARDIR/run" ] || mkdir "$VARDIR/run"
-        METHOD_OPTIONS="--cfgfile=$CONFFILE --pidfile=${PIDFILE} --persist-file=${VARDIR}/syslog-ng.persist --control=${VARDIR}/run/syslog-ng.ctl"
+        CONFIG_FILE=${CONFIG_FILE:-${SYSLOGNG_PREFIX}/etc/syslog-ng@${instance}.conf}
+        PID_FILE=${PID_FILE:-${VAR_DIR}/run/syslog-ng.pid}
+
+        [ -d "${VAR_DIR}" ] || mkdir "${VAR_DIR}"
+        [ -d "${VAR_DIR}/run" ] || mkdir "${VAR_DIR}/run"
 fi
+
+PERSIST_FILE=${PERSIST_FILE:-${VAR_DIR}/syslog-ng@${instance}.persist}
+CONTROL_FILE=${CONTROL_FILE:-${VAR_DIR}/run/syslog-ng@${instance}.ctl}
+
+METHOD_OPTIONS="--cfgfile=${CONFIG_FILE} --pidfile=${PID_FILE} --persist-file=${PERSIST_FILE} --control=${CONTROL_FILE}"
 
 export SYSLOGNG_PREFIX
 
 test -x ${SYSLOGNG} || exit $SMF_EXIT_ERR_FATAL
-test -r ${CONFFILE} || exit $SMF_EXIT_ERR_CONFIG
+test -r ${CONFIG_FILE} || exit $SMF_EXIT_ERR_CONFIG
 
 check_syntax() {
-        ${SYSLOGNG} --syntax-only --cfgfile=${CONFFILE}
+        ${SYSLOGNG} --syntax-only --cfgfile=${CONFIG_FILE}
         _rval=$?
         [ $_rval -eq 0 ] || exit $SMF_EXIT_ERR_CONFIG
 }
@@ -75,10 +78,10 @@ slng_waitforpid() {
 }
 
 slng_clean_pidfile() {
-        if [ -h $SYSLOGPIDFILE ];then
-                rm -f $SYSLOGPIDFILE
+        if [ -h $SYSLOGPID_FILE ];then
+                rm -f $SYSLOGPID_FILE
         fi
-        rm -f $PIDFILE
+        rm -f $PID_FILE
 }
 
 slng_stop() {
@@ -91,9 +94,9 @@ slng_stop() {
                 return $SMF_EXIT_OK
         fi
 
-        [ -f $PIDFILE ] || return $SMF_EXIT_ERR_FATAL
+        [ -f $PID_FILE ] || return $SMF_EXIT_ERR_FATAL
 
-        syspid=`head -1 $PIDFILE`
+        syspid=`head -1 $PID_FILE`
 
         [ -z "$syspid" ] && return $SMF_EXIT_OK
         kill -0 $syspid >/dev/null 2>&1
@@ -120,18 +123,18 @@ slng_stop() {
 
 
 slng_start () {
-        if [ -f $PIDFILE ];then
+        if [ -f $PID_FILE ];then
             _process=`basename $SYSLOGNG`
-            _pid=`head -1 $PIDFILE`
+            _pid=`head -1 $PID_FILE`
             pgrep $_process | grep $_pid > /dev/null 2>&1
             if [ $? -eq 0 ]; then
                 echo "syslog-ng already running."
                 exit 1
             fi
-            echo "syslog-ng is not running, removing $PIDFILE."
-            /usr/bin/rm -f $PIDFILE
+            echo "syslog-ng is not running, removing $PID_FILE."
+            /usr/bin/rm -f $PID_FILE
         fi
-        if [ -f $CONFFILE -a -x $SYSLOGNG ]; then
+        if [ -f $CONFIG_FILE -a -x $SYSLOGNG ]; then
                 echo 'syslog-ng service starting.'
                 #
                 # Before syslog-ng starts, save any messages from previous
@@ -148,13 +151,13 @@ slng_start () {
                     fi
                 fi
                 check_syntax
-                $SYSLOGNG $METHOD_OPTIONS $OPTIONS
+                $SYSLOGNG $OTHER_OPTIONS $METHOD_OPTIONS
                 # remove symlinks
-                if [ -h $SYSLOGPIDFILE ];then
-                        rm -f $SYSLOGPIDFILE
+                if [ -h $SYSLOGPID_FILE ];then
+                        rm -f $SYSLOGPID_FILE
                 fi
-                if [ ! -f $SYSLOGPIDFILE ];then
-                        ln -s $PIDFILE $SYSLOGPIDFILE
+                if [ ! -f $SYSLOGPID_FILE ];then
+                        ln -s $PID_FILE $SYSLOGPID_FILE
                 fi
                 return $SMF_EXIT_OK
         fi
@@ -170,8 +173,8 @@ case "$method" in
                 slng_stop
                 ;;
         refresh)
-                if [ -f $PIDFILE ]; then
-                        syspid=`head -1 $PIDFILE`
+                if [ -f $PID_FILE ]; then
+                        syspid=`head -1 $PID_FILE`
                         [ "$syspid" -gt 0 ] && kill -1 $syspid && echo "syslog-ng service reloaded"
                 fi
                 ;;
@@ -189,4 +192,3 @@ esac
 exit $?
 
 # vim: expandtab ts=8
-

--- a/contrib/solaris-packaging/syslog-ng@default
+++ b/contrib/solaris-packaging/syslog-ng@default
@@ -1,0 +1,6 @@
+SYSLOGNG_PREFIX=/usr/local
+CONFIG_FILE=/usr/local/etc/syslog-ng.conf
+PERSIST_FILE=/usr/local/var/syslog-ng.persist
+CONTROL_FILE=/usr/local/var/run/syslog-ng.ctl
+PID_FILE=/var/run/syslog.pid
+OTHER_OPTIONS="--enable-core"


### PR DESCRIPTION

contrib/solaris-packaging/syslog-ng.method: reworked to support new default files
contrib/solaris-packaging/syslog-ng@default: added an example default file
contrib/solaris-packaging/solaris10_install.txt: added step to install default file

    * added support for systemd-multi-instance type of default files
    * default files should now work the same way as with systemd instances
    * naming of the default files has changed to reflect those supporting systemd
    * reworked the method file to support additional options
    * set up a hierachy how settings take precedence of each other
    * installation directories/prefixes such as /usr/local may be a bit off
      and may require corrections by the end user to match his/her use case
    * renamed config variables to match those used with systemd's instances

Signed-off-by: Janos SZIGETVARI <jszigetvari@gmail.com>