### PR TITLE
Configuration error footnote parameterized

### DIFF
--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -277,8 +277,8 @@ report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const ch
       _report_buffer_location(level->buffer.content, yylloc);
     }
 
-  fprintf(stderr, "\nsyslog-ng documentation: https://www.balabit.com/support/documentation?product=syslog-ng-ose\n"
-          "mailing list: https://lists.balabit.hu/mailman/listinfo/syslog-ng\n");
+  fprintf(stderr, "\nsyslog-ng documentation: https://www.balabit.com/support/documentation?product=%s\n"
+          "contact: %s\n", PRODUCT_NAME, PRODUCT_CONTACT);
 
 }
 

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -91,6 +91,9 @@
  * should reference the syslog-ng version number through these macros, in order
  * to make it relatively simple to explain PE/OSE version numbers to users. */
 
+#define PRODUCT_NAME "syslog-ng-ose"
+#define PRODUCT_CONTACT "https://lists.balabit.hu/mailman/listinfo/syslog-ng"
+
 #define VERSION_3_0 "syslog-ng 3.0"
 #define VERSION_3_1 "syslog-ng 3.1"
 #define VERSION_3_2 "syslog-ng 3.2"


### PR DESCRIPTION
The error message in case of configuration issue contain a burned in product name and link to mailing-list.
Also the documentation link should point to **syslog-ng-ose** instead of **syslog-ng**.

> syslog-ng documentation: https://www.balabit.com/support/documentation?product=syslog-ng
> mailing list: https://lists.balabit.hu/mailman/listinfo/syslog-ng

This modification makes it easily replaceable via redefining macro that has the information.

The new message would be:
> syslog-ng documentation: https://www.balabit.com/support/documentation?product=syslog-ng-ose
> contact: https://lists.balabit.hu/mailman/listinfo/syslog-ng

Signed-off-by: kokan <peter.kokai@balabit.com>