### PR TITLE
riemann: configurable event time

### DIFF
--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -47,6 +47,7 @@
 %token KW_SERVER
 %token KW_STATE
 %token KW_SERVICE
+%token KW_EVENT_TIME
 %token KW_DESCRIPTION
 %token KW_METRIC
 %token KW_TTL
@@ -88,6 +89,10 @@ riemann_option
         | KW_SERVICE '(' template_content ')'
           {
             riemann_dd_set_field_service(last_driver, $3);
+          }
+        | KW_EVENT_TIME '(' template_content ')'
+          {
+            riemann_dd_set_field_event_time(last_driver, $3);
           }
         | KW_STATE '(' template_content ')'
           {

--- a/modules/riemann/riemann-parser.c
+++ b/modules/riemann/riemann-parser.c
@@ -36,6 +36,7 @@ static CfgLexerKeyword riemann_keywords[] =
   { "timeout",                  KW_TIMEOUT },
   { "host",                     KW_HOST },
   { "service",                  KW_SERVICE },
+  { "event_time",               KW_EVENT_TIME },
   { "state",                    KW_STATE },
   { "description",              KW_DESCRIPTION },
   { "metric",                   KW_METRIC },

--- a/modules/riemann/riemann.h
+++ b/modules/riemann/riemann.h
@@ -35,6 +35,7 @@ LogTemplateOptions *riemann_dd_get_template_options(LogDriver *d);
 
 void riemann_dd_set_field_host(LogDriver *d, LogTemplate *value);
 void riemann_dd_set_field_service(LogDriver *d, LogTemplate *value);
+void riemann_dd_set_field_event_time(LogDriver *d, LogTemplate *value);
 void riemann_dd_set_field_state(LogDriver *d, LogTemplate *value);
 void riemann_dd_set_field_description(LogDriver *d, LogTemplate *value);
 void riemann_dd_set_field_metric(LogDriver *d, LogTemplate *value);


### PR DESCRIPTION
New configuration parameter is added to riemann destination that
controls the calculation of event time: event_time(). In case omitted,
the default value is ${UNIXTIME}.

For example:
destination d_riemann {
    riemann(
    	server("127.0.0.1")
    	port(5555)
        event_time("${UNIXTIME}")
        [...]
    );

Fixes: https://github.com/balabit/syslog-ng/issues/1598