### PR TITLE
cfg: Fix double free/double close crashes

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -307,8 +307,13 @@ word	[^ \#'"\(\)\{\}\\;\r\n\t,|\.@:]
 <INITIAL><<EOF>>           {
                              if (!cfg_lexer_start_next_include(yyextra))
                                {
-                                 *yylloc = yyextra->include_stack[0].lloc;
-                                 yyterminate();
+                                 if (yyextra->include_depth == 0)
+                                   {
+                                     *yylloc = yyextra->include_stack[0].lloc;
+                                     yyterminate();
+                                   }
+                                 else
+                                    return LL_ERROR;
                                }
                            }
 

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -248,13 +248,17 @@ cfg_lexer_start_next_include(CfgLexer *self)
 
   /* reset the include state, should also handle initial invocations, in which case everything is NULL */
   if (level->yybuf)
-    _cfg_lexer__delete_buffer(level->yybuf, self->state);
+    {
+      _cfg_lexer__delete_buffer(level->yybuf, self->state);
+      level->yybuf = NULL;
+    }
 
   if (level->include_type == CFGI_FILE)
     {
       if (level->file.include_file)
         {
           fclose(level->file.include_file);
+          level->file.include_file = NULL;
         }
     }
 


### PR DESCRIPTION
Fix the double free of level->yy_buff and double close of
level->file.include_file that can occur during a config reload if a config
file is deleted.

This was observed on a system with frequent dynamic config change. The issue
occurs when a config file is deleted between the glob expansion/directory
scanning in cfg_lexer_include_file_*() functions and files being opened in
cfg_lexer_start_next_include.

Fixes #1720

Signed-off-by: Sam Stephenson <sam.stephenson@alliedtelesis.co.nz>