### PR TITLE
affile: Mark messages as consumed in a write failure.

### DIFF
--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -179,16 +179,15 @@ log_proto_file_writer_post(LogProtoClient *s, guchar *msg, gsize msg_len, gboole
   ++self->buf_count;
   self->sum_len += msg_len;
 
+  *consumed = TRUE;
+  log_proto_client_msg_ack(&self->super, 1);
+
   if (self->buf_count == self->buf_size)
     {
       /* we have reached the max buffer size -> we need to write the messages */
-      result = log_proto_file_writer_flush(s);
-      if (result != LPS_SUCCESS)
-        return result;
+      return log_proto_file_writer_flush(s);
     }
 
-  *consumed = TRUE;
-  log_proto_client_msg_ack(&self->super, 1);
   return LPS_SUCCESS;
 }
 


### PR DESCRIPTION
Fix a crash that occurs following a write failure when the file writer
buffer becomes full and a config reload is triggered.

If a write failure occurs in log_proto_file_writer_post as the buffer
becomes full, a subsequent call will be made where msg and
self->buffer[self->buff_count].iov_base point to the same memory.

The first call to log_proto_file_writer_flush will write the message
and free the buffer. The following call will raise an abort signal
when it attempts to free the buffer a second time.

If the message has been stored in self->buffer, it should be marked
as consumed irrespective of the result of log_proto_file_writer_flush.

This may relate to #1425

Signed-off-by: Sam Stephenson <sam.stephenson@alliedtelesis.co.nz>