### PR TITLE
xml-parser: bugfixes 

### DIFF
--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -42,6 +42,27 @@ teardown(void)
   cfg_free(configuration);
 }
 
+typedef struct
+{
+  gboolean forward_invalid;
+  gboolean strip_whitespaces;
+  GList *exclude_tags;
+} XMLParserTestOptions;
+
+static LogParser *
+_construct_xml_parser(XMLParserTestOptions options)
+{
+  LogParser *xml_parser = xml_parser_new(configuration);
+  xml_parser_set_forward_invalid(xml_parser, options.forward_invalid);
+  xml_parser_set_strip_whitespaces(xml_parser, options.strip_whitespaces);
+  xml_parser_set_exclude_tags(xml_parser, options.exclude_tags);
+
+  LogPipe *cloned = xml_parser_clone(&xml_parser->super);
+  log_pipe_init(cloned);
+  log_pipe_unref(&xml_parser->super);
+  return (LogParser *)cloned;
+}
+
 TestSuite(xmlparser, .init = setup, .fini = teardown);
 
 typedef struct
@@ -72,9 +93,7 @@ ParameterizedTestParameters(xmlparser, invalid_inputs)
 
 ParameterizedTest(XMLFailTestCase *test_case, xmlparser, invalid_inputs)
 {
-  LogParser *xml_parser = xml_parser_new(configuration);
-  xml_parser_set_forward_invalid(xml_parser, FALSE);
-  log_pipe_init((LogPipe *)xml_parser);
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions) {});
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE, test_case->input, -1);
@@ -114,8 +133,7 @@ ParameterizedTestParameters(xmlparser, valid_inputs)
 
 ParameterizedTest(ValidXMLTestCase *test_cases, xmlparser, valid_inputs)
 {
-  LogParser *xml_parser = xml_parser_new(configuration);
-  log_pipe_init((LogPipe *)xml_parser);
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions) {});
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE, test_cases->input, -1);
@@ -137,8 +155,7 @@ Test(xml_parser, test_drop_invalid)
 {
   setup();
 
-  LogParser *xml_parser = xml_parser_new(configuration);
-  log_pipe_init((LogPipe *)xml_parser);
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions) {});
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE, "<tag>", -1);
@@ -310,9 +327,10 @@ Test(xml_parser, test_strip_whitespaces)
 {
   setup();
 
-  LogParser *xml_parser = xml_parser_new(configuration);
-  xml_parser_set_strip_whitespaces(xml_parser, TRUE);
-  log_pipe_init((LogPipe *)xml_parser);
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions)
+  {
+    .strip_whitespaces = TRUE
+  });
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE,

--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -236,9 +236,10 @@ ParameterizedTest(SingleExcludeTagTestCase *test_cases, xmlparser, single_exclud
   GList *exclude_tags = NULL;
   exclude_tags = g_list_append(exclude_tags, test_cases->pattern);
 
-  LogParser *xml_parser = xml_parser_new(configuration);
-  xml_parser_set_exclude_tags(xml_parser, exclude_tags);
-  log_pipe_init((LogPipe *)xml_parser);
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions)
+  {
+    .exclude_tags = exclude_tags
+  });
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE, test_cases->input, -1);
@@ -266,9 +267,10 @@ Test(xml_parser, test_multiple_exclude_tags)
   exclude_tags = g_list_append(exclude_tags, "tag2");
   exclude_tags = g_list_append(exclude_tags, "inner*");
 
-  LogParser *xml_parser = xml_parser_new(configuration);
-  xml_parser_set_exclude_tags(xml_parser, exclude_tags);
-  log_pipe_init((LogPipe *)xml_parser);
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions)
+  {
+    .exclude_tags = exclude_tags
+  });
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE,

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -281,7 +281,7 @@ _clone_exclude_patterns(XMLParser *self)
   return array;
 }
 
-static LogPipe *
+LogPipe *
 xml_parser_clone(LogPipe *s)
 {
   XMLParser *self = (XMLParser *) s;
@@ -292,6 +292,7 @@ xml_parser_clone(LogPipe *s)
   xml_parser_set_prefix(&cloned->super, self->prefix);
   log_parser_set_template(&cloned->super, log_template_ref(self->super.template));
   xml_parser_set_forward_invalid(&cloned->super, self->forward_invalid);
+  xml_parser_set_strip_whitespaces(&cloned->super, self->strip_whitespaces);
   cloned->exclude_patterns = _clone_exclude_patterns(self);
   cloned->matchstring_shouldreverse = self->matchstring_shouldreverse;
 

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -103,6 +103,7 @@ start_element_cb(GMarkupParseContext  *context,
       msg_debug("xml: subtree skipped", evt_tag_str("tag", element_name));
       state->pop_next_time = 1;
       g_markup_parse_context_push(context, &skip, NULL);
+      g_free(reversed);
       return;
     }
 

--- a/modules/xml/xml.h
+++ b/modules/xml/xml.h
@@ -36,6 +36,7 @@ typedef struct
 } XMLParser;
 
 LogParser * xml_parser_new(GlobalConfig *cfg);
+LogPipe * xml_parser_clone(LogPipe *s);
 void xml_parser_set_prefix(LogParser *s, const gchar *prefix);
 void xml_parser_set_forward_invalid(LogParser *s, gboolean setting);
 void xml_parser_set_exclude_tags(LogParser *s, GList *exclude_tags);

--- a/modules/xml/xml.h
+++ b/modules/xml/xml.h
@@ -30,6 +30,7 @@ typedef struct
   LogParser super;
   gchar *prefix;
   gboolean forward_invalid;
+  GList *exclude_tags;
   GPtrArray *exclude_patterns;
   gboolean matchstring_shouldreverse;
   gboolean strip_whitespaces;


### PR DESCRIPTION
- strip-whitespace option is not copied during clone
- when exclude pattern is used and the pipe element is cloned, shutdown leads to double free
- memory leak when exclude patterns is used, and the provided patterns force a string reverse

Now unit tests run on a cloned version of the pipe element instead of the original.