### PR TITLE
logmsg: fix compiler warning

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -38,6 +38,7 @@
 #include "lib/host-id.h"
 #include "ack_tracker.h"
 
+#include <glib/gprintf.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
In eee3bb4bf61ad03785e97c86a18b208155f09790, a `g_sprintf()` call has been introduced, which is declared only in gprintf.h (because of the stdio dependency).

>Note that the functions g_printf(), g_fprintf(), g_sprintf(), g_snprintf(), g_vprintf(), g_vfprintf(), g_vsprintf() and g_vsnprintf() are declared in the header gprintf.h which is not included in glib.h (otherwise using glib.h would drag in stdio.h), so you'll have to explicitly include <glib/gprintf.h> in order to use the GLib printf() functions.

This PR should not be added to the NEWS file.