### PR TITLE
python: hy module related fixes

### DIFF
--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -24,7 +24,7 @@
 gboolean
 py_is_string(PyObject *object)
 {
-  return PyBytes_Check(object);
+  return PyBytes_Check(object) || PyUnicode_Check(object);
 }
 
 const gchar *

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -32,3 +32,10 @@ py_object_as_string(PyObject *object)
 {
   return PyBytes_AsString(object);
 }
+
+void
+py_init_argv(void)
+{
+  static char *argv[] = {"syslog-ng"};
+  PySys_SetArgvEx(1, argv, 0);
+}

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -32,3 +32,10 @@ py_object_as_string(PyObject *object)
 {
   return PyUnicode_AsUTF8(object);
 }
+
+void
+py_init_argv(void)
+{
+  static wchar_t *argv[] = {L"syslog-ng"};
+  PySys_SetArgvEx(1, argv, 0);
+}

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -38,4 +38,5 @@ const gchar *py_object_as_string(PyObject *object);
 #define PYTHON_BUILTIN_MODULE_NAME "builtins"
 #endif
 
+void py_init_argv(void);
 #endif

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -38,7 +38,7 @@ typedef struct
   LogThrDestDriver super;
 
   gchar *class;
-  GList *imports;
+  GList *loaders;
 
   LogTemplateOptions template_options;
   GHashTable *options;
@@ -83,12 +83,12 @@ python_dd_set_value_pairs(LogDriver *d, ValuePairs *vp)
 }
 
 void
-python_dd_set_imports(LogDriver *d, GList *imports)
+python_dd_set_loaders(LogDriver *d, GList *loaders)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
-  string_list_free(self->imports);
-  self->imports = imports;
+  string_list_free(self->loaders);
+  self->loaders = loaders;
 }
 
 PyObject *
@@ -432,7 +432,7 @@ python_dd_init(LogPipe *d)
 
   gstate = PyGILState_Ensure();
 
-  _py_perform_imports(self->imports);
+  _py_perform_imports(self->loaders);
   if (!_py_init_bindings(self) ||
       !_py_init_object(self))
     goto fail;

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -31,7 +31,7 @@
 #include "value-pairs/value-pairs.h"
 
 LogDriver *python_dd_new(GlobalConfig *cfg);
-void python_dd_set_imports(LogDriver *d, GList *imports);
+void python_dd_set_loaders(LogDriver *d, GList *loaders);
 void python_dd_set_class(LogDriver *d, gchar *class_name);
 void python_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
 void python_dd_set_option(LogDriver*  d, gchar* key, gchar* value);

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -49,6 +49,7 @@
 %token KW_PYTHON
 %token KW_CLASS
 %token KW_IMPORTS
+%token KW_LOADERS
 
 %%
 
@@ -89,10 +90,8 @@ python_dd_option
             python_dd_set_class(last_driver, $3);
             free($3);
           }
-        | KW_IMPORTS '(' string_list ')'
-          {
-            python_dd_set_imports(last_driver, $3);
-          }
+        | KW_LOADERS python_dd_loaders
+        | KW_IMPORTS python_dd_loaders
         | KW_OPTIONS '(' python_dd_custom_options ')'
         | threaded_dest_driver_option
         | value_pair_option
@@ -123,11 +122,8 @@ python_parser_option
             python_parser_set_class(last_parser, $3);
             free($3);
           }
-        | KW_IMPORTS '(' string_list ')'
-          {
-            python_parser_set_imports(last_parser, $3);
-            free($3);
-          }
+        | KW_LOADERS python_parser_loaders
+        | KW_IMPORTS python_parser_loaders
         | KW_OPTIONS '(' python_parser_custom_options ')'
         ;
 
@@ -144,6 +140,18 @@ python_parser_custom_option
            free($2);
         }
 
+
+python_dd_loaders
+          : '(' string_list ')'
+          {
+            python_dd_set_loaders(last_driver, $2);
+          }
+
+python_parser_loaders
+          : '(' string_list ')'
+          {
+            python_parser_set_loaders(last_parser, $2);
+          }
 
 /* INCLUDE_RULES */
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -70,7 +70,10 @@ static PyObject *
 _py_log_message_getattr(PyObject *o, PyObject *key)
 {
   if (!py_is_string(key))
-    return NULL;
+    {
+      PyErr_SetString(PyExc_TypeError, "key is not a string object");
+      return NULL;
+    }
 
   const gchar *name = py_object_as_string(key);
 
@@ -99,7 +102,10 @@ static int
 _py_log_message_setattr(PyObject *o, PyObject *key, PyObject *value)
 {
   if (!py_is_string(key))
-    return -1;
+    {
+      PyErr_SetString(PyExc_TypeError, "key is not a string object");
+      return -1;
+    }
 
   PyLogMessage *py_msg = (PyLogMessage *)o;
   const gchar *name = py_object_as_string(key);

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -32,7 +32,7 @@ typedef struct
   LogParser super;
 
   gchar *class;
-  GList *imports;
+  GList *loaders;
 
   GHashTable *options;
 
@@ -62,12 +62,12 @@ python_parser_set_option(LogParser *d, gchar *key, gchar *value)
 }
 
 void
-python_parser_set_imports(LogParser *d, GList *imports)
+python_parser_set_loaders(LogParser *d, GList *loaders)
 {
   PythonParser *self = (PythonParser *)d;
 
-  string_list_free(self->imports);
-  self->imports = imports;
+  string_list_free(self->loaders);
+  self->loaders = loaders;
 }
 
 static gboolean
@@ -207,7 +207,7 @@ python_parser_init(LogPipe *s)
 
   gstate = PyGILState_Ensure();
 
-  _py_perform_imports(self->imports);
+  _py_perform_imports(self->loaders);
   if (!_py_init_bindings(self) ||
       !_py_init_object(self))
     goto fail;
@@ -252,7 +252,7 @@ python_parser_free(LogPipe *d)
   if (self->options)
     g_hash_table_unref(self->options);
 
-  string_list_free(self->imports);
+  string_list_free(self->loaders);
 
   log_parser_free_method(d);
 }
@@ -264,7 +264,7 @@ python_parser_clone(LogPipe *s)
   PythonParser *cloned = (PythonParser *) python_parser_new(log_pipe_get_config(s));
   g_hash_table_unref(cloned->options);
   python_parser_set_class(&cloned->super, self->class);
-  cloned->imports = string_list_clone(self->imports);
+  cloned->loaders = string_list_clone(self->loaders);
   cloned->options = g_hash_table_ref(self->options);
 
   return &cloned->super.super;

--- a/modules/python/python-logparser.h
+++ b/modules/python/python-logparser.h
@@ -28,7 +28,7 @@
 #include "value-pairs/value-pairs.h"
 
 LogParser *python_parser_new(GlobalConfig *cfg);
-void python_parser_set_imports(LogParser *s, GList *imports);
+void python_parser_set_loaders(LogParser *s, GList *loaders);
 void python_parser_set_class(LogParser *s, gchar *class_name);
 void python_parser_set_option(LogParser*  s, gchar* key, gchar* value);
 

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -33,7 +33,11 @@ static CfgLexerKeyword python_keywords[] =
 {
   { "python",                   KW_PYTHON  },
   { "class",                    KW_CLASS   },
-  { "imports",                  KW_IMPORTS },
+  {
+    "imports",                  KW_IMPORTS, KWS_OBSOLETE,
+    "imports() has been deprecated, please use loaders()"
+  },
+  { "loaders",                    KW_LOADERS   },
   { NULL }
 };
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -64,6 +64,7 @@ _py_init_interpreter(void)
       python_debugger_append_inittab();
 
       Py_Initialize();
+      py_init_argv();
 
       PyEval_InitThreads();
       python_log_message_init();

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -32,6 +32,8 @@ static void
 _py_init_interpreter(void)
 {
   Py_Initialize();
+  py_init_argv();
+
   PyEval_InitThreads();
   python_log_message_init();
   PyEval_SaveThread();
@@ -130,4 +132,3 @@ Test(python_log_message, test_python_logmessage_set_value_indirect)
   }
   PyGILState_Release(gstate);
 }
-


### PR DESCRIPTION
This patch contains the code change identified in https://github.com/balabit/syslog-ng/issues/1361.
The goal of the patchset is to be able to write parsers/destinations in hy.

Example:
```
syslog-ng.conf
@version: 3.13

log {
    source { stdin(flags(no-parse)); };
    destination { python( imports("hy") class("mymodule.MyPyDest")); };
};
```
```
mymodule.hy:
(defclass MyPyDest [object]
  (defn init [self options] True)
  (defn send [self message] (print (get message "MESSAGE")) True)
)
```