### PR TITLE
add-contextual-data: make ordering optional

### DIFF
--- a/modules/add-contextual-data/add-contextual-data-selector.h
+++ b/modules/add-contextual-data/add-contextual-data-selector.h
@@ -29,6 +29,7 @@
 typedef struct _AddContextualDataSelector AddContextualDataSelector;
 
 struct _AddContextualDataSelector{
+  gboolean ordering_required;
   gchar *(*resolve)(AddContextualDataSelector *self, LogMessage *msg);
   void (*free)(AddContextualDataSelector *self);
   AddContextualDataSelector*(*clone)(AddContextualDataSelector *self, GlobalConfig *cfg);
@@ -75,6 +76,12 @@ add_contextual_data_selector_clone(AddContextualDataSelector *self, GlobalConfig
     }
 
   return NULL;
+}
+
+static inline gboolean
+add_contextual_data_selector_is_ordering_required(AddContextualDataSelector *self)
+{
+  return self->ordering_required;
 }
 
 #endif

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -251,6 +251,9 @@ _load_context_info_db(AddContextualData *self)
 static gboolean
 _init_context_info_db(AddContextualData *self)
 {
+  if (self->selector && add_contextual_data_selector_is_ordering_required(self->selector))
+    context_info_db_enable_ordering(self->context_info_db);
+
   if (self->filename == NULL)
     {
       msg_error("No database file set.");

--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -33,6 +33,7 @@ struct _ContextInfoDB
   GArray *data;
   GHashTable *index;
   gboolean is_data_indexed;
+  gboolean is_ordering_enabled;
   GList *ordered_selectors;
 };
 
@@ -49,6 +50,12 @@ _contextual_data_record_cmp(gconstpointer k1, gconstpointer k2)
   ContextualDataRecord *r2 = (ContextualDataRecord *) k2;
 
   return strcmp(r1->selector->str, r2->selector->str);
+}
+
+void
+context_info_db_enable_ordering(ContextInfoDB *self)
+{
+  self->is_ordering_enabled = TRUE;
 }
 
 GList *
@@ -217,7 +224,7 @@ context_info_db_insert(ContextInfoDB *self,
 {
   g_array_append_val(self->data, *record);
   self->is_data_indexed = FALSE;
-  if (!g_list_find_custom(self->ordered_selectors, record->selector->str, _g_strcmp))
+  if (self->is_ordering_enabled && !g_list_find_custom(self->ordered_selectors, record->selector->str, _g_strcmp))
     self->ordered_selectors = g_list_append(self->ordered_selectors, record->selector->str);
 }
 

--- a/modules/add-contextual-data/context-info-db.h
+++ b/modules/add-contextual-data/context-info-db.h
@@ -32,6 +32,7 @@ typedef struct _ContextInfoDB ContextInfoDB;
 typedef void (*ADD_CONTEXT_INFO_CB) (gpointer arg,
                                      const ContextualDataRecord *record);
 
+void context_info_db_enable_ordering(ContextInfoDB *self);
 GList * context_info_db_ordered_selectors(ContextInfoDB *self);
 ContextInfoDB *context_info_db_new();
 void context_info_db_free(ContextInfoDB *self);

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -119,6 +119,7 @@ _g_strcmp(const gconstpointer a, gconstpointer b)
 Test(add_contextual_data, test_insert)
 {
   ContextInfoDB *context_info_db = context_info_db_new();
+  context_info_db_enable_ordering(context_info_db);
 
   _fill_context_info_db(context_info_db, "selector", "name", "value", 2, 5);
   int ctr = 0;


### PR DESCRIPTION
**This pull request breaks the API of `AddContextualDataSelector`, so it MUST be merged together with our internal modules (branchname: acd-optional-ordering)**

Template based selection does not require ordering, so the time complexity of this operation is unnecessary here.

Fixes #1439