### PR TITLE
PackagingSclFiles: Add missing scl dirs for debian packaging

### DIFF
--- a/packaging/debian/syslog-ng-core.install
+++ b/packaging/debian/syslog-ng-core.install
@@ -33,6 +33,8 @@ usr/share/syslog-ng/include/scl/loggly/*
 usr/share/syslog-ng/include/scl/logmatic/*
 usr/share/syslog-ng/include/scl/solaris/*
 usr/share/syslog-ng/include/scl/cisco/*
+usr/share/syslog-ng/include/scl/windowseventlog/*
+usr/share/syslog-ng/include/scl/loadbalancer/*
 usr/share/syslog-ng/xsd/*
 [!kfreebsd-any] debian/syslog-ng.systemd =>  lib/systemd/system/syslog-ng.service
 

--- a/packaging/debian/syslog-ng-mod-json.install
+++ b/packaging/debian/syslog-ng-mod-json.install
@@ -1,5 +1,6 @@
 usr/lib/syslog-ng/*/libjson-plugin.so
 usr/share/syslog-ng/include/scl/nodejs/*
+usr/share/syslog-ng/include/scl/osquery/*
 
 #Templates with json dependencies
 usr/share/syslog-ng/include/scl/cim/*


### PR DESCRIPTION
Related scls
 * windowseventlog
 * loadbalancer
 * osquery

Signed-off-by: Andras Mitzki <mitzkia@gmail.com>