### PR TITLE
logmsg: sanitize sdata keys

### DIFF
--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -97,7 +97,7 @@ assert_sdata_value_with_seqnum_equals(LogMessage *msg, guint32 seq_num, const gc
   GString *result = g_string_sized_new(0);
 
   log_msg_append_format_sdata(msg, result, seq_num);
-  cr_assert_str_eq(result->str, expected, "SDATA value does not match");
+  cr_assert_str_eq(result->str, expected, "SDATA value does not match, '%s' vs '%s'", expected, result->str);
   g_string_free(result, TRUE);
 }
 
@@ -330,6 +330,40 @@ Test(log_message, test_local_logmsg_created_with_the_right_flags_and_timestamps)
 
   cr_assert_neq((msg->flags & LF_LOCAL), 0, "LogMessage created by log_msg_new_local() should have LF_LOCAL flag set");
   cr_assert(are_equals, "The timestamps in a LogMessage created by log_msg_new_local() should be equals");
+}
+
+Test(log_message, test_sdata_sanitize_keys)
+{
+  LogMessage *msg;
+  /* These keys looks strange, but JSON object can be parsed to SDATA,
+   * so the key could contain any character, while the specification
+   * does not declare any way to encode the the keys, just the values.
+   * The goal is to have a syntactically valid syslog message. */
+
+  msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, ".SDATA.foo.bar[0]", "value[0]", -1);
+  assert_sdata_value_equals(msg, "[foo bar%5B0%5D=\"value[0\\]\"]");
+  log_msg_unref(msg);
+
+  msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, ".SDATA.foo.bácsi", "bácsi", -1);
+  assert_sdata_value_equals(msg, "[foo b%C3%A1csi=\"bácsi\"]");
+  log_msg_unref(msg);
+
+  msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, ".SDATA.foo.sp ace", "sp ace", -1);
+  assert_sdata_value_equals(msg, "[foo sp%20ace=\"sp ace\"]");
+  log_msg_unref(msg);
+
+  msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, ".SDATA.foo.eq=al", "eq=al", -1);
+  assert_sdata_value_equals(msg, "[foo eq%3Dal=\"eq=al\"]");
+  log_msg_unref(msg);
+
+  msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, ".SDATA.foo.quo\"te", "quo\"te", -1);
+  assert_sdata_value_equals(msg, "[foo quo%22te=\"quo\\\"te\"]");
+  log_msg_unref(msg);
 }
 
 Test(log_message, test_sdata_value_is_updated_by_sdata_name_value_pairs)


### PR DESCRIPTION
Any JSON object can be parsed to SDATA, so the key could contain any character, while the specification does not declare any way to encode the the keys, just the values.

The goal is to have a syntactically valid syslog message.

Fixes #1583

# SDATA keys in the [RFC 5424](https://www.rfc-editor.org/rfc/rfc5424.txt)

```
...
      STRUCTURED-DATA = NILVALUE / 1*SD-ELEMENT
      SD-ELEMENT      = "[" SD-ID *(SP SD-PARAM) "]"
      SD-PARAM        = PARAM-NAME "=" %d34 PARAM-VALUE %d34
      SD-ID           = SD-NAME
      PARAM-NAME      = SD-NAME
...
      SD-NAME         = 1*32PRINTUSASCII
                        ; except '=', SP, ']', %d34 (")
...
      SP              = %d32
      PRINTUSASCII    = %d33-126
...
```