### PR TITLE
TLS: PKCS 12 support

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -606,6 +606,9 @@ tls_context_setup_context(TLSContext *self)
 
   if (self->pkcs12_file)
     {
+      if (self->cert_file || self->key_file)
+        msg_warning("WARNING: pkcs12-file() is specified, key-file() and cert-file() will be omitted");
+
       if (!tls_context_load_pkcs12(self))
         goto error;
     }

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -94,6 +94,7 @@ gint tls_context_get_verify_mode(const TLSContext *self);
 void tls_context_set_verify_mode(TLSContext *self, gint verify_mode);
 void tls_context_set_key_file(TLSContext *self, const gchar *key_file);
 void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
+void tls_context_set_pkcs12_file(TLSContext *self, const gchar *pkcs12_file);
 void tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir);
 void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -164,6 +164,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_KEY_FILE
 %token KW_CERT_FILE
 %token KW_DHPARAM_FILE
+%token KW_PKCS12_FILE
 %token KW_CA_DIR
 %token KW_CRL_DIR
 %token KW_TRUSTED_KEYS
@@ -691,6 +692,11 @@ tls_option
         | KW_DHPARAM_FILE '(' string ')'
           {
             tls_context_set_dhparam_file(last_tls_context, $3);
+            free($3);
+          }
+        | KW_PKCS12_FILE '(' string ')'
+          {
+            tls_context_set_pkcs12_file(last_tls_context, $3);
             free($3);
           }
 	| KW_CA_DIR '(' string ')'

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -48,6 +48,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "key_file",           KW_KEY_FILE },
   { "cert_file",          KW_CERT_FILE },
   { "dhparam_file",       KW_DHPARAM_FILE },
+  { "pkcs12_file",        KW_PKCS12_FILE },
   { "ca_dir",             KW_CA_DIR },
   { "crl_dir",            KW_CRL_DIR },
   { "trusted_keys",       KW_TRUSTED_KEYS },


### PR DESCRIPTION
The new `pkcs12-file()` TLS option can be used to specify a `PKCS #12` file container that can store 
 a private key, a certificate and CA certs.
`pkcs12-file()` works together with the `ca-dir()` option, but this is optional since the p12 file may contain CA certificates as well.

If this option is used in the configuration file, the value of `key-file()` and `cert-file()` will be omitted.
Passphrase is currently not supported.

Example:
```sh
openssl pkcs12 -export -inkey serverkey.pem -in servercert.pem -certfile cacert.pem -out server.p12
```

Example config:
```
source s_tls {
    syslog(
        transport(tls)
        tls(
            pkcs12-file("/path/to/server.p12")
            ca-dir("/path/to/cadir") # optional
            peer-verify(yes)
        )
    );
};
```