### PR TITLE
stdin: crash with syslog-ng reload

### DIFF
--- a/modules/affile/stdin.c
+++ b/modules/affile/stdin.c
@@ -24,6 +24,8 @@
 #include "transport/transport-file.h"
 #include "affile-source.h"
 
+#include <unistd.h>
+
 static LogTransport *
 _construct_transport(FileOpener *self, gint fd)
 {
@@ -39,7 +41,7 @@ _construct_src_proto(FileOpener *s, LogTransport *transport, LogProtoFileReaderO
 static gint
 _open(FileOpener *self, const gchar *name, gint flags)
 {
-  return 0;
+  return dup(0);
 }
 
 FileOpener *


### PR DESCRIPTION
In case stdin() driver is used: syslog-ng closes the zero file
descriptor (stdin) before restarting. After restart this same zero
file descriptor is intended to be added back to epoll in
ivykis. Being already closed: epoll_ctl returns with error:
errno=EBADF.  Hence syslog-ng cannot initialize after reload, and
when she tries to fallback, initialization will fail again with
the same reason. Hence the crash.

This patch duplicates the file descriptor of stdin, and the dupped
version will be watched, instead of zero.

Fixes: https://github.com/balabit/syslog-ng/issues/1736