### PR TITLE
Provide tls block for tls options in amqp(), http(), riemann() dest. drivers

### DIFF
--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -61,6 +61,7 @@
 %token KW_KEY_FILE
 %token KW_CERT_FILE
 %token KW_PEER_VERIFY
+%token KW_TLS
 
 %%
 
@@ -89,15 +90,26 @@ afamqp_option
 	| KW_PERSISTENT '(' yesno ')'		{ afamqp_dd_set_persistent(last_driver, $3); }
 	| KW_USERNAME '(' string ')'		{ afamqp_dd_set_user(last_driver, $3); free($3); }
 	| KW_PASSWORD '(' string ')'		{ afamqp_dd_set_password(last_driver, $3); free($3); }
-        | KW_CA_FILE '(' string ')'               { afamqp_dd_set_ca_file(last_driver, $3); free($3); }
-        | KW_KEY_FILE '(' string ')'              { afamqp_dd_set_key_file(last_driver, $3); free($3); }
-        | KW_CERT_FILE '(' string ')'              { afamqp_dd_set_cert_file(last_driver, $3); free($3); }
-        | KW_PEER_VERIFY '(' yesno ')'               { afamqp_dd_set_peer_verify(last_driver, $3); }
 	| value_pair_option			{ afamqp_dd_set_value_pairs(last_driver, $1); }
 	| dest_driver_option
 	| threaded_dest_driver_option
+    | afamqp_tls_option
+    | KW_TLS '(' afamqp_tls_options ')'
 	| { last_template_options = afamqp_dd_get_template_options(last_driver); } template_option
         ;
+
+
+afamqp_tls_options
+    : afamqp_tls_option afamqp_tls_options
+    |
+    ;
+
+afamqp_tls_option
+    : KW_CA_FILE '(' string ')'               { afamqp_dd_set_ca_file(last_driver, $3); free($3); }
+    | KW_KEY_FILE '(' string ')'              { afamqp_dd_set_key_file(last_driver, $3); free($3); }
+    | KW_CERT_FILE '(' string ')'              { afamqp_dd_set_cert_file(last_driver, $3); free($3); }
+    | KW_PEER_VERIFY '(' yesno ')'               { afamqp_dd_set_peer_verify(last_driver, $3); }
+    ;
 
 /* INCLUDE_RULES */
 

--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -48,6 +48,7 @@ static CfgLexerKeyword afamqp_keywords[] =
   { "key_file",           KW_KEY_FILE },
   { "cert_file",      KW_CERT_FILE },
   { "peer_verify",        KW_PEER_VERIFY },
+  { "tls",        KW_TLS },
   { NULL }
 };
 

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -64,6 +64,7 @@
 %token KW_SSL_VERSION
 %token KW_PEER_VERIFY
 %token KW_TIMEOUT
+%token KW_TLS
 
 %type   <ptr> driver
 %type   <ptr> http_destination
@@ -107,17 +108,27 @@ http_option
     | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free_full($3, free); }
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
-    | KW_CA_DIR     '(' string ')'            { http_dd_set_ca_dir(last_driver, $3); free($3); }
+    | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
+    | dest_driver_option
+    | threaded_dest_driver_option
+    | http_tls_option
+    | KW_TLS '(' http_tls_options ')'
+    | { last_template_options = http_dd_get_template_options(last_driver); } template_option
+    ;
+
+http_tls_options
+    : http_tls_option http_tls_options
+    |
+    ;
+
+http_tls_option
+    : KW_CA_DIR     '(' string ')'            { http_dd_set_ca_dir(last_driver, $3); free($3); }
     | KW_CA_FILE    '(' string ')'            { http_dd_set_ca_file(last_driver, $3); free($3); }
     | KW_CERT_FILE  '(' string ')'            { http_dd_set_cert_file(last_driver, $3); free($3); }
     | KW_KEY_FILE   '(' string ')'            { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
     | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
-    | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
-    | dest_driver_option
-    | threaded_dest_driver_option
-    | { last_template_options = http_dd_get_template_options(last_driver); } template_option
     ;
 
 /* INCLUDE_RULES */

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -46,6 +46,7 @@ static CfgLexerKeyword http_keywords[] =
   { "ssl_version",  KW_SSL_VERSION },
   { "peer_verify",  KW_PEER_VERIFY },
   { "timeout",      KW_TIMEOUT },
+  { "tls",          KW_TLS },
   { NULL }
 };
 

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -115,13 +115,7 @@ riemann_option
           {
             riemann_dd_set_field_tags(last_driver, $3);
           }
-        | KW_TYPE '(' LL_IDENTIFIER riemann_tls_options ')'
-          {
-            CHECK_ERROR(riemann_dd_set_connection_type(last_driver, $3), @3,
-                        "Unknown Riemann connection type: %s", $3);
-            free($3);
-          }
-        | KW_TYPE '(' LL_STRING riemann_tls_options ')'
+        | KW_TYPE '(' string riemann_tls_options ')'
           {
             CHECK_ERROR(riemann_dd_set_connection_type(last_driver, $3), @3,
                         "Unknown Riemann connection type: %s", $3);

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -56,6 +56,7 @@
 %token KW_CA_FILE
 %token KW_CERT_FILE
 %token KW_KEY_FILE
+%token KW_TLS
 
 %%
 
@@ -114,13 +115,13 @@ riemann_option
           {
             riemann_dd_set_field_tags(last_driver, $3);
           }
-        | KW_TYPE '(' LL_IDENTIFIER riemann_type_options ')'
+        | KW_TYPE '(' LL_IDENTIFIER riemann_tls_options ')'
           {
             CHECK_ERROR(riemann_dd_set_connection_type(last_driver, $3), @3,
                         "Unknown Riemann connection type: %s", $3);
             free($3);
           }
-        | KW_TYPE '(' LL_STRING riemann_type_options ')'
+        | KW_TYPE '(' LL_STRING riemann_tls_options ')'
           {
             CHECK_ERROR(riemann_dd_set_connection_type(last_driver, $3), @3,
                         "Unknown Riemann connection type: %s", $3);
@@ -144,6 +145,7 @@ riemann_option
           }
         | dest_driver_option
         | threaded_dest_driver_option
+        | KW_TLS '(' riemann_tls_options ')'
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option
         ;
 
@@ -161,12 +163,12 @@ attribute_option
         | vp_option
         ;
 
-riemann_type_options
-        : riemann_type_option riemann_type_options
+riemann_tls_options
+        : riemann_tls_option riemann_tls_options
         |
         ;
 
-riemann_type_option
+riemann_tls_option
         : KW_CA_FILE '(' string ')' { riemann_dd_set_tls_cacert(last_driver, $3); free($3); }
         | KW_CERT_FILE '(' string ')' { riemann_dd_set_tls_cert(last_driver, $3); free($3); }
         | KW_KEY_FILE '(' string ')' { riemann_dd_set_tls_key(last_driver, $3); free($3); }

--- a/modules/riemann/riemann-parser.c
+++ b/modules/riemann/riemann-parser.c
@@ -51,6 +51,8 @@ static CfgLexerKeyword riemann_keywords[] =
   { "cacert",                   KW_CA_FILE, KWS_OBSOLETE, "The cacert() option is deprecated in favour of ca-file()" },
   { "cert",                     KW_CERT_FILE, KWS_OBSOLETE, "The cert() option is deprecated in favour of cert-file()" },
 
+  { "tls",                      KW_TLS },
+
   { NULL }
 };
 


### PR DESCRIPTION
Three destination drivers: amqp(), http(), riemann() allows to use tls options inside the driver configuration. 
This patch-set provides to use these tls options also in a general tls() block as it is used in network type drivers.
The patch-set did not brake the original usage for actual drivers.
Example new type of configuration for tls options in riemann destination:
```
destination d_riemann {
	riemann(
		server("127.0.0.1") 
		port(5672) 
		tls(
			ca_file("ca") 
			key_file("key")
		)
	);
};
```