### PR TITLE
python: regression in python version auto-detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1310,13 +1310,11 @@ dnl python checks
 dnl ***************************************************************************
 if test "x$enable_python" != "xno"; then
   if test "x$with_python" = "xauto"; then
-    PKG_CHECK_MODULES(PYTHON, python3 >= 3, python_found="yes", python_found="no")
-    if test "$python_found" = "yes"; then
-      with_python="python3"
-    else
-      PKG_CHECK_MODULES(PYTHON, python2 >= 2.6, python_found="yes", python_found="no")
-      if test "$python_found" = "yes"; then
-        with_python="python2"
+    PKG_CHECK_MODULES(PYTHON, python3, python_found="yes", python_found="no")
+    if test "$python_found" = "no"; then
+      PKG_CHECK_MODULES(PYTHON, python2, python_found="yes", python_found="no")
+      if test "$python_found" = "no"; then
+        PKG_CHECK_MODULES(PYTHON, python, python_found="yes", python_found="no")
       fi
     fi
   else
@@ -1329,7 +1327,14 @@ if test "x$enable_python" != "xno"; then
           ;;
     esac
 
-    PKG_CHECK_MODULES(PYTHON, $with_python >= 2.6, python_found="yes", python_found="no")
+    PKG_CHECK_MODULES(PYTHON, $with_python, python_found="yes", python_found="no")
+  fi
+
+  if test "x$python_found" = "xyes"; then
+    old_LIBS=$LIBS
+    LIBS="$LIBS $PYTHON_LIBS"
+    AC_CHECK_FUNCS(PyUnicode_AsUTF8, with_python=python3, with_python=python2)
+    LIBS=$old_LIBS
   fi
 
   if test "x$enable_python" = "xyes" -a "x$python_found" = "xno"; then


### PR DESCRIPTION
Introduced in: https://github.com/balabit/syslog-ng/pull/1632
A distribution might not label python pkg-config pc file as python2 or
python3. In such case auto-detection will not work.

In case of autodetection, we will look for pc files in this order:
python3, python2, python. This will work on even archlinux where only
python2 or python3 is used.

The decision between v2 and v3 will be done later by a call to
AC_CHECK_FUNCS instead.