### PR TITLE
Grammar: string_list link in reverse order (eliminate reverse overhead)

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -982,11 +982,11 @@ string_or_number
         ;
 
 string_list
-        : string_list_build                     { $$ = g_list_reverse($1); }
+        : string_list_build                     { $$ = $1; }
         ;
 
 string_list_build
-        : string string_list_build		{ $$ = g_list_append($2, g_strdup($1)); free($1); }
+        : string string_list_build		{ $$ = g_list_prepend($2, g_strdup($1)); free($1); }
         |					{ $$ = NULL; }
         ;
 


### PR DESCRIPTION
**Please don't merge it.**
string_list: if we always insert into the first position into the list no reverse is needed in the end.