### PR TITLE
Limit dynamic counters

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -192,6 +192,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_MARK_MODE                   10081
 %token KW_ENCODING                    10082
 %token KW_TYPE                        10083
+%token KW_STATS_MAX_DYNAMIC           10084
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -931,6 +932,7 @@ stat_option
 	: KW_STATS_FREQ '(' nonnegative_integer ')'          { last_stats_options->log_freq = $3; }
 	| KW_STATS_LEVEL '(' nonnegative_integer ')'         { last_stats_options->level = $3; }
 	| KW_STATS_LIFETIME '(' positive_integer ')'      { last_stats_options->lifetime = $3; }
+  | KW_STATS_MAX_DYNAMIC '(' nonnegative_integer ')'   { last_stats_options->max_dynamic = $3; }
 	;
 
 dns_cache_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -86,6 +86,7 @@ static CfgLexerKeyword main_keywords[] =
   { "stats_lifetime",     KW_STATS_LIFETIME },
   { "stats_level",        KW_STATS_LEVEL },
   { "stats",              KW_STATS_FREQ, KWS_OBSOLETE, "stats_freq" },
+  { "stats_max_dynamics", KW_STATS_MAX_DYNAMIC },
   { "flush_lines",        KW_FLUSH_LINES },
   { "flush_timeout",      KW_FLUSH_TIMEOUT },
   { "suppress",           KW_SUPPRESS },

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -264,6 +264,15 @@ stats_cluster_new(const StatsClusterKey *key)
   return self;
 }
 
+StatsCluster *
+stats_cluster_dynamic_new(const StatsClusterKey *key)
+{
+  StatsCluster *sc = stats_cluster_new(key);
+  sc->dynamic = TRUE;
+
+  return sc;
+}
+
 void
 stats_counter_group_free(StatsCounterGroup *self)
 {

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -147,6 +147,7 @@ gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 gboolean stats_cluster_is_indexed(StatsCluster *self, gint type);
 
 StatsCluster *stats_cluster_new(const StatsClusterKey *key);
+StatsCluster *stats_cluster_dynamic_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
 void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance, StatsCounterGroupInit counter_group_ctor);

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -125,25 +125,18 @@ _index_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer 
 }
 
 static void
-_update_indexes_of_cluster_if_needed(gpointer key, gpointer value)
+_update_indexes_of_cluster_if_needed(StatsCluster *sc, gpointer user_data)
 {
-  StatsCluster *sc = (StatsCluster *)key;
   stats_cluster_foreach_counter(sc, _index_counter, NULL);
 }
 
 static void
 _update_index(void)
 {
-  GHashTable *counter_container = stats_registry_get_container();
-  gpointer key, value;
-  GHashTableIter iter;
-
   g_static_mutex_lock(&stats_query_mutex);
-  g_hash_table_iter_init(&iter, counter_container);
-  while (g_hash_table_iter_next(&iter, &key, &value))
-    {
-      _update_indexes_of_cluster_if_needed(key, value);
-    }
+  stats_lock();
+  stats_foreach_cluster(_update_indexes_of_cluster_if_needed, NULL);
+  stats_unlock();
   g_static_mutex_unlock(&stats_query_mutex);
 }
 

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -26,14 +26,24 @@
 #include "cfg.h"
 #include <string.h>
 
-static GHashTable *stats_cluster_container;
+typedef struct _StatsClusterContainer
+{
+  GHashTable *static_clusters;
+  GHashTable *dynamic_clusters;
+} StatsClusterContainer;
+
+static StatsClusterContainer stats_cluster_container;
+
 static GStaticMutex stats_mutex = G_STATIC_MUTEX_INIT;
 gboolean stats_locked;
 
 static void
 _insert_cluster(StatsCluster *sc)
 {
-  g_hash_table_insert(stats_cluster_container, &sc->key, sc);
+  if (sc->dynamic)
+    g_hash_table_insert(stats_cluster_container.dynamic_clusters, &sc->key, sc);
+  else
+    g_hash_table_insert(stats_cluster_container.static_clusters, &sc->key, sc);
 }
 
 void
@@ -51,31 +61,58 @@ stats_unlock(void)
 }
 
 static StatsCluster *
-_grab_cluster(gint stats_level, const StatsClusterKey *sc_key, gboolean dynamic)
+_grab_dynamic_cluster(const StatsClusterKey *sc_key)
 {
   StatsCluster *sc;
 
+  sc = g_hash_table_lookup(stats_cluster_container.dynamic_clusters, sc_key);
+  if (!sc)
+    {
+      sc = stats_cluster_dynamic_new(sc_key);
+      _insert_cluster(sc);
+    }
+
+  return sc;
+
+}
+
+static StatsCluster *
+_grab_static_cluster(const StatsClusterKey *sc_key)
+{
+  StatsCluster *sc;
+
+  sc = g_hash_table_lookup(stats_cluster_container.static_clusters, sc_key);
+  if (!sc)
+    {
+      sc = stats_cluster_new(sc_key);
+      _insert_cluster(sc);
+    }
+
+  return sc;
+}
+
+static StatsCluster *
+_grab_cluster(gint stats_level, const StatsClusterKey *sc_key, gboolean dynamic)
+{
   if (!stats_check_level(stats_level))
     return NULL;
 
-  sc = g_hash_table_lookup(stats_cluster_container, sc_key);
-  if (!sc)
-    {
-      /* no such StatsCluster instance, register one */
-      sc = stats_cluster_new(sc_key);
-      sc->dynamic = dynamic;
-      _insert_cluster(sc);
-    }
+  StatsCluster *sc = NULL;
+
+  if (dynamic)
+    sc = _grab_dynamic_cluster(sc_key);
   else
-    {
-      /* check that we are not overwriting a dynamic counter with a
-       * non-dynamic one or vica versa.  This could only happen if the same
-       * key is used for both a dynamic counter and a non-dynamic one, which
-       * is a programming error */
+    sc = _grab_static_cluster(sc_key);
 
-      g_assert(sc->dynamic == dynamic);
-    }
+  if (!sc)
+    return NULL;
 
+  /* check that we are not overwriting a dynamic counter with a
+   * non-dynamic one or vica versa.  This could only happen if the same
+   * key is used for both a dynamic counter and a non-dynamic one, which
+   * is a programming error */
+
+  g_assert(sc->dynamic == dynamic);
   return sc;
 }
 
@@ -156,6 +193,8 @@ stats_register_and_increment_dynamic_counter(gint stats_level, const StatsCluste
 
   g_assert(stats_locked);
   handle = stats_register_dynamic_counter(stats_level, sc_key, SC_TYPE_PROCESSED, &counter);
+  if (!handle)
+    return;
   stats_counter_inc(counter);
   if (timestamp >= 0)
     {
@@ -199,7 +238,7 @@ stats_unregister_counter(const StatsClusterKey *sc_key, gint type,
   if (*counter == NULL)
     return;
 
-  sc = g_hash_table_lookup(stats_cluster_container, sc_key);
+  sc = g_hash_table_lookup(stats_cluster_container.static_clusters, sc_key);
 
   stats_cluster_untrack_counter(sc, type, counter);
 }
@@ -251,7 +290,8 @@ stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data)
   gpointer args[] = { func, user_data };
 
   g_assert(stats_locked);
-  g_hash_table_foreach(stats_cluster_container, _foreach_cluster_helper, args);
+  g_hash_table_foreach(stats_cluster_container.static_clusters, _foreach_cluster_helper, args);
+  g_hash_table_foreach(stats_cluster_container.dynamic_clusters, _foreach_cluster_helper, args);
 }
 
 static gboolean
@@ -269,7 +309,8 @@ void
 stats_foreach_cluster_remove(StatsForeachClusterRemoveFunc func, gpointer user_data)
 {
   gpointer args[] = { func, user_data };
-  g_hash_table_foreach_remove(stats_cluster_container, _foreach_cluster_remove_helper, args);
+  g_hash_table_foreach_remove(stats_cluster_container.static_clusters, _foreach_cluster_remove_helper, args);
+  g_hash_table_foreach_remove(stats_cluster_container.dynamic_clusters, _foreach_cluster_remove_helper, args);
 }
 
 static void
@@ -294,16 +335,23 @@ stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data)
 void
 stats_registry_init(void)
 {
-  stats_cluster_container = g_hash_table_new_full((GHashFunc) stats_cluster_hash, (GEqualFunc) stats_cluster_equal, NULL,
-                                                  (GDestroyNotify) stats_cluster_free);
+  stats_cluster_container.static_clusters = g_hash_table_new_full((GHashFunc) stats_cluster_hash,
+                                            (GEqualFunc) stats_cluster_equal, NULL,
+                                            (GDestroyNotify) stats_cluster_free);
+  stats_cluster_container.dynamic_clusters = g_hash_table_new_full((GHashFunc) stats_cluster_hash,
+                                             (GEqualFunc) stats_cluster_equal, NULL,
+                                             (GDestroyNotify) stats_cluster_free);
+
   g_static_mutex_init(&stats_mutex);
 }
 
 void
 stats_registry_deinit(void)
 {
-  g_hash_table_destroy(stats_cluster_container);
-  stats_cluster_container = NULL;
+  g_hash_table_destroy(stats_cluster_container.static_clusters);
+  g_hash_table_destroy(stats_cluster_container.dynamic_clusters);
+  stats_cluster_container.static_clusters = NULL;
+  stats_cluster_container.dynamic_clusters = NULL;
   g_static_mutex_free(&stats_mutex);
 }
 

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -307,8 +307,3 @@ stats_registry_deinit(void)
   g_static_mutex_free(&stats_mutex);
 }
 
-GHashTable *
-stats_registry_get_container(void)
-{
-  return stats_cluster_container;
-}

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -53,4 +53,7 @@ void stats_registry_deinit(void);
 void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 void load_counter_from_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 
+gboolean stats_check_dynamic_clusters_limit(guint number_of_clusters);
+gint stats_number_of_dynamic_clusters_limit(void);
+
 #endif

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -50,8 +50,6 @@ void stats_foreach_cluster_remove(StatsForeachClusterRemoveFunc func, gpointer u
 void stats_registry_init(void);
 void stats_registry_deinit(void);
 
-GHashTable* stats_registry_get_container(void);
-
 void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 void load_counter_from_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -257,6 +257,7 @@ stats_options_defaults(StatsOptions *options)
   options->level = 0;
   options->log_freq = 600;
   options->lifetime = 600;
+  options->max_dynamic = -1;
 }
 
 gboolean
@@ -267,3 +268,22 @@ stats_check_level(gint level)
   else
     return level == 0;
 }
+
+gboolean
+stats_check_dynamic_clusters_limit(guint number_of_clusters)
+{
+  if (!stats_options)
+    return TRUE;
+  if (stats_options->max_dynamic == -1)
+    return TRUE;
+  return (stats_options->max_dynamic > number_of_clusters);
+}
+
+gint
+stats_number_of_dynamic_clusters_limit()
+{
+  if (!stats_options)
+    return -1;
+  return stats_options->max_dynamic;
+}
+

--- a/lib/stats/stats.h
+++ b/lib/stats/stats.h
@@ -33,6 +33,7 @@ typedef struct _StatsOptions
   gint log_freq;
   gint level;
   gint lifetime;
+  gint max_dynamic;
 } StatsOptions;
 
 enum
@@ -48,7 +49,6 @@ void stats_init(void);
 void stats_destroy(void);
 
 void stats_options_defaults(StatsOptions *options);
-
 
 #endif
 

--- a/lib/stats/tests/Makefile.am
+++ b/lib/stats/tests/Makefile.am
@@ -14,9 +14,15 @@ stats_test_extra_modules			= \
 	$(PREOPEN_SYSLOGFORMAT)
 
 lib_stats_tests_TESTS		+= \
-	lib/stats/tests/test_stats_query
+	lib/stats/tests/test_stats_query \
+	lib/stats/tests/test_dynamic_ctr_reg
 
 lib_stats_tests_test_stats_query_CFLAGS	= $(TEST_CFLAGS)
 lib_stats_tests_test_stats_query_LDADD	= \
 	$(TEST_LDADD) $(stats_test_extra_modules)
+
+lib_stats_tests_test_dynamic_ctr_reg_CFLAGS = $(TEST_CFLAGS)
+lib_stats_tests_test_dynamic_ctr_reg_LDADD = \
+	$(TEST_LDADD) $(stats_test_extra_modules)
+
 endif

--- a/lib/stats/tests/test_dynamic_ctr_reg.c
+++ b/lib/stats/tests/test_dynamic_ctr_reg.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#include "apphook.h"
+#include "logmsg/logmsg.h"
+#include "stats/stats-cluster.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-counter.h"
+#include "stats/stats-query.h"
+#include "stats/stats-registry.h"
+#include "syslog-ng.h"
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+#include <limits.h>
+#include <time.h>
+
+TestSuite(stats_dynamic_clusters, .init = app_startup, .fini = app_shutdown);
+
+Test(stats_dynamic_clusters, unlimited_by_default)
+{
+  StatsOptions stats_opts;
+  stats_options_defaults(&stats_opts);
+  stats_reinit(&stats_opts);
+  cr_assert_eq(stats_check_dynamic_clusters_limit(0), TRUE);
+  cr_assert_eq(stats_check_dynamic_clusters_limit(UINT_MAX), TRUE);
+}
+
+Test(stats_dynamic_clusters, limited)
+{
+  StatsOptions stats_opts;
+  stats_options_defaults(&stats_opts);
+  stats_opts.max_dynamic = 2;
+  stats_reinit(&stats_opts);
+  cr_assert_eq(stats_check_dynamic_clusters_limit(0), TRUE);
+  cr_assert_eq(stats_check_dynamic_clusters_limit(1), TRUE);
+  cr_assert_eq(stats_check_dynamic_clusters_limit(2), FALSE);
+}
+
+Test(stats_dynamic_clusters, register_limited)
+{
+  StatsOptions stats_opts;
+  stats_options_defaults(&stats_opts);
+  stats_opts.level = 3;
+  stats_opts.max_dynamic = 2;
+  stats_reinit(&stats_opts);
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost1");
+    StatsCounterItem *counter = NULL;
+    StatsCluster *sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
+    cr_assert_not_null(sc);
+    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost2");
+    sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
+    cr_assert_not_null(sc);
+    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost3");
+    sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
+    cr_assert_null(sc);
+  }
+  stats_unlock();
+}
+


### PR DESCRIPTION
##### Add config option for limiting dynamic counters
*   Users can limit the number of registered dynamic counters via the `stats_max_dynamics` global option.
    This is not a limit for the number of counters but for the number of _clusters_ which means that users
    can limit the number of different dynamic value occurrences (as each
    cluster has a pre-allocated array of counters).
*   Note that after reload, when users set a lower limit,
    they have to wait for stat-freq-timer being expired to remove the
    previously allocated dynamic clusters.
 *   Dynamic values are
      * source host (from stats level 2)
      * sender host (host from) (from stats level 3)
      * program (from stats level 3)
    
 * By default this change is backward compatible: if someone not uses this feature, number of dynamic counters won't be limited.
 * It is  possible to disable dynamic counters by setting the limit to 0.

##### The following example contains 6 different dynamic values (a sender, a  host and four different programs):

             
```                                                                                                         
    src.sender;;localhost;d;processed;4
    src.sender;;localhost;d;stamp;1509121934
    src.program;;P-18069;d;processed;1
    src.program;;P-18069;d;stamp;1509121933
    src.program;;P-21491;d;processed;1
    src.program;;P-21491;d;stamp;1509121934
    src.program;;P-9774;d;processed;1
    src.program;;P-9774;d;stamp;1509121919
    src.program;;P-14737;d;processed;1
    src.program;;P-14737;d;stamp;1509121931
    src.host;;localhost;d;processed;4
    src.host;;localhost;d;stamp;1509121934
```

Questions to reviewers:
 * What do you think about storing dynamic counters in a separate hash table?
 * What do you think about the reload-issue? (when the user sets a lower value, after a reload the already registered dynamic counters won't be removed until start-freq timer not expires)?
