### PR TITLE
memleak hunting: cleanup based on valgrind report

### DIFF
--- a/contrib/valgrind/syslog-ng.supp
+++ b/contrib/valgrind/syslog-ng.supp
@@ -24,6 +24,14 @@
 
 ## Miscellaneous non-leaks and false alarms
 {
+   suppress_journald_open: see https://github.com/systemd/systemd/issues/6539
+   Memcheck:Leak
+   ...
+   fun:journald_open
+   ...
+}
+
+{
    suppress_syslog_ng_set_argv_space
    Memcheck:Leak
    fun:*alloc
@@ -48,17 +56,6 @@
    ...
    fun:app_startup
    fun:main
-}
-
-{
-    suppress_syslog_ng_path_resolver
-    Memcheck:Leak
-    fun:*alloc
-    ...
-    fun:path_resolver_new
-    ...
-    fun:main_loop_global_init
-    fun:main
 }
 
 {
@@ -105,15 +102,6 @@
 }
 
 {
-     suppress_syslog_ng_reloc
-     Memcheck:Leak
-     fun:*alloc
-     ...
-     fun:cache_*
-     fun:get_installation_path_for
-}
-
-{
      suppress_syslog_ng_msg_limit_internal_message
      Memcheck:Leak
      fun:*alloc
@@ -130,14 +118,6 @@
      ...
      fun:msg_event_create
      fun:main_loop_run
-}
-
-{
-     suppress_syslog_ng_aftiner_message_posted
-     Memcheck:Leak
-     fun:*alloc
-     ...
-     fun:afinter_message_posted
 }
 
 {
@@ -190,30 +170,12 @@
 }
 
 {
-   suppress_crypto_ERR_leaks
-   Memcheck:Leak
-   fun:*alloc
-   ...
-   obj:*/libcrypto.so.*
-   fun:ERR_*
-}
-
-{
    suppress_crypto_OCSP_leaks
    Memcheck:Leak
    fun:*alloc
    ...
    obj:*/libcrypto.so.*
    fun:OCSP_*
-}
-
-{
-   suppress_crypto_EVP_leaks
-   Memcheck:Leak
-   fun:*alloc
-   ...
-   obj:*/libcrypto.so.*
-   fun:EVP_*
 }
 
 ## TLS/SSL related syslog-ng leaks

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -458,3 +458,19 @@ afinter_global_init(void)
 {
   register_application_hook(AH_POST_CONFIG_LOADED, afinter_register_posted_hook, NULL);
 }
+
+void
+afinter_global_deinit(void)
+{
+  if (internal_msg_queue)
+    {
+      stats_lock();
+      StatsClusterKey sc_key;
+      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL );
+      stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
+      stats_unlock();
+      g_queue_free_full(internal_msg_queue, (GDestroyNotify)log_msg_unref);
+      internal_msg_queue = NULL;
+    }
+  current_internal_source = NULL;
+}

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -41,5 +41,6 @@ typedef struct _AFInterSourceDriver
 void afinter_postpone_mark(gint mark_freq);
 LogDriver *afinter_sd_new(GlobalConfig *cfg);
 void afinter_global_init(void);
+void afinter_global_deinit(void);
 
 #endif

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -176,6 +176,7 @@ app_shutdown(void)
   log_tags_global_deinit();
   log_msg_global_deinit();
 
+  afinter_global_deinit();
   stats_destroy();
   child_manager_deinit();
   g_list_foreach(application_hooks, (GFunc) g_free, NULL);

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -29,6 +29,19 @@
 
 static GList *command_list = NULL;
 
+GList *
+get_control_command_list()
+{
+  return command_list;
+}
+
+void
+reset_control_command_list()
+{
+  g_list_free_full(command_list, (GDestroyNotify)g_free);
+  command_list = NULL;
+}
+
 void
 control_register_command(const gchar *command_name, const gchar *description, CommandFunction function,
                          gpointer user_data)

--- a/lib/control/control-commands.h
+++ b/lib/control/control-commands.h
@@ -30,5 +30,7 @@
 
 void control_register_command(const gchar *command_name, const gchar *description, CommandFunction function, gpointer user_data);
 GList *control_register_default_commands(MainLoop *main_loop);
+GList *get_control_command_list();
+void reset_control_command_list();
 
 #endif

--- a/lib/crypto.c
+++ b/lib/crypto.c
@@ -33,6 +33,9 @@
 
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
 #include <stdio.h>
 
 static gboolean randfile_loaded;
@@ -48,6 +51,10 @@ crypto_deinit(void)
       if (rnd_file[0])
         RAND_write_file(rnd_file);
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  ERR_free_strings();
+  EVP_cleanup();
+#endif
   openssl_crypto_deinit_threading();
 }
 
@@ -73,4 +80,3 @@ crypto_init(void)
                 "WARNING: a trusted random number source is not available, crypto operations will probably fail. Please set the RANDFILE environment variable.");
     }
 }
-

--- a/lib/messages.c
+++ b/lib/messages.c
@@ -261,6 +261,9 @@ msg_post_message(LogMessage *msg)
     log_msg_unref(msg);
 }
 
+static guint g_log_handler_id;
+static guint glib_handler_id;
+
 void
 msg_init(gboolean interactive)
 {
@@ -269,8 +272,8 @@ msg_init(gboolean interactive)
 
   if (!interactive)
     {
-      g_log_set_handler(G_LOG_DOMAIN, 0xff, msg_log_func, NULL);
-      g_log_set_handler("GLib", 0xff, msg_log_func, NULL);
+      g_log_handler_id = g_log_set_handler(G_LOG_DOMAIN, 0xff, msg_log_func, NULL);
+      glib_handler_id = g_log_set_handler("GLib", 0xff, msg_log_func, NULL);
     }
   else
     {
@@ -285,7 +288,19 @@ void
 msg_deinit(void)
 {
   evt_ctx_free(evt_context);
+  evt_context = NULL;
   log_stderr = TRUE;
+
+  if (g_log_handler_id)
+    {
+      g_log_remove_handler(G_LOG_DOMAIN, g_log_handler_id);
+      g_log_handler_id = 0;
+    }
+  if (glib_handler_id)
+    {
+      g_log_remove_handler("GLib", glib_handler_id);
+      glib_handler_id = 0;
+    }
 }
 
 static GOptionEntry msg_option_entries[] =

--- a/lib/reloc.c
+++ b/lib/reloc.c
@@ -179,3 +179,13 @@ get_installation_path_for(const gchar *template)
     path_cache = cache_new(path_resolver_new(lookup_sysprefix()));
   return cache_lookup(path_cache, template);
 }
+
+void
+reloc_deinit(void)
+{
+  if (path_cache)
+    {
+      cache_free(path_cache);
+      path_cache = NULL;
+    }
+}

--- a/lib/reloc.h
+++ b/lib/reloc.h
@@ -31,5 +31,6 @@ void path_resolver_add_configure_variable(CacheResolver *self, const gchar *name
 CacheResolver *path_resolver_new(const gchar *sysprefix);
 
 const gchar *get_installation_path_for(const gchar *template);
+void reloc_deinit(void);
 
 #endif

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -49,3 +49,9 @@ stats_register_control_commands(void)
   control_register_command("STATS", NULL, control_connection_send_stats, NULL);
   control_register_command("RESET_STATS", NULL, control_connection_reset_stats, NULL);
 }
+
+void
+stats_unregister_control_commands(void)
+{
+  reset_control_command_list();
+}

--- a/lib/stats/stats-control.h
+++ b/lib/stats/stats-control.h
@@ -27,5 +27,6 @@
 #include "syslog-ng.h"
 
 void stats_register_control_commands(void);
+void stats_unregister_control_commands(void);
 
 #endif

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -248,6 +248,7 @@ stats_destroy(void)
 {
   stats_query_deinit();
   stats_registry_deinit();
+  stats_unregister_control_commands();
 }
 
 void

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -986,4 +986,5 @@ value_pairs_global_init(void)
 void
 value_pairs_global_deinit(void)
 {
+  g_free(all_macros);
 }

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -306,6 +306,6 @@ main(int argc, char *argv[])
   app_shutdown();
   z_mem_trace_dump();
   g_process_finish();
+  reloc_deinit();
   return rc;
 }
-


### PR DESCRIPTION
This patchet intends to fix some entries in valgrind report. All of these issues are minors, i.e non of them accumulate over time. All of these changes intended to be cosmetic, explicitely calling deinits/frees, instead of just adding new exceptions to a valgrind suppress file.

Credits for @bkil-syslogng for https://github.com/balabit/syslog-ng/pull/975, which gave much inspiration for this pull request.
Only there are two commits in 975 that were not ported. I list them here for documentation reason.
-  g_process_set_argv_space. There were a lot of fight on these recently. The proposed change is still incomplete, see https://github.com/balabit/syslog-ng/pull/1528 for details.
- g_static_mutex_free. Syslog-ng mutexes are typically statically initialized. The glib documentation states that "[...] You don't have to call this functions for a GStaticMutex with an unbounded lifetime, i.e. objects declared 'static', [...]". In the glib implementation, when someone calls lock in the first time on such a static mutex, glib will allocate using malloc on the fly, but there is no automatic deallocation mechanism provided. As that malloc is not freed, valgrind reports it as still reachable memory. The suggested patch calls explicitely g_static_mutex_free-s on these objects. This should work, though I feel this change somewhat risky, because the documentation states we do not have to call such function. There is a small chance (very low, because we are talking about a deprecated mutex api to begin with ...) that some automatic deallocation would be introduced glib at some point. Especially, this leak comes from the design of glib, I don't want to fix it from syslog-ng side. That's why I did not pick that patch.

Edit:
<strike>The dns_cache part is reported in: https://github.com/balabit/syslog-ng/issues/1400</strike>
dns_cache will be handled in a separate pull request. 