### PR TITLE
osquery: add osquery destination as an SCL plugin

### DIFF
--- a/scl/osquery/plugin.conf
+++ b/scl/osquery/plugin.conf
@@ -27,3 +27,21 @@ block source osquery(file("/var/log/osquery/osqueryd.results.log") prefix(".osqu
     parser { json-parser (prefix("`prefix`")); };
   };
 };
+
+template t_osquery {
+  template("\"${ISODATE}\",\"${HOST}\",\"${LEVEL_NUM}\",\"${FACILITY}\",\"${PROGRAM}\",\"${ESCAPED_MESSAGE}\"\n");
+  template_escape(no);
+};
+
+block destination osquery(pipe("/var/osquery/syslog_pipe")) {
+  channel {
+    rewrite {
+      set("$MESSAGE", value("ESCAPED_MESSAGE"));
+      subst("\"","\"\"", value("ESCAPED_MESSAGE"), flags(global));
+    };
+    destination {
+        pipe(`pipe` template(t_osquery));
+        `__VARARGS__`;
+    };
+  };
+};


### PR DESCRIPTION
Send log messages to osquery's syslog table.
The interface between osquery and syslog-ng is a named pipe (default path is
set in the SCL file, custom value can be set with the `pipe()` parameter.)

* Run osqueryi:

`osqueryi --enable_syslog --disable-events=false`

* if you want to store the db on disk:
`osqueryi --enable_syslog --disable-events=false --database_path=/tmp/osquery.db`

You can check the messages by typing `select * from syslog;`

* custom named pipe:
```
 osqueryi --enable_syslog
          --disable-events=false
          --database_path=/tmp/osquery.db
          --syslog_pipe_path=/tmp/osq.pipe
```

* example config:

```
@version: 3.12
@include "scl.conf"

source s_net {
  network(port(5514));
};

destination d_osquery {
  # custom pipe path:
  #osquery(pipe("/tmp/osq.pipe"));

  # backup outgoing logs:
  #osquery(file("/var/log/osquery_inserts.log" template(t_osquery)));

  # defaults
  osquery();
};

log {
 source(s_net);
 destination(d_osquery);
 flags(flow-control);
};
```

For more details on osquery and syslog table:
https://osquery.readthedocs.io/en/stable/deployment/syslog/

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>
