### PR TITLE
elasticsearch.http: implemented onMessageQueueEmpty function

### DIFF
--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -113,4 +113,9 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 		client.deinit();
 		options.deinit();
 	}
+
+	@Override
+	public void onMessageQueueEmpty() {
+	    client.onMessageQueueEmpty();
+	}
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -33,4 +33,5 @@ public interface ESClient {
 	void deinit();
 	boolean send(ESIndex index);
 	String getClusterName();
+	void onMessageQueueEmpty();
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESNativeClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESNativeClient.java
@@ -143,4 +143,9 @@ public abstract class ESNativeClient implements ESClient {
 	public boolean send(ESIndex index) {
 		return messageProcessor.send(index);
 	}
+
+    @Override
+    public void onMessageQueueEmpty() {
+
+    }
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -166,4 +166,9 @@ public class ESHttpClient implements ESClient {
 		}
 		return clusterName;
 	}
+
+    @Override
+    public void onMessageQueueEmpty() {
+        messageProcessor.onMessageQueueEmpty();
+    }
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
@@ -72,4 +72,9 @@ public class HttpBulkMessageProcessor extends  HttpMessageProcessor {
 		messageCounter++;
 		return true;
 	}
+
+    @Override
+    public void onMessageQueueEmpty() {
+        flush();
+    }
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
@@ -60,4 +60,8 @@ public abstract class HttpMessageProcessor implements ESMessageProcessor {
 		Index req = new Index.Builder(index.getFormattedMessage()).index(index.getIndex()).type(index.getType()).id(index.getId()).build();
 		return send(req);
 	}
+
+    public void onMessageQueueEmpty() {
+
+    }
 }


### PR DESCRIPTION
Fixes: #1509
Flush the message automatically when there are no more message in the queue.
Earlier it caused problem when there were less messages than flush_limit() and syslog-ng
does not flush them only at reload/restart.

Possible side effects: if the messages come slower syslog-ng will flush more often
instead of waiting flush_limit().

The classes inherited from ESNativeClient does not use this method
because the bulkprocessor here is responsible for the auto flush.


Signed-off-by: Zoltan Pallagi <pzolee@balabit.com>