### PR TITLE
Application adapters + experimental transport for syslog-ng <> syslog-ng communication

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -25,9 +25,9 @@
 #include "cfg-block-generator.h"
 
 gboolean
-cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgLexer *lexer, CfgArgs *args)
+cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result)
 {
-  return self->generate(self, cfg, lexer, args);
+  return self->generate(self, cfg, args, result);
 }
 
 void

--- a/lib/cfg-block-generator.h
+++ b/lib/cfg-block-generator.h
@@ -43,11 +43,12 @@ struct _CfgBlockGenerator
 {
   gint context;
   gchar *name;
-  gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, CfgLexer *lexer, CfgArgs *args);
+  gboolean suppress_backticks;
+  gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result);
   void (*free_fn)(CfgBlockGenerator *self);
 };
 
-gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgLexer *lexer, CfgArgs *args);
+gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result);
 void cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const gchar *name);
 void cfg_block_generator_free_instance(CfgBlockGenerator *self);
 void cfg_block_generator_free(CfgBlockGenerator *self);

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -22,7 +22,6 @@
  *
  */
 #include "cfg-block.h"
-#include "cfg-lexer.h"
 #include "cfg-lexer-subst.h"
 #include "cfg.h"
 #include "str-utils.h"
@@ -87,7 +86,7 @@ cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GStri
 
   _fill_varargs(self, args);
 
-  value = cfg_lexer_subst_args_in_input(cfg->lexer->globals, self->arg_defs, args, self->content, -1, &length, &error);
+  value = cfg_lexer_subst_args_in_input(cfg->globals, self->arg_defs, args, self->content, -1, &length, &error);
   if (!value)
     {
       msg_warning("Syntax error while resolving backtick references in block",

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -154,7 +154,7 @@ xdigit	[0-9a-fA-F]
 odigit  [0-7]
 alpha		[a-zA-Z]
 alphanum	[a-zA-Z0-9]
-word	[^ \#'"\(\)\{\}\\;\r\n\t,|\.@:]
+word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 
 /* block related states must be last, as we use this fact in YY_INPUT */
 %x string
@@ -209,6 +209,8 @@ word	[^ \#'"\(\)\{\}\\;\r\n\t,|\.@:]
 \;			   |
 \{			   |
 \}			   |
+\[			   |
+\]			   |
 \:			   |
 \|			   { return yytext[0]; }
 \,			   ;

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -41,7 +41,7 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size)
   GError *error = NULL;
   YYLTYPE *cur_lloc = &self->include_stack[self->include_depth].lloc;
 
-  res = cfg_lexer_subst_args_in_input(self->globals, NULL, NULL, buf, -1, &len, &error);
+  res = cfg_lexer_subst_args_in_input(self->cfg->globals, NULL, NULL, buf, -1, &len, &error);
   if (!res)
     {
       msg_error("Error performing backtick substitution in configuration file",

--- a/lib/cfg-lexer-subst.c
+++ b/lib/cfg-lexer-subst.c
@@ -105,7 +105,7 @@ _extract_string_literal(const gchar *value)
   YYLTYPE yylloc, look_ahead_yylloc;
   gchar *result = NULL;
 
-  lexer = cfg_lexer_new_buffer(value, strlen(value));
+  lexer = cfg_lexer_new_buffer(configuration, value, strlen(value));
   token = cfg_lexer_lex(lexer, &yylval, &yylloc);
   if (token == LL_STRING)
     {

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -904,12 +904,24 @@ relex:
       if (cfg_parser_parse(&block_ref_parser, self, (gpointer *) &args, NULL))
         {
           gboolean success;
+          gchar buf[256];
+          GString *result = g_string_sized_new(256);
 
           self->preprocess_suppress_tokens--;
-          success = cfg_block_generator_generate(gen, configuration, self, args);
+          success = cfg_block_generator_generate(gen, configuration, args, result);
 
           free(yylval->cptr);
           cfg_args_unref(args);
+          g_snprintf(buf, sizeof(buf), "%s generator %s",
+                     cfg_lexer_lookup_context_name_by_type(gen->context),
+                     gen->name);
+
+          if (gen->suppress_backticks)
+            success = cfg_lexer_include_buffer_without_backtick_substitution(self, buf, result->str, result->len);
+          else
+            success = cfg_lexer_include_buffer(self, buf, result->str, result->len);
+          g_string_free(result, TRUE);
+
           if (success)
             {
               goto relex;

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -136,7 +136,6 @@ struct _CfgLexer
   GString *token_pretext;
   GString *token_text;
   GlobalConfig *cfg;
-  CfgArgs *globals;
   gboolean non_pragma_seen:1, ignore_pragma:1;
 };
 

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -135,6 +135,7 @@ struct _CfgLexer
   gint preprocess_suppress_tokens;
   GString *token_pretext;
   GString *token_text;
+  GlobalConfig *cfg;
   CfgArgs *globals;
   gboolean non_pragma_seen:1, ignore_pragma:1;
 };
@@ -172,8 +173,8 @@ void cfg_lexer_inject_token_block(CfgLexer *self, CfgTokenBlock *block);
 int cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc);
 void cfg_lexer_free_token(YYSTYPE *token);
 
-CfgLexer *cfg_lexer_new(FILE *file, const gchar *filename, GString *preprocess_output);
-CfgLexer *cfg_lexer_new_buffer(const gchar *buffer, gsize length);
+CfgLexer *cfg_lexer_new(GlobalConfig *cfg, FILE *file, const gchar *filename, GString *preprocess_output);
+CfgLexer *cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length);
 void  cfg_lexer_free(CfgLexer *self);
 
 gint cfg_lexer_lookup_context_type_by_name(const gchar *name);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -170,7 +170,7 @@ _sync_plugin_module_path_with_global_define(GlobalConfig *self)
    * PluginContext by default */
   if (self->lexer)
     {
-      module_path = cfg_args_get(self->lexer->globals, "module-path");
+      module_path = cfg_args_get(self->globals, "module-path");
       if (module_path)
         {
           plugin_context_set_module_path(&self->plugin_context, module_path);
@@ -188,7 +188,7 @@ cfg_load_module(GlobalConfig *cfg, const gchar *module_name)
 void
 cfg_load_candidate_modules(GlobalConfig *self)
 {
-  gboolean autoload_enabled = atoi(cfg_args_get(self->lexer->globals, "autoload-compiled-modules") ? : "1");
+  gboolean autoload_enabled = atoi(cfg_args_get(self->globals, "autoload-compiled-modules") ? : "1");
 
   if (self->use_plugin_discovery &&
       autoload_enabled)
@@ -363,7 +363,7 @@ cfg_allow_config_dups(GlobalConfig *self)
   if (cfg_is_config_version_older(self, 0x0303))
     return TRUE;
 
-  s = cfg_args_get(self->lexer->globals, "allow-config-dups");
+  s = cfg_args_get(self->globals, "allow-config-dups");
   if (s && atoi(s))
     {
       return TRUE;
@@ -388,6 +388,7 @@ cfg_new(gint version)
   GlobalConfig *self = g_new0(GlobalConfig, 1);
 
   self->module_config = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify) module_config_free);
+  self->globals = cfg_args_new();
   self->user_version = version;
 
   self->flush_lines = 100;
@@ -444,17 +445,17 @@ cfg_set_global_paths(GlobalConfig *self)
 {
   gchar *include_path;
 
-  cfg_args_set(self->lexer->globals, "syslog-ng-root", get_installation_path_for(SYSLOG_NG_PATH_PREFIX));
-  cfg_args_set(self->lexer->globals, "syslog-ng-data", get_installation_path_for(SYSLOG_NG_PATH_DATADIR));
-  cfg_args_set(self->lexer->globals, "syslog-ng-include", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
-  cfg_args_set(self->lexer->globals, "scl-root", get_installation_path_for(SYSLOG_NG_PATH_SCLDIR));
-  cfg_args_set(self->lexer->globals, "module-path", resolvedConfigurablePaths.initial_module_path);
-  cfg_args_set(self->lexer->globals, "module-install-dir", resolvedConfigurablePaths.initial_module_path);
+  cfg_args_set(self->globals, "syslog-ng-root", get_installation_path_for(SYSLOG_NG_PATH_PREFIX));
+  cfg_args_set(self->globals, "syslog-ng-data", get_installation_path_for(SYSLOG_NG_PATH_DATADIR));
+  cfg_args_set(self->globals, "syslog-ng-include", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
+  cfg_args_set(self->globals, "scl-root", get_installation_path_for(SYSLOG_NG_PATH_SCLDIR));
+  cfg_args_set(self->globals, "module-path", resolvedConfigurablePaths.initial_module_path);
+  cfg_args_set(self->globals, "module-install-dir", resolvedConfigurablePaths.initial_module_path);
 
   include_path = g_strdup_printf("%s:%s",
                                  get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR),
                                  get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
-  cfg_args_set(self->lexer->globals, "include-path", include_path);
+  cfg_args_set(self->globals, "include-path", include_path);
   g_free(include_path);
 }
 
@@ -578,6 +579,7 @@ cfg_free(GlobalConfig *self)
   plugin_context_deinit_instance(&self->plugin_context);
   cfg_tree_free_instance(&self->tree);
   g_hash_table_unref(self->module_config);
+  cfg_args_unref(self->globals);
   g_free(self);
 }
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -501,7 +501,7 @@ cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, 
   CfgLexer *lexer;
   GString *preprocess_output = g_string_sized_new(8192);
 
-  lexer = cfg_lexer_new_buffer(config_string, strlen(config_string));
+  lexer = cfg_lexer_new_buffer(self, config_string, strlen(config_string));
   lexer->preprocess_output = preprocess_output;
 
   res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
@@ -530,7 +530,7 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gboolean syntax_only, gc
       CfgLexer *lexer;
       GString *preprocess_output = g_string_sized_new(8192);
 
-      lexer = cfg_lexer_new(cfg_file, fname, preprocess_output);
+      lexer = cfg_lexer_new(self, cfg_file, fname, preprocess_output);
       res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
       fclose(cfg_file);
       if (preprocess_into)

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -69,6 +69,7 @@ struct _GlobalConfig
   PluginContext plugin_context;
   gboolean use_plugin_discovery;
   CfgLexer *lexer;
+  CfgArgs *globals;
 
   StatsOptions stats_options;
   gint mark_freq;

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -180,12 +180,6 @@ log_msg_set_flag(LogMessage *self, gint32 flag)
 }
 
 static inline void
-log_msg_unset_flag(LogMessage *self, gint32 flag)
-{
-  self->flags &= ~flag;
-}
-
-static inline void
 log_msg_set_host_id(LogMessage *msg)
 {
   msg->host_id = host_id_get();
@@ -576,7 +570,7 @@ log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *value, gssize 
   if (new_entry)
     log_msg_update_sdata(self, handle, name, name_len);
   if (handle == LM_V_PROGRAM || handle == LM_V_PID)
-    log_msg_unset_flag(self, LF_LEGACY_MSGHDR);
+    log_msg_unset_value(self, LM_V_LEGACY_MSGHDR);
 }
 
 void

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1251,6 +1251,19 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
   return self;
 }
 
+static gsize
+_determine_payload_size(gint length, MsgFormatOptions *parse_options)
+{
+  gsize payload_size;
+
+  if ((parse_options->flags & LP_STORE_RAW_MESSAGE))
+    payload_size = length * 4;
+  else
+    payload_size = length * 2;
+
+  return MAX(payload_size, 256);
+}
+
 /**
  * log_msg_new:
  * @msg: message to parse
@@ -1265,7 +1278,7 @@ log_msg_new(const gchar *msg, gint length,
             GSockAddr *saddr,
             MsgFormatOptions *parse_options)
 {
-  LogMessage *self = log_msg_alloc(length == 0 ? 256 : length * 2);
+  LogMessage *self = log_msg_alloc(_determine_payload_size(length, parse_options));
 
   log_msg_init(self, saddr);
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -126,12 +126,18 @@ enum
 
   LF_CHAINED_HOSTNAME  = 0x00010000,
 
-  /* originally parsed from RFC 3164 format and the legacy message header
-   * was saved in $LEGACY_MSGHDR. This flag is a hack to avoid a hash lookup
-   * in the fast path and indicates that the parser has saved the legacy
-   * message header intact in a value named LEGACY_MSGHDR.
+  /* NOTE: this flag is now unused.  The original intent was to save whether
+   * LEGACY_MSGHDR was saved by the parser code.  Now we simply check
+   * whether the length of ${LEGACY_MSGHDR} is non-zero.  This used to be a
+   * slow operation (when name-value pairs were stored in a hashtable), now
+   * it is much faster.  Also, this makes it possible to reproduce a message
+   * entirely based on name-value pairs.  Without this change, even if
+   * LEGACY_MSGHDR was transferred (e.g.  ewmm), the other side couldn't
+   * reproduce the original message, as this flag was not transferred.
+   *
+   * The flag remains here for documentation, and also because it is serialized in disk-buffers
    */
-  LF_LEGACY_MSGHDR    = 0x00020000,
+  __UNUSED_LF_LEGACY_MSGHDR    = 0x00020000,
 };
 
 typedef struct _LogMessageQueueNode

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1004,9 +1004,9 @@ log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result)
           g_string_append_len(result, p, len);
           g_string_append_c(result, ' ');
 
-          if ((lm->flags & LF_LEGACY_MSGHDR))
+          p = log_msg_get_value(lm, LM_V_LEGACY_MSGHDR, &len);
+          if (len > 0)
             {
-              p = log_msg_get_value(lm, LM_V_LEGACY_MSGHDR, &len);
               g_string_append_len(result, p, len);
             }
           else

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -127,6 +127,7 @@ CfgFlagHandler msg_format_flag_handlers[] =
   { "sanitize-utf8",              CFH_SET, offsetof(MsgFormatOptions, flags), LP_SANITIZE_UTF8 },
   { "no-multi-line",              CFH_SET, offsetof(MsgFormatOptions, flags), LP_NO_MULTI_LINE },
   { "store-legacy-msghdr",        CFH_SET, offsetof(MsgFormatOptions, flags), LP_STORE_LEGACY_MSGHDR },
+  { "store-raw-message",          CFH_SET, offsetof(MsgFormatOptions, flags), LP_STORE_RAW_MESSAGE },
   { "dont-store-legacy-msghdr", CFH_CLEAR, offsetof(MsgFormatOptions, flags), LP_STORE_LEGACY_MSGHDR },
   { "expect-hostname",            CFH_SET, offsetof(MsgFormatOptions, flags), LP_EXPECT_HOSTNAME },
   { "no-hostname",              CFH_CLEAR, offsetof(MsgFormatOptions, flags), LP_EXPECT_HOSTNAME },

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -55,6 +55,7 @@ enum
   LP_LOCAL = 0x0200,
   /* for the date part of a message, only skip it, don't fully parse - recommended for keep_timestamp(no) */
   LP_NO_PARSE_DATE = 0x0400,
+  LP_STORE_RAW_MESSAGE = 0x0800,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -104,7 +104,7 @@ define_stmt
 	: KW_DEFINE LL_IDENTIFIER string_or_number		{ msg_debug("Global value changed",
                                                                             evt_tag_str("define", $2),
                                                                             evt_tag_str("value", $3));
-                                                                  cfg_args_set(lexer->globals, $2, $3); free($2); free($3); }
+								  cfg_args_set(configuration->globals, $2, $3); free($2); free($3); }
 
 module_stmt
 	: KW_MODULE string { last_module_args = cfg_args_new(); } module_params

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -320,17 +320,16 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
         }
       break;
     case M_MSGHDR:
-      if ((msg->flags & LF_LEGACY_MSGHDR))
-        {
-          /* fast path for now, as most messages come from legacy devices */
+    {
+      gssize len;
+      const gchar *p;
 
-          _result_append_value(result, msg, LM_V_LEGACY_MSGHDR, escape);
-        }
+      p = log_msg_get_value(msg, LM_V_LEGACY_MSGHDR, &len);
+      if (len > 0)
+        result_append(result, p, len, escape);
       else
         {
           /* message, complete with program name and pid */
-          gssize len;
-
           len = result->len;
           _result_append_value(result, msg, LM_V_PROGRAM, escape);
           if (len != result->len)
@@ -346,6 +345,7 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
             }
         }
       break;
+    }
     case M_MESSAGE:
       _result_append_value(result, msg, LM_V_MESSAGE, escape);
       break;

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -53,7 +53,7 @@ test_parser_input(TestParser *self, const gchar *buffer)
 {
   if (self->lexer)
     cfg_lexer_free(self->lexer);
-  self->lexer = cfg_lexer_new_buffer(buffer, strlen(buffer));
+  self->lexer = cfg_lexer_new_buffer(configuration, buffer, strlen(buffer));
 }
 
 TestParser *

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -347,7 +347,8 @@ vp_cmdline_parse_rekey_shift (const gchar *option_name, const gchar *value,
 
 ValuePairs *
 value_pairs_new_from_cmdline (GlobalConfig *cfg,
-                              gint argc, gchar **argv,
+                              gint *argc, gchar ***argv,
+                              gboolean ignore_unknown_options,
                               GError **error)
 {
   ValuePairs *vp;
@@ -411,18 +412,19 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
   user_data_args[2] = NULL;
   user_data_args[3] = NULL;
 
-  ctx = g_option_context_new ("value-pairs");
-  og = g_option_group_new (NULL, NULL, NULL, user_data_args, NULL);
-  g_option_group_add_entries (og, vp_options);
-  g_option_context_set_main_group (ctx, og);
+  ctx = g_option_context_new("value-pairs");
+  og = g_option_group_new(NULL, NULL, NULL, user_data_args, NULL);
+  g_option_group_add_entries(og, vp_options);
+  g_option_context_set_main_group(ctx, og);
+  g_option_context_set_ignore_unknown_options(ctx, ignore_unknown_options);
 
-  success = g_option_context_parse (ctx, &argc, &argv, error);
-  vp_cmdline_parse_rekey_finish (user_data_args);
-  g_option_context_free (ctx);
+  success = g_option_context_parse(ctx, argc, argv, error);
+  vp_cmdline_parse_rekey_finish(user_data_args);
+  g_option_context_free(ctx);
 
   if (!success)
     {
-      value_pairs_unref (vp);
+      value_pairs_unref(vp);
       vp = NULL;
     }
 

--- a/lib/value-pairs/cmdline.h
+++ b/lib/value-pairs/cmdline.h
@@ -27,7 +27,8 @@
 #include "value-pairs/value-pairs.h"
 
 ValuePairs *value_pairs_new_from_cmdline(GlobalConfig *cfg,
-					 gint argc, gchar **argv,
+					 gint *argc, gchar ***argv,
+					 gboolean ignore_unknown_options,
 					 GError **error);
 
 #endif

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -664,13 +664,18 @@ vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
           token_end = vp_walker_skip_sdata_enterprise_id(token_end);
           break;
         case '.':
-          g_ptr_array_add(array, g_strndup(token_start, token_end - token_start));
-          ++token_end;
-          token_start = token_end;
-          break;
+          if (token_start != token_end)
+            {
+              g_ptr_array_add(array, g_strndup(token_start, token_end - token_start));
+              ++token_end;
+              token_start = token_end;
+              break;
+            }
+        /* fall through, zero length token is not considered a separate token */
         default:
           ++token_end;
           token_end += strcspn(token_end, "@.");
+          break;
         }
     }
 

--- a/libtest/config_parse_lib.c
+++ b/libtest/config_parse_lib.c
@@ -69,7 +69,7 @@ parse_plugin_config(const gchar *config_to_parse, gint context, gpointer arg)
       return NULL;
     }
 
-  lexer = cfg_lexer_new_buffer(delimited[1], strlen(delimited[1]));
+  lexer = cfg_lexer_new_buffer(configuration, delimited[1], strlen(delimited[1]));
   if (!lexer)
     {
       fprintf(stderr, "Error parsing expression\n");
@@ -116,7 +116,7 @@ static gboolean
 parse_general_config(const gchar *config_to_parse, gint context, gpointer arg)
 {
   gpointer result = NULL;
-  CfgLexer *lexer = cfg_lexer_new_buffer(config_to_parse, strlen(config_to_parse));
+  CfgLexer *lexer = cfg_lexer_new_buffer(configuration, config_to_parse, strlen(config_to_parse));
 
   if (!cfg_run_parser(configuration, lexer, &main_parser, &result, arg))
     {

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -41,6 +41,7 @@ include modules/stardate/Makefile.am
 include modules/snmptrapd-parser/Makefile.am
 include modules/tagsparser/Makefile.am
 include modules/xml/Makefile.am
+include modules/appmodel/Makefile.am
 
 SYSLOG_NG_CORE_JAR=$(top_builddir)/modules/java/syslog-ng-core/libs/syslog-ng-core.jar
 
@@ -53,8 +54,8 @@ SYSLOG_NG_MODULES	=	\
 	mod-redis mod-pseudofile mod-graphite mod-riemann \
 	mod-python mod-java mod-java-modules mod-kvformat mod-date \
 	mod-native mod-cef mod-add-contextual-data mod-diskq mod-getent \
-	mod-map-value-pairs mod-snmptrapd-parser mod-tags-parser mod-xml
-
+	mod-map-value-pairs mod-snmptrapd-parser mod-tags-parser mod-xml \
+	mod-appmodel
 
 modules modules/: ${SYSLOG_NG_MODULES}
 
@@ -69,6 +70,6 @@ modules_test_subdirs	=	\
 	modules_graphite modules_riemann modules_python \
 	modules_systemd_journal modules_kvformat modules_date \
 	modules_cef modules_diskq modules-add-contextual-data modules_getent \
-	modules_map-value-pairs modules_tagsparser
+	modules_map-value-pairs modules_tagsparser modules_xml modules_appmodel
 
 .PHONY: modules modules/

--- a/modules/appmodel/Makefile.am
+++ b/modules/appmodel/Makefile.am
@@ -1,0 +1,42 @@
+
+appmodel_sources =
+
+module_LTLIBRARIES				+= modules/appmodel/libappmodel.la
+modules_appmodel_libappmodel_la_SOURCES	=	\
+	modules/appmodel/appmodel.c		\
+	modules/appmodel/appmodel.h		\
+	modules/appmodel/appmodel-parser.c	\
+	modules/appmodel/appmodel-parser.h	\
+	modules/appmodel/appmodel-plugin.c	\
+	modules/appmodel/appmodel-context.c	\
+	modules/appmodel/appmodel-context.h	\
+	modules/appmodel/app-parser-generator.c \
+	modules/appmodel/app-parser-generator.h \
+	modules/appmodel/application.c		\
+	modules/appmodel/application.h		\
+	modules/appmodel/appmodel-grammar.y
+
+modules_appmodel_libappmodel_la_CPPFLAGS	=	\
+	$(AM_CPPFLAGS)					\
+	-I$(top_srcdir)/modules/appmodel		\
+	-I$(top_builddir)/modules/appmodel
+modules_appmodel_libappmodel_la_LIBADD	=	\
+	$(MODULE_DEPS_LIBS)
+modules_appmodel_libappmodel_la_LDFLAGS	=	\
+	$(MODULE_LDFLAGS)
+modules_appmodel_libappmodel_la_DEPENDENCIES	=	\
+	$(MODULE_DEPS_LIBS)
+
+BUILT_SOURCES					+=	\
+	modules/appmodel/appmodel-grammar.y		\
+	modules/appmodel/appmodel-grammar.c		\
+	modules/appmodel/appmodel-grammar.h
+EXTRA_DIST					+=	\
+	modules/appmodel/appmodel-grammar.ym
+
+modules/appmodel modules/appmodel/ mod-tags-parser: modules/appmodel/libappmodel.la
+.PHONY: modules/appmodel/ mod-tags-parser
+
+
+
+include modules/appmodel/tests/Makefile.am

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "app-parser-generator.h"
+#include "appmodel.h"
+
+#include <string.h>
+
+typedef struct _AppParserGenerator
+{
+  CfgBlockGenerator super;
+  GString *block;
+  const gchar *topic;
+} AppParserGenerator;
+
+static const gchar *
+_get_filter_expr(Application *app, Application *base_app)
+{
+  if (app->filter_expr)
+    return app->filter_expr;
+  if (base_app)
+    return base_app->filter_expr;
+  return NULL;
+}
+
+static const gchar *
+_get_parser_expr(Application *app, Application *base_app)
+{
+  if (app->parser_expr)
+    return app->parser_expr;
+  if (base_app)
+    return base_app->parser_expr;
+  return NULL;
+}
+
+static void
+_generate_filter(AppParserGenerator *self, const gchar *filter_expr)
+{
+  if (filter_expr)
+    g_string_append_printf(self->block, "    filter { %s };\n", filter_expr);
+}
+
+static void
+_generate_parser(AppParserGenerator *self, const gchar *parser_expr)
+{
+  if (parser_expr)
+    g_string_append_printf(self->block, "    parser { %s };\n", parser_expr);
+}
+
+static void
+_generate_action(AppParserGenerator *self, Application *app)
+{
+  g_string_append_printf(self->block, "    rewrite { set-tag('.app.%s'); };\n", app->name);
+  g_string_append(self->block, "    flags(final);\n");
+}
+
+static void
+_generate_application(Application *app, Application *base_app, gpointer user_data)
+{
+  AppParserGenerator *self = (AppParserGenerator *) user_data;
+
+  if (strcmp(self->topic, app->topic) != 0)
+    return;
+
+  g_string_append(self->block, "channel {\n");
+  _generate_filter(self, _get_filter_expr(app, base_app));
+  _generate_parser(self, _get_parser_expr(app, base_app));
+  _generate_action(self, app);
+  g_string_append(self->block, "};\n");
+
+}
+
+static void
+_generate_applications(AppParserGenerator *self, GlobalConfig *cfg)
+{
+  AppModelContext *appmodel = appmodel_get_context(cfg);
+
+  appmodel_context_iter_applications(appmodel, _generate_application, self);
+}
+
+static gboolean
+_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result)
+{
+  AppParserGenerator *self = (AppParserGenerator *) s;
+
+  g_assert(args != NULL);
+  self->topic = cfg_args_get(args, "topic");
+  if (!self->topic)
+    {
+      msg_error("app-parser() requires a topic() argument");
+      return FALSE;
+    }
+
+  self->block = result;
+  g_string_append(self->block,
+                  "\nchannel {\n"
+                  "    junction {\n");
+
+  _generate_applications(self, cfg);
+
+  g_string_append(self->block, "    };\n");
+  g_string_append(self->block, "}");
+  self->block = NULL;
+
+  return TRUE;
+}
+
+CfgBlockGenerator *
+app_parser_generator_new(gint context, const gchar *name)
+{
+  AppParserGenerator *self = g_new0(AppParserGenerator, 1);
+
+  cfg_block_generator_init_instance(&self->super, context, name);
+  self->super.generate = _generate;
+  return &self->super;
+}

--- a/modules/appmodel/app-parser-generator.h
+++ b/modules/appmodel/app-parser-generator.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef APPMODEL_APPPARSER_GENERATOR_H_INCLUDED
+#define APPMODEL_APPPARSER_GENERATOR_H_INCLUDED
+
+#include "plugin.h"
+
+CfgBlockGenerator *app_parser_generator_new(gint context, const gchar *name);
+
+#endif

--- a/modules/appmodel/application.c
+++ b/modules/appmodel/application.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "application.h"
+
+void
+application_set_filter(Application *self, const gchar *filter_expr)
+{
+  g_free(self->filter_expr);
+  self->filter_expr = g_strdup(filter_expr);
+}
+
+void
+application_set_parser(Application *self, const gchar *parser_expr)
+{
+  g_free(self->parser_expr);
+  self->parser_expr = g_strdup(parser_expr);
+}
+
+Application *
+application_new(const gchar *name, const gchar *topic)
+{
+  Application *self = g_new0(Application, 1);
+
+  self->name = g_strdup(name);
+  self->topic = g_strdup(topic);
+  return self;
+}
+
+void
+application_free(Application *self)
+{
+  g_free(self->name);
+  g_free(self->topic);
+  g_free(self->filter_expr);
+  g_free(self->parser_expr);
+  g_free(self);
+}

--- a/modules/appmodel/application.h
+++ b/modules/appmodel/application.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef APPMODEL_APPLICATION_H_INCLUDED
+#define APPMODEL_APPLICATION_H_INCLUDED
+
+#include "syslog-ng.h"
+
+typedef struct _Application
+{
+  gchar *name;
+  gchar *topic;
+  gchar *filter_expr;
+  gchar *parser_expr;
+} Application;
+
+void application_set_filter(Application *self, const gchar *filter_expr);
+void application_set_parser(Application *self, const gchar *parser_expr);
+
+Application *application_new(const gchar *name, const gchar *topic);
+void application_free(Application *s);
+
+#endif

--- a/modules/appmodel/appmodel-context.c
+++ b/modules/appmodel/appmodel-context.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "appmodel.h"
+
+#include <string.h>
+
+typedef struct _AppModelContext
+{
+  /* the context structure is registered into GlobalConfig, thus it must be
+   * derived from ModuleConfig */
+  ModuleConfig super;
+  GHashTable *applications;
+  GPtrArray *application_ptrs;
+} AppModelContext;
+
+static gboolean
+_application_equal(gconstpointer v1, gconstpointer v2)
+{
+  Application *r1 = (Application *) v1;
+  Application *r2 = (Application *) v2;
+
+  if (strcmp(r1->name, r2->name) != 0)
+    return FALSE;
+
+  if (strcmp(r1->topic, r2->topic) != 0)
+    return FALSE;
+
+  return TRUE;
+}
+
+static guint
+_application_hash(gconstpointer v)
+{
+  Application *r = (Application *) v;
+
+  return g_str_hash(r->name) + g_str_hash(r->topic);
+}
+
+void
+appmodel_context_register_application(AppModelContext *self, Application *app)
+{
+  Application *orig_app;
+
+  orig_app = g_hash_table_lookup(self->applications, app);
+  if (!orig_app)
+    {
+      g_hash_table_insert(self->applications, app, app);
+      g_ptr_array_add(self->application_ptrs, app);
+    }
+  else
+    {
+      g_hash_table_replace(self->applications, app, app);
+
+      g_ptr_array_remove(self->application_ptrs, orig_app);
+      g_ptr_array_add(self->application_ptrs, app);
+    }
+}
+
+Application *
+appmodel_context_lookup_application(AppModelContext *self, const gchar *name, const gchar *topic)
+{
+  Application lookup_app = { 0 };
+
+  lookup_app.name = (gchar *) name;
+  lookup_app.topic = (gchar *) topic;
+  return (Application *) g_hash_table_lookup(self->applications, &lookup_app);
+}
+
+void
+appmodel_context_iter_applications(AppModelContext *self, void (*foreach)(Application *app, Application *base_app,
+                                   gpointer user_data), gpointer user_data)
+{
+  gint i;
+
+  for (i = 0; i < self->application_ptrs->len; i++)
+    {
+      Application *app = g_ptr_array_index(self->application_ptrs, i);
+
+      if (strcmp(app->topic, "*") == 0)
+        continue;
+
+      Application *base_app = appmodel_context_lookup_application(self, app->name, "*");
+      foreach(app, base_app, user_data);
+    }
+}
+
+void
+appmodel_context_free_method(ModuleConfig *s)
+{
+  AppModelContext *self = (AppModelContext *) s;
+
+  g_hash_table_destroy(self->applications);
+  g_ptr_array_free(self->application_ptrs, TRUE);
+  module_config_free_method(s);
+}
+
+AppModelContext *
+appmodel_context_new(void)
+{
+  AppModelContext *self = g_new0(AppModelContext, 1);
+
+  self->super.free_fn = appmodel_context_free_method;
+  self->applications = g_hash_table_new_full(_application_hash, _application_equal,
+                                             NULL, (GDestroyNotify) application_free);
+  self->application_ptrs = g_ptr_array_new();
+  return self;
+}
+
+void
+appmodel_context_free(AppModelContext *self)
+{
+  return module_config_free(&self->super);
+}

--- a/modules/appmodel/appmodel-context.h
+++ b/modules/appmodel/appmodel-context.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef APPMODEL_CONTEXT_H_INCLUDED
+#define APPMODEL_CONTEXT_H_INCLUDED 1
+
+#include "module-config.h"
+#include "application.h"
+
+typedef struct _AppModelContext AppModelContext;
+
+void appmodel_context_iter_applications(AppModelContext *self,
+                                        void (*foreach)(Application *app, Application *base_app, gpointer user_data),
+                                        gpointer user_data);
+Application *appmodel_context_lookup_application(AppModelContext *self, const gchar *name, const gchar *topic);
+void appmodel_context_register_application(AppModelContext *self, Application *app);
+void appmodel_context_free(AppModelContext *self);
+AppModelContext *appmodel_context_new(void);
+
+#endif

--- a/modules/appmodel/appmodel-grammar.ym
+++ b/modules/appmodel/appmodel-grammar.ym
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "appmodel.h"
+#include "appmodel-parser.h"
+}
+
+
+%code {
+
+#include "cfg-parser.h"
+#include "cfg-grammar.h"
+#include "appmodel-grammar.h"
+#include "messages.h"
+
+Application *last_application;
+
+}
+
+%name-prefix "appmodel_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {gpointer *instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_APPLICATION
+
+%type	<ptr> application_definition
+
+%%
+
+start
+        : LL_CONTEXT_ROOT application_definition
+          {
+	    appmodel_register_application(configuration, last_application);
+            *instance = last_application;
+            YYACCEPT;
+          }
+        ;
+
+
+application_definition
+        : KW_APPLICATION string '[' string ']'
+          {
+	    last_application = application_new($2, $4);
+          }
+	  '{' application_options '}'
+	  {
+	    $$ = last_application;
+          }
+        ;
+
+application_options
+	: application_option ';' application_options
+	|
+	;
+
+application_option
+	: KW_FILTER
+          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "app filter block"); }
+	  LL_BLOCK
+          { cfg_lexer_pop_context(lexer); }
+          {
+            application_set_filter(last_application, $3);
+          }
+	| KW_PARSER
+          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "app parser block"); }
+	  LL_BLOCK
+          { cfg_lexer_pop_context(lexer); }
+          {
+            application_set_parser(last_application, $3);
+          }
+	;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/appmodel/appmodel-parser.c
+++ b/modules/appmodel/appmodel-parser.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017 Balabit
+ * Copyright (c) 1998-2017 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "appmodel.h"
+#include "cfg-parser.h"
+#include "appmodel-grammar.h"
+
+extern int appmodel_debug;
+
+int appmodel_parse(CfgLexer *lexer, gpointer *instance, gpointer arg);
+
+static CfgLexerKeyword appmodel_keywords[] =
+{
+  { "application",  KW_APPLICATION },
+  { NULL }
+};
+
+CfgParser appmodel_parser =
+{
+#if SYSLOG_NG_ENABLE_DEBUG
+  .debug_flag = &appmodel_debug,
+#endif
+  .name = "appmodel",
+  .keywords = appmodel_keywords,
+  .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) appmodel_parse,
+  .cleanup = NULL,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(appmodel_, gpointer *)

--- a/modules/appmodel/appmodel-parser.h
+++ b/modules/appmodel/appmodel-parser.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2015 Balabit
+ * Copyright (c) 1998-2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef APPMODEL_PARSER_H_INCLUDED
+#define APPMODEL_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+
+extern CfgParser appmodel_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(appmodel_, gpointer *)
+
+#endif

--- a/modules/appmodel/appmodel-plugin.c
+++ b/modules/appmodel/appmodel-plugin.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2015 Balabit
+ * Copyright (c) 1998-2015 Balázs Scheidler
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-parser.h"
+#include "appmodel-parser.h"
+#include "app-parser-generator.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser appmodel_parser;
+
+static gpointer
+app_parser_construct(Plugin *p)
+{
+  return app_parser_generator_new(p->type, p->name);
+}
+
+static Plugin appmodel_plugins[] =
+{
+  {
+    .type = LL_CONTEXT_ROOT,
+    .name = "application",
+    .parser = &appmodel_parser,
+  },
+  {
+    .type = LL_CONTEXT_PARSER | LL_CONTEXT_FLAG_GENERATOR,
+    .name = "app-parser",
+    .construct = app_parser_construct
+  }
+};
+
+gboolean
+appmodel_module_init(PluginContext *context, CfgArgs *args)
+{
+  plugin_register(context, appmodel_plugins, G_N_ELEMENTS(appmodel_plugins));
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "appmodel",
+  .version = SYSLOG_NG_VERSION,
+  .description = "The appmodel module provides parsing support for restoring message tags as produced by the TAGS macro.",
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
+  .plugins = appmodel_plugins,
+  .plugins_len = G_N_ELEMENTS(appmodel_plugins),
+};

--- a/modules/appmodel/appmodel.c
+++ b/modules/appmodel/appmodel.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "appmodel.h"
+#include "cfg.h"
+
+#define MODULE_CONFIG_KEY "appmodel"
+
+AppModelContext *
+appmodel_get_context(GlobalConfig *cfg)
+{
+  AppModelContext *ac = g_hash_table_lookup(cfg->module_config, MODULE_CONFIG_KEY);
+  if (!ac)
+    {
+      ac = appmodel_context_new();
+      g_hash_table_insert(cfg->module_config, g_strdup(MODULE_CONFIG_KEY), ac);
+    }
+  return ac;
+}
+
+void
+appmodel_register_application(GlobalConfig *cfg, Application *application)
+{
+  AppModelContext *ac = appmodel_get_context(cfg);
+
+  appmodel_context_register_application(ac, application);
+}

--- a/modules/appmodel/appmodel.h
+++ b/modules/appmodel/appmodel.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef APPMODEL_H_INCLUDED
+#define APPMODEL_H_INCLUDED 1
+
+#include "module-config.h"
+#include "appmodel-context.h"
+
+AppModelContext *appmodel_get_context(GlobalConfig *cfg);
+void appmodel_register_application(GlobalConfig *cfg, Application *application);
+
+#endif

--- a/modules/appmodel/tests/Makefile.am
+++ b/modules/appmodel/tests/Makefile.am
@@ -1,0 +1,52 @@
+if ENABLE_CRITERION
+
+modules_appmodel_tests_TESTS			= \
+	modules/appmodel/tests/test_appmodel	\
+	modules/appmodel/tests/test_appmodel_context	\
+	modules/appmodel/tests/test_app_parser_generator	\
+	modules/appmodel/tests/test_application
+
+check_PROGRAMS					+=	\
+	${modules_appmodel_tests_TESTS}
+
+modules_appmodel_tests_test_appmodel_CFLAGS	=	\
+	$(TEST_CFLAGS) -I$(top_srcdir)/modules/appmodel
+modules_appmodel_tests_test_appmodel_LDADD	=	\
+	$(TEST_LDADD)
+modules_appmodel_tests_test_appmodel_LDFLAGS	=	\
+	$(PREOPEN_SYSLOGFORMAT)				\
+	-dlpreopen $(top_builddir)/modules/appmodel/libappmodel.la
+modules_appmodel_tests_test_appmodel_DEPENDENCIES =      \
+        $(top_builddir)/modules/appmodel/libappmodel.la
+
+modules_appmodel_tests_test_appmodel_context_CFLAGS	=	\
+	$(TEST_CFLAGS) -I$(top_srcdir)/modules/appmodel
+modules_appmodel_tests_test_appmodel_context_LDADD	=	\
+	$(TEST_LDADD)
+modules_appmodel_tests_test_appmodel_context_LDFLAGS	=	\
+	$(PREOPEN_SYSLOGFORMAT)				\
+	-dlpreopen $(top_builddir)/modules/appmodel/libappmodel.la
+modules_appmodel_tests_test_appmodel_context_DEPENDENCIES =      \
+        $(top_builddir)/modules/appmodel/libappmodel.la
+
+modules_appmodel_tests_test_app_parser_generator_CFLAGS	=	\
+	$(TEST_CFLAGS) -I$(top_srcdir)/modules/appmodel
+modules_appmodel_tests_test_app_parser_generator_LDADD	=	\
+	$(TEST_LDADD)
+modules_appmodel_tests_test_app_parser_generator_LDFLAGS	=	\
+	$(PREOPEN_SYSLOGFORMAT)				\
+	-dlpreopen $(top_builddir)/modules/appmodel/libappmodel.la
+modules_appmodel_tests_test_app_parser_generator_DEPENDENCIES =      \
+        $(top_builddir)/modules/appmodel/libappmodel.la
+
+modules_appmodel_tests_test_application_CFLAGS	=	\
+	$(TEST_CFLAGS) -I$(top_srcdir)/modules/appmodel
+modules_appmodel_tests_test_application_LDADD	=	\
+	$(TEST_LDADD)
+modules_appmodel_tests_test_application_LDFLAGS	=	\
+	$(PREOPEN_SYSLOGFORMAT)				\
+	-dlpreopen $(top_builddir)/modules/appmodel/libappmodel.la
+modules_appmodel_tests_test_application_DEPENDENCIES =      \
+        $(top_builddir)/modules/appmodel/libappmodel.la
+
+endif

--- a/modules/appmodel/tests/test_app_parser_generator.c
+++ b/modules/appmodel/tests/test_app_parser_generator.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "app-parser-generator.h"
+#include "apphook.h"
+#include "plugin-types.h"
+
+#include "config_parse_lib.h"
+
+static CfgBlockGenerator *app_parser;
+static GString *result;
+
+void
+_register_application(const char *appmodel)
+{
+  cr_assert(parse_config(appmodel, LL_CONTEXT_ROOT, NULL, NULL),
+            "Parsing the given configuration failed: %s", appmodel);
+}
+
+static CfgBlockGenerator *
+_construct_app_parser(void)
+{
+  return app_parser_generator_new(LL_CONTEXT_PARSER, "app-parser");
+}
+
+static void
+_app_parser_generate(const gchar *topic)
+{
+  CfgArgs *args = cfg_args_new();
+
+  cfg_args_set(args, "topic", topic);
+  cfg_block_generator_generate(app_parser, configuration, args, result);
+  cfg_args_unref(args);
+}
+
+static void
+_assert_config_is_valid(const gchar *topic)
+{
+  const gchar *config_fmt = ""
+                            "parser p_test {\n"
+                            "    app-parser(topic(\"%s\"));\n"
+                            "};\n";
+  gchar *config;
+
+  config = g_strdup_printf(config_fmt, topic);
+  cr_assert(parse_config(config, LL_CONTEXT_ROOT, NULL, NULL),
+            "Parsing the given configuration failed: %s", config);
+  g_free(config);
+}
+
+static void
+_assert_snippet_is_present(const gchar *snippet)
+{
+  cr_assert(strstr(result->str, snippet),
+            "Can't find config snippet in generated output: %s, config: >>>%s<<<",
+            snippet, result->str);
+}
+
+static void
+_assert_snippet_is_not_present(const gchar *snippet)
+{
+  cr_assert(strstr(result->str, snippet) == NULL,
+            "Could find config snippet which shouldn't be there in generated output: %s, config: >>>%s<<<",
+            snippet, result->str);
+}
+
+static void
+_assert_application_is_present(const gchar *application)
+{
+  const gchar *settag_fmt = "set-tag('.app.%s');";
+  gchar *settag_snippet = g_strdup_printf(settag_fmt, application);
+
+  cr_assert(strstr(result->str, settag_snippet),
+            "Can't find set-tag() invocation for this application: %s, snippet: %s, config: >>>%s<<<",
+            application, settag_snippet, result->str);
+  g_free(settag_snippet);
+}
+
+static void
+_assert_parser_framing_is_present(void)
+{
+  cr_assert(g_str_has_prefix(result->str, "\nchannel"), "Cannot find app-parser() framing (prefix) >>>%s<<<",
+            result->str);
+  cr_assert(g_str_has_suffix(result->str, "};\n}"), "Cannot find app-parser() framing (suffix): >>>%s<<<", result->str);
+}
+
+static void
+startup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+  cfg_load_module(configuration, "appmodel");
+  app_parser = _construct_app_parser();
+  result = g_string_new("");
+}
+
+static void
+teardown(void)
+{
+  g_string_free(result, TRUE);
+  app_shutdown();
+}
+
+Test(app_parser_generator, app_parser_with_no_apps_registered_generates_empty_framing)
+{
+  _app_parser_generate("port514");
+  _assert_parser_framing_is_present();
+  _assert_config_is_valid("port514");
+}
+
+Test(app_parser_generator, app_parser_generates_references_to_apps)
+{
+  _register_application("application foo[port514] {\n"
+                        "    filter { program('foo'); };\n"
+                        "    parser { kv-parser(prefix('foo.')); };\n"
+                        "};");
+
+  _register_application("application bar[port514] {\n"
+                        "    filter { program('bar'); };\n"
+                        "    parser { kv-parser(prefix('bar.')); };\n"
+                        "};");
+  _app_parser_generate("port514");
+  _assert_parser_framing_is_present();
+  _assert_application_is_present("foo");
+  _assert_application_is_present("foo");
+  _assert_config_is_valid("port514");
+}
+
+Test(app_parser_generator, app_parser_uses_filter_or_parser_from_base_topics)
+{
+  _register_application("application foo[port514] {\n"
+                        "};");
+
+  _register_application("application foo[*] {\n"
+                        "    filter { program('foo'); };\n"
+                        "    parser { kv-parser(prefix('foo.')); };\n"
+                        "};");
+
+  _app_parser_generate("port514");
+  _assert_parser_framing_is_present();
+  _assert_application_is_present("foo");
+  _assert_snippet_is_present("program('foo')");
+  _assert_snippet_is_present("kv-parser(prefix('foo.'))");
+  _assert_config_is_valid("port514");
+}
+
+Test(app_parser_generator, app_parser_base_topics_are_skipped)
+{
+  _register_application("application foo[*] {\n"
+                        "    filter { program('foo'); };\n"
+                        "    parser { kv-parser(prefix('foo.')); };\n"
+                        "};");
+
+  _register_application("application bar[*] {\n"
+                        "    filter { program('bar'); };\n"
+                        "    parser { kv-parser(prefix('bar.')); };\n"
+                        "};");
+
+  _app_parser_generate("port514");
+  _assert_parser_framing_is_present();
+  _assert_snippet_is_not_present("program('foo')");
+  _assert_snippet_is_not_present("program('bar')");
+  _assert_config_is_valid("port514");
+}
+
+TestSuite(app_parser_generator, .init = startup, .fini = teardown);

--- a/modules/appmodel/tests/test_application.c
+++ b/modules/appmodel/tests/test_application.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <criterion/criterion.h>
+#include "application.h"
+
+Test(application, empty_application_can_be_created_and_freed)
+{
+  Application *app;
+
+  app = application_new("foobar", "*");
+  application_free(app);
+}
+
+Test(application, filter_can_be_set_and_queried)
+{
+  Application *app;
+  const gchar *filter_expr = "'1' eq '1'";
+  const gchar *filter_expr2 = "'2' eq '2'";
+
+  app = application_new("foobar", "*");
+  application_set_filter(app, filter_expr);
+  cr_assert_str_eq(app->filter_expr, filter_expr);
+
+  application_set_filter(app, filter_expr2);
+  cr_assert_str_eq(app->filter_expr, filter_expr2);
+  application_free(app);
+}
+
+Test(application, parser_can_be_set_and_queried)
+{
+  Application *app;
+  const gchar *parser_expr = "kv-parser();";
+  const gchar *parser_expr2 = "csv-parser();";
+
+  app = application_new("foobar", "*");
+  application_set_parser(app, parser_expr);
+  cr_assert_str_eq(app->parser_expr, parser_expr);
+
+  application_set_parser(app, parser_expr2);
+  cr_assert_str_eq(app->parser_expr, parser_expr2);
+  application_free(app);
+}

--- a/modules/appmodel/tests/test_appmodel.c
+++ b/modules/appmodel/tests/test_appmodel.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "appmodel.h"
+#include "application.h"
+#include "plugin.h"
+#include "apphook.h"
+#include "cfg-grammar.h"
+#include "config_parse_lib.h"
+
+Application *
+_parse_application(const char *appmodel, const gchar *name, const gchar *topic)
+{
+  AppModelContext *ac;
+
+  cfg_load_module(configuration, "appmodel");
+  cr_assert(parse_config(appmodel, LL_CONTEXT_ROOT, NULL, NULL),
+            "Parsing the given configuration failed: %s", appmodel);
+  ac = appmodel_get_context(configuration);
+  return appmodel_context_lookup_application(ac, name, topic);
+}
+
+Test(appmodel, empty_application_can_be_parsed_properly)
+{
+  Application *app;
+
+  app = _parse_application("application foobar[*] {};", "foobar", "*");
+  cr_assert(app != NULL);
+  cr_assert_str_eq(app->name, "foobar");
+  cr_assert_str_eq(app->topic, "*");
+}
+
+Test(appmodel, name_is_parsed_into_name_member)
+{
+  Application *app;
+
+  app = _parse_application("application name[*] {};", "name", "*");
+  cr_assert(app != NULL);
+}
+
+Test(appmodel, topic_in_brackets_is_parsed_into_topic)
+{
+  Application *app;
+
+  app = _parse_application("application name[port514] {};", "name", "port514");
+  cr_assert(app != NULL);
+  cr_assert_str_eq(app->topic, "port514");
+}
+
+Test(appmodel, filter_expressions_can_be_specified_with_a_filter_keyword)
+{
+  Application *app;
+
+  app = _parse_application(
+          "application name[port514] {"
+          "  filter { program(\"kernel\"); };"
+          "  parser { kv-parser(); };"
+          "};",
+          "name", "port514");
+  cr_assert(app != NULL);
+  cr_assert_str_eq(app->topic, "port514");
+  cr_assert_str_eq(app->filter_expr, " program(\"kernel\"); ");
+}
+
+Test(appmodel, parser_expressions_can_be_specified_with_a_parser_keyword)
+{
+  Application *app;
+
+  app = _parse_application(
+          "application name[port514] {"
+          "  parser { kv-parser(); };"
+          "  filter { program(\"kernel\"); };"
+          "};",
+          "name", "port514");
+  cr_assert(app != NULL);
+  cr_assert_str_eq(app->topic, "port514");
+  cr_assert_str_eq(app->parser_expr, " kv-parser(); ");
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+void
+teardown(void)
+{
+  cfg_free(configuration);
+  app_shutdown();
+}
+
+TestSuite(appmodel, .init = setup, .fini = teardown);

--- a/modules/appmodel/tests/test_appmodel_context.c
+++ b/modules/appmodel/tests/test_appmodel_context.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2017 Balazs Scheidler <balazs.scheidler@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <criterion/criterion.h>
+#include "appmodel.h"
+
+static AppModelContext *ac;
+
+static void
+startup(void)
+{
+  ac = appmodel_context_new();
+}
+
+static void
+teardown(void)
+{
+  appmodel_context_free(ac);
+  ac = NULL;
+}
+
+Test(appmodel_context, register_application_makes_the_app_available)
+{
+  appmodel_context_register_application(ac, application_new("foobar", "*"));
+  appmodel_context_lookup_application(ac, "foobar", "*");
+}
+
+static void
+_foreach_app(Application *app, Application *base_app, gpointer user_data)
+{
+  GString *result = (GString *) user_data;
+
+  g_string_append(result, app->name);
+}
+
+Test(appmodel_context, iter_applications_enumerates_apps_without_asterisk)
+{
+  GString *result = g_string_sized_new(128);
+
+  appmodel_context_register_application(ac, application_new("foo", "*"));
+  appmodel_context_register_application(ac, application_new("foo", "port514"));
+  appmodel_context_register_application(ac, application_new("bar", "*"));
+  appmodel_context_register_application(ac, application_new("bar", "port514"));
+  appmodel_context_register_application(ac, application_new("baz", "*"));
+  appmodel_context_register_application(ac, application_new("baz", "port514"));
+  appmodel_context_iter_applications(ac, _foreach_app, result);
+  cr_assert_str_eq(result->str, "foobarbaz");
+  g_string_free(result, TRUE);
+}
+
+Test(appmodel_context, iter_applications_enumerates_apps_in_the_order_of_registration)
+{
+  GString *result = g_string_sized_new(128);
+
+  appmodel_context_register_application(ac, application_new("baz", "*"));
+  appmodel_context_register_application(ac, application_new("baz", "port514"));
+  appmodel_context_register_application(ac, application_new("bar", "*"));
+  appmodel_context_register_application(ac, application_new("bar", "port514"));
+  appmodel_context_register_application(ac, application_new("foo", "*"));
+  appmodel_context_register_application(ac, application_new("foo", "port514"));
+  appmodel_context_iter_applications(ac, _foreach_app, result);
+  cr_assert_str_eq(result->str, "bazbarfoo");
+  g_string_free(result, TRUE);
+}
+
+TestSuite(appmodel_context, .init = startup, .fini = teardown);

--- a/modules/basicfuncs/cond-funcs.c
+++ b/modules/basicfuncs/cond-funcs.c
@@ -37,7 +37,7 @@ tf_cond_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
 
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-  lexer = cfg_lexer_new_buffer(argv[1], strlen(argv[1]));
+  lexer = cfg_lexer_new_buffer(parent->cfg, argv[1], strlen(argv[1]));
   if (!cfg_run_parser(parent->cfg, lexer, &filter_expr_parser, (gpointer *) &state->filter, NULL))
     {
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,

--- a/modules/cef/format-cef-extension.c
+++ b/modules/cef/format-cef-extension.c
@@ -41,7 +41,7 @@ tf_cef_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
 {
   TFCefState *state = (TFCefState *)s;
 
-  state->vp = value_pairs_new_from_cmdline(parent->cfg, argc, argv, error);
+  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, FALSE, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -31,7 +31,7 @@ pdb_action_set_condition(PDBAction *self, GlobalConfig *cfg, const gchar *filter
 {
   CfgLexer *lexer;
 
-  lexer = cfg_lexer_new_buffer(filter_string, strlen(filter_string));
+  lexer = cfg_lexer_new_buffer(cfg, filter_string, strlen(filter_string));
   if (!cfg_run_parser(cfg, lexer, &filter_expr_parser, (gpointer *) &self->condition, NULL))
     {
       g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Error compiling conditional expression");

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -420,7 +420,7 @@ pdbtool_match(int argc, char *argv[])
     {
       CfgLexer *lexer;
 
-      lexer = cfg_lexer_new_buffer(filter_string, strlen(filter_string));
+      lexer = cfg_lexer_new_buffer(configuration, filter_string, strlen(filter_string));
       if (!cfg_run_parser(configuration, lexer, &filter_expr_parser, (gpointer *) &filter, NULL))
         {
           fprintf(stderr, "Error parsing filter expression\n");

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -96,7 +96,7 @@ tf_graphite_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
       log_template_compile(state->timestamp_template, "$R_UNIXTIME", NULL);
     }
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, argc, argv, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, FALSE, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -38,21 +38,48 @@ typedef struct _TFJsonState
 } TFJsonState;
 
 static gboolean
+_parse_additional_options(gint argc, gchar **argv, gboolean *transform_initial_dot, GError **error)
+{
+  *transform_initial_dot = TRUE;
+  for (gint i = 1; i < argc; i++)
+    {
+      if (argv[i][0] != '-')
+        continue;
+
+      if (strcmp(argv[i], "--leave-initial-dot") == 0)
+        *transform_initial_dot = FALSE;
+      else
+        {
+          g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_UNKNOWN_OPTION, "$(format-json) unknown option: %s", argv[i]);
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+
+static gboolean
 tf_json_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
                 gint argc, gchar *argv[],
                 GError **error)
 {
   TFJsonState *state = (TFJsonState *)s;
   ValuePairsTransformSet *vpts;
+  gboolean transform_initial_dot;
 
   state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, TRUE, error);
   if (!state->vp)
     return FALSE;
 
-  /* Always replace a leading dot with an underscore. */
-  vpts = value_pairs_transform_set_new(".*");
-  value_pairs_transform_set_add_func(vpts, value_pairs_new_transform_replace_prefix(".", "_"));
-  value_pairs_add_transforms(state->vp, vpts);
+  if (!_parse_additional_options(argc, argv, &transform_initial_dot, error))
+    return FALSE;
+
+  if (transform_initial_dot)
+    {
+      /* Always replace a leading dot with an underscore. */
+      vpts = value_pairs_transform_set_new(".*");
+      value_pairs_transform_set_add_func(vpts, value_pairs_new_transform_replace_prefix(".", "_"));
+      value_pairs_add_transforms(state->vp, vpts);
+    }
 
   return TRUE;
 }

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -45,7 +45,7 @@ tf_json_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
   TFJsonState *state = (TFJsonState *)s;
   ValuePairsTransformSet *vpts;
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, argc, argv, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, TRUE, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -63,6 +63,10 @@ test_format_json(void)
   assert_template_format("$(format-json @.program=${PROGRAM})", "{\"@\":{\"program\":\"syslog-ng\"}}");
   assert_template_format("$(format-json .program.n@me=${PROGRAM})", "{\"_program\":{\"n@me\":\"syslog-ng\"}}");
   assert_template_format("$(format-json .program.@name=${PROGRAM})", "{\"_program\":{\"@name\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json --leave-initial-dot .program.@name=${PROGRAM})",
+                         "{\".program\":{\"@name\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json --leave-initial-dot .program.@name=${PROGRAM} .program.foo .program.bar)",
+                         "{\".program\":{\"@name\":\"syslog-ng\"}}");
 }
 
 void
@@ -152,6 +156,13 @@ test_format_json_performance(void)
 {
   perftest_template("$(format-json APP.*)\n");
   perftest_template("<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --scope all-nv-pairs "
+                    "--exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* "
+                    "--exclude 6* --exclude 7* --exclude 8* --exclude 9* "
+                    "--exclude SOURCE "
+                    "--exclude .SDATA.* "
+                    "..RSTAMP='${R_UNIXTIME}${R_TZ}' "
+                    "..TAGS=${TAGS})\n");
+  perftest_template("<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --leave-initial-dot --scope all-nv-pairs "
                     "--exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* "
                     "--exclude 6* --exclude 7* --exclude 8* --exclude 9* "
                     "--exclude SOURCE "

--- a/modules/kvformat/format-welf.c
+++ b/modules/kvformat/format-welf.c
@@ -43,7 +43,7 @@ tf_format_welf_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
 {
   TFWelfState *state = (TFWelfState *) s;
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, argc, argv, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, FALSE, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/kvformat/format-welf.c
+++ b/modules/kvformat/format-welf.c
@@ -30,6 +30,12 @@ typedef struct _TFWelfState
   ValuePairs *vp;
 } TFWelfState;
 
+typedef struct _TFWelfIterState
+{
+  GString *result;
+  gboolean initial_kv_pair_printed;
+} TFWelfIterState;
+
 static gboolean
 tf_format_welf_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
                        gint argc, gchar *argv[],
@@ -48,10 +54,14 @@ static gboolean
 tf_format_welf_foreach(const gchar *name, TypeHint type, const gchar *value,
                        gsize value_len, gpointer user_data)
 {
-  GString *result = (GString *) user_data;
+  TFWelfIterState *iter_state = (TFWelfIterState *) user_data;
+  GString *result = iter_state->result;
 
-  if (result->len > 0)
+  if (iter_state->initial_kv_pair_printed)
     g_string_append(result, " ");
+  else
+    iter_state->initial_kv_pair_printed = TRUE;
+
   g_string_append(result, name);
   g_string_append_c(result, '=');
   if (memchr(value, ' ', value_len) == NULL)
@@ -79,13 +89,18 @@ static void
 tf_format_welf_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
   TFWelfState *state = (TFWelfState *) s;
+  TFWelfIterState iter_state =
+  {
+    .result = result,
+    .initial_kv_pair_printed = FALSE
+  };
   gint i;
 
   for (i = 0; i < args->num_messages; i++)
     {
       value_pairs_foreach_sorted(state->vp,
                                  tf_format_welf_foreach, (GCompareFunc) tf_format_welf_strcmp,
-                                 args->messages[i], 0, args->tz, args->opts, result);
+                                 args->messages[i], 0, args->tz, args->opts, &iter_state);
     }
 
 }

--- a/modules/kvformat/tests/test_format_welf.c
+++ b/modules/kvformat/tests/test_format_welf.c
@@ -29,6 +29,7 @@ void
 test_format_welf(void)
 {
   assert_template_format("$(format-welf MSG=$MSG)", "MSG=árvíztűrőtükörfúrógép");
+  assert_template_format("xxx$(format-welf MSG=$MSG)yyy", "xxxMSG=árvíztűrőtükörfúrógépyyy");
   assert_template_format("$(format-welf MSG=$escaping)",
                          "MSG=\"binary stuff follows \\\"\\xad árvíztűrőtükörfúrógép\"");
   assert_template_format("$(format-welf MSG=$escaping2)", "MSG=\\xc3");

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -42,6 +42,7 @@ static struct
   gboolean initialized;
   NVHandle is_synced;
   NVHandle cisco_seqid;
+  NVHandle raw_message;
 } handles;
 
 static gboolean
@@ -1262,6 +1263,9 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
 
+  if (parse_options->flags & LP_STORE_RAW_MESSAGE)
+    log_msg_set_value(self, handles.raw_message, (gchar *) data, length);
+
   if (parse_options->flags & LP_NOPARSE)
     {
       log_msg_set_value(self, LM_V_MESSAGE, (gchar *) data, length);
@@ -1310,6 +1314,7 @@ syslog_format_init(void)
     {
       handles.is_synced = log_msg_get_value_handle(".SDATA.timeQuality.isSynced");
       handles.cisco_seqid = log_msg_get_value_handle(".SDATA.meta.sequenceId");
+      handles.raw_message = log_msg_get_value_handle("RAWMSG");
       handles.initialized = TRUE;
     }
 

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -629,7 +629,6 @@ log_msg_parse_legacy_program_name(LogMessage *self, const guchar **data, gint *l
   if ((flags & LP_STORE_LEGACY_MSGHDR))
     {
       log_msg_set_value(self, LM_V_LEGACY_MSGHDR, (gchar *) *data, *length - left);
-      self->flags |= LF_LEGACY_MSGHDR;
     }
   *data = src;
   *length = left;

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -37,8 +37,12 @@
 
 static const char aix_fwd_string[] = "Message forwarded from ";
 static const char repeat_msg_string[] = "last message repeated";
-static NVHandle is_synced;
-static NVHandle cisco_seqid;
+static struct
+{
+  gboolean initialized;
+  NVHandle is_synced;
+  NVHandle cisco_seqid;
+} handles;
 
 static gboolean
 log_msg_parse_pri(LogMessage *self, const guchar **data, gint *length, guint flags, guint16 default_pri)
@@ -196,7 +200,7 @@ log_msg_parse_seq(LogMessage *self, const guchar **data, gint *length)
   if (*src != ' ')
     return FALSE;
 
-  log_msg_set_value(self, cisco_seqid, (gchar *) *data, *length - left - 1);
+  log_msg_set_value(self, handles.cisco_seqid, (gchar *) *data, *length - left - 1);
 
   *data = src;
   *length = left;
@@ -470,14 +474,14 @@ log_msg_parse_date_unnormalized(LogMessage *self, const guchar **data, gint *len
       if (G_UNLIKELY(src[0] == '*'))
         {
           if (!(parse_flags & LP_NO_PARSE_DATE))
-            log_msg_set_value(self, is_synced, "0", 1);
+            log_msg_set_value(self, handles.is_synced, "0", 1);
           src++;
           left--;
         }
       else if (G_UNLIKELY(src[0] == '.'))
         {
           if (!(parse_flags & LP_NO_PARSE_DATE))
-            log_msg_set_value(self, is_synced, "1", 1);
+            log_msg_set_value(self, handles.is_synced, "1", 1);
           src++;
           left--;
         }
@@ -1302,13 +1306,11 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
 void
 syslog_format_init(void)
 {
-  static gboolean handles_initialized = FALSE;
-
-  if (!handles_initialized)
+  if (!handles.initialized)
     {
-      is_synced = log_msg_get_value_handle(".SDATA.timeQuality.isSynced");
-      cisco_seqid = log_msg_get_value_handle(".SDATA.meta.sequenceId");
-      handles_initialized = TRUE;
+      handles.is_synced = log_msg_get_value_handle(".SDATA.timeQuality.isSynced");
+      handles.cisco_seqid = log_msg_get_value_handle(".SDATA.meta.sequenceId");
+      handles.initialized = TRUE;
     }
 
   _init_parse_hostname_invalid_chars();

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -316,37 +316,19 @@ system_generate_system_transports(GString *sysblock)
   return TRUE;
 }
 
-static gboolean
-_is_json_parser_available(GlobalConfig *cfg)
-{
-  return cfg_find_plugin(cfg, LL_CONTEXT_PARSER, "json-parser") != NULL;
-}
-
 static void
-system_generate_cim_parser(GlobalConfig *cfg, GString *sysblock)
+system_generate_app_parser(GlobalConfig *cfg, GString *sysblock)
 {
-  if (cfg_is_config_version_older(cfg, 0x0306))
-    {
-      msg_warning_once("WARNING: Starting with " VERSION_3_6
-                       ", the system() source performs JSON parsing of messages starting with the '@cim:' prefix. No additional action is needed");
-      return;
-    }
-
-  if (!_is_json_parser_available(cfg))
-    {
-      msg_debug("system(): json-parser() is missing, skipping the automatic JSON parsing of messages submitted via syslog(3), Please install the json module");
-      return;
-    }
-
   g_string_append(sysblock,
                   "channel {\n"
                   "  channel {\n"
                   "    parser {\n"
-                  "      json-parser(prefix('.cim.') marker('@cim:'));\n"
+                  "      app-parser(topic(system-unix));\n"
+                  "      app-parser(topic(syslog));\n"
                   "    };\n"
                   "    flags(final);\n"
                   "  };\n"
-                  "  channel { };\n"
+                  "  channel { flags(final); };\n"
                   "};\n");
 }
 
@@ -366,7 +348,7 @@ system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args
 
   g_string_append(sysblock, "    }; # source\n");
 
-  system_generate_cim_parser(cfg, sysblock);
+  system_generate_app_parser(cfg, sysblock);
 
   g_string_append(sysblock, "}; # channel\n");
   result = TRUE;

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -395,7 +395,7 @@ system_source_generator_new(gint context, const gchar *name)
 gpointer
 system_source_construct(Plugin *p)
 {
-  return system_source_generator_new(LL_CONTEXT_SOURCE, "system");
+  return system_source_generator_new(p->type, p->name);
 }
 
 Plugin system_plugins[] =

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -351,15 +351,9 @@ system_generate_cim_parser(GlobalConfig *cfg, GString *sysblock)
 }
 
 static gboolean
-system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgLexer *lexer, CfgArgs *args)
+system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *sysblock)
 {
-  gchar buf[256];
-  GString *sysblock;
   gboolean result = FALSE;
-
-  g_snprintf(buf, sizeof(buf), "source confgen system");
-
-  sysblock = g_string_sized_new(1024);
 
   g_string_append(sysblock,
                   "channel {\n"
@@ -375,9 +369,8 @@ system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgLexer *lex
   system_generate_cim_parser(cfg, sysblock);
 
   g_string_append(sysblock, "}; # channel\n");
-  result = cfg_lexer_include_buffer(lexer, buf, sysblock->str, sysblock->len);
+  result = TRUE;
 exit:
-  g_string_free(sysblock, TRUE);
   return result;
 }
 

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -11,6 +11,7 @@ SCL_SUBDIRS	= \
 	elasticsearch	\
 	kafka		\
 	hdfs		\
+	iptables	\
 	apache		\
 	cisco		\
 	default-network-drivers		\

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -15,6 +15,7 @@ SCL_SUBDIRS	= \
 	cisco		\
 	default-network-drivers		\
 	ewmm		\
+	sudo		\
 	loggly		\
 	logmatic	\
 	snmptrap        \

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -13,6 +13,7 @@ SCL_SUBDIRS	= \
 	hdfs		\
 	apache		\
 	cisco		\
+	default-network-drivers		\
 	loggly		\
 	logmatic	\
 	snmptrap        \

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -14,6 +14,7 @@ SCL_SUBDIRS	= \
 	apache		\
 	cisco		\
 	default-network-drivers		\
+	ewmm		\
 	loggly		\
 	logmatic	\
 	snmptrap        \

--- a/scl/cim/adapter.conf
+++ b/scl/cim/adapter.conf
@@ -1,0 +1,26 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+application cim[syslog] {
+    parser { json-parser(prefix('.cim.') marker('@cim:')); };
+};

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -128,3 +128,7 @@ block parser cisco-parser(prefix(".cisco.")) {
         };
     };
 };
+
+application cisco[syslog-raw] {
+	parser { cisco-parser(); };
+};

--- a/scl/default-network-drivers/plugin.conf
+++ b/scl/default-network-drivers/plugin.conf
@@ -1,0 +1,86 @@
+#############################################################################
+# Copyright (c) 2017 Balazs Scheidler
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block source default-network-drivers(
+	udp-port(514)
+	tcp-port(514)
+	rfc5424-tls-port(6514)
+	rfc5424-tcp-port(601)
+	log-msg-size(65536)
+	flags()) {
+
+	channel {
+		source {
+			network(transport(tcp)
+				port(`tcp-port`)
+				log-msg-size(`log-msg-size`)
+				flags(no-parse, `flags`));
+			network(transport(udp)
+				port(`udp-port`)
+				log-msg-size(`log-msg-size`)
+				flags(no-parse, `flags`));
+		};
+		channel {
+			parser { app-parser(topic(syslog-raw)); };
+			flags(final);
+		};
+		channel {
+			parser {
+				syslog-parser(flags(syslog-protocol));
+			};
+			channel {
+				parser { ewmm-parser(); };
+				flags(final);
+			};
+			channel {
+				parser { app-parser(topic(syslog)); };
+				flags(final);
+			};
+			channel {
+				flags(final);
+			};
+			flags(final);
+		};
+	};
+
+
+	channel {
+		source {
+			syslog(transport(tls) tls(`tls`)
+			       port(`rfc5424-tls-port`)
+			       flags(`flags`)
+	                       log-msg-size(`log-msg-size`));
+			syslog(transport(tcp)
+			       port(`rfc5424-tcp-port`)
+			       flags(`flags`)
+	                       log-msg-size(`log-msg-size`));
+		};
+		channel {
+			parser { app-parser(topic(syslog)); };
+			flags(final);
+		};
+		channel {
+			flags(final);
+		};
+	};
+};

--- a/scl/ewmm/ewmm.conf
+++ b/scl/ewmm/ewmm.conf
@@ -1,0 +1,65 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# This is the experimental transport for transferring messages in whole
+# between syslog-ng instances.
+#
+# EWMM stands for "enterprise wide message model", which is also kind of an
+# experimental name, but so far it stuck.
+#
+# Format:
+#   - program name should be "@syslog-ng" which is used to recognize this message
+#   - name-values are encoded as JSON in the MSG field
+#   - name-value pairs that start with "._" should be hop-by-hop fields only
+#     to transmit syslog-ng <> syslog-ng information and is not considered
+#     part of the original message.
+#   - regexp numeric matches ($0 .. $255) are not transmitted
+#
+
+block parser ewmm-parser() {
+	channel {
+                filter { program("@syslog-ng" type(string)); };
+
+                # NOTE: this will probably overwrite all builtin
+                # name value pairs, including $MSG
+                rewrite {
+                        unset(value("PROGRAM"));
+                        unset(value("RAWMSG"));
+                };
+                parser { json-parser(); };
+		parser { tags-parser(template("${._TAGS}")); };
+                rewrite {
+			# remove hop-by-hop fields
+                        unset(value("._TAGS"));
+                };
+	};
+};
+
+template-function "format-ewmm" "<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --leave-initial-dot --scope all-nv-pairs --exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* --exclude 6* --exclude 7* --exclude 8* --exclude 9* --exclude SOURCE --exclude .SDATA.* ._TAGS=${TAGS})\n";
+
+block destination syslog-ng(server('127.0.0.1') transport(tcp) port(514)) {
+        network("`server`" transport(`transport`) port(`port`)
+                template("$(format-ewmm)")
+                frac-digits(3)
+		`__VARARGS__`
+        );
+};

--- a/scl/iptables/iptables.conf
+++ b/scl/iptables/iptables.conf
@@ -1,0 +1,32 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block parser iptables-parser(prefix('.iptables.')) {
+	kv-parser(prefix(`prefix`));
+};
+
+application iptables[syslog] {
+        filter { facility(kern) and
+                 program("kernel" type(string)) and
+                 message("PROTO=" type(string) flags(substring)); };
+        parser { iptables-parser(); };
+};

--- a/scl/sudo/sudo.conf
+++ b/scl/sudo/sudo.conf
@@ -1,0 +1,31 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block parser sudo-parser(prefix('.sudo.')) {
+	kv-parser(prefix(`prefix`) pair-separator(';') extract-stray-words-into('0'));
+        csv-parser(columns("`prefix`SUBJECT") template("$(list-head $0)") delimiters(' '));
+};
+
+application sudo[syslog] {
+        filter { program("sudo" type(string)); };
+        parser { sudo-parser(); };
+};

--- a/scl/syslog-ng.conf
+++ b/scl/syslog-ng.conf
@@ -17,6 +17,7 @@ source s_network {
 
 destination d_local {
 	file("/var/log/messages");
+	file("/var/log/messages-kv.log" template("$ISODATE $HOST $(format-welf --scope all-nv-pairs)\n") frac-digits(3));
 };
 
 log {

--- a/scl/syslog-ng.conf
+++ b/scl/syslog-ng.conf
@@ -12,7 +12,7 @@ source s_local {
 };
 
 source s_network {
-	udp();
+	default-network-drivers();
 };
 
 destination d_local {

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -61,7 +61,7 @@ tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|geoip2|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|snmptrapd-parser|xml|[^/]*$)
-modules/(add-contextual-data|tagsparser|map-value-pairs|[^/]*$)
+modules/(add-contextual-data|tagsparser|map-value-pairs|appmodel|[^/]*$)
 scl
 scripts
  GPLv2+_SSL,non-balabit


### PR DESCRIPTION
This branch is actually a combination of three features:

**1. appmodel: add app-parser()**
    
    The app-parser() is a framework that allows automatic parsing of log
    messages.  Application specific logic is encapsulated into a configuration
    snippet, which is then automatically pulled into the main configuration,
    without having to explicitly change the main configuration file.
    
    For instance:
    
    application appfoo[port514] {
            filter { program("appfoo"); };
            parser { appfoo-parser(); };
    };
    
    application appbar[port514] {
            filter { program("appbar"); };
            parser { appbar-parser(); };
    };
    
    With that defined, app-parser() will automatically incorporate "appfoo" &
    "appbar" specific log processing rules in the configuration, if used this
    way:
    
    log {
            source { udp(); };
            parser { app-parser(specialization(port514)); };  // specialization --> topic
            destination { ... };
    };
    
    app-parser() will generate processing code that would parse both "appfoo"
    and "appbar" properly, and result in name-value pairs specific to those
    applications.
    
    This is the basic idea, but there are some other features, not so easy to
    explain in a commit message, but worth at least mentioning here:
      * applications are iterated in registration order (for now), but this may
        change in the future
      * application rules should ideally be non-overlapping.  If they overlap,
        the first one wins.
      * either the filter or the parser should DROP the message if it does not
        match.  Most parsers do support dropping incorrectly formatted messages,
        but if not, please do that explicitly via a filter
      * if an application matches, a tag named ".app.<appname>" would be
        associated with the message.
      * there can be multiple instances of app-parser() with a different set of
        applications being generated (this is the "port514" above, also called a
        specialization of an application).  It is expected that we would be
        using separate specializations if the same application is logging the
        same messages via multiple channels.
    
    This patch series contains a new source driver (called port514()) that
    implicitly contains app-parser() invocation, so the main syslog-ng.conf file
    becomes very simple indeed.

**2. the ability to transport the complete syslog-ng message model accross syslog-ng instances:**

This is the experimental transport for transferring messages in whole
between syslog-ng instances.
EWMM stands for "enterprise wide message model", which is also kind of an
experimental name, but so far it stuck.
Format:
  - program name should be "@syslog-ng" which is used to recognize this message
  - name-values are encoded as JSON in the MSG field
  - name-value pairs that start with "._" should be hop-by-hop fields only
    to transmit syslog-ng <> syslog-ng information and is not considered
    part of the original message.
  - regexp numeric matches ($0 .. $255) are not transmitted


**3.  The default syslog-ng configuration is changed** 

scl/syslog-ng.conf is changed to use app-parser() automatically, both in system() and in network received logs.

To use the new transport mechanism, you just need to use the syslog-ng() destination driver, like this:

        destination { syslog-ng(server(127.0.0.1) port(2601)); };

On the server side, if the new port514() driver is used, this format would be recognized automatically. If not, you can always parse this format explicitly using the ewmm-parser() parser.

This is a culmination of several new abstractions, so I would probably have to write a blog post about.

@czanik @fekete-robert @faxm0dem 