### PR TITLE
Minor clean-up in LogReader

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -40,8 +40,6 @@ struct _LogReader
   LogReaderOptions *options;
   PollEvents *poll_events;
   GSockAddr *peer_addr;
-  ino_t inode;
-  gint64 size;
 
   /* NOTE: these used to be LogReaderWatch members, which were merged into
    * LogReader with the multi-thread refactorization */


### PR DESCRIPTION
logreader: remove unused LogReader fields (inode, size) 

They were introduced in 0a287bd61240503a970e6431d4ebfb65d42b469d, (backport most of the 3.0 PE features into OSE) without usage on the OSE side.

(Sorry for the spam, this PR is almost unavailing. I was just studying the LogReader class.)