### PR TITLE
Dbld/libmaxminddb support

### DIFF
--- a/dbld/images/centos7/dev-dependencies.txt
+++ b/dbld/images/centos7/dev-dependencies.txt
@@ -52,3 +52,4 @@ vim
 docbook-xsl
 python-nose
 python-ply
+libmaxminddb-devel

--- a/dbld/images/jessie/dev-dependencies.txt
+++ b/dbld/images/jessie/dev-dependencies.txt
@@ -52,3 +52,4 @@ python-ply
 pylint
 gradle
 devscripts
+libmaxminddb-dev

--- a/dbld/images/zesty/dev-dependencies.txt
+++ b/dbld/images/zesty/dev-dependencies.txt
@@ -53,3 +53,4 @@ python-ply
 pylint
 gradle
 devscripts
+libmaxminddb-dev


### PR DESCRIPTION
Please note, that 
* on Debian Jessie libmaxminddb-dev package is come from my OBS repo
* on CentOS7 libmaxminddb-devel package is come from EPEL