### PR TITLE
syslog-ng-ctl: implement synchronous reload (--wait option to reload …

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -60,13 +60,7 @@ register_application_hook(gint type, ApplicationHookFunc func, gpointer user_dat
 {
   if (current_state < type)
     {
-      ApplicationHookEntry *entry = g_new0(ApplicationHookEntry, 1);
-
-      entry->type = type;
-      entry->func = func;
-      entry->user_data = user_data;
-
-      application_hooks = g_list_append(application_hooks, entry);
+      register_application_hook_without_checking_current_state(type, func, user_data);
     }
   else
     {
@@ -76,6 +70,18 @@ register_application_hook(gint type, ApplicationHookFunc func, gpointer user_dat
                 evt_tag_int("hook", type));
       func(type, user_data);
     }
+}
+
+void
+register_application_hook_without_checking_current_state(gint type, ApplicationHookFunc func, gpointer user_data)
+{
+  ApplicationHookEntry *entry = g_new0(ApplicationHookEntry, 1);
+
+  entry->type = type;
+  entry->func = func;
+  entry->user_data = user_data;
+
+  application_hooks = g_list_append(application_hooks, entry);
 }
 
 static void

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -41,6 +41,7 @@ enum
 typedef void (*ApplicationHookFunc)(gint type, gpointer user_data);
 
 void register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
+void register_application_hook_without_checking_current_state(gint type, ApplicationHookFunc func, gpointer user_data);
 void app_startup(void);
 void app_finish_app_startup_after_cfg_init(void);
 void app_post_daemonized(void);

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -121,6 +121,75 @@ control_connection_reload(GString *command, gpointer user_data)
   return result;
 }
 
+typedef struct _ReloadCondvar
+{
+  GMutex mutex;
+  GCond condvar;
+  gboolean reloaded;
+} ReloadCondvar;
+
+static ReloadCondvar *
+_reload_condvar_new()
+{
+  ReloadCondvar *self = g_new0(ReloadCondvar, 1);
+  g_mutex_init(&self->mutex);
+  g_cond_init(&self->condvar);
+  self->reloaded = FALSE;
+
+  return self;
+}
+
+static void
+_reload_condvar_free(ReloadCondvar *self)
+{
+  g_mutex_clear(&self->mutex);
+  g_cond_clear(&self->condvar);
+  g_free(self);
+}
+
+static void
+_reload_condvar_emit(ReloadCondvar *self)
+{
+  g_mutex_lock(&self->mutex);
+  self->reloaded = TRUE;
+  g_cond_signal(&self->condvar);
+  g_mutex_unlock(&self->mutex);
+}
+
+static void
+_reload_condvar_wait(ReloadCondvar *self)
+{
+  g_mutex_lock(&self->mutex);
+  while (!self->reloaded)
+    g_cond_wait(&self->condvar, &self->mutex);
+  self->reloaded = FALSE;
+  g_mutex_unlock(&self->mutex);
+}
+
+static void
+_config_reloaded(gint hook_type, gpointer user_data)
+{
+  ReloadCondvar *self = (ReloadCondvar *)user_data;
+  _reload_condvar_emit(self);
+}
+
+static void
+_wait_for_syslog_ng_reload()
+{
+  ReloadCondvar *reload_condvar = _reload_condvar_new();
+  register_application_hook_without_checking_current_state(AH_POST_CONFIG_LOADED, _config_reloaded, reload_condvar);
+  _reload_condvar_wait(reload_condvar);
+  _reload_condvar_free(reload_condvar);
+}
+
+static GString *
+control_connection_reload_sync(GString *command, gpointer user_data)
+{
+  GString *result = control_connection_reload(command, user_data);
+  _wait_for_syslog_ng_reload();
+  return result;
+}
+
 static GString *
 control_connection_reopen(GString *command, gpointer user_data)
 {
@@ -136,6 +205,7 @@ ControlCommand default_commands[] =
   { "RELOAD", NULL, control_connection_reload },
   { "REOPEN", NULL, control_connection_reopen },
   { "QUERY", NULL, process_query_command },
+  { "SYNCRELOAD", NULL, control_connection_reload_sync },
   { NULL, NULL, NULL },
 };
 

--- a/lib/control/control-main.c
+++ b/lib/control/control-main.c
@@ -69,18 +69,24 @@ _thread(gpointer user_data)
   iv_deinit();
 }
 
-void
-control_thread_start(MainLoop *main_loop, const gchar *control_name)
+ControlServerLoop *
+control_server_loop_get_instance(void)
 {
-  control_server_loop.main_loop = main_loop;
-  control_server_loop.control_name = control_name;
-  control_server_loop.thread = g_thread_create((GThreadFunc) _thread, &control_server_loop, TRUE, NULL);
+  return &control_server_loop;
 }
 
 void
-control_thread_stop(void)
+control_server_loop_start(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name)
 {
-  iv_event_post(&control_server_loop.stop_requested);
-  g_thread_join(control_server_loop.thread);
+  self->main_loop = main_loop;
+  self->control_name = control_name;
+  self->thread = g_thread_create((GThreadFunc) _thread, self, TRUE, NULL);
+}
+
+void
+control_server_loop_stop(ControlServerLoop *self)
+{
+  iv_event_post(&self->stop_requested);
+  g_thread_join(self->thread);
 }
 

--- a/lib/control/control-main.c
+++ b/lib/control/control-main.c
@@ -43,19 +43,29 @@ _register_stop_requested_event(ControlServerLoop *self)
 }
 
 static void
+_control_server_loop_init(ControlServerLoop *self)
+{
+  self->control_server = control_server_new(self->control_name,
+                                            control_register_default_commands(self->main_loop));
+  iv_init();
+  _register_stop_requested_event(self);
+  control_server_start(self->control_server);
+}
+
+static void
+_control_server_loop_deinit(ControlServerLoop *self)
+{
+  control_server_free(self->control_server);
+  iv_deinit();
+}
+
+static void
 _thread(gpointer user_data)
 {
-  ControlServerLoop *cs_thread = (ControlServerLoop *)user_data;
-  ControlServer *control_server = control_server_new(cs_thread->control_name,
-                                                     control_register_default_commands(cs_thread->main_loop));
-  iv_init();
-  {
-    _register_stop_requested_event(cs_thread);
-    control_server_start(control_server);
-    iv_main();
-    control_server_free(control_server);
-  }
-  iv_deinit();
+  ControlServerLoop *cs_loop = (ControlServerLoop *)user_data;
+  _control_server_loop_init(cs_loop);
+  iv_main();
+  _control_server_loop_deinit(cs_loop);
 }
 
 void

--- a/lib/control/control-main.c
+++ b/lib/control/control-main.c
@@ -29,15 +29,15 @@
 #include <iv.h>
 #include <iv_event.h>
 
-typedef struct _ControlServerThread
+typedef struct _ControlServerLoop
 {
   GThread *thread;
   MainLoop *main_loop;
   const gchar *control_name;
   struct iv_event stop_requested;
-} ControlServerThread;
+} ControlServerLoop;
 
-static ControlServerThread control_server_thread;
+static ControlServerLoop control_server_loop;
 
 static void
 _thread_stop()
@@ -46,7 +46,7 @@ _thread_stop()
 }
 
 static void
-_register_stop_requested_event(ControlServerThread *self)
+_register_stop_requested_event(ControlServerLoop *self)
 {
   IV_EVENT_INIT(&self->stop_requested);
   self->stop_requested.handler = _thread_stop;
@@ -56,7 +56,7 @@ _register_stop_requested_event(ControlServerThread *self)
 static void
 _thread(gpointer user_data)
 {
-  ControlServerThread *cs_thread = (ControlServerThread *)user_data;
+  ControlServerLoop *cs_thread = (ControlServerLoop *)user_data;
   ControlServer *control_server = control_server_new(cs_thread->control_name,
                                                      control_register_default_commands(cs_thread->main_loop));
   iv_init();
@@ -72,15 +72,15 @@ _thread(gpointer user_data)
 void
 control_thread_start(MainLoop *main_loop, const gchar *control_name)
 {
-  control_server_thread.main_loop = main_loop;
-  control_server_thread.control_name = control_name;
-  control_server_thread.thread = g_thread_create((GThreadFunc) _thread, &control_server_thread, TRUE, NULL);
+  control_server_loop.main_loop = main_loop;
+  control_server_loop.control_name = control_name;
+  control_server_loop.thread = g_thread_create((GThreadFunc) _thread, &control_server_loop, TRUE, NULL);
 }
 
 void
 control_thread_stop(void)
 {
-  iv_event_post(&control_server_thread.stop_requested);
-  g_thread_join(control_server_thread.thread);
+  iv_event_post(&control_server_loop.stop_requested);
+  g_thread_join(control_server_loop.thread);
 }
 

--- a/lib/control/control-main.c
+++ b/lib/control/control-main.c
@@ -27,17 +27,6 @@
 #include "control-commands.h"
 
 #include <iv.h>
-#include <iv_event.h>
-
-typedef struct _ControlServerLoop
-{
-  GThread *thread;
-  MainLoop *main_loop;
-  const gchar *control_name;
-  struct iv_event stop_requested;
-} ControlServerLoop;
-
-static ControlServerLoop control_server_loop;
 
 static void
 _thread_stop()
@@ -69,17 +58,23 @@ _thread(gpointer user_data)
   iv_deinit();
 }
 
-ControlServerLoop *
-control_server_loop_get_instance(void)
+void
+control_server_loop_init_instance(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name)
 {
-  return &control_server_loop;
+  self->control_name = g_strdup(control_name);
+  self->main_loop = main_loop_ref(main_loop);
 }
 
 void
-control_server_loop_start(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name)
+control_server_loop_deinit_instance(ControlServerLoop *self)
 {
-  self->main_loop = main_loop;
-  self->control_name = control_name;
+  g_free(self->control_name);
+  main_loop_unref(self->main_loop);
+}
+
+void
+control_server_loop_start(ControlServerLoop *self)
+{
   self->thread = g_thread_create((GThreadFunc) _thread, self, TRUE, NULL);
 }
 

--- a/lib/control/control-main.h
+++ b/lib/control/control-main.h
@@ -27,6 +27,7 @@
 
 #include "mainloop.h"
 #include "control/control-commands.h"
+#include "control-server.h"
 #include <iv_event.h>
 
 typedef struct _ControlServerLoop
@@ -35,6 +36,7 @@ typedef struct _ControlServerLoop
   MainLoop *main_loop;
   gchar *control_name;
   struct iv_event stop_requested;
+  ControlServer *control_server;
 } ControlServerLoop;
 
 void control_server_loop_init_instance(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name);

--- a/lib/control/control-main.h
+++ b/lib/control/control-main.h
@@ -28,7 +28,7 @@
 #include "mainloop.h"
 #include "control/control-commands.h"
 
-void control_init(MainLoop *main_loop, const gchar *control_name);
-void control_destroy(void);
+void control_thread_start(MainLoop *main_loop, const gchar *control_name);
 
+void control_thread_stop();
 #endif

--- a/lib/control/control-main.h
+++ b/lib/control/control-main.h
@@ -27,10 +27,18 @@
 
 #include "mainloop.h"
 #include "control/control-commands.h"
+#include <iv_event.h>
 
-typedef struct _ControlServerLoop ControlServerLoop;
+typedef struct _ControlServerLoop
+{
+  GThread *thread;
+  MainLoop *main_loop;
+  gchar *control_name;
+  struct iv_event stop_requested;
+} ControlServerLoop;
 
-ControlServerLoop *control_server_loop_get_instance(void);
-void control_server_loop_start(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name);
+void control_server_loop_init_instance(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name);
+void control_server_loop_deinit_instance(ControlServerLoop *self);
+void control_server_loop_start(ControlServerLoop *self);
 void control_server_loop_stop(ControlServerLoop *self);
 #endif

--- a/lib/control/control-main.h
+++ b/lib/control/control-main.h
@@ -28,7 +28,9 @@
 #include "mainloop.h"
 #include "control/control-commands.h"
 
-void control_thread_start(MainLoop *main_loop, const gchar *control_name);
+typedef struct _ControlServerLoop ControlServerLoop;
 
-void control_thread_stop();
+ControlServerLoop *control_server_loop_get_instance(void);
+void control_server_loop_start(ControlServerLoop *self, MainLoop *main_loop, const gchar *control_name);
+void control_server_loop_stop(ControlServerLoop *self);
 #endif

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -489,7 +489,7 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
 
   main_loop_init_events(self);
   if (!self->options->syntax_only)
-    control_init(self, resolvedConfigurablePaths.ctlfilename);
+    control_thread_start(self, resolvedConfigurablePaths.ctlfilename);
   setup_signals(self);
 }
 
@@ -533,7 +533,7 @@ main_loop_deinit(MainLoop *self)
   main_loop_free_config(self);
 
   if (!self->options->syntax_only)
-    control_destroy();
+    control_thread_stop();
 
   iv_event_unregister(&self->exit_requested);
   iv_event_unregister(&self->reload_config_requested);

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -489,7 +489,10 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
 
   main_loop_init_events(self);
   if (!self->options->syntax_only)
-    control_thread_start(self, resolvedConfigurablePaths.ctlfilename);
+    {
+      ControlServerLoop *cs_loop = control_server_loop_get_instance();
+      control_server_loop_start(cs_loop, self, resolvedConfigurablePaths.ctlfilename);
+    }
   setup_signals(self);
 }
 
@@ -533,7 +536,10 @@ main_loop_deinit(MainLoop *self)
   main_loop_free_config(self);
 
   if (!self->options->syntax_only)
-    control_thread_stop();
+    {
+      ControlServerLoop *cs_loop = control_server_loop_get_instance();
+      control_server_loop_stop(cs_loop);
+    }
 
   iv_event_unregister(&self->exit_requested);
   iv_event_unregister(&self->reload_config_requested);

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -30,7 +30,6 @@
 #include "stats/stats-registry.h"
 #include "messages.h"
 #include "children.h"
-#include "control/control-main.h"
 #include "reloc.h"
 #include "service-management.h"
 #include "persist-state.h"
@@ -490,11 +489,7 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
   main_loop_call_init();
 
   main_loop_init_events(self);
-  if (!self->options->syntax_only)
-    {
-      ControlServerLoop *cs_loop = control_server_loop_get_instance();
-      control_server_loop_start(cs_loop, self, resolvedConfigurablePaths.ctlfilename);
-    }
+
   setup_signals(self);
 }
 
@@ -536,12 +531,6 @@ static void
 _deinit(MainLoop *self)
 {
   main_loop_free_config(self);
-
-  if (!self->options->syntax_only)
-    {
-      ControlServerLoop *cs_loop = control_server_loop_get_instance();
-      control_server_loop_stop(cs_loop);
-    }
 
   iv_event_unregister(&self->exit_requested);
   iv_event_unregister(&self->reload_config_requested);

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -125,6 +125,7 @@ struct _MainLoop
    * would be gone.
    */
   gboolean _is_terminating;
+  gboolean _is_terminate_requested;
 
   /* signal handling */
   struct iv_signal sighup_poll;
@@ -465,14 +466,17 @@ void
 main_loop_exit(MainLoop *self)
 {
   iv_event_post(&self->exit_requested);
+  self->_is_terminate_requested = TRUE;
   return;
 }
 
-void
+gboolean
 main_loop_reload_config(MainLoop *self)
 {
+  if (self->_is_terminate_requested)
+    return FALSE;
   iv_event_post(&self->reload_config_requested);
-  return;
+  return TRUE;
 }
 
 void

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -74,6 +74,7 @@ gboolean main_loop_is_server_mode(MainLoop *self);
 void main_loop_set_server_mode(MainLoop *self, gboolean server_mode);
 
 gboolean main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename);
-
+MainLoop *main_loop_ref(MainLoop *self);
+void main_loop_unref(MainLoop *self);
 
 #endif

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -59,7 +59,7 @@ main_loop_is_main_thread(void)
   return threads_equal(main_thread_handle, get_thread_id());
 }
 
-void main_loop_reload_config(MainLoop *self);
+gboolean main_loop_reload_config(MainLoop *self);
 void main_loop_exit(MainLoop *self);
 
 int main_loop_read_and_init_config(MainLoop *self);

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -154,9 +154,21 @@ slng_stop(int argc, char *argv[], const gchar *mode)
   return _dispatch_command("STOP");
 }
 
+static gboolean reload_wait = FALSE;
+
+static GOptionEntry reload_options[] =
+{
+  { "wait", 'W', 0, G_OPTION_ARG_NONE, &reload_wait, "wait reload", NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
 static gint
 slng_reload(int argc, char *argv[], const gchar *mode)
 {
+  if (reload_wait)
+    {
+      return _dispatch_command("SYNCRELOAD");
+    }
   return _dispatch_command("RELOAD");
 }
 
@@ -388,7 +400,7 @@ static struct
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose },
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose },
   { "stop", no_options, "Stop syslog-ng process", slng_stop },
-  { "reload", no_options, "Reload syslog-ng", slng_reload },
+  { "reload", reload_options, "Reload syslog-ng. --wait will wait until syslog-ng reloads the config", slng_reload },
   { "reopen", no_options, "Re-open of log destination files", slng_reopen },
   { "query", query_options, "Query syslog-ng statistics. Possible commands: list, get, get --sum", slng_query },
   { "show-license-info", license_options, "Show information about the license", slng_license },

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -33,6 +33,7 @@
 #include "logqueue.h"
 #include "gprocess.h"
 #include "control/control.h"
+#include "control/control-main.h"
 #include "timeutils.h"
 #include "logsource.h"
 #include "mainloop.h"
@@ -65,6 +66,7 @@ static gboolean display_module_registry = FALSE;
 static gboolean dummy = FALSE;
 
 static MainLoopOptions main_loop_options;
+static ControlServerLoop control_server_loop;
 
 #ifdef YYDEBUG
 extern int cfg_parser_debug;
@@ -289,6 +291,11 @@ main(int argc, char *argv[])
 
   /* we are running as a non-root user from this point */
 
+  if (!main_loop_options.syntax_only)
+    {
+      control_server_loop_init_instance(&control_server_loop, main_loop, resolvedConfigurablePaths.ctlfilename);
+      control_server_loop_start(&control_server_loop);
+    }
   app_post_daemonized();
   app_post_config_loaded();
 
@@ -301,6 +308,10 @@ main(int argc, char *argv[])
   /* from now on internal messages are written to the system log as well */
 
   main_loop_run(main_loop);
+  if (!main_loop_options.syntax_only)
+    {
+      control_server_loop_stop(&control_server_loop);
+    }
   main_loop_deinit(main_loop);
 
   app_shutdown();


### PR DESCRIPTION
…command)

When `syslog-ng-ctl reload --wait` is called, syslog-ng-ctl will be blocked
until reload finished. So don't need any log parsing to decide whether
the reload processed is finished or not.

Technical details:
 * add SYNCRELOAD command
 * when SYNCRELOAD is called, an AH_POST_CONFIG_LOADED callback is registered
 * a condvar is waiting for a signal emitted by our
   AH_POST_CONFIG_LOADED callback
 * after the signal is received, answer is sent back to the
   syslog-ng-ctl client

Future devlopment could be:
 * send back status of the reload to the user
 * define a condwait timeout at syslog-ng-ctl site

Questions to Reviewer(s):
 * is it possible to miss an `AH_POST_CONFIG_LOADED`? (`control_connection_reload` is called _before_ registering the callback...)
 * is it possible to rename `SYNCRELOAD` to `RELOAD_SYNC`? when can we use `RELOAD_SYNC`?
 * how could we avoid using conditional variables (what should we have to refactor)?
 * is it possible that our registered callback will be remain active after it is called? (what if we send a SIGHUP after we run `syslog-ng-ctl reload --wait` ? )

(please note that these questions is for helping the reviewers, if I won't get answers within two weeks, I will answer these questions :) )