### PR TITLE
Mongodb: original status variable was not free, cause memory leak

### DIFF
--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -181,12 +181,12 @@ _connect(MongoDBDestDriver *self, gboolean reconnect)
         }
     }
 
-  bson_t *status = bson_new();
+  bson_t reply;
   bson_error_t error;
   const mongoc_read_prefs_t *read_prefs = mongoc_collection_get_read_prefs(self->coll_obj);
   gboolean ok = mongoc_client_get_server_status(self->client, (mongoc_read_prefs_t *)read_prefs,
-                                                status, &error);
-  bson_destroy(status);
+                                                &reply, &error);
+  bson_destroy(&reply);
   if (!ok)
     {
       msg_error("Error connecting to MongoDB",


### PR DESCRIPTION
 * rename status to reply

There is a small leak in afmongodb.c: at:

Reproduction:
 * start syslog-ng behind a valgrind with the following config below:
```
@version: 3.12

source s_file {file("/dev/stdin");};
destination d_mongodb {mongodb();};
log {source(s_file); destination(d_mongodb);};
```
 * valgrind start:
```
valgrind --run-libc-freeres=no --leak-check=full --tool=memcheck sbin/syslog-ng -Fedv -f syslog_ng_mongodb.conf
```
 * send some SIGHUP to syslog-ng process


Valgrind:
 * Relevant part of valgrind log:
```
==12168== 768 bytes in 6 blocks are definitely lost in loss record 77 of 89
==12168==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12168==    by 0x75D7BFD: bson_malloc (bson-memory.c:67)
==12168==    by 0x75CAE2C: bson_new (bson.c:1863)
==12168==    by 0x75C0EAD: _connect (afmongodb.c:184)
==12168==    by 0x75C1BDA: _worker_thread_init (afmongodb.c:483)
==12168==    by 0x4E836EE: log_threaded_dest_driver_worker_thread_main (logthrdestdrv.c:296)
==12168==    by 0x4E899A2: _worker_thread_func (mainloop-worker.c:339)
==12168==    by 0x519C644: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.5400.1)
==12168==    by 0x54457FB: start_thread (pthread_create.c:465)
==12168==    by 0x5771B0E: clone (clone.S:95)
```

Investigation:
 * from afmongodb.c: 184
```
  bson_t *status = bson_new();
  bson_error_t error;
  const mongoc_read_prefs_t *read_prefs = mongoc_collection_get_read_prefs(self->coll_obj);
  gboolean ok = mongoc_client_get_server_status(self->client, (mongoc_read_prefs_t *)read_prefs,
                                                status, &error);
  bson_destroy(status);
```
 * from mongoc_client_get_server_status docs (http://mongoc.org/libmongoc/current/mongoc_client_get_server_status.html):
  * the third parameter is better known as: "reply"
 * status from bson_new() will never free. 
 



Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>