### PR TITLE
Binary template function

### DIFF
--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -149,7 +149,7 @@ _parse_number(const gchar *s, gchar **endptr, gint64 *d)
   gint64 val;
 
   errno = 0;
-  val = strtoll(s, endptr, 10);
+  val = strtoll(s, endptr, 0);
 
   if (errno == ERANGE || errno == EINVAL)
     return FALSE;

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -82,6 +82,15 @@ test_simple_numbers_are_parsed_properly(void)
 }
 
 static void
+test_c_like_prefixes_select_base(void)
+{
+  assert_parse("0x20", 32);
+  assert_parse("020", 16);
+  assert_parse("20", 20);
+  assert_parse_with_suffix("0x20kiB", 32 * 1024);
+}
+
+static void
 test_exponent_suffix_is_parsed_properly(void)
 {
   assert_parse_with_suffix("1K", 1000);
@@ -137,6 +146,7 @@ main(int argc, char *argv[])
   test_byte_units_are_accepted();
   test_base2_is_selected_by_an_i_modifier();
   test_invalid_formats_are_not_accepted();
+  test_c_like_prefixes_select_base();
 
   return 0;
 }

--- a/libtest/template_lib.h
+++ b/libtest/template_lib.h
@@ -37,6 +37,10 @@ void assert_template_format_with_escaping_msg(const gchar *template, gboolean es
                                      const gchar *expected, LogMessage *msg);
 void assert_template_format_with_context(const gchar *template, const gchar *expected);
 void assert_template_format_with_context_msgs(const gchar *template, const gchar *expected, LogMessage **msgs, gint num_messages);
+void assert_template_format_with_len(const gchar *template, const gchar *expected, gssize expected_len);
+void assert_template_format_with_escaping_and_context_msgs(const gchar *template, gboolean escaping,
+                                                           const gchar *expected, gssize expected_len,
+                                                           LogMessage **msgs, gint num_messages);
 void assert_template_failure(const gchar *template, const gchar *expected_failure);
 void perftest_template(gchar *template);
 

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -70,6 +70,7 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_uppercase, "uppercase"),
   TEMPLATE_FUNCTION_PLUGIN(tf_replace_delimiter, "replace-delimiter"),
   TEMPLATE_FUNCTION_PLUGIN(tf_string_padding, "padding"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_binary, "binary"),
 
   /* fname-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_dirname, "dirname"),

--- a/modules/basicfuncs/cond-funcs.c
+++ b/modules/basicfuncs/cond-funcs.c
@@ -40,7 +40,8 @@ tf_cond_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
   lexer = cfg_lexer_new_buffer(argv[1], strlen(argv[1]));
   if (!cfg_run_parser(parent->cfg, lexer, &filter_expr_parser, (gpointer *) &state->filter, NULL))
     {
-      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE, "Error parsing conditional filter expression");
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(%s) Error parsing conditional filter expression", argv[0]);
       return FALSE;
     }
   memmove(&argv[1], &argv[2], sizeof(argv[0]) * (argc - 2));

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -153,6 +153,14 @@ test_str_funcs(void)
   assert_template_format("$(padding foo 10)", "       foo");
   assert_template_format("$(padding foo 10 x)", "xxxxxxxfoo");
   assert_template_format("$(padding foo 10 abc)", "abcabcafoo");
+
+  assert_template_failure("$(binary)", "Incorrect parameters");
+  assert_template_failure("$(binary abc)", "unable to parse abc");
+  assert_template_failure("$(binary 256)", "256 is above 255");
+  assert_template_format("$(binary 1)", "\1");
+  assert_template_format("$(binary 1 0x1)", "\1\1");
+  assert_template_format("$(binary 0xFF 255 0377)", "\xFF\xFF\xFF");
+  assert_template_format_with_len("$(binary 0xFF 0x00 0x40)", "\xFF\000@", 3);
 }
 
 void

--- a/modules/basicfuncs/tf-template.c
+++ b/modules/basicfuncs/tf-template.c
@@ -36,7 +36,8 @@ tf_template_lookup_invoked_template(TFTemplateState *state, GlobalConfig *cfg, c
   state->invoked_template = cfg_tree_lookup_template(&cfg->tree, function_name);
   if (!state->invoked_template)
     {
-      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE, "Unknown template function or template \"%s\"",
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(template) Unknown template function or template \"%s\"",
                   function_name);
       return FALSE;
     }


### PR DESCRIPTION
This branch adds a $(binary) template function, evolving the code originally found in PR #531 

The rationale of this function needs some explanation, as the configuration lexer enables us to encode binary characters in any string, by using C like backslash escapes, e.g. this should work:

template("\x00");

The issue with that is that the lexer->grammar interface does not support embedded NUL characters, thus anything past the NUL would be dropped when the configuration is loaded.

With this function the sample above would become:

template("$(binary 0x00)");

Which is properly parsed, and the embedded zero would only be processed by the destination, which might be supporting embedded NULs. All LogWriter based destinations (file, socket based stuff, program(), pipe, etc) do support that, so this is actually a useful feature.