### PR TITLE
java destination: sequence number support for templates

### DIFF
--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -64,6 +64,13 @@ Java_org_syslog_1ng_LogDestination_getTemplateOptionsHandle(JNIEnv *env, jobject
   return (jlong)(&self->template_options);
 }
 
+JNIEXPORT jint JNICALL
+Java_org_syslog_1ng_LogDestination_getSeqNum(JNIEnv *env, jobject obj, jlong handle)
+{
+  JavaDestDriver *self = (JavaDestDriver *)handle;
+  return (jint)(self->super.seq_num);
+}
+
 JNIEXPORT jlong JNICALL
 Java_org_syslog_1ng_LogPipe_getConfigHandle(JNIEnv *env, jobject obj, jlong handle)
 {
@@ -124,7 +131,7 @@ java_dd_init(LogPipe *s)
     }
 
   self->proxy = java_destination_proxy_new(self->class_name, self->class_path->str, self, self->template,
-                                           cfg->jvm_options);
+                                           &self->super.seq_num, cfg->jvm_options);
   if (!self->proxy)
     return FALSE;
 

--- a/modules/java/proxies/java-destination-proxy.h
+++ b/modules/java/proxies/java-destination-proxy.h
@@ -33,7 +33,7 @@
 
 typedef struct _JavaDestinationProxy JavaDestinationProxy;
 
-JavaDestinationProxy *java_destination_proxy_new(const gchar *class_name, const gchar *class_path, gpointer handle, LogTemplate *template, const gchar *jvm_options);
+JavaDestinationProxy *java_destination_proxy_new(const gchar *class_name, const gchar *class_path, gpointer handle, LogTemplate *template, gint32 *seq_num, const gchar *jvm_options);
 
 gboolean java_destination_proxy_init(JavaDestinationProxy *self);
 void java_destination_proxy_deinit(JavaDestinationProxy *self);

--- a/modules/java/proxies/java-template-proxy.c
+++ b/modules/java/proxies/java-template-proxy.c
@@ -56,14 +56,14 @@ JNICALL Java_org_syslog_1ng_LogTemplate_compile(JNIEnv *env, jobject obj, jlong 
 
 JNIEXPORT jstring JNICALL
 Java_org_syslog_1ng_LogTemplate_format(JNIEnv *env, jobject obj, jlong template_handle, jlong msg_handle,
-                                       jlong logtemplate_options_handle, jint tz)
+                                       jlong logtemplate_options_handle, jint tz, jint seqnum)
 {
   LogTemplate *template = (LogTemplate *)template_handle;
   LogTemplateOptions *template_options = (LogTemplateOptions *)logtemplate_options_handle;
   LogMessage *msg = (LogMessage *)msg_handle;
   GString *formatted_message = g_string_sized_new(1024);
   jstring result = NULL;
-  log_template_format(template, msg, template_options, tz, 0, NULL, formatted_message);
+  log_template_format(template, msg, template_options, tz, seqnum, NULL, formatted_message);
   result = (*env)->NewStringUTF(env, formatted_message->str);
   g_string_free(formatted_message, TRUE);
   return result;

--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -38,6 +38,10 @@ public abstract class LogDestination extends LogPipe {
 		return getTemplateOptionsHandle(getHandle());
 	}
 
+	public int getSeqNum() {
+ 		return getSeqNum(getHandle());
+        }
+
 	protected abstract boolean open();
 
 	protected abstract void close();
@@ -49,6 +53,8 @@ public abstract class LogDestination extends LogPipe {
 	private native String getOption(long ptr, String key);
 
 	private native long getTemplateOptionsHandle(long ptr);
+
+	private native int getSeqNum(long ptr);
 
 	protected void onMessageQueueEmpty() {
 		return;

--- a/modules/java/src/main/java/org/syslog_ng/LogTemplate.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogTemplate.java
@@ -49,7 +49,11 @@ public class LogTemplate {
   }
 
   public String format(LogMessage msg, long logTemplateOptionsHandle, int timezone) {
-    return format(templateHandle, msg.getHandle(), logTemplateOptionsHandle, timezone);
+    return format(templateHandle, msg.getHandle(), logTemplateOptionsHandle, timezone, 0);
+  }
+
+  public String format(LogMessage msg, long logTemplateOptionsHandle, int timezone, int seqnum) {
+    return format(templateHandle, msg.getHandle(), logTemplateOptionsHandle, timezone, seqnum);
   }
 
   public void release() {
@@ -58,6 +62,6 @@ public class LogTemplate {
 
   private native long create_new_template_instance(long configHandle);
   private native boolean compile(long templateHandle, String template);
-  private native String format(long templateHandle, long msgHandle, long templateOptionsHandle, int timezone);
+  private native String format(long templateHandle, long msgHandle, long templateOptionsHandle, int timezone, int seqnum);
   private native void unref(long templateHandle);
 }


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/1410

Prior this patch zero was passed as sequence number in java destination templates. This patch propagates the sequence number controlled by the threaded destination driver into LogDestination class, so it will be available in the inherited classes. Thus users can pass it to LogTemplate object when sequence number is used in a template formula.

For example:
```
LogTemplate logTemplate = new LogTemplate(getConfigHandle());
logTemplate.compile("${SEQNUM}\n");
InternalMessageSender.debug(logTemplate.format(logMessage, 0, logTemplate.LTZ_SEND, getSeqNum()));
```