### PR TITLE
Fix distdir target in case of system option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ AC_ARG_ENABLE(mongodb,
 AC_ARG_WITH(mongoc,
               [  --with-mongoc=[system/internal/auto/no]
                                          Link against the system supplied or the built-in mongo-c-driver library. (default: auto)]
-              ,,with_mongoc="auto")
+              ,,with_mongoc="internal")
 
 AC_ARG_ENABLE(legacy-mongodb-options,
               [  --enable-legacy-mongodb-options=[yes/no]
@@ -243,7 +243,7 @@ AC_ARG_ENABLE(legacy-mongodb-options,
 AC_ARG_WITH(jsonc,
               [  --with-jsonc=[system/internal/auto/no]
                                          Link against the system supplied or the built-in jsonc library or explicitly disable it. (default:auto)]
-              ,,with_jsonc="auto")
+              ,,with_jsonc="internal")
 
 AC_ARG_ENABLE(json,
              [ --enable-json=[yes/no]            Enable JSON support (default: yes)]

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -56,6 +56,9 @@ lib/ivykis/src/libivykis.la:
 
 CLEAN_SUBDIRS				+= @IVYKIS_SUBDIRS@
 
+EXTRA_DIST += \
+	lib/ivykis/configure.gnu
+
 install-ivykis:
 	${MAKE} -C lib/ivykis/src \
 		install-includeHEADERS \
@@ -278,8 +281,7 @@ EXTRA_DIST += \
 	lib/block-ref-grammar.ym	\
 	lib/pragma-grammar.ym		\
 	lib/merge-grammar.py		\
-	lib/hostname-unix.c		\
-	lib/ivykis/configure.gnu
+	lib/hostname-unix.c
 
 lib/plugin-types.h: lib/cfg-grammar.h
 

--- a/modules/afamqp/Makefile.am
+++ b/modules/afamqp/Makefile.am
@@ -38,13 +38,19 @@ else
 modules/afamqp modules/afamqp/ mod-afamqp mod-amqp:
 endif
 
+if LIBRABBITMQ_INTERNAL
+
+EXTRA_DIST				+=	\
+		modules/afamqp/rabbitmq-c/configure.gnu
+
+endif
+
 BUILT_SOURCES				+=	\
 		modules/afamqp/afamqp-grammar.y \
 		modules/afamqp/afamqp-grammar.c \
 		modules/afamqp/afamqp-grammar.h
 
 EXTRA_DIST				+=	\
-		modules/afamqp/afamqp-grammar.ym	\
-		modules/afamqp/rabbitmq-c/configure.gnu
+		modules/afamqp/afamqp-grammar.ym
 
 .PHONY: modules/afamqp/ mod-afamqp mod-amqp

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -52,13 +52,19 @@ else
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb:
 endif
 
+if LIBMONGO_INTERNAL
+
+EXTRA_DIST					+=	\
+	modules/afmongodb/mongo-c-driver/configure.gnu
+
+endif
+
 BUILT_SOURCES					+=	\
 	modules/afmongodb/afmongodb-grammar.y		\
 	modules/afmongodb/afmongodb-grammar.c		\
 	modules/afmongodb/afmongodb-grammar.h
 
 EXTRA_DIST					+=	\
-	modules/afmongodb/afmongodb-grammar.ym		\
-	modules/afmongodb/mongo-c-driver/configure.gnu
+	modules/afmongodb/afmongodb-grammar.ym
 
 .PHONY: modules/afmongodb/ mod-afmongodb mod-mongodb


### PR DESCRIPTION

The following dependencies (as git submodules) were optional to include into the dist compressed files:
* ivykis
* librabbitmq-c
* mongoc

This should be only in case of internal option, and not in case of system, as the system shall provide those files.

Signed-off-by: kokan <peter.kokai@balabit.com>