### PR TITLE
dns-cache: during shutdown: possible use after free

### DIFF
--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -58,7 +58,7 @@ volatile gboolean main_loop_workers_quit;
 volatile gboolean is_reloading_scheduled;
 
 /* number of I/O worker jobs running */
-static gint main_loop_workers_running;
+static gint main_loop_jobs_running;
 
 static struct iv_task main_loop_workers_reenable_jobs_task;
 
@@ -202,7 +202,7 @@ main_loop_worker_job_start(void)
 {
   main_loop_assert_main_thread();
 
-  main_loop_workers_running++;
+  main_loop_jobs_running++;
 }
 
 typedef struct
@@ -250,8 +250,8 @@ main_loop_worker_job_complete(void)
 {
   main_loop_assert_main_thread();
 
-  main_loop_workers_running--;
-  if (main_loop_workers_quit && main_loop_workers_running == 0)
+  main_loop_jobs_running--;
+  if (main_loop_workers_quit && main_loop_jobs_running == 0)
     {
       /* NOTE: we can't reenable I/O jobs by setting
        * main_loop_io_workers_quit to FALSE right here, because a task
@@ -378,7 +378,7 @@ main_loop_worker_sync_call(void (*func)(gpointer user_data), gpointer user_data)
 
   _register_sync_call_action(&sync_call_actions, func, user_data);
 
-  if (main_loop_workers_running == 0)
+  if (main_loop_jobs_running == 0)
     {
       _invoke_sync_call_actions();
       _reenable_worker_jobs(NULL);

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -176,6 +176,11 @@ main_loop_worker_thread_start(void *cookie)
 
   _allocate_thread_id();
   INIT_IV_LIST_HEAD(&batch_callbacks);
+
+  g_mutex_lock(&workers_running_lock);
+  main_loop_workers_running++;
+  g_mutex_unlock(&workers_running_lock);
+
   app_thread_start();
 }
 
@@ -185,6 +190,12 @@ main_loop_worker_thread_stop(void)
 {
   app_thread_stop();
   _release_thread_id();
+
+  g_mutex_lock(&workers_running_lock);
+  main_loop_workers_running--;
+  g_mutex_unlock(&workers_running_lock);
+
+  g_cond_signal(&thread_halt_cond);
 }
 
 void

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -89,6 +89,8 @@
  */
 
 ThreadId main_thread_handle;
+GCond thread_halt_cond;
+GMutex workers_running_lock = G_STATIC_MUTEX_INIT;
 
 struct _MainLoop
 {
@@ -295,6 +297,25 @@ main_loop_reload_config_initiate(gpointer user_data)
 
   is_reloading_scheduled = TRUE;
   main_loop_worker_sync_call(main_loop_reload_config_apply, self);
+}
+
+static void
+block_till_workers_exit()
+{
+  gint64 end_time;
+  end_time = g_get_monotonic_time() + 15*G_TIME_SPAN_SECOND;
+
+  g_mutex_lock(&workers_running_lock);
+  while (main_loop_workers_running)
+    if (!g_cond_wait_until(&thread_halt_cond, &workers_running_lock, end_time))
+      {
+        /* timeout has passed. */
+        fprintf(stderr, "Main thread timed out (15s) while waiting workers threads to exit. "
+                "workers_running: %d. Continuing ...\n", main_loop_workers_running);
+        break;
+      }
+
+  g_mutex_unlock (&workers_running_lock);
 }
 
 /************************************************************************************
@@ -511,6 +532,7 @@ main_loop_deinit(MainLoop *self)
   main_loop_call_deinit();
   main_loop_io_worker_deinit();
   main_loop_worker_deinit();
+  block_till_workers_exit();
   scratch_buffers_automatic_gc_deinit();
 }
 

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -27,6 +27,8 @@
 #include "syslog-ng.h"
 #include "thread-utils.h"
 
+volatile gint main_loop_workers_running;
+
 typedef struct _MainLoop MainLoop;
 
 typedef struct _MainLoopOptions
@@ -38,6 +40,8 @@ typedef struct _MainLoopOptions
 } MainLoopOptions;
 
 extern ThreadId main_thread_handle;
+extern GCond thread_halt_cond;
+extern GMutex workers_running_lock;
 
 typedef gpointer (*MainLoopTaskFunc)(gpointer user_data);
 


### PR DESCRIPTION
During shutdown, mainloop did not wait worker threads to stop: app_shutdown and app_thread_stop was racing. This could lead to a use after free issue in the code: a dns_cache object could be returned to an already unallocated pool: unused_dns_caches.

Two possible resolutions to the problem:
- Reference counting for unused_dns_caches.
- Blocking mainloop until all workers exit.

This patchset contains both versions. I would like to open up a discussion if we need either one or both. 

Me seems reference counting is simpler in terms of code complexity, and has less possible side effects comparing to the version of blocking mainloop. Though the latter one could eliminate the currently unknown or possible future race conditions of these functions as well.

I could only manually test the blocking mainloop version by adding some printf-s to the beginning and the end of the racing functions, and see if the debug-log sandwich form turns into a disjoint form. In the end, leaving these debug logs felt awkward in the code, so I removed them in the final version. Feel free to indicate if I should put them back, or if anyone has any more reasonable idea to test such thing.

The reference counting is tested only manually as well: in a simple file source file destination configuration, sending a single message created a thread with a dns_cache, and stopping syslog-ng instantly after that caused an entry in the valgrind report. On my development machine, unused_dns_caches was steadily freed before the dns_cache was appended to the list so reproducing was not a problem.

This ticket intends to resolve the dns_cache part of the two issues reported in: https://github.com/balabit/syslog-ng/issues/1400