### PR TITLE
Use latest config version by default for cfg_snippet_new

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -426,7 +426,7 @@ afinter_postpone_mark(gint mark_freq)
 }
 
 static void
-_release_internal_msg_queue()
+_release_internal_msg_queue(void)
 {
   LogMessage *internal_message = g_queue_pop_head(internal_msg_queue);
   while (internal_message)

--- a/lib/alarms.c
+++ b/lib/alarms.c
@@ -51,7 +51,7 @@ alarm_set(int timeout)
 }
 
 void
-alarm_cancel()
+alarm_cancel(void)
 {
   alarm(0);
   sig_alarm_received = FALSE;
@@ -59,14 +59,14 @@ alarm_cancel()
 }
 
 gboolean
-alarm_has_fired()
+alarm_has_fired(void)
 {
   gboolean res = sig_alarm_received;
   return res;
 }
 
 void
-alarm_init()
+alarm_init(void)
 {
   struct sigaction sa;
 

--- a/lib/alarms.h
+++ b/lib/alarms.h
@@ -28,10 +28,10 @@
 #include "syslog-ng.h"
 
 void alarm_set(int timeout);
-void alarm_cancel();
-gboolean alarm_has_fired();
+void alarm_cancel(void);
+gboolean alarm_has_fired(void);
 
-void alarm_init();
+void alarm_init(void);
 
 
 #endif

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -41,14 +41,14 @@ enum
 typedef void (*ApplicationHookFunc)(gint type, gpointer user_data);
 
 void register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
-void app_startup();
-void app_finish_app_startup_after_cfg_init();
-void app_post_daemonized();
-void app_pre_config_loaded();
-void app_post_config_loaded();
+void app_startup(void);
+void app_finish_app_startup_after_cfg_init(void);
+void app_post_daemonized(void);
+void app_pre_config_loaded(void);
+void app_post_config_loaded(void);
 void app_thread_start(void);
 void app_thread_stop(void);
-void app_shutdown();
+void app_shutdown(void);
 void app_reopen(void);
 
 #endif

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1154,7 +1154,7 @@ cfg_token_block_get_token(CfgTokenBlock *self)
 }
 
 CfgTokenBlock *
-cfg_token_block_new()
+cfg_token_block_new(void)
 {
   CfgTokenBlock *self = g_new0(CfgTokenBlock, 1);
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -345,7 +345,7 @@ _cfg_new_object(gint version)
 }
 
 GlobalConfig *
-cfg_new_snippet()
+cfg_new_snippet(void)
 {
   return _cfg_new_object(VERSION_VALUE);
 }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -300,7 +300,7 @@ cfg_register_builtin_plugins(GlobalConfig *self)
 }
 
 GlobalConfig *
-cfg_new_snippet(gint version)
+_cfg_new_object(gint version)
 {
   GlobalConfig *self = g_new0(GlobalConfig, 1);
 
@@ -345,9 +345,15 @@ cfg_new_snippet(gint version)
 }
 
 GlobalConfig *
+cfg_new_snippet()
+{
+  return _cfg_new_object(VERSION_VALUE);
+}
+
+GlobalConfig *
 cfg_new(gint version)
 {
-  GlobalConfig *self = cfg_new_snippet(version);
+  GlobalConfig *self = _cfg_new_object(version);
   cfg_load_candidate_modules(self);
   return self;
 }

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -135,7 +135,7 @@ void cfg_load_candidate_modules(GlobalConfig *self);
 void cfg_set_global_paths(GlobalConfig *self);
 
 GlobalConfig *cfg_new(gint version);
-GlobalConfig *cfg_new_snippet(gint version);
+GlobalConfig *cfg_new_snippet();
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
 gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gboolean syntax_only, gchar *preprocess_into);
 gboolean cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, gchar *preprocess_into);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -135,7 +135,7 @@ void cfg_load_candidate_modules(GlobalConfig *self);
 void cfg_set_global_paths(GlobalConfig *self);
 
 GlobalConfig *cfg_new(gint version);
-GlobalConfig *cfg_new_snippet();
+GlobalConfig *cfg_new_snippet(void);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
 gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gboolean syntax_only, gchar *preprocess_into);
 gboolean cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, gchar *preprocess_into);

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -60,9 +60,9 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 
 void openssl_ctx_setup_ecdh(SSL_CTX *ctx);
 
-void openssl_init();
-void openssl_crypto_init_threading();
-void openssl_crypto_deinit_threading();
+void openssl_init(void);
+void openssl_crypto_init_threading(void);
+void openssl_crypto_deinit_threading(void);
 
 #endif
 

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -31,13 +31,13 @@
 static GList *command_list = NULL;
 
 GList *
-get_control_command_list()
+get_control_command_list(void)
 {
   return command_list;
 }
 
 void
-reset_control_command_list()
+reset_control_command_list(void)
 {
   g_list_free_full(command_list, (GDestroyNotify)g_free);
   command_list = NULL;

--- a/lib/control/control-commands.h
+++ b/lib/control/control-commands.h
@@ -30,7 +30,7 @@
 
 void control_register_command(const gchar *command_name, const gchar *description, CommandFunction function, gpointer user_data);
 GList *control_register_default_commands(MainLoop *main_loop);
-GList *get_control_command_list();
-void reset_control_command_list();
+GList *get_control_command_list(void);
+void reset_control_command_list(void);
 
 #endif

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -31,7 +31,7 @@
 #include "apphook.h"
 
 void
-test_log()
+test_log(void)
 {
   GString *command = g_string_sized_new(128);
   GString *reply;
@@ -87,7 +87,7 @@ test_log()
 }
 
 void
-test_stats()
+test_stats(void)
 {
   GString *reply = NULL;
   GString *command = g_string_sized_new(128);
@@ -116,7 +116,7 @@ test_stats()
 }
 
 void
-test_reset_stats()
+test_reset_stats(void)
 {
   GString *reply = NULL;
   GString *command = g_string_sized_new(128);

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -37,7 +37,7 @@ int
 main()
 {
   app_startup();
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   test_debugger();
   cfg_free(configuration);
 }

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -34,7 +34,7 @@ test_debugger(void)
 }
 
 int
-main()
+main(void)
 {
   app_startup();
   configuration = cfg_new_snippet();

--- a/lib/eventlog/tests/evtsyslog.c
+++ b/lib/eventlog/tests/evtsyslog.c
@@ -5,7 +5,7 @@
 #endif
 
 int
-main()
+main(void)
 {
   openlog("evtsyslog", LOG_PID, 0);
   syslog(LOG_AUTH | LOG_NOTICE, "test message");

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -243,7 +243,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   app_startup();
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/lib/filter/tests/test_filters_in_list.c
+++ b/lib/filter/tests/test_filters_in_list.c
@@ -161,7 +161,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 
   app_startup();
 
-  configuration = cfg_new_snippet(0x0305);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/lib/filter/tests/test_filters_netmask6.c
+++ b/lib/filter/tests/test_filters_netmask6.c
@@ -72,7 +72,7 @@ assert_netmask6(const gchar *ipv6, gint prefix, gchar *expected_network)
 }
 
 int
-main()
+main(void)
 {
   const gchar *ipv6 = "2001:db80:85a3:8d30:1319:8a2e:3700:7348";
 

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -72,7 +72,7 @@ Test(test_filters_statistics, filter_stastistics)
 {
   app_startup();
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   configuration->stats_options.level = 1;
   plugin_load_module("syslogformat", configuration, NULL);
   cr_assert(cfg_init(configuration));

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -40,7 +40,7 @@ level_bits(gchar *lev)
 MsgFormatOptions parse_options;
 
 static LogFilterPipe *
-create_log_filter_pipe()
+create_log_filter_pipe(void)
 {
   FilterExprNode *filter = filter_level_new(level_bits("debug"));
   filter_expr_init(filter, configuration);

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -358,7 +358,7 @@ g_process_set_mode(GProcessMode mode)
  * Return the processing mode applied to the daemon.
  **/
 GProcessMode
-g_process_get_mode()
+g_process_get_mode(void)
 {
   return process_opts.mode;
 }

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -63,7 +63,7 @@ typedef gpointer cap_t;
 void g_process_message(const gchar *fmt, ...);
 
 void g_process_set_mode(GProcessMode mode);
-GProcessMode g_process_get_mode();
+GProcessMode g_process_get_mode(void);
 void g_process_set_name(const gchar *name);
 void g_process_set_user(const gchar *user);
 void g_process_set_group(const gchar *group);

--- a/lib/host-id.c
+++ b/lib/host-id.c
@@ -29,7 +29,7 @@
 guint32 global_host_id = 0;
 
 static guint32
-_create_host_id()
+_create_host_id(void)
 {
   union
   {

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -920,7 +920,7 @@ log_matcher_options_destroy(LogMatcherOptions *options)
 }
 
 GQuark
-log_matcher_error_quark()
+log_matcher_error_quark(void)
 {
   return g_quark_from_static_string("log-matcher-error-quark");
 }

--- a/lib/logmsg/tests/test_logmsg_ack.c
+++ b/lib/logmsg/tests/test_logmsg_ack.c
@@ -70,7 +70,7 @@ ack_record_free(AckRecord *self)
 }
 
 static AckRecord *
-ack_record_new()
+ack_record_new(void)
 {
   AckRecord *self = g_new0(AckRecord, 1);
   self->init = _init;

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -102,7 +102,7 @@ _alloc_dummy_values_to_change_handle_values_accross_restarts(void)
 }
 
 static void
-_reset_log_msg_registry()
+_reset_log_msg_registry(void)
 {
   log_msg_registry_deinit();
   log_msg_registry_init();

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -268,7 +268,7 @@ int
 main(int argc, char **argv)
 {
   app_startup();
-  cfg = cfg_new_snippet(0x0307);
+  cfg = cfg_new_snippet();
   plugin_load_module("syslogformat", cfg, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, cfg);

--- a/lib/logmsg/tests/test_tags.c
+++ b/lib/logmsg/tests/test_tags.c
@@ -104,7 +104,7 @@ test_tags(void)
 }
 
 void
-test_msg_tags()
+test_msg_tags(void)
 {
   gchar *name;
   gint i, set;

--- a/lib/logmsg/tests/test_timestamp_serialize.c
+++ b/lib/logmsg/tests/test_timestamp_serialize.c
@@ -42,7 +42,7 @@
   g_string_free(stream, TRUE);
 
 static void
-test_normal_working()
+test_normal_working(void)
 {
   PREPARE_TEST
   assert_true(timestamp_serialize(sa, input_timestamps), "Failed to serialize timestamps");
@@ -56,7 +56,7 @@ test_normal_working()
 }
 
 static void
-test_derializing_injured_timestamp()
+test_derializing_injured_timestamp(void)
 {
   PREPARE_TEST
 

--- a/lib/logproto/tests/test_findeom.c
+++ b/lib/logproto/tests/test_findeom.c
@@ -49,7 +49,7 @@ testcase(const gchar *msg_, gsize msg_len, gint eom_ofs)
 }
 
 int
-main()
+main(void)
 {
   testcase("a\nb\nc\n",  6,  1);
   testcase("ab\nb\nc\n",  7,  2);

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -231,7 +231,7 @@ _consume_action(SyncCallAction *action, gpointer dummy)
 }
 
 static void
-_invoke_sync_call_actions()
+_invoke_sync_call_actions(void)
 {
   g_queue_foreach(&sync_call_actions, (GFunc)_consume_action, NULL);
   g_queue_clear(&sync_call_actions);

--- a/lib/memtrace.c
+++ b/lib/memtrace.c
@@ -209,7 +209,7 @@ z_mem_trace_stats(void)
 static gpointer z_mem_trace_check_canaries(gpointer ptr);
 
 void
-z_mem_trace_dump()
+z_mem_trace_dump(void)
 {
   int i;
 
@@ -613,7 +613,7 @@ z_mem_trace_stats(void)
 }
 
 void
-z_mem_trace_dump()
+z_mem_trace_dump(void)
 {
 }
 

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -34,7 +34,7 @@ expect_config_parse_failure(const char *raw_rewrite_rule)
 {
   char raw_config[1024];
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   snprintf(raw_config, sizeof(raw_config), "rewrite s_test{ %s };", raw_rewrite_rule);
   assert_false(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL),
                ASSERTION_ERROR("Parsing the given configuration failed"));
@@ -46,7 +46,7 @@ create_rewrite_rule(const char *raw_rewrite_rule)
 {
   char raw_config[1024];
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   snprintf(raw_config, sizeof(raw_config), "rewrite s_test{ %s }; log{ rewrite(s_test); };", raw_rewrite_rule);
   assert_true(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL),
               ASSERTION_ERROR("Parsing the given configuration failed"));

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -98,7 +98,7 @@ rewrite_teardown(LogMessage *msg)
 }
 
 void
-test_condition_success()
+test_condition_success(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"00100\", value(\"device_id\") condition(program(\"ARCGIS\")));");
   LogMessage *msg = create_message_with_field("PROGRAM", "ARCGIS");
@@ -108,7 +108,7 @@ test_condition_success()
 }
 
 void
-test_reference_on_condition_cloned()
+test_reference_on_condition_cloned(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"00100\", value(\"device_id\") condition(program(\"ARCGIS\")));");
   LogPipe *cloned_rule = log_pipe_clone(&test_rewrite->super);
@@ -118,7 +118,7 @@ test_reference_on_condition_cloned()
   cfg_free(configuration);
 }
 
-void test_set_field_exist_and_set_literal_string()
+void test_set_field_exist_and_set_literal_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"value\" value(\"field1\") );");
   LogMessage *msg = create_message_with_field("field1", "oldvalue");
@@ -127,7 +127,7 @@ void test_set_field_exist_and_set_literal_string()
   rewrite_teardown(msg);
 }
 
-void test_set_field_not_exist_and_set_literal_string()
+void test_set_field_not_exist_and_set_literal_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"value\" value(\"field1\") );");
   LogMessage *msg = log_msg_new_empty();
@@ -137,7 +137,7 @@ void test_set_field_not_exist_and_set_literal_string()
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_set_template_string()
+void test_set_field_exist_and_set_template_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"$field2\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "field2","newvalue", NULL);
@@ -147,7 +147,7 @@ void test_set_field_exist_and_set_template_string()
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted()
+void test_subst_field_exist_and_substring_substituted(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"substitute\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "asubstringb", NULL);
@@ -157,7 +157,7 @@ void test_subst_field_exist_and_substring_substituted()
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_with_template()
+void test_subst_field_exist_and_substring_substituted_with_template(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"$field2\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "asubstringb", "field2","substitute", NULL);
@@ -167,7 +167,7 @@ void test_subst_field_exist_and_substring_substituted_with_template()
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_only_once_without_global()
+void test_subst_field_exist_and_substring_substituted_only_once_without_global(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"substitute\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "substring substring", NULL);
@@ -177,7 +177,7 @@ void test_subst_field_exist_and_substring_substituted_only_once_without_global()
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_every_occurence_with_global()
+void test_subst_field_exist_and_substring_substituted_every_occurence_with_global(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"substitute\" value(\"field1\") flags(global) );");
   LogMessage *msg = create_message_with_fields("field1", "substring substring", NULL);
@@ -187,7 +187,7 @@ void test_subst_field_exist_and_substring_substituted_every_occurence_with_globa
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_when_regexp_matched()
+void test_subst_field_exist_and_substring_substituted_when_regexp_matched(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"[0-9]+\" \"substitute\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "a123b", NULL);
@@ -197,7 +197,7 @@ void test_subst_field_exist_and_substring_substituted_when_regexp_matched()
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_literal_string()
+void test_set_field_exist_and_group_set_literal_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field1\") );");
   LogMessage *msg = create_message_with_field("field1", "oldvalue");
@@ -206,7 +206,7 @@ void test_set_field_exist_and_group_set_literal_string()
   rewrite_teardown(msg);
 }
 
-void test_set_field_honors_time_zone()
+void test_set_field_honors_time_zone(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set('${ISODATE}' value('UTCDATE') time-zone('Asia/Tokyo'));");
   LogMessage *msg = create_message_with_fields("field1", "a123b", NULL);
@@ -216,7 +216,7 @@ void test_set_field_honors_time_zone()
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_multiple_fields_with_glob_pattern_literal_string()
+void test_set_field_exist_and_group_set_multiple_fields_with_glob_pattern_literal_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field.*\") );");
   LogMessage *msg = create_message_with_fields("field.name1", "oldvalue","field.name2", "oldvalue", NULL);
@@ -226,7 +226,7 @@ void test_set_field_exist_and_group_set_multiple_fields_with_glob_pattern_litera
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_multiple_fields_with_glob_question_mark_pattern_literal_string()
+void test_set_field_exist_and_group_set_multiple_fields_with_glob_question_mark_pattern_literal_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field?\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue","field2", "oldvalue", NULL);
@@ -236,7 +236,7 @@ void test_set_field_exist_and_group_set_multiple_fields_with_glob_question_mark_
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_multiple_fields_with_multiple_glob_pattern_literal_string()
+void test_set_field_exist_and_group_set_multiple_fields_with_multiple_glob_pattern_literal_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field1\" \"field2\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue","field2", "oldvalue", NULL);
@@ -246,7 +246,7 @@ void test_set_field_exist_and_group_set_multiple_fields_with_multiple_glob_patte
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_template_string()
+void test_set_field_exist_and_group_set_template_string(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"$field2\" values(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "field2", "value", NULL);
@@ -255,7 +255,7 @@ void test_set_field_exist_and_group_set_template_string()
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_template_string_with_old_value()
+void test_set_field_exist_and_group_set_template_string_with_old_value(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"$_ alma\" values(\"field1\") );");
   LogMessage *msg = create_message_with_field("field1", "value");
@@ -264,7 +264,7 @@ void test_set_field_exist_and_group_set_template_string_with_old_value()
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_when_condition_doesnt_match()
+void test_set_field_exist_and_group_set_when_condition_doesnt_match(void)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("groupset(\"value\" values(\"field1\") condition( program(\"program1\") ) );");
@@ -275,7 +275,7 @@ void test_set_field_exist_and_group_set_when_condition_doesnt_match()
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_when_condition_matches()
+void test_set_field_exist_and_group_set_when_condition_matches(void)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("groupset(\"value\" values(\"field1\") condition( program(\"program\") ) );");
@@ -285,7 +285,7 @@ void test_set_field_exist_and_group_set_when_condition_matches()
   rewrite_teardown(msg);
 }
 
-void test_set_field_cloned()
+void test_set_field_cloned(void)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("groupset(\"value\" values(\"field1\") condition( program(\"program\") ) );");
@@ -295,7 +295,7 @@ void test_set_field_cloned()
   cfg_free(configuration);
 }
 
-void test_set_field_invalid_template()
+void test_set_field_invalid_template(void)
 {
   expect_config_parse_failure("groupset(\"${alma\" values(\"field1\") );");
 }

--- a/lib/service-management.c
+++ b/lib/service-management.c
@@ -60,19 +60,19 @@ service_management_systemd_publish_status(const gchar *status)
 }
 
 static inline void
-service_management_systemd_clear_status()
+service_management_systemd_clear_status(void)
 {
   sd_notify(0, "STATUS=");
 }
 
 static inline void
-service_management_systemd_indicate_readiness()
+service_management_systemd_indicate_readiness(void)
 {
   sd_notify(0, "READY=1");
 }
 
 static gboolean
-service_management_systemd_is_active()
+service_management_systemd_is_active(void)
 {
   struct stat st;
 
@@ -120,17 +120,17 @@ service_management_dummy_publish_status(const gchar *status)
 }
 
 static inline void
-service_management_dummy_clear_status()
+service_management_dummy_clear_status(void)
 {
 }
 
 static inline void
-service_management_dummy_indicate_readiness()
+service_management_dummy_indicate_readiness(void)
 {
 }
 
 static gboolean
-service_management_dummy_is_active()
+service_management_dummy_is_active(void)
 {
   return TRUE;
 }
@@ -156,7 +156,7 @@ ServiceManagement service_managements[] =
 };
 
 void
-service_management_init()
+service_management_init(void)
 {
   gint i = 0;
   while (i < sizeof(service_managements) / sizeof(ServiceManagement))

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -99,7 +99,7 @@ _register_counters(const CounterHashContent *counters, size_t n, ClusterKeySet k
 }
 
 static void
-_register_single_counter_with_name()
+_register_single_counter_with_name(void)
 {
   stats_lock();
   {

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -323,7 +323,7 @@ log_template_options_defaults(LogTemplateOptions *options)
 }
 
 GQuark
-log_template_error_quark()
+log_template_error_quark(void)
 {
   return g_quark_from_static_string("log-template-error-quark");
 }

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -249,7 +249,7 @@ test_colon_dash_in_braces_is_parsed_as_default_value(void)
 }
 
 static void
-test_double_dollars_is_a_literal_dollar()
+test_double_dollars_is_a_literal_dollar(void)
 {
   assert_template_compile("$$VALUE_NAME");
   assert_compiled_template(text = "$VALUE_NAME", default_value = NULL, macro = M_NONE, type = LTE_MACRO, msg_ref = 0);
@@ -343,7 +343,7 @@ test_value_name_can_be_the_empty_string_when_referenced_using_braces(void)
 }
 
 static void
-test_template_compile_value()
+test_template_compile_value(void)
 {
   TEMPLATE_TESTCASE(test_simple_value);
   TEMPLATE_TESTCASE(test_value_without_braces);

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
 {
   msg_init(FALSE);
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   log_msg_registry_init();
   log_template_global_init();
   plugin_register(configuration, &hello_plugin, 1);

--- a/lib/tests/test_cfg_lexer_subst.c
+++ b/lib/tests/test_cfg_lexer_subst.c
@@ -317,7 +317,7 @@ test_cfg_lexer_subst(void)
   SUBST_TESTCASE(test_strings_with_embedded_apostrophe_cause_an_error_when_encoding_in_qstring);
 }
 
-int main()
+int main(void)
 {
   app_startup();
 

--- a/lib/tests/test_host_resolve.c
+++ b/lib/tests/test_host_resolve.c
@@ -308,7 +308,7 @@ main(int argc, char *argv[])
 {
   app_startup();
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   test_resolve_hostname_to_hostname();
   test_resolve_hostname_to_sockaddr();
   test_resolve_sockaddr_to_hostname();

--- a/lib/tests/test_pathutils.c
+++ b/lib/tests/test_pathutils.c
@@ -46,7 +46,7 @@ test_is_directory_return_false_in_case_of_regular_file(void)
 }
 
 int
-main()
+main(void)
 {
   test_is_directory_return_false_in_case_of_regular_file();
 }

--- a/lib/tests/test_rcptid.c
+++ b/lib/tests/test_rcptid.c
@@ -34,14 +34,14 @@ gboolean verbose = FALSE;
 PersistState *state;
 
 void
-setup_persist_id_test()
+setup_persist_id_test(void)
 {
   state = clean_and_create_persist_state_for_test("test_values.persist");
   rcptid_init(state, TRUE);
 }
 
 void
-teardown_persist_id_test()
+teardown_persist_id_test(void)
 {
   commit_and_destroy_persist_state(state);
   rcptid_deinit();
@@ -115,7 +115,7 @@ test_rcptid_is_an_empty_string_when_zero(void)
 }
 
 static void
-rcptid_test_case()
+rcptid_test_case(void)
 {
   test_rcptid_is_persistent_across_persist_backend_reinits();
   test_rcptid_overflows_at_64bits_and_is_reset_to_one();

--- a/lib/tests/test_runid.c
+++ b/lib/tests/test_runid.c
@@ -152,7 +152,7 @@ test_run_id_macro__macro_is_empty_if_run_id_is_not_inited(void)
 
 
 int
-main()
+main(void)
 {
   app_startup();
   test_run_id__first_run__run_id_is_one();

--- a/lib/tests/test_str_format.c
+++ b/lib/tests/test_str_format.c
@@ -26,7 +26,7 @@
 #include "str-format.h"
 #include "testutils.h"
 
-void test_format_hex_string__single_byte__perfect()
+void test_format_hex_string__single_byte__perfect(void)
 {
   gchar expected_output[3] = "40";
   gchar output[3];
@@ -38,7 +38,7 @@ void test_format_hex_string__single_byte__perfect()
                  "format_hex_string output does not match!", NULL);
 }
 
-void test_format_hex_string__two_bytes__perfect()
+void test_format_hex_string__two_bytes__perfect(void)
 {
   gchar expected_output[5] = "4041";
   gchar output[5];
@@ -50,7 +50,7 @@ void test_format_hex_string__two_bytes__perfect()
                  "format_hex_string output does not match with two bytes!", NULL);
 }
 
-void test_format_hex_string_with_delimiter__single_byte__perfect()
+void test_format_hex_string_with_delimiter__single_byte__perfect(void)
 {
   gchar expected_output[3] = "40";
   gchar output[3];
@@ -62,7 +62,7 @@ void test_format_hex_string_with_delimiter__single_byte__perfect()
                  "format_hex_string_with_delimiter output does not match!", NULL);
 }
 
-void test_format_hex_string_with_delimiter__two_bytes__perfect()
+void test_format_hex_string_with_delimiter__two_bytes__perfect(void)
 {
   gchar expected_output[6] = "40 41";
   gchar output[6];
@@ -74,7 +74,7 @@ void test_format_hex_string_with_delimiter__two_bytes__perfect()
                  "format_hex_string_with_delimiter output does not match in case of two bytes!", NULL);
 }
 
-int main()
+int main(void)
 {
   test_format_hex_string__single_byte__perfect();
   test_format_hex_string__two_bytes__perfect();

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -150,7 +150,7 @@ cached_g_current_time(GTimeVal *result)
 }
 
 time_t
-cached_g_current_time_sec()
+cached_g_current_time_sec(void)
 {
   GTimeVal now;
 

--- a/lib/transport/tests/test_aux_data.c
+++ b/lib/transport/tests/test_aux_data.c
@@ -171,7 +171,7 @@ test_aux_data(void)
   AUX_DATA_TESTCASE(test_add_nv_pair_to_a_NULL_aux_data_will_do_nothing);
 }
 
-int main()
+int main(void)
 {
   test_aux_data();
   return 0;

--- a/lib/type-hinting.c
+++ b/lib/type-hinting.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 
 GQuark
-type_hinting_error_quark()
+type_hinting_error_quark(void)
 {
   return g_quark_from_static_string("type-hinting-error-quark");
 }

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
   putenv("TZ=MET-1METDST");
   tzset();
 
-  cfg = cfg_new_snippet(VERSION_VALUE);
+  cfg = cfg_new_snippet();
   plugin_load_module("syslogformat", cfg, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, cfg);

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -132,7 +132,7 @@ int main()
 {
   app_startup();
 
-  configuration = cfg_new_snippet(0x0303);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -128,7 +128,7 @@ test_value_pairs_walk_prefix_data(GlobalConfig *cfg)
   log_msg_unref(msg);
 };
 
-int main()
+int main(void)
 {
   app_startup();
 

--- a/libtest/libtest.c
+++ b/libtest/libtest.c
@@ -29,7 +29,7 @@ msg_event(int prio, const char *desc, void *tag1, ...)
 }
 
 void
-main_loop_wakeup()
+main_loop_wakeup(void)
 {
   ;
 }

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -26,7 +26,7 @@
 #include "plugin.h"
 
 void
-init_and_load_syslogformat_module()
+init_and_load_syslogformat_module(void)
 {
   configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
@@ -35,7 +35,7 @@ init_and_load_syslogformat_module()
 }
 
 void
-deinit_syslogformat_module()
+deinit_syslogformat_module(void)
 {
   if (configuration)
     cfg_free(configuration);

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -28,7 +28,7 @@
 void
 init_and_load_syslogformat_module()
 {
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -49,8 +49,8 @@ MsgFormatOptions parse_options;
   while (0)
 
 
-void init_and_load_syslogformat_module();
-void deinit_syslogformat_module();
+void init_and_load_syslogformat_module(void);
+void deinit_syslogformat_module(void);
 
 void assert_log_messages_equal(LogMessage *log_message_a, LogMessage *log_message_b);
 

--- a/libtest/stopwatch.h
+++ b/libtest/stopwatch.h
@@ -28,7 +28,7 @@
 
 #include <glib.h>
 
-void start_stopwatch();
+void start_stopwatch(void);
 void stop_stopwatch_and_display_result(gint iterations, gchar *message_template, ...);
 
 #endif

--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -159,7 +159,7 @@ _free(ContextInfoDB *self)
 }
 
 ContextInfoDB *
-context_info_db_new()
+context_info_db_new(void)
 {
   ContextInfoDB *self = g_new0(ContextInfoDB, 1);
 

--- a/modules/add-contextual-data/context-info-db.h
+++ b/modules/add-contextual-data/context-info-db.h
@@ -34,7 +34,7 @@ typedef void (*ADD_CONTEXT_INFO_CB) (gpointer arg,
 
 void context_info_db_enable_ordering(ContextInfoDB *self);
 GList * context_info_db_ordered_selectors(ContextInfoDB *self);
-ContextInfoDB *context_info_db_new();
+ContextInfoDB *context_info_db_new(void);
 void context_info_db_free(ContextInfoDB *self);
 
 ContextInfoDB *context_info_db_ref(ContextInfoDB *self);

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.c
@@ -90,7 +90,7 @@ csv_contextual_data_record_scanner_free(ContextualDataRecordScanner *s)
 }
 
 ContextualDataRecordScanner *
-csv_contextual_data_record_scanner_new()
+csv_contextual_data_record_scanner_new(void)
 {
   CSVContextualDataRecordScanner *self =
     g_new0(CSVContextualDataRecordScanner, 1);

--- a/modules/add-contextual-data/csv-contextual-data-record-scanner.h
+++ b/modules/add-contextual-data/csv-contextual-data-record-scanner.h
@@ -33,6 +33,6 @@ typedef struct _CSVContextualDataRecordScanner
   CSVScannerOptions options;
 } CSVContextualDataRecordScanner;
 
-ContextualDataRecordScanner *csv_contextual_data_record_scanner_new();
+ContextualDataRecordScanner *csv_contextual_data_record_scanner_new(void);
 
 #endif

--- a/modules/add-contextual-data/tests/test_selector.c
+++ b/modules/add-contextual-data/tests/test_selector.c
@@ -54,7 +54,7 @@ Test(add_contextual_data_template_selector, test_given_empty_selector_when_resol
 static AddContextualDataSelector *
 _create_template_selector(const gchar *template_string)
 {
-  GlobalConfig *cfg = cfg_new_snippet(VERSION_VALUE);
+  GlobalConfig *cfg = cfg_new_snippet();
   AddContextualDataSelector *selector = add_contextual_data_template_selector_new(cfg, template_string);
   add_contextual_data_selector_init(selector, NULL);
 

--- a/modules/affile/collection-comporator.c
+++ b/modules/affile/collection-comporator.c
@@ -61,7 +61,7 @@ collection_comporator_free(CollectionComporator *self)
 }
 
 CollectionComporator *
-collection_comporator_new()
+collection_comporator_new(void)
 {
   CollectionComporator *self = g_new0(CollectionComporator, 1);
   self->original_map = g_hash_table_new(g_str_hash, g_str_equal);

--- a/modules/affile/collection-comporator.h
+++ b/modules/affile/collection-comporator.h
@@ -28,7 +28,7 @@ typedef struct _CollectionComporator CollectionComporator;
 
 typedef void (*cc_callback)(const gchar *value, gpointer user_data);
 
-CollectionComporator *collection_comporator_new();
+CollectionComporator *collection_comporator_new(void);
 void collection_comporator_free(CollectionComporator *self);
 void collection_comporator_start(CollectionComporator *self);
 void collection_comporator_stop(CollectionComporator *self);

--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -54,7 +54,7 @@ build_filename(const gchar *basedir, const gchar *path)
 #define PATH_MAX_GUESS 1024
 
 static inline long
-get_path_max()
+get_path_max(void)
 {
   static long path_max = 0;
   if (path_max == 0)

--- a/modules/affile/tests/test_collection_comporator.c
+++ b/modules/affile/tests/test_collection_comporator.c
@@ -36,7 +36,7 @@ typedef struct _TestData
 static const gchar *TEST = "test";
 
 TestData *
-test_data_new()
+test_data_new(void)
 {
   TestData *self = g_new0(TestData, 1);
   self->deleted_entries = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);

--- a/modules/affile/tests/test_wildcard_source.c
+++ b/modules/affile/tests/test_wildcard_source.c
@@ -32,7 +32,7 @@ static void
 _init(void)
 {
   app_startup();
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   cr_assert(plugin_load_module("affile", configuration, NULL));
 }
 

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -304,7 +304,7 @@ _setup(void)
 
   log_msg_registry_init();
 
-  test_cfg = cfg_new_snippet(0x0308);
+  test_cfg = cfg_new_snippet();
   g_assert(test_cfg);
 
   const gchar *persist_filename = "";

--- a/modules/afsocket/tests/test-transport-mapper-unix.c
+++ b/modules/afsocket/tests/test-transport-mapper-unix.c
@@ -26,7 +26,7 @@
 #include "transport-mapper-lib.h"
 
 static void
-test_transport_mapper_unix_stream_apply_transport_sets_defaults()
+test_transport_mapper_unix_stream_apply_transport_sets_defaults(void)
 {
   assert_transport_mapper_apply(transport_mapper, NULL);
   assert_transport_mapper_transport(transport_mapper, "unix-stream");
@@ -38,7 +38,7 @@ test_transport_mapper_unix_stream_apply_transport_sets_defaults()
 }
 
 static void
-test_transport_mapper_unix_dgram_apply_transport_sets_defaults()
+test_transport_mapper_unix_dgram_apply_transport_sets_defaults(void)
 {
   assert_transport_mapper_apply(transport_mapper, NULL);
   assert_transport_mapper_transport(transport_mapper, "unix-dgram");

--- a/modules/afstomp/tests/test_stomp_proto.c
+++ b/modules/afstomp/tests/test_stomp_proto.c
@@ -45,7 +45,7 @@ assert_stomp_body(stomp_frame *frame, char *body)
 }
 
 void
-test_only_command()
+test_only_command(void)
 {
   stomp_frame frame;
 
@@ -55,7 +55,7 @@ test_only_command()
 }
 
 void
-test_command_and_data()
+test_command_and_data(void)
 {
   stomp_frame frame;
 
@@ -66,7 +66,7 @@ test_command_and_data()
 };
 
 void
-test_command_and_header_and_data()
+test_command_and_header_and_data(void)
 {
   stomp_frame frame;
 
@@ -78,7 +78,7 @@ test_command_and_header_and_data()
 };
 
 void
-test_command_and_header()
+test_command_and_header(void)
 {
   stomp_frame frame;
 
@@ -89,7 +89,7 @@ test_command_and_header()
 };
 
 void
-test_generate_gstring_from_frame()
+test_generate_gstring_from_frame(void)
 {
   stomp_frame frame;
   GString *actual;

--- a/modules/cef/tests/test-format-cef-extension.c
+++ b/modules/cef/tests/test-format-cef-extension.c
@@ -76,7 +76,7 @@ _expect_cef_result_format_va(const gchar *format, const gchar *expected, ...)
 }
 
 static void
-_test_null_in_value()
+_test_null_in_value(void)
 {
   LogMessage *msg = create_empty_message();
 

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -176,7 +176,7 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new_snippet(0x0302);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/modules/csvparser/tests/test_csvparser_statistics.c
+++ b/modules/csvparser/tests/test_csvparser_statistics.c
@@ -74,7 +74,7 @@ _parse_msg(LogParser *self, gchar *msg)
 Test(test_filters_statistics, filter_stastistics)
 {
   app_startup();
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   configuration->stats_options.level = 1;
   cr_assert(cfg_init(configuration));
 

--- a/modules/date/tests/test_date.c
+++ b/modules/date/tests/test_date.c
@@ -76,7 +76,7 @@ setup(void)
   putenv("TZ=CET-1");
   tzset();
 
-  configuration = cfg_new_snippet(0x0302);
+  configuration = cfg_new_snippet();
 }
 
 void

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1233,7 +1233,7 @@ main(int argc, char *argv[])
   pattern_db_global_init();
   crypto_init();
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
 
   if (!g_option_context_parse(ctx, &argc, &argv, &error))
     {

--- a/modules/dbparser/tests/test_parsers_e2e.c
+++ b/modules/dbparser/tests/test_parsers_e2e.c
@@ -249,7 +249,7 @@ gchar *test12 [] =
 gchar **parsers[] = {test1, test2, test3, test4, test5, test6, test7, test8, test9, test10, test11, test12, NULL};
 
 void
-test_patterndb_parsers()
+test_patterndb_parsers(void)
 {
   gint i;
 

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -1119,7 +1119,7 @@ main(int argc, char *argv[])
 
   msg_init(TRUE);
 
-  configuration = cfg_new_snippet(0x0302);
+  configuration = cfg_new_snippet();
   plugin_load_module("basicfuncs", configuration, NULL);
   plugin_load_module("syslogformat", configuration, NULL);
 

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -891,7 +891,7 @@ gchar *pdb_inheritance_enabled_skeleton = "<patterndb version='4' pub_date='2010
 </patterndb>";
 
 void
-test_patterndb_message_property_inheritance_enabled()
+test_patterndb_message_property_inheritance_enabled(void)
 {
   _load_pattern_db_from_string(pdb_inheritance_enabled_skeleton);
 
@@ -937,7 +937,7 @@ gchar *pdb_inheritance_disabled_skeleton = "<patterndb version='4' pub_date='201
 </patterndb>";
 
 void
-test_patterndb_message_property_inheritance_disabled()
+test_patterndb_message_property_inheritance_disabled(void)
 {
   _load_pattern_db_from_string(pdb_inheritance_disabled_skeleton);
 
@@ -1068,7 +1068,7 @@ gchar *pdb_msg_count_skeleton = "<patterndb version='4' pub_date='2010-02-22'>\
 </patterndb>";
 
 void
-test_patterndb_context_length()
+test_patterndb_context_length(void)
 {
   _load_pattern_db_from_string(pdb_msg_count_skeleton);
 
@@ -1095,7 +1095,7 @@ gchar *tag_outside_of_rule_skeleton = "<patterndb version='3' pub_date='2010-02-
 </patterndb>";
 
 void
-test_patterndb_tags_outside_of_rule()
+test_patterndb_tags_outside_of_rule(void)
 {
   patterndb = pattern_db_new();
   messages = NULL;

--- a/modules/dbparser/tests/test_patternize.c
+++ b/modules/dbparser/tests/test_patternize.c
@@ -448,7 +448,7 @@ int
 main()
 {
   app_startup();
-  configuration = cfg_new_snippet(0x0201);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/modules/dbparser/tests/test_patternize.c
+++ b/modules/dbparser/tests/test_patternize.c
@@ -151,7 +151,7 @@ testcase_frequent_words(gchar *logs, guint support, gchar *expected)
 }
 
 void
-frequent_words_tests()
+frequent_words_tests(void)
 {
 
   /* simple tests */
@@ -367,7 +367,7 @@ testcase_find_clusters_slct(gchar *logs, guint support, gchar *expected)
 }
 
 void
-find_clusters_slct_tests()
+find_clusters_slct_tests(void)
 {
   testcase_find_clusters_slct(
     "a\n", 0,
@@ -445,7 +445,7 @@ find_clusters_slct_tests()
 }
 
 int
-main()
+main(void)
 {
   app_startup();
   configuration = cfg_new_snippet();

--- a/modules/dbparser/tests/test_timer_wheel.c
+++ b/modules/dbparser/tests/test_timer_wheel.c
@@ -136,7 +136,7 @@ test_wheel(gint seed)
 }
 
 int
-main()
+main(void)
 {
   test_wheel(1234567890);
   test_wheel(time(NULL));

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -290,7 +290,7 @@ main(int argc, char *argv[])
       return 0;
     }
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
 
   configuration->template_options.frac_digits = 3;
   configuration->template_options.time_zone_info[LTZ_LOCAL] = time_zone_info_new(NULL);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1010,7 +1010,7 @@ qdisk_free(QDisk *self)
 }
 
 QDisk *
-qdisk_new()
+qdisk_new(void)
 {
   QDisk *self = g_new0(QDisk, 1);
   return self;

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -39,7 +39,7 @@
 
 typedef struct _QDisk QDisk;
 
-QDisk *qdisk_new();
+QDisk *qdisk_new(void);
 
 gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
 gboolean qdisk_push_tail(QDisk *self, GString *record);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -489,7 +489,7 @@ main()
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   configuration->stats_options.level = 1;
   assert_true(cfg_init(configuration), "cfg_init failed!");
   plugin_load_module("syslogformat", configuration, NULL);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -52,7 +52,7 @@
 MsgFormatOptions parse_options;
 
 static void
-testcase_zero_diskbuf_and_normal_acks()
+testcase_zero_diskbuf_and_normal_acks(void)
 {
   LogQueue *q;
   gint i;
@@ -86,7 +86,7 @@ testcase_zero_diskbuf_and_normal_acks()
 }
 
 static void
-testcase_zero_diskbuf_alternating_send_acks()
+testcase_zero_diskbuf_alternating_send_acks(void)
 {
   LogQueue *q;
   gint i;
@@ -121,7 +121,7 @@ testcase_zero_diskbuf_alternating_send_acks()
 }
 
 static void
-testcase_ack_and_rewind_messages()
+testcase_ack_and_rewind_messages(void)
 {
   LogQueue *q;
   gint i;
@@ -273,7 +273,7 @@ threaded_consume(gpointer st)
 
 
 static void
-testcase_with_threads()
+testcase_with_threads(void)
 {
   LogQueue *q;
   GThread *thread_feed[FEEDERS], *thread_consume;
@@ -478,7 +478,7 @@ testcase_diskq_statistics(diskq_tester_parameters_t parameters)
 }
 
 int
-main()
+main(void)
 {
 #if _AIX
   fprintf(stderr,

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -94,7 +94,7 @@ main()
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new_snippet(0x0308);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL );
   plugin_load_module("disk-buffer", configuration, NULL );
   plugin_load_module("builtin-serializer", configuration, NULL );

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -88,7 +88,7 @@ test_diskq_become_full(gboolean reliable)
 }
 
 int
-main()
+main(void)
 {
   app_startup();
   putenv("TZ=MET-1METDST");

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -106,7 +106,7 @@ get_serialized_message_size(LogMessage *msg)
 }
 
 static void
-set_mark_message_serialized_size()
+set_mark_message_serialized_size(void)
 {
   LogMessage *mark_message = log_msg_new_mark();
   mark_message_serialized_size = get_serialized_message_size(mark_message);
@@ -216,7 +216,7 @@ test_ack_over_eof(LogQueueDiskReliable *dq, LogMessage *msg1, LogMessage *msg2)
 /* TODO: add 3 messages and rewind 1 instead of 0 */
 /* TODO: split this test into 3 tests (read ack rewind mechanism  (setup method) */
 static void
-test_over_EOF()
+test_over_EOF(void)
 {
   LogQueueDiskReliable *dq = _init_diskq_for_test(TEST_DISKQ_SIZE, TEST_DISKQ_SIZE);
   LogMessage *msg1;
@@ -360,7 +360,7 @@ test_rewind_backlog_use_whole_qbacklog(LogQueueDiskReliable *dq)
  * qbacklog must be always in sync with backlog
  */
 void
-test_rewind_backlog()
+test_rewind_backlog(void)
 {
   LogQueueDiskReliable *dq = _init_diskq_for_test(QDISK_RESERVED_SPACE + mark_message_serialized_size * 10,
                                                   mark_message_serialized_size * 5);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -384,7 +384,7 @@ main(gint argc, gchar **argv)
   putenv("TZ=MET-1METDST");
   tzset();
 
-  configuration = cfg_new_snippet(0x0308);
+  configuration = cfg_new_snippet();
   plugin_load_module("syslogformat", configuration, NULL);
   plugin_load_module("disk-buffer", configuration, NULL);
   msg_format_options_defaults(&parse_options);

--- a/modules/geoip2/tests/test_geoip_parser.c
+++ b/modules/geoip2/tests/test_geoip_parser.c
@@ -84,7 +84,7 @@ parse_geoip_into_log_message(const gchar *input)
 }
 
 static void
-test_geoip_parser_basics()
+test_geoip_parser_basics(void)
 {
   LogMessage *msg;
 
@@ -101,7 +101,7 @@ test_geoip_parser_basics()
 }
 
 static void
-test_geoip_parser_uses_template_to_parse_input()
+test_geoip_parser_uses_template_to_parse_input(void)
 {
   LogMessage *msg;
   LogTemplate *template;

--- a/modules/java/proxies/java-logmsg-proxy.c
+++ b/modules/java/proxies/java-logmsg-proxy.c
@@ -122,7 +122,7 @@ java_log_message_proxy_free(JavaLogMessageProxy *self)
 }
 
 JavaLogMessageProxy *
-java_log_message_proxy_new(LogMessage *msg)
+java_log_message_proxy_new(void)
 {
   JavaLogMessageProxy *self = g_new0(JavaLogMessageProxy, 1);
   self->java_machine = java_machine_ref();

--- a/modules/java/proxies/java-logmsg-proxy.h
+++ b/modules/java/proxies/java-logmsg-proxy.h
@@ -31,7 +31,7 @@
 
 typedef struct _JavaLogMessageProxy JavaLogMessageProxy;
 
-JavaLogMessageProxy *java_log_message_proxy_new();
+JavaLogMessageProxy *java_log_message_proxy_new(void);
 void java_log_message_proxy_free(JavaLogMessageProxy *self);
 
 jobject java_log_message_proxy_create_java_object(JavaLogMessageProxy *self, LogMessage *msg);

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -173,7 +173,7 @@ test_kmsg_device_parsing(void)
 void
 init_and_load_kmsgformat_module()
 {
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   plugin_load_module("linux-kmsg-format", configuration, NULL);
   parse_options.format = "linux-kmsg";
 

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -171,7 +171,7 @@ test_kmsg_device_parsing(void)
 }
 
 void
-init_and_load_kmsgformat_module()
+init_and_load_kmsgformat_module(void)
 {
   configuration = cfg_new_snippet();
   plugin_load_module("linux-kmsg-format", configuration, NULL);
@@ -182,7 +182,7 @@ init_and_load_kmsgformat_module()
 }
 
 void
-deinit_kmsgformat_module()
+deinit_kmsgformat_module(void)
 {
   if (configuration)
     cfg_free(configuration);

--- a/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
+++ b/modules/snmptrapd-parser/tests/test_snmptrapd_parser.c
@@ -125,7 +125,7 @@ assert_log_message_name_values(const gchar *input, TestNameValue *expected, gsiz
 void
 setup(void)
 {
-  configuration = cfg_new_snippet(0x0390);
+  configuration = cfg_new_snippet();
   app_startup();
 }
 

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -48,7 +48,7 @@ stardate_assert(const gchar *msg_str, const int precision, const gchar *expected
 }
 
 void
-test_stardate()
+test_stardate(void)
 {
   stardate_assert("2012-07-15T00:00:00", 1, "2012.5"); // 2012.01.01 + 365/2 day
   stardate_assert("2013-07-01T00:00:00", 2, "2013.49");

--- a/modules/systemd-journal/journald-subsystem.c
+++ b/modules/systemd-journal/journald-subsystem.c
@@ -33,7 +33,7 @@ struct _Journald
 };
 
 gboolean
-load_journald_subsystem()
+load_journald_subsystem(void)
 {
   return TRUE;
 }
@@ -96,7 +96,7 @@ static SD_JOURNAL_PROCESS sd_journal_process;
 static SD_JOURNAL_GET_REALTIME_USEC sd_journal_get_realtime_usec;
 
 static GModule *
-_journald_module_open()
+_journald_module_open(void)
 {
   for (gint i = 0; (journald_libraries[i] != NULL) && !journald_module; i++)
     journald_module = g_module_open(journald_libraries[i], 0);
@@ -105,7 +105,7 @@ _journald_module_open()
 }
 
 static gboolean
-_load_journald_symbols()
+_load_journald_symbols(void)
 {
   if (!LOAD_SYMBOL(journald_module, sd_journal_open))
     return FALSE;
@@ -147,7 +147,7 @@ _load_journald_symbols()
 }
 
 gboolean
-load_journald_subsystem()
+load_journald_subsystem(void)
 {
   if (!journald_module)
     {
@@ -243,7 +243,7 @@ journald_get_realtime_usec(Journald *self, guint64 *usec)
 }
 
 Journald *
-journald_new()
+journald_new(void)
 {
   Journald *self = g_new0(Journald, 1);
   return self;

--- a/modules/systemd-journal/journald-subsystem.h
+++ b/modules/systemd-journal/journald-subsystem.h
@@ -47,8 +47,8 @@ typedef void (*FOREACH_DATA_CALLBACK)(gchar *key, gchar *value, gpointer user_da
 void journald_foreach_data(Journald *self, FOREACH_DATA_CALLBACK func, gpointer user_data);
 
 
-gboolean load_journald_subsystem();
-Journald *journald_new();
+gboolean load_journald_subsystem(void);
+Journald *journald_new(void);
 void journald_free(Journald *self);
 
 int journald_open(Journald *self, int flags);

--- a/modules/systemd-journal/tests/journald-mock.c
+++ b/modules/systemd-journal/tests/journald-mock.c
@@ -179,7 +179,7 @@ journald_get_realtime_usec(Journald *self, guint64 *usec)
 }
 
 Journald *
-journald_mock_new()
+journald_mock_new(void)
 {
   Journald *self = g_new0(Journald, 1);
 

--- a/modules/systemd-journal/tests/journald-mock.h
+++ b/modules/systemd-journal/tests/journald-mock.h
@@ -28,7 +28,7 @@
 
 typedef struct _MockEntry MockEntry;
 
-Journald *journald_mock_new();
+Journald *journald_mock_new(void);
 
 MockEntry *mock_entry_new(const gchar *cursor);
 

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -527,7 +527,7 @@ main(int argc, char **argv)
 {
   app_startup();
   main_thread_handle =  get_thread_id();
-  configuration = cfg_new_snippet(VERSION_VALUE);
+  configuration = cfg_new_snippet();
   configuration->threaded = FALSE;
   configuration->state = persist_state_new(TEST_PERSIST_FILE_NAME);
   configuration->keep_hostname = TRUE;

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -214,7 +214,7 @@ __test_fd_handling(Journald *journald)
 }
 
 void
-test_journald_mock()
+test_journald_mock(void)
 {
   Journald *journald = journald_mock_new();
   gint result = journald_open(journald, 0);
@@ -241,7 +241,7 @@ __helper_test(gchar *key, gchar *value, gpointer user_data)
 
 
 void
-test_journald_helper()
+test_journald_helper(void)
 {
   Journald *journald = journald_mock_new();
   journald_open(journald, 0);
@@ -499,7 +499,7 @@ _test_program_field_test(TestCase *self, TestSource *src, LogMessage *msg)
 }
 
 void
-test_journal_reader()
+test_journal_reader(void)
 {
   TestSource *src = test_source_new(configuration);
   TestCase tc_default_working = { _test_default_working_init, _test_default_working_test, NULL, NULL };

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -333,7 +333,7 @@ _test_default_working_test(TestCase *self, TestSource *src, LogMessage *msg)
   assert_gint(msg->pri, options->default_pri, ASSERTION_ERROR("Bad default prio"));
   assert_gint(options->fetch_limit, 10, ASSERTION_ERROR("Bad default fetch_limit"));
   assert_gint(options->max_field_size, 64 * 1024, ASSERTION_ERROR("Bad max field size"));
-  assert_gpointer(options->prefix, NULL, ASSERTION_ERROR("Bad default prefix value"));
+  assert_string(options->prefix, ".journald.", ASSERTION_ERROR("Bad default prefix value"));
   assert_string(options->recv_time_zone, configuration->recv_time_zone, ASSERTION_ERROR("Bad default timezone"));
   test_source_finish_tc(src);
 }
@@ -527,7 +527,7 @@ main(int argc, char **argv)
 {
   app_startup();
   main_thread_handle =  get_thread_id();
-  configuration = cfg_new_snippet(0x306);
+  configuration = cfg_new_snippet(VERSION_VALUE);
   configuration->threaded = FALSE;
   configuration->state = persist_state_new(TEST_PERSIST_FILE_NAME);
   configuration->keep_hostname = TRUE;

--- a/modules/tagsparser/tests/test_tagsparser.c
+++ b/modules/tagsparser/tests/test_tagsparser.c
@@ -30,7 +30,7 @@
 void
 setup(void)
 {
-  configuration = cfg_new_snippet(0x0390);
+  configuration = cfg_new_snippet();
   app_startup();
 }
 

--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -30,7 +30,7 @@
 void
 setup(void)
 {
-  configuration = cfg_new_snippet(0x0390);
+  configuration = cfg_new_snippet();
   app_startup();
 }
 

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -137,7 +137,7 @@ static GOptionEntry stats_options[] =
 };
 
 static const gchar *
-_stats_command_builder()
+_stats_command_builder(void)
 {
   return stats_options_reset_is_set ? "RESET_STATS" : "STATS";
 }
@@ -222,7 +222,7 @@ slng_license(int argc, char *argv[], const gchar *mode)
 }
 
 static gint
-_get_query_list_cmd()
+_get_query_list_cmd(void)
 {
   if (query_is_get_sum)
     return -1;
@@ -234,7 +234,7 @@ _get_query_list_cmd()
 }
 
 static gint
-_get_query_get_cmd()
+_get_query_get_cmd(void)
 {
   if (query_is_get_sum)
     {
@@ -264,13 +264,13 @@ _get_query_cmd(gchar *cmd)
 }
 
 static gboolean
-_is_query_params_empty()
+_is_query_params_empty(void)
 {
   return raw_query_params == NULL;
 }
 
 static gchar *
-_shift_query_command_out_of_params()
+_shift_query_command_out_of_params(void)
 {
   if (raw_query_params[QUERY_COMMAND] != NULL)
     return *(raw_query_params++);
@@ -308,7 +308,7 @@ _get_query_command_string(gint query_cmd)
 }
 
 static gchar *
-_get_dispatchable_query_command()
+_get_dispatchable_query_command(void)
 {
   gint query_cmd;
 

--- a/tests/unit/test_hostid.c
+++ b/tests/unit/test_hostid.c
@@ -37,7 +37,7 @@
 static GlobalConfig *
 _create_cfg()
 {
-  GlobalConfig *cfg = cfg_new_snippet(0x0302);
+  GlobalConfig *cfg = cfg_new_snippet();
   return cfg;
 }
 

--- a/tests/unit/test_hostid.c
+++ b/tests/unit/test_hostid.c
@@ -35,7 +35,7 @@
 #include <unistd.h>
 
 static GlobalConfig *
-_create_cfg()
+_create_cfg(void)
 {
   GlobalConfig *cfg = cfg_new_snippet();
   return cfg;

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -176,7 +176,7 @@ _assert_logwriter_output(LogWriterTestCase c)
 
 Test(logwriter, test_logwriter)
 {
-  configuration = cfg_new_snippet(0x0300);
+  configuration = cfg_new_snippet();
   LogWriterTestCase test_cases[] =
   {
     {MSG_SYSLOG_STR, TRUE, NULL, LW_SYSLOG_PROTOCOL, EXPECTED_MSG_SYSLOG_STR},

--- a/tests/unit/test_thread_wakeup.c
+++ b/tests/unit/test_thread_wakeup.c
@@ -122,7 +122,7 @@ accept_thread_func(gpointer args)
 }
 
 int
-test_accept_wakeup()
+test_accept_wakeup(void)
 {
   struct sockaddr_un s;
 
@@ -173,7 +173,7 @@ read_thread_func(gpointer args)
 }
 
 int
-test_read_wakeup()
+test_read_wakeup(void)
 {
   gint pair[2];
 


### PR DESCRIPTION
Do not use `version` parameter for creating a config snippet object, use always the `VERSION_VALUE` constants. Since commit 172c67af9dd049f0773217b5cede51a25d93fb1e it was required to use `@version` pragma for config snippets.

### Production code usage
```
modules/dbparser/pdbtool/pdbtool.c:1236:  configuration = cfg_new_snippet(VERSION_VALUE);
modules/diskq/dqtool.c:293:  configuration = cfg_new_snippet(VERSION_VALUE);
```

### Test code usage
```
lib/debugger/tests/test-debugger.c:40:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/filter/tests/test_filters.c:246:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/filter/tests/test_filters_in_list.c:164:  configuration = cfg_new_snippet(0x0305);
lib/filter/tests/test_filters_statistics.c:75:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/logmsg/tests/test_logmsg_serialize.c:271:  cfg = cfg_new_snippet(0x0307);
lib/rewrite/tests/test_rewrite.c:37:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/rewrite/tests/test_rewrite.c:49:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/template/tests/test_template_compile.c:466:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/tests/test_host_resolve.c:311:  configuration = cfg_new_snippet(VERSION_VALUE);
lib/value-pairs/tests/test_value_pairs.c:154:  cfg = cfg_new_snippet(VERSION_VALUE);
lib/value-pairs/tests/test_value_pairs_walk.c:135:  configuration = cfg_new_snippet(0x0303);
libtest/msg_parse_lib.c:31:  configuration = cfg_new_snippet(VERSION_VALUE);
modules/add-contextual-data/tests/test_selector.c:57:  GlobalConfig *cfg = cfg_new_snippet(VERSION_VALUE);
modules/affile/tests/test_wildcard_source.c:35:  configuration = cfg_new_snippet(VERSION_VALUE);
modules/afmongodb/tests/test-mongodb-config.c:307:  test_cfg = cfg_new_snippet(0x0308);
modules/csvparser/tests/test_csvparser.c:179:  configuration = cfg_new_snippet(0x0302);
modules/csvparser/tests/test_csvparser_statistics.c:77:  configuration = cfg_new_snippet(VERSION_VALUE);
modules/date/tests/test_date.c:79:  configuration = cfg_new_snippet(0x0302);
modules/dbparser/tests/test_patterndb.c:1122:  configuration = cfg_new_snippet(0x0302);
modules/dbparser/tests/test_patternize.c:451:  configuration = cfg_new_snippet(0x0201);
modules/diskq/tests/test_diskq.c:492:  configuration = cfg_new_snippet(VERSION_VALUE);
modules/diskq/tests/test_diskq_full.c:97:  configuration = cfg_new_snippet(0x0308);
modules/diskq/tests/test_reliable_backlog.c:387:  configuration = cfg_new_snippet(0x0308);
modules/linux-kmsg-format/tests/test_linux_format_kmsg.c:176:  configuration = cfg_new_snippet(VERSION_VALUE);
modules/snmptrapd-parser/tests/test_snmptrapd_parser.c:128:  configuration = cfg_new_snippet(0x0390);
modules/systemd-journal/tests/test_systemd_journal.c:530:  configuration = cfg_new_snippet(0x306);
modules/tagsparser/tests/test_tagsparser.c:33:  configuration = cfg_new_snippet(0x0390);
modules/xml/tests/test_xml_parser.c:33:  configuration = cfg_new_snippet(0x0390);
tests/unit/test_hostid.c:40:  GlobalConfig *cfg = cfg_new_snippet(0x0302);
tests/unit/test_logwriter.c:179:  configuration = cfg_new_snippet(0x0300);
```