### PR TITLE
tests: replace cfg_new() with cfg_new_snippet()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
       xsltproc
       criterion-dev
       libmaxminddb-dev
+      libxml2-utils
   - sudo pip install -r requirements.txt
 before_script:
   - ./autogen.sh

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -37,7 +37,7 @@ int
 main()
 {
   app_startup();
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   test_debugger();
   cfg_free(configuration);
 }

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -243,7 +243,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   app_startup();
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/lib/filter/tests/test_filters_in_list.c
+++ b/lib/filter/tests/test_filters_in_list.c
@@ -161,7 +161,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   app_startup();
 
-  configuration = cfg_new(0x0305);
+  configuration = cfg_new_snippet(0x0305);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -72,7 +72,7 @@ Test(test_filters_statistics, filter_stastistics)
 {
   app_startup();
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   configuration->stats_options.level = 1;
   plugin_load_module("syslogformat", configuration, NULL);
   cr_assert(cfg_init(configuration));

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -268,7 +268,7 @@ int
 main(int argc, char **argv)
 {
   app_startup();
-  cfg = cfg_new(0x0307);
+  cfg = cfg_new_snippet(0x0307);
   plugin_load_module("syslogformat", cfg, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, cfg);

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -34,7 +34,7 @@ expect_config_parse_failure(const char *raw_rewrite_rule)
 {
   char raw_config[1024];
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   snprintf(raw_config, sizeof(raw_config), "rewrite s_test{ %s };", raw_rewrite_rule);
   assert_false(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL),
                ASSERTION_ERROR("Parsing the given configuration failed"));
@@ -46,7 +46,7 @@ create_rewrite_rule(const char *raw_rewrite_rule)
 {
   char raw_config[1024];
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   snprintf(raw_config, sizeof(raw_config), "rewrite s_test{ %s }; log{ rewrite(s_test); };", raw_rewrite_rule);
   assert_true(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL),
               ASSERTION_ERROR("Parsing the given configuration failed"));

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
 {
   msg_init(FALSE);
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   log_msg_registry_init();
   log_template_global_init();
   plugin_register(configuration, &hello_plugin, 1);

--- a/lib/tests/test_host_resolve.c
+++ b/lib/tests/test_host_resolve.c
@@ -308,7 +308,7 @@ main(int argc, char *argv[])
 {
   app_startup();
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   test_resolve_hostname_to_hostname();
   test_resolve_hostname_to_sockaddr();
   test_resolve_sockaddr_to_hostname();

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
   putenv("TZ=MET-1METDST");
   tzset();
 
-  cfg = cfg_new(VERSION_VALUE);
+  cfg = cfg_new_snippet(VERSION_VALUE);
   plugin_load_module("syslogformat", cfg, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, cfg);

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -132,7 +132,7 @@ int main()
 {
   app_startup();
 
-  configuration = cfg_new(0x0303);
+  configuration = cfg_new_snippet(0x0303);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -28,7 +28,7 @@
 void
 init_and_load_syslogformat_module()
 {
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/modules/add-contextual-data/tests/test_selector.c
+++ b/modules/add-contextual-data/tests/test_selector.c
@@ -54,7 +54,7 @@ Test(add_contextual_data_template_selector, test_given_empty_selector_when_resol
 static AddContextualDataSelector *
 _create_template_selector(const gchar *template_string)
 {
-  GlobalConfig *cfg = cfg_new(VERSION_VALUE);
+  GlobalConfig *cfg = cfg_new_snippet(VERSION_VALUE);
   AddContextualDataSelector *selector = add_contextual_data_template_selector_new(cfg, template_string);
   add_contextual_data_selector_init(selector, NULL);
 

--- a/modules/affile/tests/test_wildcard_source.c
+++ b/modules/affile/tests/test_wildcard_source.c
@@ -32,7 +32,7 @@ static void
 _init(void)
 {
   app_startup();
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   cr_assert(plugin_load_module("affile", configuration, NULL));
 }
 

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -304,7 +304,7 @@ _setup(void)
 
   log_msg_registry_init();
 
-  test_cfg = cfg_new(0x0308);
+  test_cfg = cfg_new_snippet(0x0308);
   g_assert(test_cfg);
 
   const gchar *persist_filename = "";

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -176,7 +176,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new(0x0302);
+  configuration = cfg_new_snippet(0x0302);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/modules/csvparser/tests/test_csvparser_statistics.c
+++ b/modules/csvparser/tests/test_csvparser_statistics.c
@@ -74,7 +74,7 @@ _parse_msg(LogParser *self, gchar *msg)
 Test(test_filters_statistics, filter_stastistics)
 {
   app_startup();
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   configuration->stats_options.level = 1;
   cr_assert(cfg_init(configuration));
 

--- a/modules/date/tests/test_date.c
+++ b/modules/date/tests/test_date.c
@@ -76,7 +76,7 @@ setup(void)
   putenv("TZ=CET-1");
   tzset();
 
-  configuration = cfg_new(0x0302);
+  configuration = cfg_new_snippet(0x0302);
 }
 
 void

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -1119,7 +1119,7 @@ main(int argc, char *argv[])
 
   msg_init(TRUE);
 
-  configuration = cfg_new(0x0302);
+  configuration = cfg_new_snippet(0x0302);
   plugin_load_module("basicfuncs", configuration, NULL);
   plugin_load_module("syslogformat", configuration, NULL);
 

--- a/modules/dbparser/tests/test_patternize.c
+++ b/modules/dbparser/tests/test_patternize.c
@@ -448,7 +448,7 @@ int
 main()
 {
   app_startup();
-  configuration = cfg_new(0x0201);
+  configuration = cfg_new_snippet(0x0201);
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -489,7 +489,7 @@ main()
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   configuration->stats_options.level = 1;
   assert_true(cfg_init(configuration), "cfg_init failed!");
   plugin_load_module("syslogformat", configuration, NULL);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -94,7 +94,7 @@ main()
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new(0x0308);
+  configuration = cfg_new_snippet(0x0308);
   plugin_load_module("syslogformat", configuration, NULL );
   plugin_load_module("disk-buffer", configuration, NULL );
   plugin_load_module("builtin-serializer", configuration, NULL );

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -384,7 +384,7 @@ main(gint argc, gchar **argv)
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new(0x0308);
+  configuration = cfg_new_snippet(0x0308);
   plugin_load_module("syslogformat", configuration, NULL);
   plugin_load_module("disk-buffer", configuration, NULL);
   msg_format_options_defaults(&parse_options);

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -173,7 +173,7 @@ test_kmsg_device_parsing(void)
 void
 init_and_load_kmsgformat_module()
 {
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   plugin_load_module("linux-kmsg-format", configuration, NULL);
   parse_options.format = "linux-kmsg";
 

--- a/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
+++ b/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
@@ -125,7 +125,7 @@ assert_log_message_name_values(const gchar *input, TestNameValue *expected, gsiz
 void
 setup(void)
 {
-  configuration = cfg_new(0x0390);
+  configuration = cfg_new_snippet(0x0390);
   app_startup();
 }
 

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -527,7 +527,7 @@ main(int argc, char **argv)
 {
   app_startup();
   main_thread_handle =  get_thread_id();
-  configuration = cfg_new(0x306);
+  configuration = cfg_new_snippet(0x306);
   configuration->threaded = FALSE;
   configuration->state = persist_state_new(TEST_PERSIST_FILE_NAME);
   configuration->keep_hostname = TRUE;

--- a/tests/unit/test_hostid.c
+++ b/tests/unit/test_hostid.c
@@ -37,7 +37,7 @@
 static GlobalConfig *
 _create_cfg()
 {
-  GlobalConfig *cfg = cfg_new(0x0302);
+  GlobalConfig *cfg = cfg_new_snippet(0x0302);
   return cfg;
 }
 

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -176,7 +176,7 @@ _assert_logwriter_output(LogWriterTestCase c)
 
 Test(logwriter, test_logwriter)
 {
-  configuration = cfg_new(0x0300);
+  configuration = cfg_new_snippet(0x0300);
   LogWriterTestCase test_cases[] =
   {
     {MSG_SYSLOG_STR, TRUE, NULL, LW_SYSLOG_PROTOCOL, EXPECTED_MSG_SYSLOG_STR},


### PR DESCRIPTION
Loading all candidate modules in unit tests is unnecessary.

This PR also contains a small Travis configuration modification to make our master green.

Finalize #1575 and #1597