### PR TITLE
Memory leak related to cloning pipes

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -464,6 +464,8 @@ cfg_tree_compile_single(CfgTree *self, LogExprNode *node,
     {
       /* first reference to the pipe uses the same instance, further ones will get cloned */
       pipe->flags |= PIF_INLINED;
+      /* The pipe object is borrowed, so the reference counter must be increased. */
+      log_pipe_ref(pipe);
     }
   else
     {
@@ -477,7 +479,7 @@ cfg_tree_compile_single(CfgTree *self, LogExprNode *node,
         }
       pipe->flags |= PIF_INLINED;
     }
-  g_ptr_array_add(self->initialized_pipes, log_pipe_ref(pipe));
+  g_ptr_array_add(self->initialized_pipes, pipe);
   pipe->expr_node = node;
 
   if ((pipe->flags & PIF_SOURCE) == 0)

--- a/lib/rewrite/rewrite-subst.c
+++ b/lib/rewrite/rewrite-subst.c
@@ -92,7 +92,7 @@ log_rewrite_subst_clone(LogPipe *s)
   LogRewriteSubst *self = (LogRewriteSubst *) s;
   LogRewriteSubst *cloned;
 
-  cloned = (LogRewriteSubst *) log_rewrite_subst_new(log_template_ref(self->replacement), s->cfg);
+  cloned = (LogRewriteSubst *) log_rewrite_subst_new(self->replacement, s->cfg);
   cloned->matcher = log_matcher_ref(self->matcher);
   cloned->super.value_handle = self->super.value_handle;
 


### PR DESCRIPTION
There are two kind of memory leaks in syslog-ng related to cloning pipes. One of them is general: all clone invocations are affected. The other one is rewrite rule specific.
Please see the commit messages for detailed explanation of the issues and the patches.

These memory leaks can be reproduced if one defines a named filter/rewrite rule, and refer them twice in the configuration. For example:
```
@version: 3.11
@include "scl.conf"
filter f_warn  { level(warn, err, crit)  };
log {
  filter(f_warn);
  filter(f_warn);
};
```
These leaks are accumulated during reload.

As a workaround: configuration can be changed to use every reference only once.

Reported in: https://github.com/balabit/syslog-ng/issues/1317