### PR TITLE
afsocket: Remove invalid assertion from afsocket_dd_restore_writer.

### DIFF
--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -384,12 +384,11 @@ afsocket_dd_restore_writer(AFSocketDestDriver *self)
   GlobalConfig *cfg;
   ReloadStoreItem *item;
 
-  g_assert(self->writer == NULL);
-
   cfg = log_pipe_get_config(&self->super.super.super);
   item = cfg_persist_config_fetch(cfg, afsocket_dd_format_connections_name(self));
 
-  if (item && !_is_protocol_type_changed_during_reload(self, item))
+  /* If we are reinitializing an old config, an existing writer may be present */
+  if (!self->writer && item && !_is_protocol_type_changed_during_reload(self, item))
     self->writer = _reload_store_item_release_writer(item);
 
   _reload_store_item_free(item);


### PR DESCRIPTION
Asserting that self->writer is null seems to be incorrect.

If the config being initialized is new, self->writer is guaranteed
to be null, however if we are re-initializing an old config after initializing
a new configuration failed, an existing writer may be present if keep-alive
is off (old_config self->writer is set to null if the connection is saved)

Fixes #1722

Signed-off-by: Sam Stephenson <sam.stephenson@alliedtelesis.co.nz>