### PR TITLE
mainloop: regression: reload not finalized if no workers around

### DIFF
--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -381,6 +381,7 @@ main_loop_worker_sync_call(void (*func)(gpointer user_data), gpointer user_data)
   if (main_loop_workers_running == 0)
     {
       _invoke_sync_call_actions();
+      _reenable_worker_jobs(NULL);
     }
   else
     {


### PR DESCRIPTION
The reload mechanism is syslog-ng is done in 3 stages.

- Stage1: ctl/hup signal initiates reload
Old configuration saved, new configuration validated, stage2 is
registered to be executed when no workers are
running (main_loop_worker_sync_call).
All workers are notified to stop as soon as possible.

- Stage2: Configuration applied.
Configuration applied, (workers are still stopped), stage3 registered to be executed later.

- Stage3: Reenables workers, reload finished.

There is a special case when no workers are created. In that case the
three stages can be executed in one step. It is handled by a special
if-branch in main_loop_worker_sync_call. But this branch only called
stage2, and did not call stage3. This means the reload was never
finalized, resulting in that users cannot reinitiate reload anymore.

This patch calls stage3 after stage2 in this special case, fixing the
problem.

Regression was introduced in: https://github.com/balabit/syslog-ng/pull/1537