### PR TITLE
affile: Do not iterate writer_hash if uninitialized

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -371,7 +371,7 @@ affile_dd_reopen_all_writers(gpointer data, gpointer user_data)
   AFFileDestDriver *driver = (AFFileDestDriver *) data;
   if (driver->single_writer)
     affile_dw_reopen(driver->single_writer);
-  else
+  else if (driver->writer_hash)
     g_hash_table_foreach(driver->writer_hash, affile_dw_reopen_writer, NULL);
 }
 


### PR DESCRIPTION
Both single_writer and writer_hash can be uninitialized as the opening of a file is deferred until there is some message to write.

Fixes: #1699

See comment on code from the pull request that introduced this feature for more information: https://github.com/balabit/syslog-ng/pull/1530#pullrequestreview-65297802