### PR TITLE
Style check for amqp

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -25,5 +25,5 @@
 --ignore-exclude-errors
 --exclude="lib/ivykis"
 --exclude="lib/jsonc"
---exclude="modules/afamqp"
+--exclude="modules/afamqp/rabbitmq-c"
 --exclude="modules/afmongodb/mongo-c-driver"

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,8 @@ matrix:
           astyle
       before_script:
       script:
-      - scripts/style-checker.sh check
+      - scripts/style-checker.sh format
+      - git diff --exit-code
     - env: B=copyright-check
       sudo: false
       compiler: gcc

--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -29,24 +29,25 @@
 extern int afamqp_debug;
 int afamqp_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 
-static CfgLexerKeyword afamqp_keywords[] = {
-  { "amqp",			KW_AMQP },
-  { "vhost",			KW_VHOST },
-  { "host",			KW_HOST },
-  { "port",			KW_PORT },
-  { "exchange",			KW_EXCHANGE },
-  { "exchange_declare",		KW_EXCHANGE_DECLARE },
-  { "exchange_type",		KW_EXCHANGE_TYPE },
-  { "routing_key",		KW_ROUTING_KEY },
-  { "persistent",		KW_PERSISTENT },
-  { "username",			KW_USERNAME },
-  { "password",			KW_PASSWORD },
-  { "log_fifo_size",		KW_LOG_FIFO_SIZE  },
-  { "body",			KW_BODY },
-  { "ca_file",     		KW_CA_FILE },
-  { "key_file",       		KW_KEY_FILE },
-  { "cert_file",   		KW_CERT_FILE },
-  { "peer_verify",    		KW_PEER_VERIFY },
+static CfgLexerKeyword afamqp_keywords[] =
+{
+  { "amqp",     KW_AMQP },
+  { "vhost",      KW_VHOST },
+  { "host",     KW_HOST },
+  { "port",     KW_PORT },
+  { "exchange",     KW_EXCHANGE },
+  { "exchange_declare",   KW_EXCHANGE_DECLARE },
+  { "exchange_type",    KW_EXCHANGE_TYPE },
+  { "routing_key",    KW_ROUTING_KEY },
+  { "persistent",   KW_PERSISTENT },
+  { "username",     KW_USERNAME },
+  { "password",     KW_PASSWORD },
+  { "log_fifo_size",    KW_LOG_FIFO_SIZE  },
+  { "body",     KW_BODY },
+  { "ca_file",        KW_CA_FILE },
+  { "key_file",           KW_KEY_FILE },
+  { "cert_file",      KW_CERT_FILE },
+  { "peer_verify",        KW_PEER_VERIFY },
   { NULL }
 };
 


### PR DESCRIPTION
There are three improvement in the initial PR #1683 is blocked by #1657 from which two of them could be merged without issue.

This PR aims to contains only those changes:
1) Style check excludes the *amqp* module, but it should only exclude the *rabbitmq-c* submodule under it.
2) In Travis CI if the style-check fails, in the console output it is going to print, why.