### PR TITLE
contrib/syslog-ng-debun: bug fix

### DIFF
--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -7,7 +7,7 @@
 ### This software may be used and distributed according to the terms of GNU GPLv2
 ### http://www.gnu.org/licenses/gpl-2.0.html
 
-version="0.3.8.20170913"
+version="0.3.8.20170926"
 
 ### Check for "local" variable support
 if type local >/dev/null; then
@@ -719,7 +719,7 @@ acquire_syslog_var () {
 			printf "Do you really want to copy its contents? Type 'YES' with all capitals: "
 			read ans
 			if [ "$ans" = "YES" ]; then
-				find . |grep -v grep -v "syslog-ng*\.ctl" | cpio -pd ${tmpdir}/var
+				find . | grep -v "syslog-ng*\.ctl" | cpio -pd ${tmpdir}/var
 			fi
 		fi
 	else


### PR DESCRIPTION
Fixed a trivial minor bug that broke file collection for syslog-ng's var directory when its total size was greater than 1000 KB.