### PR TITLE
solaris: compile errors in getent and sun_streams

### DIFF
--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -9,6 +9,8 @@ set(COMPAT_HEADERS
     compat/time.h
     compat/openssl_support.h
     compat/pcre.h
+    compat/getent.h
+    compat/getent-bb.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES
@@ -21,4 +23,5 @@ set(COMPAT_SOURCES
     compat/strtok_r.c
     compat/time.c
     compat/openssl_support.c
+    compat/getent.c
     PARENT_SCOPE)

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -10,7 +10,9 @@ compatinclude_HEADERS		= 	\
 	lib/compat/string.h		\
 	lib/compat/time.h		\
 	lib/compat/openssl_support.h	\
-	lib/compat/pcre.h
+	lib/compat/pcre.h	\
+	lib/compat/getent.h	\
+	lib/compat/getent-bb.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\
@@ -21,6 +23,7 @@ compat_sources			= 	\
 	lib/compat/strcasestr.c		\
 	lib/compat/strtok_r.c		\
 	lib/compat/time.c		\
-	lib/compat/openssl_support.c
+	lib/compat/openssl_support.c	\
+	lib/compat/getent.c
 
 include lib/compat/tests/Makefile.am

--- a/lib/compat/getent-bb.h
+++ b/lib/compat/getent-bb.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef GETENT_BB_H_INCLUDED
+#define GETENT_BB_H_INCLUDED
+
+#if defined(sun) || defined(__sun)
+
+#include <sys/types.h>
+#include <grp.h>
+#include <pwd.h>
+#include <netdb.h>
+
+int bb__getprotobynumber_r(int proto,
+			   struct protoent *result_buf, char *buf,
+			   size_t buflen, struct protoent **result);
+
+int bb__getprotobyname_r(const char *name,
+			 struct protoent *result_buf, char *buf,
+			 size_t buflen, struct protoent **result);
+
+int bb__getservbyport_r(int port, const char *proto,
+			struct servent *result_buf, char *buf,
+			size_t buflen, struct servent **result);
+
+int bb__getservbyname_r(const char *name, const char *proto,
+			struct servent *result_buf, char *buf,
+			size_t buflen, struct servent **result);
+
+#endif
+
+#endif

--- a/lib/compat/getent.c
+++ b/lib/compat/getent.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#if defined(sun) || defined(__sun)
+
+#include "compat/getent-bb.h"
+#include <errno.h>
+
+int bb__getprotobynumber_r(int proto,
+                           struct protoent *result_buf, char *buf,
+                           size_t buflen, struct protoent **result)
+{
+  *result = getprotobynumber_r(proto, result_buf, buf, buflen);
+  return (*result ? NULL : errno);
+}
+
+int bb__getprotobyname_r(const char *name,
+                         struct protoent *result_buf, char *buf,
+                         size_t buflen, struct protoent **result)
+{
+  *result = getprotobyname_r(name, result_buf, buf, buflen);
+  return (*result ? NULL : errno);
+}
+
+int bb__getservbyport_r(int port, const char *proto,
+                        struct servent *result_buf, char *buf,
+                        size_t buflen, struct servent **result)
+{
+  *result =  getservbyport_r(port, proto, result_buf, buf, buflen);
+  return (*result ? NULL : errno);
+}
+
+int bb__getservbyname_r(const char *name, const char *proto,
+                        struct servent *result_buf, char *buf,
+                        size_t buflen, struct servent **result)
+{
+  *result =  getservbyname_r(name, proto, result_buf, buf, buflen);
+  return (*result ? NULL : errno);
+}
+#endif

--- a/lib/compat/getent.h
+++ b/lib/compat/getent.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef GETENT_COMPAT_H_INCLUDED
+#define GETENT_COMPAT_H_INCLUDED
+
+#include <sys/types.h>
+#include <grp.h>
+#include <pwd.h>
+#include <netdb.h>
+
+#if defined(sun) || defined(__sun)
+
+#define getprotobynumber_r bb__getprotobynumber_r
+#define getprotobyname_r bb__getprotobyname_r
+#define getservbyport_r bb__getservbyport_r
+#define getservbyname_r bb__getservbyname_r
+
+#include "getent-bb.h"
+
+#endif // Solaris
+#endif

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -275,7 +275,7 @@ afstreams_sd_new(gchar *filename, GlobalConfig *cfg)
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;
   self->reader_options.parse_options.flags &= ~LP_EXPECT_HOSTNAME;
-  self->reader_options.stats_level = STATS_LEVEL1;
-  self->reader_options.stats_source = SCS_SUN_STREAMS;
+  self->reader_options.super.stats_level = STATS_LEVEL1;
+  self->reader_options.super.stats_source = SCS_SUN_STREAMS;
   return &self->super.super;
 }

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -85,7 +85,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
     }
 
   r = group_field_map[s].format(member_name,
-                                ((uint8_t *)res) + group_field_map[s].offset,
+                                res->gr_mem,
                                 result);
   g_free(buf);
   return r;

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -20,6 +20,10 @@
  * COPYING for details.
  */
 
+#if defined(sun) || defined(__sun)
+#define _POSIX_PTHREAD_SEMANTICS
+#endif
+
 #include "syslog-ng.h"
 #include "logmsg/logmsg.h"
 #include "plugin.h"
@@ -27,6 +31,7 @@
 #include "cfg.h"
 #include "parse-number.h"
 #include "template/simple-function.h"
+#include "compat/getent.h"
 
 #include <grp.h>
 #include <pwd.h>

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -53,21 +53,26 @@ typedef struct
 } formatter_map_t;
 
 static gboolean
-_getent_format_array(gchar *member_name, gpointer member, GString *result)
+_getent_format_array(gchar *name_or_gid, gpointer members, GString *result)
 {
-  int i = 0;
-  char *o = *(char **)member;
-  char *p = *(char **)o;
-  char *sep = "";
 
-  do
+  gchar **member_array = (gchar **)members;
+  int i = 0;
+
+  if (member_array[i])
     {
-      g_string_append(result, sep);
-      g_string_append(result, p);
-      sep = ",";
-      p = *((char **)o + ++i);
+      g_string_append(result, member_array[i]);
+      i++;
     }
-  while (p != NULL && p != '\0');
+  else
+    return TRUE;
+
+  while (member_array[i])
+    {
+      g_string_append(result, ",");
+      g_string_append(result, member_array[i]);
+      i++;
+    }
 
   return TRUE;
 }


### PR DESCRIPTION
There is a little API difference between the linux and solaris version of getent functions.

In Linux, they return errno, and data in an output parameter.
In solaris, they return the data, and set errno.

This patch provides wrapper around the solaris versions, so that we can use them as in linux: errno is returned, and data is written to the output parameter.

There was a minor compile error in sun_streams, it is fixed as well.

Fixes: https://github.com/balabit/syslog-ng/issues/1667 and https://github.com/balabit/syslog-ng/issues/1692