### PR TITLE
cfg: load license after '@module' pragma initialization

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -30,6 +30,7 @@
 #include "pragma-parser.h"
 #include "messages.h"
 #include "pathutils.h"
+#include "syslog-ng-config.h"
 
 #include <string.h>
 #include <glob.h>
@@ -946,6 +947,15 @@ relex:
           msg_warning("WARNING: Configuration file has no version number, assuming syslog-ng 2.1 format. Please add @version: maj.min to the beginning of the file to indicate this explicitly");
           cfg_set_version(configuration, 0x0201);
         }
+
+#if (!SYSLOG_NG_ENABLE_FORCED_SERVER_MODE)
+      if (!plugin_load_module("license", self, NULL))
+        {
+          msg_error("Error loading the license module, forcing exit");
+          exit(1);
+        }
+#endif
+
       self->non_pragma_seen = TRUE;
     }
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -382,14 +382,6 @@ void
 cfg_load_candidate_modules(GlobalConfig *self)
 {
   plugin_load_candidate_modules(self);
-
-#if (!SYSLOG_NG_ENABLE_FORCED_SERVER_MODE)
-  if (!plugin_load_module("license", self, NULL))
-    {
-      msg_error("Error loading the license module, forcing exit");
-      exit(1);
-    }
-#endif
 }
 
 static void


### PR DESCRIPTION
At this point, all plugin info should be available for license.

This is the Lagrangian point of the license module.