### PR TITLE
Read old records

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -234,6 +234,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_PERSIST_NAME                10302
 
 %token KW_JVM_OPTIONS                 10303
+%token KW_READ_OLD_RECORDS            10304
 
 /* log statement options */
 %token KW_FLAGS                       10190
@@ -1039,6 +1040,7 @@ source_option
 	| KW_HOST_OVERRIDE '(' string ')'	{ last_source_options->host_override = g_strdup($3); free($3); }
 	| KW_LOG_PREFIX '(' string ')'	        { gchar *p = strrchr($3, ':'); if (p) *p = 0; last_source_options->program_override = g_strdup($3); free($3); }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ last_source_options->keep_timestamp = $3; }
+	| KW_READ_OLD_RECORDS '(' yesno ')'	{ last_source_options->read_old_records = $3; }
         | KW_TAGS '(' string_list ')'		{ log_source_options_set_tags(last_source_options, $3); }
         | { last_host_resolve_options = &last_source_options->host_resolve_options; } host_resolve_option
         | driver_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -156,6 +156,7 @@ static CfgLexerKeyword main_keywords[] =
 
   { "retries",            KW_RETRIES },
 
+  { "read_old_records",   KW_READ_OLD_RECORDS},
   /* filter items */
   { "type",               KW_TYPE },
   { "tags",               KW_TAGS },

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -444,6 +444,7 @@ log_source_options_defaults(LogSourceOptions *options)
   options->program_override_len = -1;
   options->host_override_len = -1;
   options->tags = NULL;
+  options->read_old_records = TRUE;
   host_resolve_options_defaults(&options->host_resolve_options);
 }
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -41,6 +41,7 @@ typedef struct _LogSourceOptions
   gchar *host_override;
   gint host_override_len;
   LogTagId source_group_tag;
+  gboolean read_old_records;
   GArray *tags;
   GList *source_queue_callbacks;
   gint stats_level;


### PR DESCRIPTION
This PR supports `read_old_records` only for journal source.
