### PR TITLE
geoip: deprecated notice in geoip template function

### DIFF
--- a/modules/geoip/tfgeoip.c
+++ b/modules/geoip/tfgeoip.c
@@ -99,6 +99,8 @@ tf_geoip_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
   TFGeoIPState *state = (TFGeoIPState *) s;
   state->database = NULL;
 
+  msg_notice("The geoip template function is deprecated. Please use geoip2 template function instead");
+
   GOptionEntry geoip_options[] =
   {
     { "database", 'd', 0, G_OPTION_ARG_FILENAME, &state->database, "geoip database location", NULL },


### PR DESCRIPTION
Prior this patch only the geoip parser was marked as deprecated,
although template function and parser should have been marked as
deprecated at the same time. Now a notice will be emitted if user uses
geoip template function too, suggesting to change for geoip2.