### PR TITLE
Simple rr-network load balancer

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -17,7 +17,9 @@ SCL_SUBDIRS	= \
 	logmatic	\
 	snmptrap        \
 	osquery	        \
-        windowseventlog
+        windowseventlog  \
+        loadbalancer
+
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS))

--- a/scl/loadbalancer/gen-loadbalancer.sh
+++ b/scl/loadbalancer/gen-loadbalancer.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+TARGETS=$confgen_targets
+TARGET_PARAMS=$confgen_parameters
+
+target_cnt=$(echo $TARGETS | wc -w)
+target_id=0
+echo 'channel {'
+for target in $TARGETS
+do
+#    other_targets=$(echo $TARGETS | sed -e s/\\b${target}\\b//)
+    echo '  channel {'
+    echo '    filter {'
+    echo -n '    "'
+    echo -n $target_id
+    echo -n '" == "$(% ${R_MSEC} '
+    echo -n $target_cnt
+    echo ')"'
+    echo '    };'
+    echo '    destination {'
+    echo -n '      network("'
+    echo -n $target
+    echo -n '" '
+    echo -n $TARGET_PARAMS
+#echo -n 'failover-servers("'
+#echo -n $other_targets
+#echo -n '")'
+    echo '      );'
+    echo '    };'
+    echo '    flags(final);'
+    echo '  };'
+    target_id=$((target_id+1))
+done
+echo '};'
+

--- a/scl/loadbalancer/plugin.conf
+++ b/scl/loadbalancer/plugin.conf
@@ -1,0 +1,32 @@
+#############################################################################
+# Copyright (c) 2017 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@module confgen context(destination) name(genlb) exec("`scl-root`/loadbalancer/gen-loadbalancer.sh")
+
+
+block destination network-load-balancer(targets()) {
+  genlb(
+      targets(`targets`)
+      parameters(`__VARARGS__`)
+    )
+};
+


### PR DESCRIPTION
    It implements a simple round-robin load balancing between multiple destination.
    Balancing is based on MSEC hashing where destinations share the same configuration
    except the destination address.
    The main purpose to make load balance configuration simple.
    
    It can be used as a simple network destination and all network parameters are
    recognized, the destination servers must be configured as a space separated list
    of host using the "targets" option:
    
    destination mydest {
        load-balancer(
                targets(server1 server2 server2) # mandatory option
    
                # additional network options can be set as well:
                transport(udp)
                port(3456)
        )
    };
    
    NOTE: as failover-server is not supported in this version it is left out. Otherwise
    nodes are used for fail-over servers to maintain availability.
    
    The idea and original configuration comes from Ferenc Sipos.
    Big kudos for the inspiration and for his persistence on pushing me to add
    this function on our flight from New York to Memphis, TN! Thx!

Also extended confgen module:
    confgen: enable passing arguments to confgen external program as env variables
    
    Options can be set when invoking confgen external program. These options are
    passed as environment variables. Note that env variables are overwritten and
    cleared after the external execution.
    
    This comes handy as this way configuration can be generated not only dynamically,
    but also driven from the configuration.
    
    @module confgen context(destination) name(mygen) exec("gen.sh")
    
    And later that can be used as:
    mygen(
        option1(param1)
        option2("my other option")
    )

This functionality probably addresses #1210 mostly.
