### PR TITLE
Astyle for headers, minor travis improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
       - sudo apt-get install -qq
           astyle
       before_script:
+      - astyle --version
       script:
       - scripts/style-checker.sh format
       - git diff --exit-code

--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -32,7 +32,7 @@ struct _AckTracker
 {
   gboolean late;
   LogSource *source;
-  Bookmark* (*request_bookmark)(AckTracker *self);
+  Bookmark *(*request_bookmark)(AckTracker *self);
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, AckType ack_type);
 };
@@ -42,8 +42,8 @@ struct _AckRecord
   AckTracker *tracker;
 };
 
-AckTracker* late_ack_tracker_new(LogSource *source);
-AckTracker* early_ack_tracker_new(LogSource *source);
+AckTracker *late_ack_tracker_new(LogSource *source);
+AckTracker *early_ack_tracker_new(LogSource *source);
 
 void late_ack_tracker_free(AckTracker *self);
 void early_ack_tracker_free(AckTracker *self);
@@ -66,7 +66,7 @@ ack_tracker_is_late(AckTracker *self)
   return self->late;
 }
 
-static inline Bookmark*
+static inline Bookmark *
 ack_tracker_request_bookmark(AckTracker *self)
 {
   return self->request_bookmark(self);

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef SDINTER_H_INCLUDED
 #define SDINTER_H_INCLUDED
 

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef APPHOOK_H_INCLUDED
 #define APPHOOK_H_INCLUDED
 

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef ATOMIC_H_INCLUDED
 #define ATOMIC_H_INCLUDED
 
@@ -73,7 +73,7 @@ g_atomic_counter_set(GAtomicCounter *c, gint value)
    * thus atomic write is not strictly needed as there's no concurrency
    * while initializing a refcounter.
    */
-  
+
   c->counter = value;
 }
 

--- a/lib/cfg-lexer-subst.h
+++ b/lib/cfg-lexer-subst.h
@@ -30,12 +30,14 @@
 
 typedef struct _CfgLexerSubst CfgLexerSubst;
 
-gchar *cfg_lexer_subst_invoke(CfgLexerSubst *self, const gchar *input, gssize input_len, gsize *output_length, GError **error);
+gchar *cfg_lexer_subst_invoke(CfgLexerSubst *self, const gchar *input, gssize input_len, gsize *output_length,
+                              GError **error);
 
 CfgLexerSubst *cfg_lexer_subst_new(CfgArgs *globals, CfgArgs *defs, CfgArgs *args);
 void cfg_lexer_subst_free(CfgLexerSubst *self);
 
 gchar *
-cfg_lexer_subst_args_in_input(CfgArgs *globals, CfgArgs *defs, CfgArgs *args, const gchar *input, gssize input_length, gsize *output_length, GError **error);
+cfg_lexer_subst_args_in_input(CfgArgs *globals, CfgArgs *defs, CfgArgs *args, const gchar *input, gssize input_length,
+                              gsize *output_length, GError **error);
 
 #endif

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -157,7 +157,7 @@ gboolean cfg_lexer_start_next_include(CfgLexer *self);
 gboolean cfg_lexer_include_file(CfgLexer *self, const gchar *filename);
 gboolean cfg_lexer_include_buffer(CfgLexer *self, const gchar *name, const gchar *buffer, gssize length);
 gboolean cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self,
-                                                                const gchar *name, const gchar *buffer, gsize length);
+    const gchar *name, const gchar *buffer, gsize length);
 EVTTAG *cfg_lexer_format_location_tag(CfgLexer *self, YYLTYPE *yylloc);
 
 /* context tracking */

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -129,7 +129,8 @@ void log_expr_node_set_object(LogExprNode *self, gpointer object, GDestroyNotify
 const gchar *log_expr_node_format_location(LogExprNode *self, gchar *buf, gsize buf_len);
 EVTTAG *log_expr_node_location_tag(LogExprNode *self);
 
-LogExprNode *log_expr_node_new(gint layout, gint content, const gchar *name, LogExprNode *children, guint32 flags, YYLTYPE *yylloc);
+LogExprNode *log_expr_node_new(gint layout, gint content, const gchar *name, LogExprNode *children, guint32 flags,
+                               YYLTYPE *yylloc);
 void log_expr_node_free(LogExprNode *self);
 
 LogExprNode *log_expr_node_new_pipe(LogPipe *pipe, YYLTYPE *yylloc);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef CFG_H_INCLUDED
 #define CFG_H_INCLUDED
 
@@ -61,7 +61,7 @@ struct _GlobalConfig
   /* version number specified by the user, set _after_ parsing is complete */
   /* hex-encoded syslog-ng major/minor, e.g. 0x0201 is syslog-ng 2.1 format */
   gint user_version;
-  
+
   /* version number as parsed from the configuration file, it can be set
    * multiple times if the user uses @version multiple times */
   gint parsed_version;
@@ -99,24 +99,24 @@ struct _GlobalConfig
   GList *source_mangle_callback_list;
   gboolean use_uniqid;
 
-  gboolean keep_timestamp;  
+  gboolean keep_timestamp;
 
   gchar *recv_time_zone;
   LogTemplateOptions template_options;
   HostResolveOptions host_resolve_options;
-  
+
   gchar *file_template_name;
   gchar *proto_template_name;
 
   gchar *jvm_options;
-  
+
   LogTemplate *file_template;
   LogTemplate *proto_template;
-  
+
   PersistConfig *persist;
   PersistState *state;
   GHashTable *module_config;
-  
+
   CfgTree tree;
 
 };
@@ -153,7 +153,8 @@ gboolean cfg_deinit(GlobalConfig *cfg);
 PersistConfig *persist_config_new(void);
 void persist_config_free(PersistConfig *self);
 void cfg_persist_config_move(GlobalConfig *src, GlobalConfig *dest);
-void cfg_persist_config_add(GlobalConfig *cfg, const gchar *name, gpointer value, GDestroyNotify destroy, gboolean force);
+void cfg_persist_config_add(GlobalConfig *cfg, const gchar *name, gpointer value, GDestroyNotify destroy,
+                            gboolean force);
 gpointer cfg_persist_config_fetch(GlobalConfig *cfg, const gchar *name);
 
 typedef gboolean(* mangle_callback)(GlobalConfig *cfg, LogMessage *msg, gpointer user_data);
@@ -179,6 +180,6 @@ cfg_set_use_uniqid(gboolean flag)
 
 gint cfg_get_user_version(const GlobalConfig *cfg);
 gint cfg_get_parsed_version(const GlobalConfig *cfg);
-const gchar* cfg_get_filename(const GlobalConfig *cfg);
+const gchar *cfg_get_filename(const GlobalConfig *cfg);
 
 #endif

--- a/lib/children.h
+++ b/lib/children.h
@@ -21,14 +21,15 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef CHILDREN_H_INCLUDED
 #define CHILDREN_H_INCLUDED
 
 #include "syslog-ng.h"
 #include <sys/types.h>
 
-void child_manager_register(pid_t pid, void (*callback)(pid_t, int, gpointer), gpointer user_data, GDestroyNotify user_data_destroy);
+void child_manager_register(pid_t pid, void (*callback)(pid_t, int, gpointer), gpointer user_data,
+                            GDestroyNotify user_data_destroy);
 void child_manager_unregister(pid_t pid);
 void child_manager_sigchild(pid_t pid, int status);
 

--- a/lib/compat/getent-bb.h
+++ b/lib/compat/getent-bb.h
@@ -32,20 +32,20 @@
 #include <netdb.h>
 
 int bb__getprotobynumber_r(int proto,
-			   struct protoent *result_buf, char *buf,
-			   size_t buflen, struct protoent **result);
+                           struct protoent *result_buf, char *buf,
+                           size_t buflen, struct protoent **result);
 
 int bb__getprotobyname_r(const char *name,
-			 struct protoent *result_buf, char *buf,
-			 size_t buflen, struct protoent **result);
+                         struct protoent *result_buf, char *buf,
+                         size_t buflen, struct protoent **result);
 
 int bb__getservbyport_r(int port, const char *proto,
-			struct servent *result_buf, char *buf,
-			size_t buflen, struct servent **result);
+                        struct servent *result_buf, char *buf,
+                        size_t buflen, struct servent **result);
 
 int bb__getservbyname_r(const char *name, const char *proto,
-			struct servent *result_buf, char *buf,
-			size_t buflen, struct servent **result);
+                        struct servent *result_buf, char *buf,
+                        size_t buflen, struct servent **result);
 
 #endif
 

--- a/lib/compat/getutent.h
+++ b/lib/compat/getutent.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef COMPAT_GETUTENT_H_INCLUDED
 #define COMPAT_GETUTENT_H_INCLUDED
 

--- a/lib/compat/socket.h
+++ b/lib/compat/socket.h
@@ -32,7 +32,7 @@
 #include <netinet/in.h>
 
 #ifndef SYSLOG_NG_HAVE_STRUCT_SOCKADDR_STORAGE
-struct sockaddr_storage 
+struct sockaddr_storage
 {
   union
   {

--- a/lib/compat/string.h
+++ b/lib/compat/string.h
@@ -28,11 +28,11 @@
 
 #if !SYSLOG_NG_HAVE_STRTOLL
 # if SYSLOG_NG_HAVE_STRTOIMAX || defined(strtoimax)
-   /* HP-UX has an strtoimax macro, not a function */
-   #define strtoll(nptr, endptr, base) strtoimax(nptr, endptr, base)
+/* HP-UX has an strtoimax macro, not a function */
+#define strtoll(nptr, endptr, base) strtoimax(nptr, endptr, base)
 # else
-   /* this requires Glib 2.12 */
-   #define strtoll(nptr, endptr, base) g_ascii_strtoll(nptr, endptr, base)
+/* this requires Glib 2.12 */
+#define strtoll(nptr, endptr, base) g_ascii_strtoll(nptr, endptr, base)
 # endif
 #endif
 

--- a/lib/control/control-commands.h
+++ b/lib/control/control-commands.h
@@ -28,7 +28,8 @@
 #include "control/control.h"
 #include "mainloop.h"
 
-void control_register_command(const gchar *command_name, const gchar *description, CommandFunction function, gpointer user_data);
+void control_register_command(const gchar *command_name, const gchar *description, CommandFunction function,
+                              gpointer user_data);
 GList *control_register_default_commands(MainLoop *main_loop);
 GList *get_control_command_list(void);
 void reset_control_command_list(void);

--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -40,7 +40,8 @@ typedef struct _DNSCache DNSCache;
 
 void dns_cache_store_persistent(DNSCache *self, gint family, void *addr, const gchar *hostname);
 void dns_cache_store_dynamic(DNSCache *self, gint family, void *addr, const gchar *hostname, gboolean positive);
-gboolean dns_cache_lookup(DNSCache *self, gint family, void *addr, const gchar **hostname, gsize *hostname_len, gboolean *positive);
+gboolean dns_cache_lookup(DNSCache *self, gint family, void *addr, const gchar **hostname, gsize *hostname_len,
+                          gboolean *positive);
 DNSCache *dns_cache_new(const DNSCacheOptions *options);
 void dns_cache_free(DNSCache *self);
 

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef DRIVER_H_INCLUDED
 #define DRIVER_H_INCLUDED
 

--- a/lib/eventlog/src/evt_internals.h
+++ b/lib/eventlog/src/evt_internals.h
@@ -36,7 +36,7 @@
  * SUCH DAMAGE.
  *
  */
-                                   
+
 #ifndef __EVT_INTERNALS_H_INCLUDED
 #define __EVT_INTERNALS_H_INCLUDED
 
@@ -53,13 +53,13 @@
 #include <sys/types.h>
 
 /* whether to add the given default tag */
-#define EF_ADD_PID	0x0001
-#define EF_ADD_PROG	0x0002
-#define EF_ADD_ISOSTAMP	0x0004
-#define EF_ADD_UTCSTAMP	0x0008
-#define EF_ADD_TIMEZONE	0x0010
-#define EF_ADD_MSGID	0x0020
-#define EF_ADD_ALL	0x003F
+#define EF_ADD_PID  0x0001
+#define EF_ADD_PROG 0x0002
+#define EF_ADD_ISOSTAMP 0x0004
+#define EF_ADD_UTCSTAMP 0x0008
+#define EF_ADD_TIMEZONE 0x0010
+#define EF_ADD_MSGID  0x0020
+#define EF_ADD_ALL  0x003F
 
 #define EF_INITIALIZED  0x8000
 

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -36,7 +36,7 @@
  * SUCH DAMAGE.
  *
  */
- 
+
 #ifndef __EVTLOG_H_INCLUDED
 #define __EVTLOG_H_INCLUDED
 
@@ -69,7 +69,7 @@
 #define EVT_FAC_AUTHPRIV    (10<<3) /* security/authorization messages (private) */
 #define EVT_FAC_FTP         (11<<3) /* ftp daemon */
 
-        /* other codes through 15 reserved for system use */
+/* other codes through 15 reserved for system use */
 #define EVT_FAC_LOCAL0      (16<<3) /* reserved for local use */
 #define EVT_FAC_LOCAL1      (17<<3) /* reserved for local use */
 #define EVT_FAC_LOCAL2      (18<<3) /* reserved for local use */
@@ -151,7 +151,7 @@ EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) EVT_GNUC_PRINTF
  * @e: event record
  *
  * Formats the given event as specified by the current configuration.
- * 
+ *
  * Return value: returns a newly allocated string. The caller is responsible
  * for freeing the returned value.
  **/

--- a/lib/eventlog/src/evtmaps.h
+++ b/lib/eventlog/src/evtmaps.h
@@ -40,15 +40,15 @@
 
 /* base event map, with no namespace */
 
-#define EVT_TAG_PID		"pid"
-#define EVT_TAG_PROG		"prog"
-#define EVT_TAG_ISOSTAMP	"isostamp"
-#define EVT_TAG_UTCSTAMP	"utcstamp"
-#define EVT_TAG_TIMEZONE	"tz"
-#define EVT_TAG_MSGID		"msgid"
+#define EVT_TAG_PID   "pid"
+#define EVT_TAG_PROG    "prog"
+#define EVT_TAG_ISOSTAMP  "isostamp"
+#define EVT_TAG_UTCSTAMP  "utcstamp"
+#define EVT_TAG_TIMEZONE  "tz"
+#define EVT_TAG_MSGID   "msgid"
 
-#define EVT_TAG_FD		"fd"
-#define EVT_TAG_OSERROR		"error"
-#define EVT_TAG_FILENAME	"filename"
+#define EVT_TAG_FD    "fd"
+#define EVT_TAG_OSERROR   "error"
+#define EVT_TAG_FILENAME  "filename"
 
 #endif

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -56,7 +56,8 @@ filter_expr_init(FilterExprNode *self, GlobalConfig *cfg)
 gboolean filter_expr_eval(FilterExprNode *self, LogMessage *msg);
 gboolean filter_expr_eval_with_context(FilterExprNode *self, LogMessage **msgs, gint num_msg);
 gboolean filter_expr_eval_root(FilterExprNode *self, LogMessage **msg, const LogPathOptions *path_options);
-gboolean filter_expr_eval_root_with_context(FilterExprNode *self, LogMessage **msgs, gint num_msg, const LogPathOptions *path_options);
+gboolean filter_expr_eval_root_with_context(FilterExprNode *self, LogMessage **msgs, gint num_msg,
+                                            const LogPathOptions *path_options);
 void filter_expr_node_init_instance(FilterExprNode *self);
 FilterExprNode *filter_expr_ref(FilterExprNode *self);
 void filter_expr_unref(FilterExprNode *self);

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef G_SOCKADDR_H_INCLUDED
 #define G_SOCKADDR_H_INCLUDED
 
@@ -51,7 +51,7 @@ typedef struct _GSockAddr
   struct sockaddr sa;
 } GSockAddr;
 
-struct _GSockAddrFuncs 
+struct _GSockAddrFuncs
 {
   GIOStatus (*bind_prepare)(gint sock, GSockAddr *addr);
   GIOStatus (*bind)(int sock, GSockAddr *addr);
@@ -82,10 +82,10 @@ static inline struct sockaddr_in *
 g_sockaddr_inet_get_sa(GSockAddr *s)
 {
   g_assert(g_sockaddr_inet_check(s));
-  
+
   return (struct sockaddr_in *) g_sockaddr_get_sa(s);
 }
-    
+
 
 /**
  * g_sockaddr_inet_get_address:
@@ -124,7 +124,7 @@ static inline struct sockaddr_in6 *
 g_sockaddr_inet6_get_sa(GSockAddr *s)
 {
   g_assert(g_sockaddr_inet6_check(s));
-  
+
   return (struct sockaddr_in6 *) g_sockaddr_get_sa(s);
 }
 

--- a/lib/gsocket.h
+++ b/lib/gsocket.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef G_SOCKET_H_INCLUDED
 #define G_SOCKET_H_INCLUDED
 

--- a/lib/host-id.h
+++ b/lib/host-id.h
@@ -38,6 +38,6 @@ typedef struct _HostIdState
 void host_id_init(PersistState *state);
 void host_id_deinit(void);
 guint32 host_id_get(void);
-void host_id_append_formatted_id(GString* str, guint32 id);
+void host_id_append_formatted_id(GString *str, guint32 id);
 
 #endif

--- a/lib/host-resolve.h
+++ b/lib/host-resolve.h
@@ -35,7 +35,8 @@ typedef struct _HostResolveOptions
 } HostResolveOptions;
 
 /* name resolution */
-const gchar *resolve_sockaddr_to_hostname(gsize *result_len, GSockAddr *saddr, const HostResolveOptions *host_resolve_options);
+const gchar *resolve_sockaddr_to_hostname(gsize *result_len, GSockAddr *saddr,
+                                          const HostResolveOptions *host_resolve_options);
 gboolean resolve_hostname_to_sockaddr(GSockAddr **addr, gint family, const gchar *name);
 const gchar *resolve_hostname_to_hostname(gsize *result_len, const gchar *hostname, HostResolveOptions *options);
 

--- a/lib/logmatcher.h
+++ b/lib/logmatcher.h
@@ -68,11 +68,12 @@ struct _LogMatcher
   /* value_len can be -1 to indicate unknown length */
   gboolean (*match)(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len);
   /* value_len can be -1 to indicate unknown length, new_length can be returned as -1 to indicate unknown length */
-  gchar *(*replace)(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len, LogTemplate *replacement, gssize *new_length);
+  gchar *(*replace)(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len,
+                    LogTemplate *replacement, gssize *new_length);
   void (*free_fn)(LogMatcher *s);
 };
 
-static inline gboolean 
+static inline gboolean
 log_matcher_compile(LogMatcher *s, const gchar *re, GError **error)
 {
   return s->compile(s, re, error);
@@ -85,7 +86,8 @@ log_matcher_match(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar
 }
 
 static inline gchar *
-log_matcher_replace(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len, LogTemplate *replacement, gssize *new_length)
+log_matcher_replace(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len,
+                    LogTemplate *replacement, gssize *new_length)
 {
   if (s->replace)
     return s->replace(s, msg, value_handle, value, value_len, replacement, new_length);

--- a/lib/logmpx.h
+++ b/lib/logmpx.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef LOGMPX_H_INCLUDED
 #define LOGMPX_H_INCLUDED
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -193,7 +193,7 @@ struct _LogMessage
   guint32 flags;
   guint16 pri;
   guint8 initial_parse:1,
-    recursed:1;
+         recursed:1;
   guint8 num_matches;
   guint8 num_tags;
   guint8 alloc_sdata;
@@ -280,15 +280,18 @@ log_msg_get_value_name(NVHandle handle, gssize *name_len)
   return nv_registry_get_handle_name(logmsg_registry, handle, name_len);
 }
 
-typedef gboolean (*LogMessageTagsForeachFunc)(const LogMessage *self, LogTagId tag_id, const gchar *name, gpointer user_data);
+typedef gboolean (*LogMessageTagsForeachFunc)(const LogMessage *self, LogTagId tag_id, const gchar *name,
+                                              gpointer user_data);
 
 void log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *new_value, gssize length);
-void log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
+void log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handle, guint8 type, guint16 ofs,
+                                guint16 len);
 void log_msg_unset_value(LogMessage *self, NVHandle handle);
 void log_msg_unset_value_by_name(LogMessage *self, const gchar *name);
 gboolean log_msg_values_foreach(const LogMessage *self, NVTableForeachFunc func, gpointer user_data);
 void log_msg_set_match(LogMessage *self, gint index, const gchar *value, gssize value_len);
-void log_msg_set_match_indirect(LogMessage *self, gint index, NVHandle ref_handle, guint8 type, guint16 ofs, guint16 len);
+void log_msg_set_match_indirect(LogMessage *self, gint index, NVHandle ref_handle, guint8 type, guint16 ofs,
+                                guint16 len);
 void log_msg_clear_matches(LogMessage *self);
 
 static inline void
@@ -329,7 +332,8 @@ LogMessage *log_msg_new_local(void);
 void log_msg_add_ack(LogMessage *msg, const LogPathOptions *path_options);
 void log_msg_ack(LogMessage *msg, const LogPathOptions *path_options, AckType ack_type);
 void log_msg_drop(LogMessage *msg, const LogPathOptions *path_options, AckType ack_type);
-const LogPathOptions *log_msg_break_ack(LogMessage *msg, const LogPathOptions *path_options, LogPathOptions *local_options);
+const LogPathOptions *log_msg_break_ack(LogMessage *msg, const LogPathOptions *path_options,
+                                        LogPathOptions *local_options);
 
 void log_msg_refcache_start_producer(LogMessage *self);
 void log_msg_refcache_start_consumer(LogMessage *self, const LogPathOptions *path_options);

--- a/lib/logmsg/nvtable-serialize-endianutils.h
+++ b/lib/logmsg/nvtable-serialize-endianutils.h
@@ -60,7 +60,7 @@ nv_entry_swap_bytes(NVEntry *entry)
 }
 
 static inline void
-nv_table_dyn_value_swap_bytes(NVIndexEntry* self)
+nv_table_dyn_value_swap_bytes(NVIndexEntry *self)
 {
   self->handle = GUINT32_SWAP_LE_BE(self->handle);
   self->ofs = GUINT32_SWAP_LE_BE(self->handle);

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -33,8 +33,10 @@ typedef struct _NVIndexEntry NVIndexEntry;
 typedef struct _NVEntry NVEntry;
 typedef guint32 NVHandle;
 typedef struct _NVHandleDesc NVHandleDesc;
-typedef gboolean (*NVTableForeachFunc)(NVHandle handle, const gchar *name, const gchar *value, gssize value_len, gpointer user_data);
-typedef gboolean (*NVTableForeachEntryFunc)(NVHandle handle, NVEntry *entry, NVIndexEntry *index_entry, gpointer user_data);
+typedef gboolean (*NVTableForeachFunc)(NVHandle handle, const gchar *name, const gchar *value, gssize value_len,
+                                       gpointer user_data);
+typedef gboolean (*NVTableForeachEntryFunc)(NVHandle handle, NVEntry *entry, NVIndexEntry *index_entry,
+                                            gpointer user_data);
 
 #define NVHANDLE_MAX_VALUE ((NVHandle)-1)
 
@@ -128,8 +130,10 @@ typedef struct _NVReferencedSlice
 struct _NVEntry
 {
   /* negative offset, counting from string table top, e.g. start of the string is at @top + ofs */
-  union {
-    struct {
+  union
+  {
+    struct
+    {
       /* make sure you don't exceed 8 bits here. So if you want to add new
        * bits, decrease the size of __bit_padding below */
       guint8 indirect:1,
@@ -235,7 +239,7 @@ struct _NVTable
   guint16 index_size;
   guint8 num_static_entries;
   guint8 ref_cnt:7,
-    borrowed:1; /* specifies if the memory used by NVTable was borrowed from the container struct */
+         borrowed:1; /* specifies if the memory used by NVTable was borrowed from the container struct */
 
   /* variable data, see memory layout in the comment above */
   union
@@ -257,7 +261,8 @@ struct _NVTable
  * static values */
 #define NV_TABLE_MIN_BYTES  128
 
-gboolean nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name_len, const gchar *value, gsize value_len, gboolean *new_entry);
+gboolean nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name_len, const gchar *value,
+                            gsize value_len, gboolean *new_entry);
 void nv_table_unset_value(NVTable *self, NVHandle handle);
 gboolean nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, gsize name_len,
                                      NVReferencedSlice *referenced_slice, gboolean *new_entry);
@@ -279,7 +284,8 @@ nv_table_get_alloc_size(gint num_static_entries, gint index_size_hint, gint init
   NVTable *self G_GNUC_UNUSED = NULL;
   gsize size;
 
-  size = NV_TABLE_BOUND(init_length) + NV_TABLE_BOUND(sizeof(NVTable) + num_static_entries * sizeof(self->static_entries[0]) + index_size_hint * sizeof(NVIndexEntry));
+  size = NV_TABLE_BOUND(init_length) + NV_TABLE_BOUND(sizeof(NVTable) + num_static_entries * sizeof(
+                                                        self->static_entries[0]) + index_size_hint * sizeof(NVIndexEntry));
   if (size < NV_TABLE_MIN_BYTES)
     return NV_TABLE_MIN_BYTES;
   if (size > NV_TABLE_MAX_BYTES)
@@ -415,8 +421,8 @@ static inline gssize
 nv_table_get_memory_consumption(NVTable *self)
 {
   return sizeof(*self)+
-    self->num_static_entries*sizeof(self->static_entries[0])+
-    self->used;
+         self->num_static_entries*sizeof(self->static_entries[0])+
+         self->used;
 }
 
 #endif

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -175,14 +175,14 @@
 
 struct _LogPathOptions
 {
-   /* an acknowledgement is "passed" to this path, an ACK is still
-    * needed to close the window slot. This was called "flow-control"
-    * and meant both of these things: the user requested
-    * flags(flow-control), _AND_ an acknowledgement was needed. With
-    * the latest change, the one below specifies the user option,
-    * while the "ack is still needed" condition is stored in
-    * ack_needed.
-    */
+  /* an acknowledgement is "passed" to this path, an ACK is still
+   * needed to close the window slot. This was called "flow-control"
+   * and meant both of these things: the user requested
+   * flags(flow-control), _AND_ an acknowledgement was needed. With
+   * the latest change, the one below specifies the user option,
+   * while the "ack is still needed" condition is stored in
+   * ack_needed.
+   */
 
   gboolean ack_needed;
 

--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -64,23 +64,24 @@ typedef struct _LogProtoBufferedServer LogProtoBufferedServer;
 struct _LogProtoBufferedServer
 {
   LogProtoServer super;
-  gboolean (*fetch_from_buffer)(LogProtoBufferedServer *self, const guchar *buffer_start, gsize buffer_bytes, const guchar **msg, gsize *msg_len);
+  gboolean (*fetch_from_buffer)(LogProtoBufferedServer *self, const guchar *buffer_start, gsize buffer_bytes,
+                                const guchar **msg, gsize *msg_len);
   gint (*read_data)(LogProtoBufferedServer *self, guchar *buf, gsize len, LogTransportAuxData *aux);
 
   gboolean
-    /* track & record the position in the input, to be used for file
-     * position tracking.  It's not always on as it's expensive when
-     * an encoding is specified and the last record in the input is
-     * not complete.
-     */
-    pos_tracking:1,
+  /* track & record the position in the input, to be used for file
+   * position tracking.  It's not always on as it's expensive when
+   * an encoding is specified and the last record in the input is
+   * not complete.
+   */
+  pos_tracking:1,
 
-    /* specifies that the input is a stream of bytes, size of chunks
-     * read split the input randomly.  Non-stream based stuff is udp
-     * or fixed-size records read from a file.  */
-    stream_based:1,
+               /* specifies that the input is a stream of bytes, size of chunks
+                * read split the input randomly.  Non-stream based stuff is udp
+                * or fixed-size records read from a file.  */
+               stream_based:1,
 
-    no_multi_read:1;
+               no_multi_read:1;
   gint fetch_state;
   GIOStatus io_status;
   LogProtoBufferedServerState *state1;
@@ -106,7 +107,8 @@ void log_proto_buffered_server_put_state(LogProtoBufferedServer *self);
 
 /* LogProtoBufferedServer */
 gboolean log_proto_buffered_server_validate_options_method(LogProtoServer *s);
-void log_proto_buffered_server_init(LogProtoBufferedServer *self, LogTransport *transport, const LogProtoServerOptions *options);
+void log_proto_buffered_server_init(LogProtoBufferedServer *self, LogTransport *transport,
+                                    const LogProtoServerOptions *options);
 void log_proto_buffered_server_free_method(LogProtoServer *s);
 
 #endif

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -138,7 +138,7 @@ void log_proto_client_free_method(LogProtoClient *s);
 
 #define DEFINE_LOG_PROTO_CLIENT(prefix) \
   static gpointer                                                       \
-  prefix ## _client_plugin_construct(Plugin *self) 		        \
+  prefix ## _client_plugin_construct(Plugin *self)            \
   {                                                                     \
     static LogProtoClientFactory proto = {                              \
       .construct = prefix ## _client_new,                               \
@@ -147,10 +147,10 @@ void log_proto_client_free_method(LogProtoClient *s);
   }
 
 #define LOG_PROTO_CLIENT_PLUGIN(prefix, __name) \
-  {							\
-    .type = LL_CONTEXT_CLIENT_PROTO,		        \
-    .name = __name,					\
-    .construct = prefix ## _client_plugin_construct,	\
+  {             \
+    .type = LL_CONTEXT_CLIENT_PROTO,            \
+    .name = __name,         \
+    .construct = prefix ## _client_plugin_construct,  \
   }
 
 typedef struct _LogProtoClientFactory LogProtoClientFactory;
@@ -161,7 +161,8 @@ struct _LogProtoClientFactory
 };
 
 static inline LogProtoClient *
-log_proto_client_factory_construct(LogProtoClientFactory *self, LogTransport *transport, const LogProtoClientOptions *options)
+log_proto_client_factory_construct(LogProtoClientFactory *self, LogTransport *transport,
+                                   const LogProtoClientOptions *options)
 {
   return self->construct(transport, options);
 }

--- a/lib/logproto/logproto-multiline-server.h
+++ b/lib/logproto/logproto-multiline-server.h
@@ -47,8 +47,10 @@ log_proto_multiline_server_new(LogTransport *transport,
                                const LogProtoMultiLineServerOptions *options);
 
 gboolean log_proto_multi_line_server_options_set_mode(LogProtoMultiLineServerOptions *options, const gchar *mode);
-gboolean log_proto_multi_line_server_options_set_prefix(LogProtoMultiLineServerOptions *options, const gchar *prefix_regexp, GError **error);
-gboolean log_proto_multi_line_server_options_set_garbage(LogProtoMultiLineServerOptions *options, const gchar *garbage_regexp, GError **error);
+gboolean log_proto_multi_line_server_options_set_prefix(LogProtoMultiLineServerOptions *options,
+                                                        const gchar *prefix_regexp, GError **error);
+gboolean log_proto_multi_line_server_options_set_garbage(LogProtoMultiLineServerOptions *options,
+                                                         const gchar *garbage_regexp, GError **error);
 
 void log_proto_multi_line_server_options_defaults(LogProtoMultiLineServerOptions *options);
 void log_proto_multi_line_server_options_init(LogProtoMultiLineServerOptions *options);

--- a/lib/logproto/logproto-record-server.h
+++ b/lib/logproto/logproto-record-server.h
@@ -32,7 +32,8 @@
  * This class reads input in equally sized chunks. The message is the
  * whole record, regardless of embedded NUL/NL characters.
  */
-LogProtoServer *log_proto_binary_record_server_new(LogTransport *transport, const LogProtoServerOptions *options, gint record_size);
+LogProtoServer *log_proto_binary_record_server_new(LogTransport *transport, const LogProtoServerOptions *options,
+                                                   gint record_size);
 
 /*
  * LogProtoPaddedRecordServer
@@ -40,7 +41,8 @@ LogProtoServer *log_proto_binary_record_server_new(LogTransport *transport, cons
  * This class reads input in equally sized chunks. The message lasts
  * until the first EOL/NUL character within the chunk.
  */
-LogProtoServer *log_proto_padded_record_server_new(LogTransport *transport, const LogProtoServerOptions *options, gint record_size);
+LogProtoServer *log_proto_padded_record_server_new(LogTransport *transport, const LogProtoServerOptions *options,
+                                                   gint record_size);
 
 
 #endif

--- a/lib/logproto/logproto-regexp-multiline-server.h
+++ b/lib/logproto/logproto-regexp-multiline-server.h
@@ -40,17 +40,17 @@ void multi_line_regexp_free(MultiLineRegexp *self);
  * when we reach a line that starts with non-whitespace, or EOF.
  */
 LogProtoServer *log_proto_prefix_garbage_multiline_server_new(LogTransport *transport,
-                                                      const LogProtoServerOptions *options,
-                                                      MultiLineRegexp *prefix,
-                                                      MultiLineRegexp *garbage);
+    const LogProtoServerOptions *options,
+    MultiLineRegexp *prefix,
+    MultiLineRegexp *garbage);
 void log_proto_regexp_multiline_server_init(LogProtoREMultiLineServer *self,
                                             LogTransport *transport,
                                             const LogProtoServerOptions *options,
                                             MultiLineRegexp *prefix,
                                             MultiLineRegexp *garbage);
 LogProtoServer *log_proto_prefix_suffix_multiline_server_new(LogTransport *transport,
-                                                      const LogProtoServerOptions *options,
-                                                      MultiLineRegexp *prefix,
-                                                      MultiLineRegexp *suffix);
+    const LogProtoServerOptions *options,
+    MultiLineRegexp *prefix,
+    MultiLineRegexp *suffix);
 
 #endif

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -68,7 +68,8 @@ struct _LogProtoServer
   gboolean (*is_position_tracked)(LogProtoServer *s);
   gboolean (*prepare)(LogProtoServer *s, GIOCondition *cond);
   gboolean (*restart_with_state)(LogProtoServer *s, PersistState *state, const gchar *persist_name);
-  LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read, LogTransportAuxData *aux, Bookmark *bookmark);
+  LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
+                          LogTransportAuxData *aux, Bookmark *bookmark);
   gboolean (*validate_options)(LogProtoServer *s);
   void (*free_fn)(LogProtoServer *s);
 };
@@ -100,7 +101,8 @@ log_proto_server_restart_with_state(LogProtoServer *s, PersistState *state, cons
 }
 
 static inline LogProtoStatus
-log_proto_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read, LogTransportAuxData *aux, Bookmark *bookmark)
+log_proto_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
+                       LogTransportAuxData *aux, Bookmark *bookmark)
 {
   if (s->status == LPS_SUCCESS)
     return s->fetch(s, msg, msg_len, may_read, aux, bookmark);
@@ -141,16 +143,16 @@ void log_proto_server_free(LogProtoServer *s);
   prefix ## _server_plugin_construct(Plugin *self)                      \
   {                                                                     \
     static LogProtoServerFactory proto = {                              \
-      .construct = prefix ## _server_new,                    		\
+      .construct = prefix ## _server_new,                       \
     };                                                                  \
     return &proto;                                                      \
   }
 
 #define LOG_PROTO_SERVER_PLUGIN(prefix, __name) \
-  {							\
-    .type = LL_CONTEXT_SERVER_PROTO,		        \
-    .name = __name,					\
-    .construct = prefix ## _server_plugin_construct,	\
+  {             \
+    .type = LL_CONTEXT_SERVER_PROTO,            \
+    .name = __name,         \
+    .construct = prefix ## _server_plugin_construct,  \
   }
 
 typedef struct _LogProtoServerFactory LogProtoServerFactory;
@@ -161,7 +163,8 @@ struct _LogProtoServerFactory
 };
 
 static inline LogProtoServer *
-log_proto_server_factory_construct(LogProtoServerFactory *self, LogTransport *transport, const LogProtoServerOptions *options)
+log_proto_server_factory_construct(LogProtoServerFactory *self, LogTransport *transport,
+                                   const LogProtoServerOptions *options)
 {
   return self->construct(transport, options);
 }

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -35,8 +35,10 @@ typedef struct _LogProtoTextClient
   gsize partial_len, partial_pos;
 } LogProtoTextClient;
 
-LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len, GDestroyNotify msg_free, gint next_state);
-void log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport, const LogProtoClientOptions *options);
+LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len,
+                                                  GDestroyNotify msg_free, gint next_state);
+void log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport,
+                                const LogProtoClientOptions *options);
 LogProtoClient *log_proto_text_client_new(LogTransport *transport, const LogProtoClientOptions *options);
 
 #define log_proto_text_client_free_method log_proto_client_free_method

--- a/lib/logproto/logproto-text-server.h
+++ b/lib/logproto/logproto-text-server.h
@@ -62,7 +62,8 @@ struct _LogProtoTextServer
  * This class processes text files/streams. Each record is terminated via an EOL character.
  */
 LogProtoServer *log_proto_text_server_new(LogTransport *transport, const LogProtoServerOptions *options);
-void log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, const LogProtoServerOptions *options);
+void log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport,
+                                const LogProtoServerOptions *options);
 
 static inline gint
 log_proto_text_server_accumulate_line(LogProtoTextServer *self,

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -196,9 +196,12 @@ log_queue_set_use_backlog(LogQueue *self, gboolean use_backlog)
 
 void log_queue_push_notify(LogQueue *self);
 void log_queue_reset_parallel_push(LogQueue *self);
-void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data, GDestroyNotify user_data_destroy);
-gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data, GDestroyNotify user_data_destroy);
-void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages, StatsCounterItem *memory_usage);
+void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data,
+                                 GDestroyNotify user_data_destroy);
+gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify,
+                               gpointer user_data, GDestroyNotify user_data_destroy);
+void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages,
+                            StatsCounterItem *memory_usage);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
 void log_queue_free_method(LogQueue *self);
 

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -51,7 +51,8 @@ typedef struct _LogReaderOptions
 
 typedef struct _LogReader LogReader;
 
-void log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options, const gchar *stats_id, const gchar *stats_instance);
+void log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options, const gchar *stats_id,
+                            const gchar *stats_instance);
 void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filename);
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_immediate_check(LogReader *s);

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef LOGSOURCE_H_INCLUDED
 #define LOGSOURCE_H_INCLUDED
 
@@ -96,7 +96,8 @@ gboolean log_source_deinit(LogPipe *s);
 
 void log_source_post(LogSource *self, LogMessage *msg);
 
-void log_source_set_options(LogSource *self, LogSourceOptions *options, const gchar *stats_id, const gchar *stats_instance, gboolean threaded, gboolean pos_tracked, LogExprNode *expr_node);
+void log_source_set_options(LogSource *self, LogSourceOptions *options, const gchar *stats_id,
+                            const gchar *stats_instance, gboolean threaded, gboolean pos_tracked, LogExprNode *expr_node);
 void log_source_mangle_hostname(LogSource *self, LogMessage *msg);
 void log_source_init_instance(LogSource *self, GlobalConfig *cfg);
 void log_source_options_defaults(LogSourceOptions *options);

--- a/lib/logstamp.h
+++ b/lib/logstamp.h
@@ -49,7 +49,8 @@ log_stamp_is_timezone_set(const LogStamp *self)
 }
 
 void log_stamp_format(LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
-void log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset, gint frac_digits);
+void log_stamp_append_format(const LogStamp *stamp, GString *target, gint ts_format, glong zone_offset,
+                             gint frac_digits);
 gboolean log_stamp_eq(const LogStamp *a, const LogStamp *b);
 
 #endif

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef LOG_WRITER_H_INCLUDED
 #define LOG_WRITER_H_INCLUDED
 
@@ -53,16 +53,16 @@ typedef struct _LogWriterOptions
   gboolean initialized;
   /* bitmask of LWO_* */
   guint32 options;
-  
+
   /* minimum number of entries to trigger a flush */
   gint flush_lines;
-  
+
   /* flush anyway if this time was elapsed */
   gint flush_timeout;
   LogTemplate *template;
   LogTemplate *file_template;
   LogTemplate *proto_template;
-  
+
   LogTemplateOptions template_options;
   HostResolveOptions host_resolve_options;
   LogProtoClientOptionsStorage proto_options;
@@ -80,7 +80,8 @@ typedef struct _LogWriter LogWriter;
 
 void log_writer_set_flags(LogWriter *self, guint32 flags);
 guint32 log_writer_get_flags(LogWriter *self);
-void log_writer_set_options(LogWriter *self, LogPipe *control, LogWriterOptions *options, const gchar *stats_id, const gchar *stats_instance);
+void log_writer_set_options(LogWriter *self, LogPipe *control, LogWriterOptions *options, const gchar *stats_id,
+                            const gchar *stats_instance);
 void log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result);
 gboolean log_writer_has_pending_writes(LogWriter *self);
 gboolean log_writer_opened(LogWriter *self);

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -76,7 +76,8 @@ void main_loop_worker_thread_start(void *cookie);
 void main_loop_worker_thread_stop(void);
 void main_loop_worker_run_gc(void);
 
-void main_loop_create_worker_thread(WorkerThreadFunc func, WorkerExitNotificationFunc terminate_func, gpointer data, WorkerOptions *worker_options);
+void main_loop_create_worker_thread(WorkerThreadFunc func, WorkerExitNotificationFunc terminate_func, gpointer data,
+                                    WorkerOptions *worker_options);
 
 void main_loop_worker_sync_call(void (*func)(void *user_data), void *user_data);
 

--- a/lib/memtrace.h
+++ b/lib/memtrace.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef ZORP_MEMTRACE_H_INCLUDED
 #define ZORP_MEMTRACE_H_INCLUDED
 

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef MESSAGES_H_INCLUDED
 #define MESSAGES_H_INCLUDED
 
@@ -60,55 +60,55 @@ void msg_add_option_group(GOptionContext *ctx);
 
 /* just like msg_info, but prepends the message with a timestamp -- useful in interactive
  * tools with long running time to provide some feedback */
-#define msg_progress(desc, tags...) 					  \
-        do { 									  \
-          time_t t;								  \
-          char *timestamp, *newdesc; 						  \
+#define msg_progress(desc, tags...)             \
+        do {                    \
+          time_t t;                 \
+          char *timestamp, *newdesc;              \
                                                                                   \
-          t = time(0); 							          \
-          timestamp = ctime(&t); 						  \
-          timestamp[strlen(timestamp) - 1] = 0; 				  \
-          newdesc = g_strdup_printf("[%s] %s", timestamp, desc); 		  \
+          t = time(0);                        \
+          timestamp = ctime(&t);              \
+          timestamp[strlen(timestamp) - 1] = 0;           \
+          newdesc = g_strdup_printf("[%s] %s", timestamp, desc);      \
           msg_event_send(msg_event_create(EVT_PRI_INFO, newdesc, ##tags, NULL )); \
-          g_free(newdesc); 							  \
+          g_free(newdesc);                \
         } while (0)
 
 #define msg_verbose(desc, tags...)                                          \
-	do {                                                                      \
-	  if (G_UNLIKELY(verbose_flag))                                           \
-	    msg_info(desc, ##tags );                                        \
-	} while (0)
+  do {                                                                      \
+    if (G_UNLIKELY(verbose_flag))                                           \
+      msg_info(desc, ##tags );                                        \
+  } while (0)
 
-#define msg_debug(desc, tags...) 						  \
-	do { 									  \
-	  if (G_UNLIKELY(debug_flag))                                             \
-	    msg_event_suppress_recursions_and_send(                               \
-	          msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
-	} while (0)
+#define msg_debug(desc, tags...)              \
+  do {                    \
+    if (G_UNLIKELY(debug_flag))                                             \
+      msg_event_suppress_recursions_and_send(                               \
+            msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
+  } while (0)
 
 #if SYSLOG_NG_ENABLE_DEBUG
-#define msg_trace(desc, tags...) 						  \
-	do { 									  \
-	  if (G_UNLIKELY(trace_flag))            				  \
+#define msg_trace(desc, tags...)              \
+  do {                    \
+    if (G_UNLIKELY(trace_flag))                     \
             msg_event_suppress_recursions_and_send(                               \
                   msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
-	} while (0)
+  } while (0)
 #else
 #define msg_trace(desc, tags...)
 #endif
 
-#define __once()					\
-        ({						\
-          static gboolean __guard = TRUE;		\
-          gboolean __current_guard = __guard;		\
-          __guard = FALSE;				\
-          __current_guard;				\
+#define __once()          \
+        ({            \
+          static gboolean __guard = TRUE;   \
+          gboolean __current_guard = __guard;   \
+          __guard = FALSE;        \
+          __current_guard;        \
         })
 
-#define msg_warning_once(desc, tags...)	\
-        do {				\
-          if (__once())			\
-            msg_warning(desc, ##tags );	\
+#define msg_warning_once(desc, tags...) \
+        do {        \
+          if (__once())     \
+            msg_warning(desc, ##tags ); \
         } while (0)
 
 void msg_post_message(LogMessage *msg);

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -79,7 +79,8 @@ struct _MsgFormatHandler
    * match the requirements of the "format" in question.  This is used by
    * the "pacct" plugin to set the record length the proper size
    */
-  LogProtoServer *(*construct_proto)(const MsgFormatOptions *options, LogTransport *transport, const LogProtoServerOptions *proto_options);
+  LogProtoServer *(*construct_proto)(const MsgFormatOptions *options, LogTransport *transport,
+                                     const LogProtoServerOptions *proto_options);
   void (*parse)(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg);
 };
 

--- a/lib/parser/parser-expr.h
+++ b/lib/parser/parser-expr.h
@@ -38,7 +38,8 @@ struct _LogParser
 {
   LogPipe super;
   LogTemplate *template;
-  gboolean (*process)(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input, gsize input_len);
+  gboolean (*process)(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
+                      gsize input_len);
   gchar *name;
 };
 
@@ -57,10 +58,11 @@ void log_parser_init_instance(LogParser *self, GlobalConfig *cfg);
 void log_parser_free_method(LogPipe *self);
 
 static inline gboolean
-log_parser_process(LogParser *self, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input, gssize input_len)
+log_parser_process(LogParser *self, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
+                   gssize input_len)
 {
   if (input_len < 0)
-    input_len = strlen(input);
+        input_len = strlen(input);
   return self->process(self, pmsg, path_options, input, input_len);
 }
 

--- a/lib/pathutils.h
+++ b/lib/pathutils.h
@@ -32,6 +32,6 @@ gboolean is_file_directory(const char *filename);
 gboolean is_file_device(const gchar *name);
 
 gchar *find_file_in_path(const gchar *path, const gchar *filename, GFileTest test);
-const gchar* get_filename_extension(const gchar *filename);
+const gchar *get_filename_extension(const gchar *filename);
 
 #endif

--- a/lib/persist-state.h
+++ b/lib/persist-state.h
@@ -34,7 +34,8 @@ gpointer persist_state_map_entry(PersistState *self, PersistEntryHandle handle);
 void persist_state_unmap_entry(PersistState *self, PersistEntryHandle handle);
 
 PersistEntryHandle persist_state_alloc_entry(PersistState *self, const gchar *persist_name, gsize alloc_size);
-PersistEntryHandle persist_state_lookup_entry(PersistState *self, const gchar *persist_name, gsize *size, guint8 *version);
+PersistEntryHandle persist_state_lookup_entry(PersistState *self, const gchar *persist_name, gsize *size,
+                                              guint8 *version);
 gboolean persist_state_remove_entry(PersistState *self, const gchar *persist_name);
 
 gchar *persist_state_lookup_string(PersistState *self, const gchar *key, gsize *length, guint8 *version);
@@ -43,7 +44,7 @@ void persist_state_alloc_string(PersistState *self, const gchar *persist_name, c
 
 void persist_state_free_entry(PersistEntryHandle handle);
 
-typedef void (*PersistStateForeachFunc)(gchar* name, gint entry_size, gpointer entry, gpointer userdata);
+typedef void (*PersistStateForeachFunc)(gchar *name, gint entry_size, gpointer entry, gpointer userdata);
 void persist_state_foreach_entry(PersistState *self, PersistStateForeachFunc func, gpointer userdata);
 
 gboolean persist_state_start(PersistState *self);

--- a/lib/persistable-state-presenter.h
+++ b/lib/persistable-state-presenter.h
@@ -30,7 +30,8 @@
 #include "presented-persistable-state.h"
 #include "persistable-state-header.h"
 
-struct _PersistableStatePresenter {
+struct _PersistableStatePresenter
+{
   gboolean (*dump)(PersistableStateHeader *state, PresentedPersistableState *representation);
   gboolean (*load)(PersistableStateHeader *state, PresentedPersistableState *representation);
   PersistEntryHandle (*alloc)(PersistState *state, const gchar *name);
@@ -39,14 +40,16 @@ struct _PersistableStatePresenter {
 typedef struct _PersistableStatePresenter PersistableStatePresenter;
 
 static inline gboolean
-persistable_state_presenter_load(PersistableStatePresenter *self, PersistableStateHeader *state, PresentedPersistableState *representation)
+persistable_state_presenter_load(PersistableStatePresenter *self, PersistableStateHeader *state,
+                                 PresentedPersistableState *representation)
 {
   g_assert(self->load != NULL);
   return self->load(state, representation);
 }
 
 static inline gboolean
-persistable_state_presenter_dump(PersistableStatePresenter *self, PersistableStateHeader *state, PresentedPersistableState *representation)
+persistable_state_presenter_dump(PersistableStatePresenter *self, PersistableStateHeader *state,
+                                 PresentedPersistableState *representation)
 {
   g_assert(self->dump != NULL);
   return self->dump(state, representation);
@@ -59,9 +62,10 @@ persistable_state_presenter_alloc(PersistableStatePresenter *self, PersistState 
   return self->alloc(state, name);
 }
 
-typedef PersistableStatePresenter* (*PersistableStatePresenterConstructFunc)(const gchar *name);
+typedef PersistableStatePresenter *(*PersistableStatePresenterConstructFunc)(const gchar *name);
 
 PersistableStatePresenterConstructFunc persistable_state_presenter_get_constructor_by_prefix(const gchar *prefix);
-void persistable_state_presenter_register_constructor(const gchar *prefix, PersistableStatePresenterConstructFunc handler);
+void persistable_state_presenter_register_constructor(const gchar *prefix,
+                                                      PersistableStatePresenterConstructFunc handler);
 
 #endif

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -98,7 +98,7 @@ struct _PluginContext
 Plugin *plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name);
 
 /* plugin side API */
-PluginCandidate * plugin_candidate_new(gint plugin_type, const gchar *name, const gchar *module_name);
+PluginCandidate *plugin_candidate_new(gint plugin_type, const gchar *name, const gchar *module_name);
 void plugin_candidate_free(PluginCandidate *self);
 
 void plugin_register(PluginContext *context, Plugin *p, gint number);

--- a/lib/presented-persistable-state.h
+++ b/lib/presented-persistable-state.h
@@ -30,12 +30,12 @@ typedef struct _PresentedPersistableState PresentedPersistableState;
 
 struct _PresentedPersistableState
 {
-  void (*add_string)(PresentedPersistableState *self, gchar* name, gchar* value);
-  void (*add_boolean)(PresentedPersistableState *self, gchar* name, gboolean value);
+  void (*add_string)(PresentedPersistableState *self, gchar *name, gchar *value);
+  void (*add_boolean)(PresentedPersistableState *self, gchar *name, gboolean value);
   void (*add_int64)(PresentedPersistableState *self, gchar *name, gint64 value);
   void (*add_int)(PresentedPersistableState *self, gchar *name, gint value);
 
-  const gchar* (*get_string)(PresentedPersistableState *self, gchar *name);
+  const gchar *(*get_string)(PresentedPersistableState *self, gchar *name);
   gboolean (*get_boolean)(PresentedPersistableState *self, gchar *name);
   gint (*get_int)(PresentedPersistableState *self, gchar *name);
   gint64 (*get_int64)(PresentedPersistableState *self, gchar *name);
@@ -95,7 +95,8 @@ presented_persistable_state_get_int64(PresentedPersistableState *self, gchar *na
 }
 
 static inline void
-presented_persistable_state_foreach(PresentedPersistableState *self, void (callback)(gchar *name, const gchar *value, gpointer user_data), gpointer user_data)
+presented_persistable_state_foreach(PresentedPersistableState *self, void (callback)(gchar *name, const gchar *value,
+                                    gpointer user_data), gpointer user_data)
 {
   self->foreach(self, callback, user_data);
 }

--- a/lib/rewrite/rewrite-groupset.h
+++ b/lib/rewrite/rewrite-groupset.h
@@ -25,7 +25,8 @@
 #include "rewrite/rewrite-expr.h"
 #include "value-pairs/value-pairs.h"
 
-typedef struct _LogRewriteGroupSet {
+typedef struct _LogRewriteGroupSet
+{
   LogRewrite super;
   ValuePairs *query;
   LogTemplate *replacement;

--- a/lib/run-id.h
+++ b/lib/run-id.h
@@ -31,6 +31,6 @@ void run_id_init(PersistState *state);
 void run_id_deinit(void);
 int run_id_get(void);
 gboolean run_id_is_same_run(gint other_run_id);
-void run_id_append_formatted_id(GString* str);
+void run_id_append_formatted_id(GString *str);
 
 #endif

--- a/lib/scanner/csv-scanner/csv-scanner.h
+++ b/lib/scanner/csv-scanner/csv-scanner.h
@@ -59,12 +59,14 @@ void csv_scanner_options_set_flags(CSVScannerOptions *options, guint32 flags);
 void csv_scanner_options_set_columns(CSVScannerOptions *options, GList *columns);
 void csv_scanner_options_set_delimiters(CSVScannerOptions *options, const gchar *delimiters);
 void csv_scanner_options_set_string_delimiters(CSVScannerOptions *options, GList *string_delimiters);
-void csv_scanner_options_set_quotes_start_and_end(CSVScannerOptions *options, const gchar *quotes_start, const gchar *quotes_end);
+void csv_scanner_options_set_quotes_start_and_end(CSVScannerOptions *options, const gchar *quotes_start,
+                                                  const gchar *quotes_end);
 void csv_scanner_options_set_quotes(CSVScannerOptions *options, const gchar *quotes);
 void csv_scanner_options_set_quote_pairs(CSVScannerOptions *options, const gchar *quote_pairs);
 void csv_scanner_options_set_null_value(CSVScannerOptions *options, const gchar *null_value);
 
-typedef struct {
+typedef struct
+{
   CSVScannerOptions *options;
   GList *current_column;
   const gchar *src;

--- a/lib/service-management.h
+++ b/lib/service-management.h
@@ -26,10 +26,11 @@
 
 #include "syslog-ng.h"
 
-typedef enum _ServiceManagementType {
-    SMT_NONE,
-    SMT_SYSTEMD,
-    SMT_MAX
+typedef enum _ServiceManagementType
+{
+  SMT_NONE,
+  SMT_SYSTEMD,
+  SMT_MAX
 } ServiceManagementType;
 
 void service_management_publish_status(const gchar *status);

--- a/lib/stats/stats-cluster-single.h
+++ b/lib/stats/stats-cluster-single.h
@@ -25,7 +25,7 @@
 #ifndef STATS_CLUSTER_SINGLE_H_INCLUDED
 #define STATS_CLUSTER_SINGLE_H_INCLUDED
 
-#include "syslog-ng.h" 
+#include "syslog-ng.h"
 
 typedef enum
 {
@@ -34,7 +34,8 @@ typedef enum
 } StatsCounterGroupSingle;
 
 void stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance);
-void stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance, const gchar *name);
+void stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, const gchar *id,
+                                            const gchar *instance, const gchar *name);
 
 #endif
 

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -74,7 +74,7 @@ enum
   SCS_FILTER         = 38,
   SCS_PARSER         = 39,
   SCS_MONITORING     = 40,
-  SCS_STDIN	     = 41,
+  SCS_STDIN      = 41,
   SCS_MAX,
   SCS_SOURCE_MASK    = 0xff
 };
@@ -150,6 +150,7 @@ StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 StatsCluster *stats_cluster_dynamic_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
-void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance, StatsCounterGroupInit counter_group_ctor);
+void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance,
+                           StatsCounterGroupInit counter_group_ctor);
 
 #endif

--- a/lib/stats/stats-query-commands.h
+++ b/lib/stats/stats-query-commands.h
@@ -26,6 +26,6 @@
 
 #include "syslog-ng.h"
 
-GString* process_query_command(GString *cmd, gpointer user_data);
+GString *process_query_command(GString *cmd, gpointer user_data);
 
 #endif

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -34,8 +34,10 @@ void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
 StatsCluster *stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
-StatsCluster *stats_register_counter_and_index(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
-StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+StatsCluster *stats_register_counter_and_index(gint level, const StatsClusterKey *sc_key, gint type,
+                                               StatsCounterItem **counter);
+StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type,
+                                             StatsCounterItem **counter);
 void stats_register_and_increment_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 void stats_unregister_counter(const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);

--- a/lib/stats/stats.h
+++ b/lib/stats/stats.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef STATS_H_INCLUDED
 #define STATS_H_INCLUDED
 

--- a/lib/str-repr/decode.h
+++ b/lib/str-repr/decode.h
@@ -38,7 +38,9 @@ typedef struct _StrReprDecodeOptions
 gboolean str_repr_decode(GString *value, const gchar *input, const gchar **end);
 gboolean str_repr_decode_append(GString *value, const gchar *input, const gchar **end);
 
-gboolean str_repr_decode_with_options(GString *value, const gchar *input, const gchar **end, const StrReprDecodeOptions *options);
-gboolean str_repr_decode_append_with_options(GString *value, const gchar *input, const gchar **end, const StrReprDecodeOptions *options);
+gboolean str_repr_decode_with_options(GString *value, const gchar *input, const gchar **end,
+                                      const StrReprDecodeOptions *options);
+gboolean str_repr_decode_append_with_options(GString *value, const gchar *input, const gchar **end,
+                                             const StrReprDecodeOptions *options);
 
 #endif

--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -61,7 +61,7 @@ g_string_append_unichar_optimized(GString *string, gunichar wc)
  * would be freed when the inline function exits (e.g.  when it is in fact
  * not inlined).
  */
-#define APPEND_ZERO(dest, value, value_len)	\
+#define APPEND_ZERO(dest, value, value_len) \
   do { \
     gchar *__buf; \
     if (G_UNLIKELY(value[value_len] != 0)) \
@@ -80,7 +80,7 @@ g_string_append_unichar_optimized(GString *string, gunichar wc)
     dest = __buf; \
   } while (0)
 
-gchar *__normalize_key(const gchar* buffer);
+gchar *__normalize_key(const gchar *buffer);
 
 
 /* This version of strchr() is optimized for cases where the string we are

--- a/lib/syslog-names.h
+++ b/lib/syslog-names.h
@@ -21,20 +21,20 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef __SYSLOG_NAMES_H_INCLUDED
 #define __SYSLOG_NAMES_H_INCLUDED
 
 #include "syslog-ng.h"
 
-#define	LOG_FACMASK	0x03f8	/* mask to extract facility part */
-				/* facility of pri */
-#define	LOG_FAC(p)	(((p) & LOG_FACMASK) >> 3)
+#define LOG_FACMASK 0x03f8  /* mask to extract facility part */
+/* facility of pri */
+#define LOG_FAC(p)  (((p) & LOG_FACMASK) >> 3)
 #ifndef LOG_PRIMASK
-#define	LOG_PRIMASK	0x07	/* mask to extract priority part (internal) */
+#define LOG_PRIMASK 0x07  /* mask to extract priority part (internal) */
 #endif
-				/* extract priority */
-#define	LOG_PRI(p)	((p) & LOG_PRIMASK)
+/* extract priority */
+#define LOG_PRI(p)  ((p) & LOG_PRIMASK)
 
 struct sl_name
 {
@@ -53,13 +53,13 @@ const char *syslog_name_lookup_name_by_value(int value, struct sl_name names[]);
 guint32 syslog_make_range(guint32 r1, guint32 r2);
 
 static inline guint32
-syslog_name_lookup_level_by_name(const gchar *name) 
+syslog_name_lookup_level_by_name(const gchar *name)
 {
   return syslog_name_lookup_value_by_name(name, sl_levels);
 }
 
 static inline guint32
-syslog_name_lookup_facility_by_name(const gchar *name) 
+syslog_name_lookup_facility_by_name(const gchar *name)
 {
   return syslog_name_lookup_value_by_name(name, sl_facilities);
 }

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef SYSLOG_NG_H_INCLUDED
 #define SYSLOG_NG_H_INCLUDED
 
@@ -36,7 +36,7 @@
 #include "versioning.h"
 
 #define PATH_SYSLOG_NG_CONF     SYSLOG_NG_PATH_SYSCONFDIR "/syslog-ng.conf"
-#define PATH_INSTALL_DAT	SYSLOG_NG_PATH_SYSCONFDIR "/install.dat"
+#define PATH_INSTALL_DAT  SYSLOG_NG_PATH_SYSCONFDIR "/install.dat"
 #define PATH_PIDFILE            SYSLOG_NG_PATH_PIDFILEDIR "/syslog-ng.pid"
 #define PATH_CONTROL_SOCKET     SYSLOG_NG_PATH_PIDFILEDIR "/syslog-ng.ctl"
 #if SYSLOG_NG_ENABLE_ENV_WRAPPER

--- a/lib/template/function.h
+++ b/lib/template/function.h
@@ -62,7 +62,8 @@ struct _LogTemplateFunction
 
   /* called when parsing the arguments to be compiled into an internal
    * representation if necessary.  Returns the compiled state in state */
-  gboolean (*prepare)(LogTemplateFunction *self, gpointer state, LogTemplate *parent, gint argc, gchar *argv[], GError **error);
+  gboolean (*prepare)(LogTemplateFunction *self, gpointer state, LogTemplate *parent, gint argc, gchar *argv[],
+                      GError **error);
 
   /* evaluate arguments, storing argument buffers in arg_bufs in case it
    * makes sense to reuse those buffers */
@@ -85,12 +86,12 @@ struct _LogTemplateFunction
   gpointer                                                              \
   prefix ## _construct(Plugin *self)
 
-#define TEMPLATE_FUNCTION_DECLARE(prefix)	\
+#define TEMPLATE_FUNCTION_DECLARE(prefix) \
   TEMPLATE_FUNCTION_PROTOTYPE(prefix);
 
 /* helper macros for template function plugins */
 #define TEMPLATE_FUNCTION(state_struct, prefix, prepare, eval, call, free_state, arg) \
-  TEMPLATE_FUNCTION_PROTOTYPE(prefix) 					\
+  TEMPLATE_FUNCTION_PROTOTYPE(prefix)           \
   {                                                                     \
     static LogTemplateFunction func = {                                 \
       sizeof(state_struct),                                             \
@@ -98,7 +99,7 @@ struct _LogTemplateFunction
       eval,                                                             \
       call,                                                             \
       free_state,                                                       \
-      NULL,								\
+      NULL,               \
       arg                                                               \
     };                                                                  \
     return &func;                                                       \

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -111,7 +111,8 @@ extern LogMacroDef macros[];
 
 /* low level macro functions */
 guint log_macro_lookup(gchar *macro, gint len);
-gboolean log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, const LogMessage *msg);
+gboolean log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz,
+                          gint32 seq_num, const gchar *context_id, const LogMessage *msg);
 gboolean log_macro_expand_simple(GString *result, gint id, const LogMessage *msg);
 
 void log_macros_global_init(void);

--- a/lib/template/simple-function.h
+++ b/lib/template/simple-function.h
@@ -37,7 +37,8 @@ typedef struct _TFSimpleFuncState
 
 typedef void (*TFSimpleFunc)(LogMessage *msg, gint argc, GString *argv[], GString *result);
 
-gboolean tf_simple_func_prepare(LogTemplateFunction *self, gpointer state, LogTemplate *parent, gint argc, gchar *argv[], GError **error);
+gboolean tf_simple_func_prepare(LogTemplateFunction *self, gpointer state, LogTemplate *parent, gint argc,
+                                gchar *argv[], GError **error);
 void tf_simple_func_eval(LogTemplateFunction *self, gpointer state, const LogTemplateInvokeArgs *args);
 void tf_simple_func_call(LogTemplateFunction *self, gpointer state, const LogTemplateInvokeArgs *args, GString *result);
 void tf_simple_func_free_state(gpointer state);

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -93,10 +93,14 @@ struct _LogTemplateOptions
 void log_template_set_escape(LogTemplate *self, gboolean enable);
 gboolean log_template_set_type_hint(LogTemplate *self, const gchar *hint, GError **error);
 gboolean log_template_compile(LogTemplate *self, const gchar *template, GError **error);
-void log_template_format(LogTemplate *self, LogMessage *lm, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, GString *result);
-void log_template_append_format(LogTemplate *self, LogMessage *lm, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, GString *result);
-void log_template_append_format_with_context(LogTemplate *self, LogMessage **messages, gint num_messages, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, GString *result);
-void log_template_format_with_context(LogTemplate *self, LogMessage **messages, gint num_messages, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, GString *result);
+void log_template_format(LogTemplate *self, LogMessage *lm, const LogTemplateOptions *opts, gint tz, gint32 seq_num,
+                         const gchar *context_id, GString *result);
+void log_template_append_format(LogTemplate *self, LogMessage *lm, const LogTemplateOptions *opts, gint tz,
+                                gint32 seq_num, const gchar *context_id, GString *result);
+void log_template_append_format_with_context(LogTemplate *self, LogMessage **messages, gint num_messages,
+                                             const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, GString *result);
+void log_template_format_with_context(LogTemplate *self, LogMessage **messages, gint num_messages,
+                                      const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, GString *result);
 void log_template_set_name(LogTemplate *self, const gchar *name);
 
 LogTemplate *log_template_new(GlobalConfig *cfg, const gchar *name);

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef TIMEUTILS_H_INCLUDED
 #define TIMEUTILS_H_INCLUDED
 
@@ -53,7 +53,7 @@ typedef struct _ZoneInfo ZoneInfo;
 typedef struct _TimeZoneInfo TimeZoneInfo;
 
 gint32 time_zone_info_get_offset(const TimeZoneInfo *self, time_t stamp);
-TimeZoneInfo* time_zone_info_new(const gchar *tz);
+TimeZoneInfo *time_zone_info_new(const gchar *tz);
 void time_zone_info_free(TimeZoneInfo *self);
 
 extern const char *month_names_abbrev[];

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -77,7 +77,8 @@ typedef struct _TLSSession
   } peer_info;
 } TLSSession;
 
-void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, gpointer verify_data, GDestroyNotify verify_destroy);
+void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, gpointer verify_data,
+                            GDestroyNotify verify_destroy);
 void tls_session_free(TLSSession *self);
 
 gboolean tls_context_setup_context(TLSContext *self);

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -39,7 +39,7 @@ struct _LogTransport
   void (*free_fn)(LogTransport *self);
 };
 
-static inline gssize 
+static inline gssize
 log_transport_write(LogTransport *self, const gpointer buf, gsize count)
 {
   return self->write(self, buf, count);

--- a/lib/transport/transport-aux-data.h
+++ b/lib/transport/transport-aux-data.h
@@ -72,6 +72,7 @@ log_transport_aux_data_set_peer_addr_ref(LogTransportAuxData *self, GSockAddr *p
 }
 
 void log_transport_aux_data_add_nv_pair(LogTransportAuxData *self, const gchar *name, const gchar *value);
-void log_transport_aux_data_foreach(LogTransportAuxData *self, void (*func)(const gchar *, const gchar *, gsize, gpointer), gpointer user_data);
+void log_transport_aux_data_foreach(LogTransportAuxData *self, void (*func)(const gchar *, const gchar *, gsize,
+                                    gpointer), gpointer user_data);
 
 #endif

--- a/lib/transport/transport-file.h
+++ b/lib/transport/transport-file.h
@@ -35,7 +35,8 @@ struct _LogTransportFile
 };
 
 gssize log_transport_file_read_method(LogTransport *self, gpointer buf, gsize buflen, LogTransportAuxData *aux);
-gssize log_transport_file_read_and_ignore_eof_method(LogTransport *self, gpointer buf, gsize buflen, LogTransportAuxData *aux);
+gssize log_transport_file_read_and_ignore_eof_method(LogTransport *self, gpointer buf, gsize buflen,
+                                                     LogTransportAuxData *aux);
 gssize log_transport_file_write_method(LogTransport *self, const gpointer buf, gsize buflen);
 
 void log_transport_file_init_instance(LogTransportFile *self, gint fd);

--- a/lib/value-pairs/cmdline.h
+++ b/lib/value-pairs/cmdline.h
@@ -27,8 +27,8 @@
 #include "value-pairs/value-pairs.h"
 
 ValuePairs *value_pairs_new_from_cmdline(GlobalConfig *cfg,
-					 gint *argc, gchar ***argv,
-					 gboolean ignore_unknown_options,
-					 GError **error);
+                                         gint *argc, gchar ***argv,
+                                         gboolean ignore_unknown_options,
+                                         GError **error);
 
 #endif

--- a/lib/value-pairs/evttag.h
+++ b/lib/value-pairs/evttag.h
@@ -27,6 +27,7 @@
 #include "value-pairs.h"
 #include "messages.h"
 
-EVTTAG *evt_tag_value_pairs(const char* key, ValuePairs *vp, LogMessage *msg, gint32 seq_num, gint time_zone_mode, LogTemplateOptions *template_options);
+EVTTAG *evt_tag_value_pairs(const char *key, ValuePairs *vp, LogMessage *msg, gint32 seq_num, gint time_zone_mode,
+                            LogTemplateOptions *template_options);
 
 #endif

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -31,7 +31,7 @@
 #define LTM_INJECT_ERROR(err)   (GUINT_TO_POINTER(err)), 0
 /* macro to be used at the end of the I/O stream */
 #define LTM_EOF                 NULL, 0
-#define LTM_PADDING		"padd", -1, "padd", -1, "padd", -1, "padd", -1, "padd", -1
+#define LTM_PADDING   "padd", -1, "padd", -1, "padd", -1, "padd", -1, "padd", -1
 
 LogTransport *
 log_transport_mock_stream_new(gchar *read_buffer1, gssize read_buffer_length1, ...);

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -34,18 +34,18 @@ MsgFormatOptions parse_options;
 
 #define MSG_TESTCASE(x, ...) do { log_message_testcase_begin(#x, #__VA_ARGS__); x(__VA_ARGS__); log_message_testcase_end(); } while(0)
 
-#define log_message_testcase_begin(func, args) 			\
-  do                                          			\
-    {                                         			\
+#define log_message_testcase_begin(func, args)      \
+  do                                                \
+    {                                               \
       testcase_begin("%s(%s)", func, args);                     \
-    }                                         			\
+    }                                               \
   while (0)
 
-#define log_message_testcase_end()				\
-  do								\
-    {								\
-      testcase_end();						\
-    }								\
+#define log_message_testcase_end()        \
+  do                \
+    {               \
+      testcase_end();           \
+    }               \
   while (0)
 
 

--- a/libtest/proto_lib.h
+++ b/libtest/proto_lib.h
@@ -32,26 +32,27 @@ extern LogProtoServerOptions proto_server_options;
 
 #define PROTO_TESTCASE(x, ...) do { log_proto_testcase_begin(#x, #__VA_ARGS__); x(__VA_ARGS__); log_proto_testcase_end(); } while(0)
 
-#define log_proto_testcase_begin(func, args) 			\
-  do                                          			\
-    {                                         			\
+#define log_proto_testcase_begin(func, args)      \
+  do                                                \
+    {                                               \
       testcase_begin("%s(%s)", func, args);                     \
-      log_proto_server_options_defaults(&proto_server_options);	\
-    }                                         			\
+      log_proto_server_options_defaults(&proto_server_options); \
+    }                                               \
   while (0)
 
-#define log_proto_testcase_end()				\
-  do								\
-    {								\
-      log_proto_server_options_destroy(&proto_server_options);	\
-      testcase_end();						\
-    }								\
+#define log_proto_testcase_end()        \
+  do                \
+    {               \
+      log_proto_server_options_destroy(&proto_server_options);  \
+      testcase_end();           \
+    }               \
   while (0)
 
 void assert_proto_server_status(LogProtoServer *proto, LogProtoStatus status, LogProtoStatus expected_status);
 void assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len);
 void assert_proto_server_fetch_single_read(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len);
-void assert_proto_server_fetch_failure(LogProtoServer *proto, LogProtoStatus expected_status, const gchar *error_message);
+void assert_proto_server_fetch_failure(LogProtoServer *proto, LogProtoStatus expected_status,
+                                       const gchar *error_message);
 void assert_proto_server_fetch_ignored_eof(LogProtoServer *proto);
 
 LogProtoServer *construct_server_proto_plugin(const gchar *name, LogTransport *transport);

--- a/libtest/template_lib.h
+++ b/libtest/template_lib.h
@@ -31,12 +31,13 @@
 
 void assert_template_format(const gchar *template, const gchar *expected);
 void assert_template_format_msg(const gchar *template,
-                                     const gchar *expected, LogMessage *msg);
+                                const gchar *expected, LogMessage *msg);
 void assert_template_format_with_escaping(const gchar *template, gboolean escaping, const gchar *expected);
 void assert_template_format_with_escaping_msg(const gchar *template, gboolean escaping,
-                                     const gchar *expected, LogMessage *msg);
+                                              const gchar *expected, LogMessage *msg);
 void assert_template_format_with_context(const gchar *template, const gchar *expected);
-void assert_template_format_with_context_msgs(const gchar *template, const gchar *expected, LogMessage **msgs, gint num_messages);
+void assert_template_format_with_context_msgs(const gchar *template, const gchar *expected, LogMessage **msgs,
+                                              gint num_messages);
 void assert_template_format_with_len(const gchar *template, const gchar *expected, gssize expected_len);
 void assert_template_format_with_escaping_and_context_msgs(const gchar *template, gboolean escaping,
                                                            const gchar *expected, gssize expected_len,

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -60,16 +60,21 @@ gboolean assert_guint16_non_fatal(guint16 actual, guint16 expected, const gchar 
 gboolean assert_gint64_non_fatal(gint64 actual, gint64 expected, const gchar *error_message, ...);
 gboolean assert_guint64_non_fatal(guint64 actual, guint64 expected, const gchar *error_message, ...);
 gboolean assert_gdouble_non_fatal(gdouble actual, gdouble expected, const gchar *error_message, ...);
-gboolean assert_nstring_non_fatal(const gchar *actual, gint actual_len, const gchar *expected, gint expected_len, const gchar *error_message, ...);
-gboolean assert_guint32_array_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected, guint32 expected_length, const gchar *error_message, ...);
-gboolean assert_string_array_non_fatal(gchar **actual, guint32 actual_length, gchar **expected, guint32 expected_length, const gchar *error_message, ...);
+gboolean assert_nstring_non_fatal(const gchar *actual, gint actual_len, const gchar *expected, gint expected_len,
+                                  const gchar *error_message, ...);
+gboolean assert_guint32_array_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected,
+                                        guint32 expected_length, const gchar *error_message, ...);
+gboolean assert_string_array_non_fatal(gchar **actual, guint32 actual_length, gchar **expected, guint32 expected_length,
+                                       const gchar *error_message, ...);
 gboolean assert_gboolean_non_fatal(gboolean actual, gboolean expected, const gchar *error_message, ...);
 gboolean assert_null_non_fatal(const void *pointer, const gchar *error_message, ...);
 gboolean assert_not_null_non_fatal(void *pointer, const gchar *error_message, ...);
 gboolean assert_no_error_non_fatal(GError *error, const gchar *error_message, ...);
-gboolean assert_guint32_set_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected, guint32 expected_length, const gchar *error_message, ...);
+gboolean assert_guint32_set_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected,
+                                      guint32 expected_length, const gchar *error_message, ...);
 gboolean assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error_message, ...);
-gboolean assert_msg_field_equals_non_fatal(LogMessage *msg, gchar *field_name, gchar *expected_value, gssize expected_value_len, const gchar *error_message, ...);
+gboolean assert_msg_field_equals_non_fatal(LogMessage *msg, gchar *field_name, gchar *expected_value,
+                                           gssize expected_value_len, const gchar *error_message, ...);
 gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, gchar *field_name, const gchar *error_message, ...);
 gboolean expect_not_reached(const gchar *error_message, ...);
 

--- a/modules/add-contextual-data/add-contextual-data-selector.h
+++ b/modules/add-contextual-data/add-contextual-data-selector.h
@@ -28,15 +28,16 @@
 
 typedef struct _AddContextualDataSelector AddContextualDataSelector;
 
-struct _AddContextualDataSelector{
+struct _AddContextualDataSelector
+{
   gboolean ordering_required;
   gchar *(*resolve)(AddContextualDataSelector *self, LogMessage *msg);
   void (*free)(AddContextualDataSelector *self);
-  AddContextualDataSelector*(*clone)(AddContextualDataSelector *self, GlobalConfig *cfg);
+  AddContextualDataSelector *(*clone)(AddContextualDataSelector *self, GlobalConfig *cfg);
   gboolean (*init)(AddContextualDataSelector *self, GList *ordered_selectors);
 };
 
-static inline gchar*
+static inline gchar *
 add_contextual_data_selector_resolve(AddContextualDataSelector *self, LogMessage *msg)
 {
   if (self && self->resolve)

--- a/modules/add-contextual-data/add-contextual-data-template-selector.h
+++ b/modules/add-contextual-data/add-contextual-data-template-selector.h
@@ -25,7 +25,7 @@
 
 #include "add-contextual-data-selector.h"
 
-AddContextualDataSelector*
+AddContextualDataSelector *
 add_contextual_data_template_selector_new(GlobalConfig *cfg, const gchar *selector_template_string);
 
 #endif

--- a/modules/add-contextual-data/context-info-db.h
+++ b/modules/add-contextual-data/context-info-db.h
@@ -33,7 +33,7 @@ typedef void (*ADD_CONTEXT_INFO_CB) (gpointer arg,
                                      const ContextualDataRecord *record);
 
 void context_info_db_enable_ordering(ContextInfoDB *self);
-GList * context_info_db_ordered_selectors(ContextInfoDB *self);
+GList *context_info_db_ordered_selectors(ContextInfoDB *self);
 ContextInfoDB *context_info_db_new(void);
 void context_info_db_free(ContextInfoDB *self);
 

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef AFFILE_DEST_H_INCLUDED
 #define AFFILE_DEST_H_INCLUDED
 
@@ -45,7 +45,7 @@ typedef struct _AFFileDestDriver
   LogWriterOptions writer_options;
   guint32 writer_flags;
   GHashTable *writer_hash;
-    
+
   gint overwrite_if_older;
   gboolean use_time_recvd;
   gint time_reap;

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef AFFILE_SOURCE_H_INCLUDED
 #define AFFILE_SOURCE_H_INCLUDED
 

--- a/modules/affile/collection-comporator.h
+++ b/modules/affile/collection-comporator.h
@@ -35,7 +35,8 @@ void collection_comporator_stop(CollectionComporator *self);
 void collection_comporator_add_value(CollectionComporator *self, const gchar *value);
 void collection_comporator_add_initial_value(CollectionComporator *self, const gchar *value);
 
-void collection_comporator_set_callbacks(CollectionComporator *self, cc_callback handle_new, cc_callback handle_delete, gpointer user_data);
+void collection_comporator_set_callbacks(CollectionComporator *self, cc_callback handle_new, cc_callback handle_delete,
+                                         gpointer user_data);
 
 
 #endif /* MODULES_AFFILE_COLLECTION_COMPORATOR_H_ */

--- a/modules/affile/directory-monitor-factory.h
+++ b/modules/affile/directory-monitor-factory.h
@@ -26,14 +26,16 @@
 
 typedef DirectoryMonitor *(*DirectoryMonitorConstructor)(const gchar *dir, guint recheck_time);
 
-typedef enum {
+typedef enum
+{
   MM_AUTO,
   MM_POLL,
   MM_INOTIFY,
   MM_UNKNOWN
 } MonitorMethod;
 
-typedef struct _DirectoryMonitorOptions {
+typedef struct _DirectoryMonitorOptions
+{
   const gchar *dir;
   guint follow_freq;
   MonitorMethod method;

--- a/modules/affile/directory-monitor.h
+++ b/modules/affile/directory-monitor.h
@@ -25,25 +25,28 @@
 #include <syslog-ng.h>
 #include <iv.h>
 
-typedef enum {
+typedef enum
+{
   FILE_CREATED,
   DIRECTORY_CREATED,
   DELETED,
   UNKNOWN
 } DirectoryMonitorEventType;
 
-typedef struct _DirectoryMonitorEvent {
+typedef struct _DirectoryMonitorEvent
+{
   const gchar *name;
   gchar *full_path;
   DirectoryMonitorEventType event_type;
 } DirectoryMonitorEvent;
 
 typedef  void (*DirectoryMonitorEventCallback)(const DirectoryMonitorEvent *event,
-                                        gpointer user_data);
+                                               gpointer user_data);
 
 typedef struct _DirectoryMonitor DirectoryMonitor;
 
-struct _DirectoryMonitor {
+struct _DirectoryMonitor
+{
   gchar *dir;
   gchar *real_path;
   DirectoryMonitorEventCallback callback;
@@ -58,7 +61,7 @@ struct _DirectoryMonitor {
   void (*free_fn)(DirectoryMonitor *self);
 };
 
-DirectoryMonitor* directory_monitor_new(const gchar *dir, guint recheck_time);
+DirectoryMonitor *directory_monitor_new(const gchar *dir, guint recheck_time);
 void directory_monitor_init_instance(DirectoryMonitor *self, const gchar *dir, guint recheck_time);
 void directory_monitor_free(DirectoryMonitor *self);
 void directory_monitor_set_callback(DirectoryMonitor *self, DirectoryMonitorEventCallback callback, gpointer user_data);

--- a/modules/affile/file-opener.h
+++ b/modules/affile/file-opener.h
@@ -55,7 +55,8 @@ struct _FileOpener
   gint (*open)(FileOpener *self, const gchar *name, gint flags);
   gint (*get_open_flags)(FileOpener *self, FileDirection dir);
   LogTransport *(*construct_transport)(FileOpener *self, gint fd);
-  LogProtoServer *(*construct_src_proto)(FileOpener *self, LogTransport *transport, LogProtoFileReaderOptions *proto_options);
+  LogProtoServer *(*construct_src_proto)(FileOpener *self, LogTransport *transport,
+                                         LogProtoFileReaderOptions *proto_options);
   LogProtoClient *(*construct_dst_proto)(FileOpener *self, LogTransport *transport, LogProtoClientOptions *proto_options);
 };
 

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -51,7 +51,8 @@ file_reader_options_get_log_proto_options(FileReaderOptions *options)
   return (LogProtoFileReaderOptions *) &options->reader_options.proto_options;
 }
 
-FileReader *file_reader_new(const gchar *filename, FileReaderOptions *options, FileOpener *opener, LogSrcDriver *owner, GlobalConfig *cfg);
+FileReader *file_reader_new(const gchar *filename, FileReaderOptions *options, FileOpener *opener, LogSrcDriver *owner,
+                            GlobalConfig *cfg);
 
 void file_reader_remove_persist_state(FileReader *self);
 

--- a/modules/affile/logproto-file-writer.h
+++ b/modules/affile/logproto-file-writer.h
@@ -26,6 +26,7 @@
 
 #include "logproto/logproto-client.h"
 
-LogProtoClient *log_proto_file_writer_new(LogTransport *transport, const LogProtoClientOptions *options, gint flush_lines, gboolean fsync);
+LogProtoClient *log_proto_file_writer_new(LogTransport *transport, const LogProtoClientOptions *options,
+                                          gint flush_lines, gboolean fsync);
 
 #endif

--- a/modules/afprog/afprog.h
+++ b/modules/afprog/afprog.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef AFPROG_H_INCLUDED
 #define AFPROG_H_INCLUDED
 

--- a/modules/afsmtp/afsmtp.h
+++ b/modules/afsmtp/afsmtp.h
@@ -27,14 +27,14 @@
 #include "driver.h"
 
 typedef enum
-  {
-    AFSMTP_RCPT_TYPE_NONE,
-    AFSMTP_RCPT_TYPE_TO,
-    AFSMTP_RCPT_TYPE_CC,
-    AFSMTP_RCPT_TYPE_BCC,
-    AFSMTP_RCPT_TYPE_REPLY_TO,
-    AFSMTP_RCPT_TYPE_SENDER,
-  } afsmtp_rcpt_type_t;
+{
+  AFSMTP_RCPT_TYPE_NONE,
+  AFSMTP_RCPT_TYPE_TO,
+  AFSMTP_RCPT_TYPE_CC,
+  AFSMTP_RCPT_TYPE_BCC,
+  AFSMTP_RCPT_TYPE_REPLY_TO,
+  AFSMTP_RCPT_TYPE_SENDER,
+} afsmtp_rcpt_type_t;
 
 LogDriver *afsmtp_dd_new(GlobalConfig *cfg);
 

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -39,7 +39,7 @@ struct _AFSocketDestDriver
   LogDestDriver super;
 
   gboolean
-    connections_kept_alive_across_reloads:1;
+  connections_kept_alive_across_reloads:1;
   gint fd;
   LogWriter *writer;
   LogWriterOptions writer_options;
@@ -80,7 +80,8 @@ afsocket_dd_get_dest_name(const AFSocketDestDriver *s)
 LogWriter *afsocket_dd_construct_writer_method(AFSocketDestDriver *self);
 gboolean afsocket_dd_setup_addresses_method(AFSocketDestDriver *self);
 void afsocket_dd_set_keep_alive(LogDriver *self, gint enable);
-void afsocket_dd_init_instance(AFSocketDestDriver *self, SocketOptions *socket_options, TransportMapper *transport_mapper, GlobalConfig *cfg);
+void afsocket_dd_init_instance(AFSocketDestDriver *self, SocketOptions *socket_options,
+                               TransportMapper *transport_mapper, GlobalConfig *cfg);
 LogTransport *afsocket_dd_construct_transport_method(AFSocketDestDriver *self, gint fd);
 
 gboolean afsocket_dd_init(LogPipe *s);

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -40,9 +40,9 @@ struct _AFSocketSourceDriver
 {
   LogSrcDriver super;
   guint32 recvd_messages_are_local:1,
-    connections_kept_alive_across_reloads:1,
-    require_tls:1,
-    window_size_initialized:1;
+          connections_kept_alive_across_reloads:1,
+          require_tls:1,
+          window_size_initialized:1;
   struct iv_fd listen_fd;
   gint fd;
   LogReaderOptions reader_options;
@@ -97,6 +97,7 @@ gboolean afsocket_sd_init_method(LogPipe *s);
 gboolean afsocket_sd_deinit_method(LogPipe *s);
 void afsocket_sd_free_method(LogPipe *self);
 
-void afsocket_sd_init_instance(AFSocketSourceDriver *self, SocketOptions *socket_options, TransportMapper *transport_mapper, GlobalConfig *cfg);
+void afsocket_sd_init_instance(AFSocketSourceDriver *self, SocketOptions *socket_options,
+                               TransportMapper *transport_mapper, GlobalConfig *cfg);
 
 #endif

--- a/modules/afsocket/tests/transport-mapper-lib.h
+++ b/modules/afsocket/tests/transport-mapper-lib.h
@@ -29,18 +29,18 @@
 
 extern TransportMapper *transport_mapper;
 
-#define transport_mapper_testcase_begin(init_name, func, args) 	        \
+#define transport_mapper_testcase_begin(init_name, func, args)          \
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      transport_mapper = transport_mapper_ ## init_name ## _new();	        \
+      transport_mapper = transport_mapper_ ## init_name ## _new();          \
     }                                                           \
   while (0)
 
 #define transport_mapper_testcase_end()                           \
   do                                                            \
     {                                                           \
-      transport_mapper_free(transport_mapper);             	\
+      transport_mapper_free(transport_mapper);              \
       testcase_end();                                           \
     }                                                           \
   while (0)
@@ -65,7 +65,8 @@ assert_transport_mapper_apply_fails(TransportMapper *self, const gchar *transpor
 {
   if (transport)
     transport_mapper_set_transport(self, transport);
-  assert_false(transport_mapper_apply_transport(self, configuration), "afsocket_apply_transport() succeeded while we expected failure");
+  assert_false(transport_mapper_apply_transport(self, configuration),
+               "afsocket_apply_transport() succeeded while we expected failure");
 }
 
 static inline void

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -54,7 +54,8 @@ transport_mapper_inet_get_port_change_warning(TransportMapper *s)
 }
 
 static inline void
-transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context, TLSSessionVerifyFunc tls_verify_callback, gpointer tls_verify_data)
+transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context,
+                                      TLSSessionVerifyFunc tls_verify_callback, gpointer tls_verify_data)
 {
   self->tls_context = tls_context;
   self->tls_verify_callback = tls_verify_callback;

--- a/modules/afstomp/stomp.h
+++ b/modules/afstomp/stomp.h
@@ -37,7 +37,7 @@ typedef struct stomp_connection
 typedef struct stomp_frame
 {
   char *command;
-  GHashTable* headers;
+  GHashTable *headers;
   char *body;
   int body_length;
 } stomp_frame;

--- a/modules/afuser/afuser.h
+++ b/modules/afuser/afuser.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef AFUSER_H_INCLUDED
 #define AFUSER_H_INCLUDED
 

--- a/modules/dbparser/patterndb.h
+++ b/modules/dbparser/patterndb.h
@@ -41,7 +41,8 @@ gboolean pattern_db_reload_ruleset(PatternDB *self, GlobalConfig *cfg, const gch
 void pattern_db_advance_time(PatternDB *self, gint timeout);
 void pattern_db_timer_tick(PatternDB *self);
 gboolean pattern_db_process(PatternDB *self, LogMessage *msg);
-gboolean pattern_db_process_with_custom_message(PatternDB *self, LogMessage *msg, const gchar *message, gssize message_len);
+gboolean pattern_db_process_with_custom_message(PatternDB *self, LogMessage *msg, const gchar *message,
+                                                gssize message_len);
 void pattern_db_debug_ruleset(PatternDB *self, LogMessage *msg, GArray *dbg_list);
 void pattern_db_expire_state(PatternDB *self);
 void pattern_db_forget_state(PatternDB *self);

--- a/modules/dbparser/pdb-action.h
+++ b/modules/dbparser/pdb-action.h
@@ -30,7 +30,7 @@
 
 /* rule action triggers */
 typedef enum
- {
+{
   RAT_MATCH = 1,
   RAT_TIMEOUT
 } PDBActionTrigger;

--- a/modules/dbparser/radix.h
+++ b/modules/dbparser/radix.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef RADIX_H_INCLUDED
 #define RADIX_H_INCLUDED
 
@@ -113,36 +113,36 @@ r_parser_type_name(guint8 type)
 {
   switch (type)
     {
-      case RPT_STRING:
-        return "STRING";
-      case RPT_QSTRING:
-        return "QSTRING";
-      case RPT_ESTRING:
-        return "ESTRING";
-      case RPT_IPV4:
-        return "IPv4";
-      case RPT_NUMBER:
-        return "NUMBER";
-      case RPT_ANYSTRING:
-        return "ANYSTRING";
-      case RPT_IPV6:
-        return "IPv6";
-      case RPT_IP:
-        return "IP";
-      case RPT_FLOAT:
-        return "FLOAT";
-      case RPT_SET:
-        return "SET";
-      case RPT_MACADDR:
-        return "MACADDR";
-      case RPT_EMAIL:
-        return "EMAIL";
-      case RPT_HOSTNAME:
-        return "HOSTNAME";
-      case RPT_LLADDR:
-        return "LLADDR";
-      default:
-        return "UNKNOWN";
+    case RPT_STRING:
+      return "STRING";
+    case RPT_QSTRING:
+      return "QSTRING";
+    case RPT_ESTRING:
+      return "ESTRING";
+    case RPT_IPV4:
+      return "IPv4";
+    case RPT_NUMBER:
+      return "NUMBER";
+    case RPT_ANYSTRING:
+      return "ANYSTRING";
+    case RPT_IPV6:
+      return "IPv6";
+    case RPT_IP:
+      return "IP";
+    case RPT_FLOAT:
+      return "FLOAT";
+    case RPT_SET:
+      return "SET";
+    case RPT_MACADDR:
+      return "MACADDR";
+    case RPT_EMAIL:
+      return "EMAIL";
+    case RPT_HOSTNAME:
+      return "HOSTNAME";
+    case RPT_LLADDR:
+      return "LLADDR";
+    default:
+      return "UNKNOWN";
     }
 }
 

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -42,14 +42,18 @@ typedef struct _SyntheticMessage
 } SyntheticMessage;
 
 LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg, GString *buffer);
-LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context, GString *buffer);
+LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context,
+                                                    GString *buffer);
 
 
 void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
-gboolean synthetic_message_add_value_template_string(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name, const gchar *value, GError **error);
+gboolean synthetic_message_add_value_template_string(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name,
+                                                     const gchar *value, GError **error);
 void synthetic_message_set_inherit_mode(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode);
-void synthetic_message_set_inherit_properties_string(SyntheticMessage *self, const gchar *inherit_properties, GError **error);
-gboolean synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const gchar *inherit_mode_name, GError **error);
+void synthetic_message_set_inherit_properties_string(SyntheticMessage *self, const gchar *inherit_properties,
+                                                     GError **error);
+gboolean synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const gchar *inherit_mode_name,
+                                                   GError **error);
 void synthetic_message_add_value_template(SyntheticMessage *self, const gchar *name, LogTemplate *value);
 void synthetic_message_add_tag(SyntheticMessage *self, const gchar *text);
 void synthetic_message_init(SyntheticMessage *self);

--- a/modules/dbparser/timerwheel.h
+++ b/modules/dbparser/timerwheel.h
@@ -30,7 +30,8 @@ typedef struct _TWEntry TWEntry;
 typedef struct _TimerWheel TimerWheel;
 typedef void (*TWCallbackFunc)(TimerWheel *tw, guint64 now, gpointer user_data);
 
-TWEntry *timer_wheel_add_timer(TimerWheel *self, gint timeout, TWCallbackFunc cb, gpointer user_data, GDestroyNotify user_data_free);
+TWEntry *timer_wheel_add_timer(TimerWheel *self, gint timeout, TWCallbackFunc cb, gpointer user_data,
+                               GDestroyNotify user_data_free);
 void timer_wheel_del_timer(TimerWheel *self, TWEntry *entry);
 void timer_wheel_mod_timer(TimerWheel *self, TWEntry *entry, gint new_timeout);
 guint64 timer_wheel_get_timer_expiration(TimerWheel *self, TWEntry *entry);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -36,7 +36,8 @@ struct _LogQueueDisk
   LogQueue super;
   QDisk *qdisk;         /* disk based queue */
   gint64 (*get_length)(LogQueueDisk *s);
-  gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, const LogPathOptions *path_options);
+  gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options,
+                        const LogPathOptions *path_options);
   void (*push_head)(LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options);
   LogMessage *(*pop_head)(LogQueueDisk *s, LogPathOptions *path_options);
   void (*ack_backlog)(LogQueueDisk *s, guint num_msg_to_ack);
@@ -46,7 +47,7 @@ struct _LogQueueDisk
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);
   void (*free_fn)(LogQueueDisk *s);
   gboolean (*is_reliable)(LogQueueDisk *s);
-  LogMessage * (*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
+  LogMessage *(*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
   gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
   void (*restart)(LogQueueDisk *self);
   void (*restart_corrupted)(LogQueueDisk *self);

--- a/modules/geoip2/maxminddb-helper.h
+++ b/modules/geoip2/maxminddb-helper.h
@@ -27,9 +27,9 @@
 #include <maxminddb.h>
 void append_mmdb_entry_data_to_gstring(GString *target, MMDB_entry_data_s *entry_data);
 gboolean mmdb_open_database(const gchar *path, MMDB_s *database);
-MMDB_entry_data_list_s * dump_geodata_into_msg(LogMessage *msg,
-                                               MMDB_entry_data_list_s *entry_data_list,
-                                               GArray *path, gint *status);
+MMDB_entry_data_list_s *dump_geodata_into_msg(LogMessage *msg,
+                                              MMDB_entry_data_list_s *entry_data_list,
+                                              GArray *path, gint *status);
 
 
 #endif

--- a/modules/java/native/java-class-loader.h
+++ b/modules/java/native/java-class-loader.h
@@ -29,7 +29,8 @@
 #include <jni.h>
 #include <syslog-ng.h>
 
-typedef struct _ClassLoader {
+typedef struct _ClassLoader
+{
   jclass syslogng_class_loader;
   jobject loader_object;
   jmethodID loader_constructor;

--- a/modules/java/native/java_machine.h
+++ b/modules/java/native/java_machine.h
@@ -35,7 +35,7 @@ typedef struct _JavaVMSingleton JavaVMSingleton;
 
 JavaVMSingleton *java_machine_ref(void);
 void java_machine_unref(JavaVMSingleton *self);
-gboolean java_machine_start(JavaVMSingleton* self, const gchar *jvm_options);
+gboolean java_machine_start(JavaVMSingleton *self, const gchar *jvm_options);
 
 void java_machine_detach_thread(void);
 

--- a/modules/java/proxies/java-destination-proxy.h
+++ b/modules/java/proxies/java-destination-proxy.h
@@ -33,7 +33,8 @@
 
 typedef struct _JavaDestinationProxy JavaDestinationProxy;
 
-JavaDestinationProxy *java_destination_proxy_new(const gchar *class_name, const gchar *class_path, gpointer handle, LogTemplate *template, gint32 *seq_num, const gchar *jvm_options);
+JavaDestinationProxy *java_destination_proxy_new(const gchar *class_name, const gchar *class_path, gpointer handle,
+                                                 LogTemplate *template, gint32 *seq_num, const gchar *jvm_options);
 
 gboolean java_destination_proxy_init(JavaDestinationProxy *self);
 void java_destination_proxy_deinit(JavaDestinationProxy *self);

--- a/modules/native/parser.h
+++ b/modules/native/parser.h
@@ -27,7 +27,7 @@
 
 #include "parser/parser-expr.h"
 
-gboolean native_parser_set_option(LogParser *s, gchar* key, gchar* value);
-LogParser* native_parser_new(GlobalConfig *cfg);
+gboolean native_parser_set_option(LogParser *s, gchar *key, gchar *value);
+LogParser *native_parser_new(GlobalConfig *cfg);
 
 #endif

--- a/modules/pseudofile/pseudofile.h
+++ b/modules/pseudofile/pseudofile.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef PSEUDOFILE_H_INCLUDED
 #define PSEUDOFILE_H_INCLUDED
 

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -34,7 +34,7 @@ LogDriver *python_dd_new(GlobalConfig *cfg);
 void python_dd_set_imports(LogDriver *d, GList *imports);
 void python_dd_set_class(LogDriver *d, gchar *class_name);
 void python_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
-void python_dd_set_option(LogDriver*  d, gchar* key, gchar* value);
+void python_dd_set_option(LogDriver  *d, gchar *key, gchar *value);
 LogTemplateOptions *python_dd_get_template_options(LogDriver *d);
 
 #endif

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -35,10 +35,13 @@ PyObject *_py_create_arg_dict(GHashTable *args);
 PyObject *_py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *module);
 void _py_invoke_void_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *module);
 gboolean _py_invoke_bool_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *module);
-PyObject * _py_get_method(PyObject *instance, const gchar *method_name, const gchar *module);
-void _py_invoke_void_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class, const gchar *module);
-gboolean _py_invoke_bool_method_by_name_with_args(PyObject *instance, const gchar *method_name, GHashTable *args, const gchar *class, const gchar *module);
-gboolean _py_invoke_bool_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class, const gchar *module);
+PyObject *_py_get_method(PyObject *instance, const gchar *method_name, const gchar *module);
+void _py_invoke_void_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class,
+                                    const gchar *module);
+gboolean _py_invoke_bool_method_by_name_with_args(PyObject *instance, const gchar *method_name, GHashTable *args,
+                                                  const gchar *class, const gchar *module);
+gboolean _py_invoke_bool_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class,
+                                        const gchar *module);
 void _py_perform_imports(GList *imports);
 
 #endif

--- a/modules/python/python-logparser.h
+++ b/modules/python/python-logparser.h
@@ -30,6 +30,6 @@
 LogParser *python_parser_new(GlobalConfig *cfg);
 void python_parser_set_imports(LogParser *s, GList *imports);
 void python_parser_set_class(LogParser *s, gchar *class_name);
-void python_parser_set_option(LogParser*  s, gchar* key, gchar* value);
+void python_parser_set_option(LogParser  *s, gchar *key, gchar *value);
 
 #endif

--- a/modules/python/python-value-pairs.h
+++ b/modules/python/python-value-pairs.h
@@ -28,6 +28,7 @@
 #include "python-module.h"
 #include "value-pairs/value-pairs.h"
 
-gboolean py_value_pairs_apply(ValuePairs *vp, const LogTemplateOptions *template_options, guint32 seq_num, LogMessage *msg, PyObject **result);
+gboolean py_value_pairs_apply(ValuePairs *vp, const LogTemplateOptions *template_options, guint32 seq_num,
+                              LogMessage *msg, PyObject **result);
 
 #endif

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -29,7 +29,8 @@
 
 typedef struct _JournalReader JournalReader;
 
-typedef struct _JournalReaderOptions {
+typedef struct _JournalReaderOptions
+{
   LogSourceOptions super;
   gboolean initialized;
   gint fetch_limit;
@@ -43,7 +44,8 @@ typedef struct _JournalReaderOptions {
 
 JournalReader *journal_reader_new(GlobalConfig *cfg, Journald *journal);
 void journal_reader_set_persist_name(JournalReader *self, gchar *persist_name);
-void journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptions *options, const gchar *stats_id, const gchar *stats_instance);
+void journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptions *options, const gchar *stats_id,
+                                const gchar *stats_instance);
 
 void journal_reader_options_init(JournalReaderOptions *options, GlobalConfig *cfg, const gchar *group_name);
 void journal_reader_options_defaults(JournalReaderOptions *options);

--- a/modules/systemd-journal/journald-subsystem.h
+++ b/modules/systemd-journal/journald-subsystem.h
@@ -32,10 +32,11 @@
 #include <systemd/sd-journal.h>
 #else
 /* Open flags */
-enum {
-        SD_JOURNAL_LOCAL_ONLY = 1,
-        SD_JOURNAL_RUNTIME_ONLY = 2,
-        SD_JOURNAL_SYSTEM_ONLY = 4
+enum
+{
+  SD_JOURNAL_LOCAL_ONLY = 1,
+  SD_JOURNAL_RUNTIME_ONLY = 2,
+  SD_JOURNAL_SYSTEM_ONLY = 4
 };
 #endif
 

--- a/modules/systemd-journal/tests/test-source.h
+++ b/modules/systemd-journal/tests/test-source.h
@@ -32,11 +32,12 @@
 typedef struct _TestSource TestSource;
 typedef struct _TestCase TestCase;
 
-struct _TestCase {
-    void (*init)(TestCase *self, TestSource *src, Journald *journal, JournalReader *reader, JournalReaderOptions *options);
-    void (*checker)(TestCase *self, TestSource *src, LogMessage *msg);
-    void (*finish)(TestCase *self);
-    gpointer user_data;
+struct _TestCase
+{
+  void (*init)(TestCase *self, TestSource *src, Journald *journal, JournalReader *reader, JournalReaderOptions *options);
+  void (*checker)(TestCase *self, TestSource *src, LogMessage *msg);
+  void (*finish)(TestCase *self);
+  gpointer user_data;
 };
 
 

--- a/modules/xml/xml.h
+++ b/modules/xml/xml.h
@@ -36,8 +36,8 @@ typedef struct
   gboolean strip_whitespaces;
 } XMLParser;
 
-LogParser * xml_parser_new(GlobalConfig *cfg);
-LogPipe * xml_parser_clone(LogPipe *s);
+LogParser *xml_parser_new(GlobalConfig *cfg);
+LogPipe *xml_parser_clone(LogPipe *s);
 void xml_parser_set_prefix(LogParser *s, const gchar *prefix);
 void xml_parser_set_forward_invalid(LogParser *s, gboolean setting);
 void xml_parser_set_exclude_tags(LogParser *s, GList *exclude_tags);

--- a/scripts/style-checker.sh
+++ b/scripts/style-checker.sh
@@ -34,7 +34,7 @@ function setup_root_dir
 
 function astyle_c_check
 {
-    astyle --options="$root_dir/.astylerc" --dry-run "$root_dir/*.c" | grep "Formatted" | tee badly-formatted-files.list | wc -l | while read badly_formatted_c_files
+    astyle --options="$root_dir/.astylerc" --dry-run "$root_dir/*.h" "$root_dir/*.c" | grep "Formatted" | tee badly-formatted-files.list | wc -l | while read badly_formatted_c_files
     do
         echo "Number of badly formatted files: $badly_formatted_c_files"
         if [ "$badly_formatted_c_files" == "0" ]; then
@@ -48,7 +48,7 @@ function astyle_c_check
 
 function astyle_c_format
 {
-    astyle --options="$root_dir/.astylerc" "$root_dir/*.c" | grep "Formatted"
+    astyle --options="$root_dir/.astylerc" "$root_dir/*.h" "$root_dir/*.c" | grep "Formatted"
     exit 0
 }
 

--- a/syslog-ng-ctl/control-client.h
+++ b/syslog-ng-ctl/control-client.h
@@ -32,7 +32,7 @@ typedef struct _ControlClient ControlClient;
 ControlClient *control_client_new(const gchar *path);
 gboolean control_client_connect(ControlClient *self);
 gint control_client_send_command(ControlClient *self, const gchar *cmd);
-GString* control_client_read_reply(ControlClient *self);
+GString *control_client_read_reply(ControlClient *self);
 void control_client_free(ControlClient *self);
 
 #endif


### PR DESCRIPTION
* Astyle check apply for headers also
* Astyle excludeded afamqp, while it should have excluded only the rabbitmq-c submodule
* Travis now shows what should be changed in the style-check job (calling format and git diff)
