### PR TITLE
pdbtool,dqtool: replace cfg_new() with cfg_new_snippet()

### DIFF
--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1233,7 +1233,7 @@ main(int argc, char *argv[])
   pattern_db_global_init();
   crypto_init();
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
 
   if (!g_option_context_parse(ctx, &argc, &argv, &error))
     {

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -290,7 +290,8 @@ main(int argc, char *argv[])
       return 0;
     }
 
-  configuration = cfg_new(VERSION_VALUE);
+  configuration = cfg_new_snippet(VERSION_VALUE);
+
   configuration->template_options.frac_digits = 3;
   configuration->template_options.time_zone_info[LTZ_LOCAL] = time_zone_info_new(NULL);
 


### PR DESCRIPTION
Loading candidate_modules is unnecessary.