### PR TITLE
riemann: microseconds support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1308,6 +1308,14 @@ if test "$enable_riemann" != "no"; then
  else
    enable_riemann="yes";
  fi
+
+ if test "$enable_riemann" = "yes"; then
+
+    old_CFLAGS=$CFLAGS
+    CFLAGS=`pkg-config --cflags riemann-client`
+    AC_CHECK_DECLS(RIEMANN_EVENT_FIELD_TIME_MICROS, [riemann_micros="yes"], [riemann_micros="no"], [[#include <riemann/event.h>]])
+    CFLAGS=$old_CFLAGS
+ fi
 fi
 
 dnl ***************************************************************************
@@ -1678,6 +1686,7 @@ AC_DEFINE_UNQUOTED(SYSTEMD_JOURNAL_MODE, `journald_mode`, [Systemd-journal suppo
 AC_DEFINE_UNQUOTED(HAVE_INOTIFY, `enable_value $ac_cv_func_inotify_init`, [Have inotify])
 AC_DEFINE_UNQUOTED(ENABLE_PYTHONv2, `(echo "$with_python" | grep -Eq "python-?2.*") && echo 1 || echo 0`, [Python2 c api])
 AC_DEFINE_UNQUOTED(ENABLE_PYTHONv3, `(echo "$with_python" | grep -Eq "python-?3.*") && echo 1 || echo 0`, [Python3 c api])
+AC_DEFINE_UNQUOTED(HAVE_RIEMANN_MICROSECONDS, `enable_value $riemann_micros`, [Riemann microseconds support])
 
 
 AM_CONDITIONAL(ENABLE_ENV_WRAPPER, [test "$enable_env_wrapper" = "yes"])
@@ -1826,7 +1835,7 @@ echo "  STOMP destination (module)  : ${enable_stomp:=no}"
 echo "  GEOIP support (module)      : ${enable_geoip:=no}"
 echo "  GEOIP2 support (module)     : ${enable_geoip2:=no}"
 echo "  Redis support (module)      : ${enable_redis:=no}"
-echo "  Riemann destination (module): ${enable_riemann:=no}"
+echo "  Riemann destination (module): ${enable_riemann:=no}, microseconds: ${riemann_micros:=no}"
 echo "  python                      : ${enable_python:=no} (pkg-config package: ${with_python:=none})"
 echo "  java                        : ${enable_java:=no}"
 echo "  java modules                : ${enable_java_modules:=no}"

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -33,6 +33,7 @@
 #include "cfg-grammar.h"
 #include "cfg-parser.h"
 #include "plugin.h"
+#include "riemann/event.h"
 }
 
 %name-prefix "riemann_"
@@ -48,6 +49,8 @@
 %token KW_STATE
 %token KW_SERVICE
 %token KW_EVENT_TIME
+%token KW_SECONDS
+%token KW_MICROSECONDS
 %token KW_DESCRIPTION
 %token KW_METRIC
 %token KW_TTL
@@ -90,7 +93,7 @@ riemann_option
           {
             riemann_dd_set_field_service(last_driver, $3);
           }
-        | KW_EVENT_TIME '(' template_content ')'
+        | KW_EVENT_TIME '(' template_content event_time_unit ')'
           {
             riemann_dd_set_field_event_time(last_driver, $3);
           }
@@ -146,6 +149,20 @@ riemann_option
         | threaded_dest_driver_option
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option
         ;
+
+
+event_time_unit
+	: KW_SECONDS { riemann_dd_set_event_time_unit(last_driver, RIEMANN_EVENT_FIELD_TIME); }
+	| KW_MICROSECONDS
+           {
+#if SYSLOG_NG_HAVE_RIEMANN_MICROSECONDS
+	     riemann_dd_set_event_time_unit(last_driver, RIEMANN_EVENT_FIELD_TIME_MICROS);
+#else
+            CHECK_ERROR(0, @1, "Riemann destination was not compiled with microseconds support");
+#endif
+           }
+	| { riemann_dd_set_event_time_unit(last_driver, RIEMANN_EVENT_FIELD_TIME); }
+	;
 
 attribute_options
         : attribute_option attribute_options

--- a/modules/riemann/riemann-parser.c
+++ b/modules/riemann/riemann-parser.c
@@ -37,6 +37,8 @@ static CfgLexerKeyword riemann_keywords[] =
   { "host",                     KW_HOST },
   { "service",                  KW_SERVICE },
   { "event_time",               KW_EVENT_TIME },
+  { "seconds",                  KW_SECONDS },
+  { "microseconds",             KW_MICROSECONDS },
   { "state",                    KW_STATE },
   { "description",              KW_DESCRIPTION },
   { "metric",                   KW_METRIC },

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -46,6 +46,7 @@ typedef struct
     LogTemplate *host;
     LogTemplate *service;
     LogTemplate *event_time;
+    gint event_time_unit;
     LogTemplate *state;
     LogTemplate *description;
     LogTemplate *metric;
@@ -116,6 +117,12 @@ riemann_dd_set_field_event_time(LogDriver *d, LogTemplate *value)
   self->fields.event_time = log_template_ref(value);
 }
 
+void riemann_dd_set_event_time_unit(LogDriver *d, gint unit)
+{
+  RiemannDestDriver *self = (RiemannDestDriver *)d;
+
+  self->fields.event_time_unit = unit;
+}
 
 void
 riemann_dd_set_field_state(LogDriver *d, LogTemplate *value)
@@ -364,6 +371,7 @@ riemann_worker_init(LogPipe *s)
     {
       self->fields.event_time = log_template_new(cfg, NULL);
       log_template_compile(self->fields.event_time, "${UNIXTIME}", NULL);
+      self->fields.event_time_unit = RIEMANN_EVENT_FIELD_TIME;
     }
 
   _value_pairs_always_exclude_properties(self);
@@ -561,7 +569,7 @@ riemann_worker_insert_one(RiemannDestDriver *self, LogMessage *msg)
                                         self->super.seq_num, str);
       riemann_dd_field_integer_maybe_add(event, msg, self->fields.event_time,
                                          &self->template_options,
-                                         RIEMANN_EVENT_FIELD_TIME,
+                                         self->fields.event_time_unit,
                                          self->super.seq_num, str);
       riemann_dd_field_string_maybe_add(event, msg, self->fields.description,
                                         &self->template_options,

--- a/modules/riemann/riemann.h
+++ b/modules/riemann/riemann.h
@@ -48,5 +48,5 @@ void riemann_dd_set_tls_cert(LogDriver *d, const gchar *path);
 void riemann_dd_set_tls_key(LogDriver *d, const gchar *path);
 void riemann_dd_set_flush_lines(LogDriver *d, gint lines);
 void riemann_dd_set_timeout(LogDriver *d, guint timeout);
-
+void riemann_dd_set_event_time_unit(LogDriver *d, gint unit);
 #endif


### PR DESCRIPTION
This patch introduces support for event time as microseconds in Riemann destination. 

The event_time() option in Riemann destination configuration
shall take an extra optional parameter specifying the time format
is in seconds (unixtime) or microseconds.
For example:
```
  event_time("$(* $UNIXTIME 1000000)" microseconds)
  event_time("12345678" microseconds)
  event_time("12345678" seconds)
  event_time("12345678")
```

In case the parameter is omitted, syslog-ng defaults to the seconds version. In case event_time is omitted, syslog-ng will default to the seconds version with $UNIXTIME, the same as the original behaviour.

Dependencies:
 - riemann-c-client: 1.10.0 or newer
 - Riemann: 2.13 or newer

With older riemann-c-client, the microseconds option will not be
available.

Older Riemann cannot understand microseconds, though she will not
signal an error either. In that case the :time of the event will be
set to the timestamp when the message arrived to Riemann.

In case the distribution does not contain recent enough riemann-c-client, one needs to install a newer version from https://github.com/algernon/riemann-c-client to use microseconds (for example xenial ships 1.8.1 which is not recent enough). riemann-c-client provides a pkg-config file (.pc file), so one can optionally install it to a custom location and just append the directory of the .pc file to the environment variable `export PKG_CONFIG_PATH=...` before calling configure.

If all goes well in the end of the configure command one will see:
```
[...]
 Riemann destination (module): yes, microseconds: yes
[...]
```
reporting that microseconds support is successfully detected or not.

Fixes: https://github.com/balabit/syslog-ng/issues/1598