### PR TITLE
criterion: disabling aslr for testcases

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ TEST_CFLAGS		+= $(CRITERION_CFLAGS)
 TEST_LDADD		+= $(CRITERION_LIBS)
 endif
 
-test_ldflags		= -no-install
+test_ldflags		= -no-install $(NO_PIE_LDFLAG)
 
 PREOPEN_SYSLOGFORMAT	= -dlpreopen ${top_builddir}/modules/syslogformat/libsyslogformat.la
 PREOPEN_BASICFUNCS	= -dlpreopen ${top_builddir}/modules/basicfuncs/libbasicfuncs.la
@@ -88,7 +88,7 @@ local-check:
 	${AM_v_at}${MAKE} check check_PROGRAMS="${current_tests} ${subdir_tests}" \
 				TESTS="${current_tests} ${subdir_tests}"
 
-${check_PROGRAMS}: LDFLAGS+="${test_ldflags}"
+${check_PROGRAMS}: LDFLAGS+=${test_ldflags}
 
 noinst_LIBRARIES	=
 noinst_DATA		=

--- a/configure.ac
+++ b/configure.ac
@@ -437,6 +437,22 @@ if test $lex_ok = 0 ; then
 fi
 
 dnl ***************************************************************************
+dnl Set up NO_PIE_LDFLAG: -no-pie is compatible with $CC.
+old_LDFLAGS="$LDFLAGS"
+LDFLAGS="$LDFLAGS -no-pie"
+
+AC_LINK_IFELSE([AC_LANG_SOURCE([int main(void) {return 0;}])],
+	[no_pie_option_available=yes],
+	[no_pie_option_available=no])
+
+LDFLAGS="$old_LDFLAGS"
+
+if test "$no_pie_option_available" = "yes"; then
+  NO_PIE_LDFLAG="-no-pie"
+fi
+AC_SUBST([NO_PIE_LDFLAG])
+
+dnl ***************************************************************************
 dnl Set up CFLAGS
 
 if test "x$ac_compiler_gnu" = "xyes"; then


### PR DESCRIPTION
Parametrized tests in criterion crashes with aslr enabled.
https://github.com/Snaipe/Criterion/issues/208

This can be a problem, because for example in ubuntu 17.04 gcc
produces position  independent executable code by default. With
randomize_va_space > 0, it leads criterion tests to crash.

This patch will compile the tests into a non position independent
binary, avoiding the crash.
Non test related binaries are untouched.

Test:
$ file modules/xml/tests/test_xml_parser
modules/xml/tests/test_xml_parser: ELF 64-bit LSB executable [...]

However for syslog-ng binary:
$ file ../root/sbin/syslog-ng
../root/sbin/syslog-ng: ELF 64-bit LSB shared object