### PR TITLE
Fix reload race in msg macro + drop compatbility with syslog-ng < 3.0

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -935,7 +935,8 @@ relex:
     }
   else if (configuration->user_version == 0 && configuration->parsed_version != 0)
     {
-      cfg_set_version(configuration, configuration->parsed_version);
+      if (!cfg_set_version(configuration, configuration->parsed_version))
+        return LL_ERROR;
     }
   else if (cfg_lexer_get_context_type(self) != LL_CONTEXT_PRAGMA && !self->non_pragma_seen)
     {
@@ -943,10 +944,9 @@ relex:
 
       if (configuration->user_version == 0 && configuration->parsed_version == 0)
         {
-          /* no version selected yet, and we have a non-pragma token, this
-           * means that the configuration is meant for syslog-ng 2.1 */
-          msg_warning("WARNING: Configuration file has no version number, assuming syslog-ng 2.1 format. Please add @version: maj.min to the beginning of the file to indicate this explicitly");
-          cfg_set_version(configuration, 0x0201);
+          msg_error("ERROR: configuration files without a version number has become unsupported in " VERSION_3_13
+                    ", please specify a version number using @version and update your configuration accordingly");
+          return LL_ERROR;
         }
 
 #if (!SYSLOG_NG_ENABLE_FORCED_SERVER_MODE)

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -237,15 +237,21 @@ cfg_deinit(GlobalConfig *cfg)
   return cfg_tree_stop(&cfg->tree);
 }
 
-void
+gboolean
 cfg_set_version(GlobalConfig *self, gint version)
 {
   self->user_version = version;
+  if (cfg_is_config_version_older(self, 0x0300))
+    {
+      msg_error("ERROR: compatibility with configurations below 3.0 was dropped in " VERSION_3_13
+                ", please update your configuration accordingly");
+      return FALSE;
+    }
+
   if (cfg_is_config_version_older(self, VERSION_VALUE))
     {
-      msg_warning("WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode "
-                  "Please update it to use the " VERSION_CURRENT " format at your time of convenience, "
-                  "compatibility mode can operate less efficiently in some cases. "
+      msg_warning("WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. "
+                  "Please update it to use the " VERSION_CURRENT " format at your time of convenience. "
                   "To upgrade the configuration, please review the warnings about incompatible changes printed "
                   "by syslog-ng, and once completed change the @version header at the top of the configuration "
                   "file.");
@@ -258,18 +264,12 @@ cfg_set_version(GlobalConfig *self, gint version)
       self->user_version = VERSION_VALUE;
     }
 
-  if (cfg_is_config_version_older(self, 0x0300))
-    {
-      msg_warning("WARNING: global: the default value of chain_hostnames is changing to 'no' in " VERSION_3_0
-                  ", please update your configuration accordingly");
-      self->chain_hostnames = TRUE;
-    }
   if (cfg_is_config_version_older(self, 0x0303))
     {
       msg_warning("WARNING: global: the default value of log_fifo_size() has changed to 10000 in " VERSION_3_3
                   " to reflect log_iw_size() changes for tcp()/udp() window size changes");
     }
-
+  return TRUE;
 }
 
 gboolean

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -129,7 +129,7 @@ void cfg_set_mark_mode(GlobalConfig *self, gchar *mark_mode);
 gint cfg_tz_convert_value(gchar *convert);
 gint cfg_ts_format_value(gchar *format);
 
-void cfg_set_version(GlobalConfig *self, gint version);
+gboolean cfg_set_version(GlobalConfig *self, gint version);
 void cfg_load_candidate_modules(GlobalConfig *self);
 
 void cfg_set_global_paths(GlobalConfig *self);

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -230,12 +230,6 @@ log_matcher_posix_re_new(GlobalConfig *cfg, const LogMatcherOptions *options)
   self->super.replace = log_matcher_posix_re_replace;
   self->super.free_fn = log_matcher_posix_re_free;
 
-  if (cfg_is_config_version_older(cfg, 0x0300))
-    {
-      msg_warning_once("WARNING: filters do not store matches in macros by default from " VERSION_3_0
-                       ", please update your configuration by using an explicit 'store-matches' flag to achieve that");
-      self->super.flags = LMF_STORE_MATCHES;
-    }
   return &self->super;
 }
 
@@ -796,14 +790,6 @@ log_matcher_pcre_re_new(GlobalConfig *cfg, const LogMatcherOptions *options)
   self->super.match = log_matcher_pcre_re_match;
   self->super.replace = log_matcher_pcre_re_replace;
   self->super.free_fn = log_matcher_pcre_re_free;
-
-  if (cfg_is_config_version_older(cfg, 0x0300))
-    {
-      msg_warning_once("WARNING: filters do not store matches in macros by default from " VERSION_3_0
-                       ", please update your configuration by using an explicit 'store-matches' flag to achieve that");
-      self->super.flags = LMF_STORE_MATCHES;
-    }
-
 
   return &self->super;
 }

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -580,12 +580,6 @@ log_reader_options_defaults(LogReaderOptions *options)
   log_proto_server_options_defaults(&options->proto_options.super);
   msg_format_options_defaults(&options->parse_options);
   options->fetch_limit = 10;
-  if (configuration && cfg_is_config_version_older(configuration, 0x0300))
-    {
-      msg_warning_once("WARNING: input: sources do not remove new-line characters from messages by default from " VERSION_3_0
-                       ", please add 'no-multi-line' flag to your configuration if you want to retain this functionality");
-      options->parse_options.flags |= LP_NO_MULTI_LINE;
-    }
 }
 
 /*

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -347,8 +347,6 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
         }
       break;
     case M_MESSAGE:
-      if (cfg_is_config_version_older(configuration, 0x0300))
-        log_macro_expand(result, M_MSGHDR, escape, opts, tz, seq_num, context_id, msg);
       _result_append_value(result, msg, LM_V_MESSAGE, escape);
       break;
     case M_SOURCE_IP:
@@ -595,12 +593,6 @@ log_macro_lookup(gchar *macro, gint len)
   g_assert(macro_hash);
   g_strlcpy(buf, macro, MIN(sizeof(buf), len+1));
   macro_id = GPOINTER_TO_INT(g_hash_table_lookup(macro_hash, buf));
-
-  if (cfg_is_config_version_older(configuration, 0x0300) && (macro_id == M_MESSAGE))
-    {
-      msg_warning_once("WARNING: template: the meaning of the $MSG/$MESSAGE macros has changed from " VERSION_3_0
-                       ", please prepend a $MSGHDR when upgrading to " VERSION_3_0 " config format");
-    }
   return macro_id;
 }
 

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -230,12 +230,6 @@ log_template_new(GlobalConfig *cfg, const gchar *name)
   self->ref_cnt = 1;
   self->cfg = cfg;
   g_static_mutex_init(&self->arg_lock);
-  if (cfg_is_config_version_older(cfg, 0x0300))
-    {
-      msg_warning_once("WARNING: template: the default value for template-escape has changed to 'no' from " VERSION_3_0
-                       ", please update your configuration file accordingly");
-      self->escape = TRUE;
-    }
   return self;
 }
 

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -245,34 +245,6 @@ test_syntax_errors(void)
 }
 
 static void
-test_compat(void)
-{
-  gint old_version;
-
-  old_version = configuration->user_version;
-  /* old version for various macros */
-  configuration->user_version = 0x0201;
-
-  start_grabbing_messages();
-  assert_template_format("$MSGHDR", "syslog-ng[23323]:");
-  gchar *expected_msg_default_value_changed =
-    g_strdup_printf("the default value for template-escape has changed to 'no' from %s", VERSION_3_0);
-  assert_grabbed_messages_contain(expected_msg_default_value_changed, NULL);
-  reset_grabbed_messages();
-  assert_template_format("$MSG", "syslog-ng[23323]:árvíztűrőtükörfúrógép");
-  gchar *expected_msg_macros_changed = g_strdup_printf("the meaning of the $MSG/$MESSAGE macros has changed from %s",
-                                                       VERSION_3_0);
-  assert_grabbed_messages_contain(expected_msg_macros_changed, NULL);
-  stop_grabbing_messages();
-  g_free(expected_msg_default_value_changed);
-  g_free(expected_msg_macros_changed);
-  assert_template_format("$MSGONLY", "árvíztűrőtükörfúrógép");
-  assert_template_format("$MESSAGE", "syslog-ng[23323]:árvíztűrőtükörfúrógép");
-
-  configuration->user_version = old_version;
-}
-
-static void
 test_multi_thread(void)
 {
   /* name-value pair */
@@ -333,7 +305,6 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   test_template_functions();
   test_message_refs();
   test_syntax_errors();
-  test_compat();
   test_multi_thread();
   test_escaping();
   test_template_function_args();

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -104,6 +104,7 @@
 #define VERSION_3_10 "syslog-ng 3.10"
 #define VERSION_3_11 "syslog-ng 3.11"
 #define VERSION_3_12 "syslog-ng 3.12"
+#define VERSION_3_13 "syslog-ng 3.13"
 
 #define VERSION_VALUE_3_0  0x0300
 #define VERSION_VALUE_3_1  0x0301
@@ -118,11 +119,12 @@
 #define VERSION_VALUE_3_10 0x030a
 #define VERSION_VALUE_3_11 0x030b
 #define VERSION_VALUE_3_12 0x030c
+#define VERSION_VALUE_3_13 0x030d
 
 /* config version code, in the same format as GlobalConfig->version */
-#define VERSION_VALUE   0x030c
-#define VERSION_CURRENT VERSION_3_12
-#define VERSION_CURRENT_VER_ONLY "3.12"
+#define VERSION_VALUE   0x030d
+#define VERSION_CURRENT VERSION_3_13
+#define VERSION_CURRENT_VER_ONLY "3.13"
 
 #define version_convert_from_user(v)  (v)
 

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -177,19 +177,11 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
 
   self->file_reader_options.reader_options.super.stats_source = SCS_FILE;
 
-  if (cfg_is_config_version_older(cfg, 0x0300))
-    {
-      msg_warning_once("WARNING: file source: default value of follow_freq in file sources has changed in " VERSION_3_0
-                       " to '1' for all files except /proc/kmsg");
-      self->file_reader_options.follow_freq = -1;
-    }
+  if (_is_device_node(filename) || _is_linux_proc_kmsg(filename))
+    self->file_reader_options.follow_freq = 0;
   else
-    {
-      if (_is_device_node(filename) || _is_linux_proc_kmsg(filename))
-        self->file_reader_options.follow_freq = 0;
-      else
-        self->file_reader_options.follow_freq = 1000;
-    }
+    self->file_reader_options.follow_freq = 1000;
+
   if (self->file_reader_options.follow_freq > 0)
     self->file_opener = file_opener_for_regular_source_files_new();
   else if (_is_linux_proc_kmsg(self->filename->str))


### PR DESCRIPTION
This branch fixes #1423 as well as it drops the compatibility to syslog-ng versions below 3.0.

The bug itself manifests because of the compatibility support and fixing it is pretty complicated, as it would require propagating the GlobalConfig instance to a place where it isn't present.

Anyway, I felt it was time to drop support for syslog-ng config versions below 3.0, as 3.0 is roughly 9 years old anyway (released on 24th December 2008 as a christmas present :)

