### PR TITLE
Redis: Do not init redis driver without command() option

### DIFF
--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -346,6 +346,13 @@ redis_dd_init(LogPipe *s)
   if (!log_dest_driver_init_method(s))
     return FALSE;
 
+  if (!self->key && !self->param1)
+    {
+      msg_error("Error initializing Redis destination, command option MUST be set",
+                log_pipe_location_tag(s));
+      return FALSE;
+    }
+
   log_template_options_init(&self->template_options, cfg);
 
   msg_verbose("Initializing Redis destination",


### PR DESCRIPTION
 - without this syslog-ng gets segfault


syslog-ng crashes when we start redis destination driver without defining command() option

Reproduction:
 * start syslog-ng with the config below (command() option is commented out)

```
@version: 3.12

source s_file {file("/dev/stdin");};
destination d_redis {redis( 
    # command("HINCRBY", "hosts", "$HOST", "1")
    );
};
log {source(s_file); destination(d_redis);};
```

Crash:
```
[2017-11-17T17:53:57.998296] Initializing Redis destination; driver='d_redis#0', host='127.0.0.1', port='6379'
[New Thread 0x7ffff7fd4700 (LWP 29778)]
[2017-11-17T17:53:57.998529] Worker thread started; driver='d_redis#0'
[2017-11-17T17:53:57.998547] Worker thread started; driver='d_redis#0'
[2017-11-17T17:53:57.998643] Running application hooks; hook='1'
[2017-11-17T17:53:57.998651] Running application hooks; hook='3'
[2017-11-17T17:53:57.998675] syslog-ng starting up; version='3.12.1'
[New Thread 0x7ffff5446700 (LWP 29779)]
[2017-11-17T17:53:57.998973] Incoming log entry; line='aaa sd klasjdlk ajsdlkjas lkdjasl kdjaslj dalskjd'
[2017-11-17T17:53:57.999027] Setting value; msg='0x7fffe8015800', name='HOST_FROM', value='tristram'
[2017-11-17T17:53:57.999038] Setting value; msg='0x7fffe8015800', name='HOST', value='tristram'
[2017-11-17T17:53:57.999064] Setting value; msg='0x7fffe8015800', name='FILE_NAME', value='/tmp/in'
[2017-11-17T17:53:57.999075] Setting value; msg='0x7fffe8015800', name='SOURCE', value='s_file'
[2017-11-17T17:53:57.999111] Connecting to REDIS succeeded; driver='d_redis#0'

Thread 2 "syslog-ng" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff7fd4700 (LWP 29778)]
0x00007ffff7b6c136 in log_template_append_format_with_context (self=0x0, messages=0x7ffff7fd1970, num_messages=1, opts=0x5555557b77f8, 
    tz=1, seq_num=1, context_id=0x0, result=0x7ffff0001e00) at ../lib/template/templates.c:82
82	  for (p = self->compiled_template; p; p = g_list_next(p))
(gdb) bt
#0  0x00007ffff7b6c136 in log_template_append_format_with_context (self=0x0, messages=0x7ffff7fd1970, num_messages=1, opts=0x5555557b77f8, 
    tz=1, seq_num=1, context_id=0x0, result=0x7ffff0001e00) at ../lib/template/templates.c:82
#1  0x00007ffff7b6c57d in log_template_append_format (self=0x0, lm=0x7fffe8015800, opts=0x5555557b77f8, tz=1, seq_num=1, context_id=0x0, 
    result=0x7ffff0001e00) at ../lib/template/templates.c:181
#2  0x00007ffff7b6c5dc in log_template_format (self=0x0, lm=0x7fffe8015800, opts=0x5555557b77f8, tz=1, seq_num=1, context_id=0x0, 
    result=0x7ffff0001e00) at ../lib/template/templates.c:189
#3  0x00007ffff5868e65 in redis_worker_insert (s=0x5555557b7550, msg=0x7fffe8015800) at ../modules/redis/redis.c:256
#4  0x00007ffff7b2e137 in log_threaded_dest_driver_do_insert (self=0x5555557b7550) at ../lib/logthrdestdrv.c:157
#5  0x00007ffff7b2e466 in log_threaded_dest_driver_do_work (data=0x5555557b7550) at ../lib/logthrdestdrv.c:239
#6  0x00007ffff7b847cf in iv_run_tasks (st=0x7ffff0004610) at ../../../../lib/ivykis/src/iv_task.c:48
#7  0x00007ffff7b88140 in iv_main () at ../../../../lib/ivykis/src/iv_main_posix.c:99
#8  0x00007ffff7b2e6f4 in log_threaded_dest_driver_worker_thread_main (arg=0x5555557b7550) at ../lib/logthrdestdrv.c:298
#9  0x00007ffff7b349a3 in _worker_thread_func (st=0x55555579da80) at ../lib/mainloop-worker.c:339
#10 0x00007ffff7845645 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#11 0x00007ffff75bb7fc in start_thread (arg=0x7ffff7fd4700) at pthread_create.c:465
#12 0x00007ffff72e8b0f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```


Investigation:
 * from redis.c:256
```
  log_template_format(self->key, msg, &self->template_options, LTZ_SEND,
                      self->super.seq_num, NULL, self->key_str);
```

 * from backtrace (self->key is 0x0):
```
(gdb) fr 3
#3  0x00007ffff5868e65 in redis_worker_insert (s=0x5555557b7550, msg=0x7fffe8015800) at ../modules/redis/redis.c:256
256	  log_template_format(self->key, msg, &self->template_options, LTZ_SEND,
(gdb) p self
$3 = (RedisDriver *) 0x5555557b7550
(gdb) p *self
$4 = {super = {super = {super = {super = {ref_cnt = {counter = 2}, flags = 3, cfg = 0x555555792800, expr_node = 0x5555557b78e0, 
          pipe_next = 0x55555579c1e0, discarded_messages = 0x0, persist_name = 0x0, queue_data = 0x0, queue = 
    0x7ffff7b2eca2 <log_threaded_dest_driver_queue>, plugin_name = 0x5555557b19c0 "redis", init = 0x7ffff58693e2 <redis_dd_init>, 
          deinit = 0x7ffff7b2eab2 <log_threaded_dest_driver_deinit_method>, 
          generate_persist_name = 0x7ffff5868878 <redis_dd_format_persist_name>, clone = 0x0, free_fn = 0x7ffff58694de <redis_dd_free>, 
          notify = 0x0}, optional = 0, group = 0x55555579d760 "d_redis", id = 0x55555579d7a0 "d_redis#0", plugins = 0x0, 
        processed_group_messages = 0x55555579d8d8}, acquire_queue_data = 0x0, acquire_queue = 
    0x7ffff7b21221 <log_dest_driver_acquire_queue_method>, release_queue_data = 0x0, release_queue = 
    0x7ffff7b212f1 <log_dest_driver_release_queue_method>, queues = 0x5555557b5520 = {0x55555579dcd0}, log_fifo_size = -1, throttle = 0, 
      queued_global_messages = 0x55555579da88}, dropped_messages = 0x55555579dfb0, queued_messages = 0x55555579dfe0, 
    processed_messages = 0x55555579dfc8, written_messages = 0x0, memory_usage = 0x0, suspended = 0, under_termination = 0, 
    time_reopen = 60, queue = 0x55555579dcd0, worker = {connected = 1, thread_init = 0x7ffff58692c6 <redis_worker_thread_init>, 
      thread_deinit = 0x7ffff5869383 <redis_worker_thread_deinit>, insert = 0x7ffff5868d40 <redis_worker_insert>, connect = 0x0, 
      worker_message_queue_empty = 0x0, disconnect = 0x7ffff5868cf7 <redis_dd_disconnect>}, messages = {retry_over = 0x0}, format = {
      stats_instance = 0x7ffff58687ec <redis_dd_format_stats_instance>}, stats_source = 31, seq_num = 1, retries = {counter = 0, max = 3}, 
    queue_method = 0x0, worker_options = {is_output_thread = 1, is_external_input = 0}, wake_up_event = {cookie = 0x5555557b7550, 
      handler = 0x7ffff7b2dea6 <log_threaded_dest_driver_wake_up>, owner = 0x7ffff0004610, list = {next = 0x5555557b76e8, 
        prev = 0x5555557b76e8}}, shutdown_event = {cookie = 0x5555557b7550, handler = 0x7ffff7b2df8d <log_threaded_dest_driver_shutdown>, 
      owner = 0x7ffff0004610, list = {next = 0x5555557b7710, prev = 0x5555557b7710}}, timer_reopen = {expires = {tv_sec = 0, tv_nsec = 0}, 
      cookie = 0x5555557b7550, handler = 0x7ffff7b2e3c3 <log_threaded_dest_driver_do_work>, pad = {0x0, 0x0, 0xffffffff, 0x0}}, 
    timer_throttle = {expires = {tv_sec = 0, tv_nsec = 0}, cookie = 0x5555557b7550, 
      handler = 0x7ffff7b2e3c3 <log_threaded_dest_driver_do_work>, pad = {0x0, 0x0, 0xffffffff, 0x0}}, do_work = {cookie = 0x5555557b7550, 
      handler = 0x7ffff7b2e3c3 <log_threaded_dest_driver_do_work>, pad = {0x5555557b77b0, 0x5555557b77b0, 0x2, 0x0, 0x0, 0x0}}}, 
  host = 0x5555557b7480 "127.0.0.1", port = 6379, auth = 0x0, template_options = {initialized = 1, ts_format = 0, frac_digits = 0, 
    time_zone = {0x0, 0x0}, time_zone_info = {0x55555579db70, 0x55555579db90}, on_error = 1}, command = 0x5555557b5940, key = 0x0, 
  key_str = 0x7ffff0001e00, param1 = 0x0, param1_str = 0x7ffff0001e20, param2 = 0x0, param2_str = 0x7ffff0001e40, c = 0x7ffff00076b0}
```

Question:
 * would it be better to check exist of command() option from grammar?


Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>