### PR TITLE
 logreader/logproto: remove preemption

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -37,8 +37,7 @@
 #define NC_WRITE_ERROR 3
 #define NC_FILE_MOVED  4
 #define NC_FILE_EOF    5
-#define NC_FILE_SKIP   6
-#define NC_REOPEN_REQUIRED 7
+#define NC_REOPEN_REQUIRED 6
 
 /* indicates that the LogPipe was initialized */
 #define PIF_INITIALIZED       0x0001

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -67,7 +67,6 @@ struct _LogProtoServer
   /* FIXME: rename to something else */
   gboolean (*is_position_tracked)(LogProtoServer *s);
   gboolean (*prepare)(LogProtoServer *s, GIOCondition *cond);
-  gboolean (*is_preemptable)(LogProtoServer *s);
   gboolean (*restart_with_state)(LogProtoServer *s, PersistState *state, const gchar *persist_name);
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read, LogTransportAuxData *aux, Bookmark *bookmark);
   gboolean (*validate_options)(LogProtoServer *s);
@@ -90,14 +89,6 @@ static inline gboolean
 log_proto_server_prepare(LogProtoServer *s, GIOCondition *cond)
 {
   return s->prepare(s, cond);
-}
-
-static inline gboolean
-log_proto_server_is_preemptable(LogProtoServer *s)
-{
-  if (s->is_preemptable)
-    return s->is_preemptable(s);
-  return TRUE;
 }
 
 static inline gboolean

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -83,25 +83,6 @@ log_proto_get_char_size_for_fixed_encoding(const gchar *encoding)
 }
 
 
-/**
- * This function is called in cases when several files are continously
- * polled for changes.  Whenever the caller would like to switch to another
- * file, it will call this function to check whether it should be allowed to do so.
- *
- * This function returns true if the current state of this LogProtoServer would
- * allow preemption, e.g.  the contents of the current buffer can be
- * discarded.
- **/
-static gboolean
-log_proto_text_server_is_preemptable(LogProtoServer *s)
-{
-  LogProtoTextServer *self = (LogProtoTextServer *) s;
-  gboolean preemptable;
-
-  preemptable = (self->cached_eol_pos == 0);
-  return preemptable;
-}
-
 static gboolean
 log_proto_text_server_prepare(LogProtoServer *s, GIOCondition *cond)
 {
@@ -444,7 +425,6 @@ void
 log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, const LogProtoServerOptions *options)
 {
   log_proto_buffered_server_init(&self->super, transport, options);
-  self->super.super.is_preemptable = log_proto_text_server_is_preemptable;
   self->super.super.prepare = log_proto_text_server_prepare;
   self->super.super.free_fn = log_proto_text_server_free;
   self->super.fetch_from_buffer = log_proto_text_server_fetch_from_buffer;

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -21,7 +21,7 @@
  * COPYING for details.
  *
  */
-  
+
 #ifndef LOGREADER_H_INCLUDED
 #define LOGREADER_H_INCLUDED
 
@@ -33,8 +33,6 @@
 /* flags */
 #define LR_KERNEL          0x0002
 #define LR_EMPTY_LINES     0x0004
-#define LR_IGNORE_TIMEOUT  0x0008
-#define LR_SYSLOG_PROTOCOL 0x0010
 #define LR_THREADED        0x0040
 
 /* options */

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -35,7 +35,6 @@
 #define LR_EMPTY_LINES     0x0004
 #define LR_IGNORE_TIMEOUT  0x0008
 #define LR_SYSLOG_PROTOCOL 0x0010
-#define LR_PREEMPT         0x0020
 #define LR_THREADED        0x0040
 
 /* options */


### PR DESCRIPTION
The "preemption" logic with NC_FILE_SKIP was an implementation detail of the old wildcard file source.
This is dead code now.

This PR removes code from a "hot path", but I guess this is not a significant performance improvement. :)