### PR TITLE
xml-parser: eliminate side effect g_list_copy_deep

### DIFF
--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -45,7 +45,7 @@ g_list_copy_deep(GList     *list,
   GList *new_list = g_list_copy(list);
   if (func)
     {
-      GList *iter = list;
+      GList *iter = new_list;
       while (iter != NULL)
         {
           iter->data = func(iter->data, user_data);


### PR DESCRIPTION
Due to coding error, the backported g_list_copy_deep modified the
original list instead of the new list, causing a side effect, and
returns with a new list. This causes crash during free in xml parser.