### PR TITLE
WIP! Fix: put back counter registration to app_startup

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -135,15 +135,8 @@ app_startup(void)
   log_template_global_init();
   value_pairs_global_init();
   service_management_init();
-  scratch_buffers_allocator_init();
-}
-
-void
-app_finish_app_startup_after_cfg_init(void)
-{
-  log_tags_reinit_stats();
-  log_msg_stats_global_init();
   scratch_buffers_global_init();
+  scratch_buffers_allocator_init();
 }
 
 void

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -41,7 +41,6 @@ typedef void (*ApplicationHookFunc)(gint type, gpointer user_data);
 
 void register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
 void app_startup();
-void app_finish_app_startup_after_cfg_init();
 void app_post_daemonized();
 void app_pre_config_loaded();
 void app_post_config_loaded();

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -219,6 +219,7 @@ cfg_init(GlobalConfig *cfg)
     return FALSE;
 
   stats_reinit(&cfg->stats_options);
+  log_tags_reinit_stats();
 
   dns_caching_update_options(&cfg->dns_cache_options);
   hostname_reinit(cfg->custom_domain);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1799,11 +1799,6 @@ void
 log_msg_global_init(void)
 {
   log_msg_registry_init();
-}
-
-void
-log_msg_stats_global_init(void)
-{
   stats_lock();
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL );

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1811,7 +1811,7 @@ log_msg_global_init(void)
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_sdata_updates);
 
   stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, "msg_allocated_bytes", NULL);
-  stats_register_counter(1, &sc_key, SC_TYPE_SINGLE_VALUE, &count_allocated_bytes);
+  stats_register_counter(0, &sc_key, SC_TYPE_SINGLE_VALUE, &count_allocated_bytes);
   stats_unlock();
 }
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -333,7 +333,6 @@ void log_msg_registry_init(void);
 void log_msg_registry_deinit(void);
 void log_msg_global_init(void);
 void log_msg_global_deinit(void);
-void log_msg_stats_global_init(void);
 void log_msg_registry_foreach(GHFunc func, gpointer user_data);
 
 gint log_msg_lookup_time_stamp_name(const gchar *name);

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -272,7 +272,6 @@ main(int argc, char *argv[])
   main_loop_options.server_mode = ((SYSLOG_NG_ENABLE_FORCED_SERVER_MODE) == 1 ? TRUE : FALSE);
   main_loop_init(main_loop, &main_loop_options);
   rc = main_loop_read_and_init_config(main_loop);
-  app_finish_app_startup_after_cfg_init();
 
   if (rc)
     {


### PR DESCRIPTION
Currently some counters are used before they are registered (e.g. allocated_bytes in log_msg_alloc when diskq is loaded)
This has been introduced with a patch with the aim to be able to register these counters to stats_level 1.
See [patch](https://github.com/balabit/syslog-ng/commit/4a5182580e254f96195194b8e0486d527fd39d4c).

For these counters registration had been put back to app_startup, however
stats level at this phase can only be on stats_level 0 as cfg is not yet parsed.