### PR TITLE
SCL: Add missing reference for osquery into scl/Makefile.am

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -15,7 +15,8 @@ SCL_SUBDIRS	= \
 	cisco		\
 	loggly		\
 	logmatic	\
-	snmptrap
+	snmptrap        \
+	osquery
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))


### PR DESCRIPTION
* without this patch "scl/osquery/plugin.conf" will not copied under share/syslog-ng/include/scl/


Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>