### PR TITLE
[getent] protocol number look up by name returns incorrect number

### DIFF
--- a/modules/getent/getent-protocols.c
+++ b/modules/getent/getent-protocols.c
@@ -39,7 +39,7 @@ tf_getent_protocols(gchar *key, gchar *member_name, GString *result)
   if (is_num)
     g_string_append(result, res->p_name);
   else
-    g_string_append_printf(result, "%i", htons(res->p_proto));
+    g_string_append_printf(result, "%d", res->p_proto);
 
   return TRUE;
 }


### PR DESCRIPTION
The `p_proto` returned by  `getprotobyname_r` does not require the `htons` call.
(See the man page for `getprotobyname_r`.)

Signed-off-by: kokan <peter.kokai@balabit.com>