### PR TITLE
statistics: msg_size issue in unit testcase

### DIFF
--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -318,8 +318,8 @@ testcase_with_threads()
 static gboolean
 is_valid_msg_size(guint32 one_msg_size)
 {
-  /* 460 as of writing */
-  return (one_msg_size < 500 && one_msg_size > 400);
+  /* 460 as of writing on x86-64 and 384 on x86*/
+  return (one_msg_size < 500 && one_msg_size > 300);
 }
 
 struct diskq_tester_parameters;


### PR DESCRIPTION
The goal of the referring assertion is to have some estimate of the
memory usage of a message, and to track its change in future
developments. As it is hard to give precise memory usage, only a
reasonable lower and upper bound was given. The problem was that only
64bit systems were taken into consideration. On 32bit systems, message
size can be lower. This patch extends the boundaries so that assertion
would not be triggered on 32bit systems either.

Fixes: https://github.com/balabit/syslog-ng/issues/1545