### PR TITLE
HDFS destination: Added append support

### DIFF
--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
@@ -41,6 +41,8 @@ public class HdfsOptions {
     public static String KERBEROS_KEYTAB_FILE = "kerberos_keytab_file";
     public static String TEMPLATE = "template";
     public static String TEMPLATE_DEFAULT = "${ISODATE} ${HOST} ${MSGHDR}${MSG}\n";
+    public static String APPEND_ENABLED = "hdfs_append_enabled";
+    public static String APPEND_ENABLED_DEFAULT = "false";
 
     private LogDestination owner;
     private Options options;
@@ -98,6 +100,11 @@ public class HdfsOptions {
 
     private void fillOptions() {
         fillStringOptions();
+        fillBooleanOptions();
+    }
+
+    public boolean getAppendEnabled() {
+        return options.get(APPEND_ENABLED).getValueAsBoolean();
     }
 
     private void fillStringOptions() {
@@ -107,6 +114,10 @@ public class HdfsOptions {
         options.put(new StringOption(owner, MAX_FILENAME_LENGTH, MAX_FILENAME_LENGTH_DEFAULT));
         options.put(new StringOption(owner, KERBEROS_PRINCIPAL));
         options.put(new StringOption(owner, KERBEROS_KEYTAB_FILE));
+    }
+
+    private void fillBooleanOptions() {
+        options.put(new BooleanOptionDecorator(new StringOption(owner, APPEND_ENABLED, APPEND_ENABLED_DEFAULT)));
     }
 
     private void fillTemplateOptions() {

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -32,6 +32,7 @@ block destination hdfs(
   kerberos_principal("")
   kerberos_keytab_file("")
   template("")
+  hdfs_append_enabled("")
 )
 {
   java(
@@ -45,6 +46,7 @@ block destination hdfs(
     option("kerberos_principal", `kerberos_principal`)
     option("kerberos_keytab_file", `kerberos_keytab_file`)
     option("template", `template`)
+    option("hdfs_append_enabled", `hdfs_append_enabled`)
     `__VARARGS__`
   );
 };


### PR DESCRIPTION
New option: hdfs_append_enabled("true|false"), default: false
When this option is enabled, syslog-ng will append the file if it already exists.
In that case, syslog-ng does not extend the filename with a unique id as earlier.

!!!
Warning: always ensure that your hdfs server supports append (and it is enabled) before enable this option!
!!!

Note: if you have a very small hdfs cluster (number of nodes < replication factor, for example for testing purpose), you can receive
"Failed to replace a bad datanode on the existing pipeline due to no more good datanodes being available to try"
error message at flush. In that case either decrease the value of dfs.replication or
add dfs.client.block.write.replace-datanode-on-failure.policy key with "NEVER" value
in hdfs-site.xml and give it as resource in the configuration. If you receive this error message
in a production ready hdfs cluster, that means your cluster is not healthy.

Signed-off-by: Zoltan Pallagi <pzolee@balabit.com>