### PR TITLE
logthrdestdrv: add missing GC call

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -222,6 +222,7 @@ log_threaded_dest_driver_do_work(gpointer data)
   gint timeout_msec = 0;
 
   self->suspended = FALSE;
+  main_loop_worker_run_gc();
   log_threaded_dest_driver_stop_watches(self);
 
   if (!self->worker.connected)


### PR DESCRIPTION
Like in afsql, an explicit GC call is necessary before (at least) every do_work().