### PR TITLE
groupingby: add missing "discarded" counter

### DIFF
--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -139,6 +139,7 @@ log_parser_init_instance(LogParser *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
   self->super.init = log_parser_init_method;
+  self->super.deinit = log_parser_deinit_method;
   self->super.free_fn = log_parser_free_method;
   self->super.queue = log_parser_queue;
 }

--- a/lib/parser/parser-expr.h
+++ b/lib/parser/parser-expr.h
@@ -42,8 +42,17 @@ struct _LogParser
   gchar *name;
 };
 
-void log_parser_set_template(LogParser *self, LogTemplate *template);
+static inline gboolean
+log_parser_deinit_method(LogPipe *s)
+{
+  /* NOTE: placeholder for the future and to pair up with
+   * log_parser_init_method().  There's no log_pipe_deinit_method() to call
+   */
+  return TRUE;
+}
+
 gboolean log_parser_init_method(LogPipe *s);
+void log_parser_set_template(LogParser *self, LogTemplate *template);
 void log_parser_init_instance(LogParser *self, GlobalConfig *cfg);
 void log_parser_free_method(LogPipe *self);
 

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -156,7 +156,7 @@ log_db_parser_init(LogPipe *s)
   iv_timer_register(&self->tick);
   if (!self->db)
     return FALSE;
-  return log_parser_init_method(s);
+  return stateful_parser_init_method(s);
 }
 
 static gboolean
@@ -172,7 +172,7 @@ log_db_parser_deinit(LogPipe *s)
 
   cfg_persist_config_add(cfg, log_db_parser_format_persist_name(self), self->db, (GDestroyNotify) pattern_db_free, FALSE);
   self->db = NULL;
-  return TRUE;
+  return stateful_parser_deinit_method(s);
 }
 
 static gboolean

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -419,7 +419,7 @@ grouping_by_init(LogPipe *s)
   self->tick.expires.tv_sec++;
   self->tick.expires.tv_nsec = 0;
   iv_timer_register(&self->tick);
-  return TRUE;
+  return stateful_parser_init_method(s);
 }
 
 static gboolean
@@ -436,7 +436,7 @@ grouping_by_deinit(LogPipe *s)
   cfg_persist_config_add(cfg, grouping_by_format_persist_name(self), self->correllation,
                          (GDestroyNotify) correllation_state_free, FALSE);
   self->correllation = NULL;
-  return TRUE;
+  return stateful_parser_deinit_method(s);
 }
 
 static LogPipe *

--- a/modules/dbparser/stateful-parser.h
+++ b/modules/dbparser/stateful-parser.h
@@ -38,6 +38,18 @@ typedef struct _StatefulParser
   LogDBParserInjectMode inject_mode;
 } StatefulParser;
 
+static inline gboolean
+stateful_parser_init_method(LogPipe *s)
+{
+  return log_parser_init_method(s);
+}
+
+static inline gboolean
+stateful_parser_deinit_method(LogPipe *s)
+{
+  return log_parser_deinit_method(s);
+}
+
 void stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inject_mode);
 void stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg);
 void stateful_parser_init_instance(StatefulParser *self, GlobalConfig *cfg);

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -178,7 +178,7 @@ kv_parser_deinit_method(LogPipe *s)
 
   kv_scanner_free(self->kv_scanner);
   self->kv_scanner = NULL;
-  return TRUE;
+  return log_parser_deinit_method(s);
 }
 
 void

--- a/modules/native/parser.c
+++ b/modules/native/parser.c
@@ -88,7 +88,9 @@ native_parser_deinit(LogPipe *s)
 {
   ParserNative *self = (ParserNative *) s;
 
-  return !!native_parser_proxy_deinit(self->native_object);
+  if (!native_parser_proxy_deinit(self->native_object))
+    return FALSE;
+  return log_parser_deinit_method(s);
 }
 
 static void

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -234,7 +234,7 @@ python_parser_deinit(LogPipe *d)
   _py_invoke_deinit(self);
   PyGILState_Release(gstate);
 
-  return log_parser_deinit_method(s);
+  return log_parser_deinit_method(d);
 }
 
 static void

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -234,7 +234,7 @@ python_parser_deinit(LogPipe *d)
   _py_invoke_deinit(self);
   PyGILState_Release(gstate);
 
-  return TRUE;
+  return log_parser_deinit_method(s);
 }
 
 static void


### PR DESCRIPTION
This patch adds log_parser_init_method() to the init() call chain,
where it was missing. This fixes #1738, as well as any potential
missing initialization problem in the future.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>