### PR TITLE
Crash with SIGBUS when persist_file cannot grow

### DIFF
--- a/lib/host-id.c
+++ b/lib/host-id.c
@@ -24,6 +24,7 @@
 
 #include "host-id.h"
 #include "str-format.h"
+#include "messages.h"
 #include <openssl/rand.h>
 
 guint32 global_host_id = 0;
@@ -42,7 +43,7 @@ _create_host_id(void)
   return host_id.id;
 }
 
-void
+gboolean
 host_id_init(PersistState *state)
 {
   gsize size;
@@ -59,6 +60,12 @@ host_id_init(PersistState *state)
       handle = persist_state_alloc_entry(state, HOST_ID_PERSIST_KEY, sizeof(HostIdState));
     }
 
+  if (!handle)
+    {
+      msg_error("host-id: could not allocate persist state");
+      return FALSE;
+    }
+
   host_id_state = persist_state_map_entry(state, handle);
   {
     if (new_host_id_required)
@@ -72,6 +79,8 @@ host_id_init(PersistState *state)
       }
   }
   persist_state_unmap_entry(state, handle);
+
+  return TRUE;
 }
 
 guint32

--- a/lib/host-id.h
+++ b/lib/host-id.h
@@ -35,7 +35,7 @@ typedef struct _HostIdState
   guint32 host_id;
 } HostIdState;
 
-void host_id_init(PersistState *state);
+gboolean host_id_init(PersistState *state);
 void host_id_deinit(void);
 guint32 host_id_get(void);
 void host_id_append_formatted_id(GString *str, guint32 id);

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -527,7 +527,10 @@ error:
       if (new_state_handle)
         log_proto_buffered_server_apply_state(self, new_state_handle, persist_name);
       else
-        self->state1 = new_state;
+        {
+          self->persist_state = NULL;
+          self->state1 = new_state;
+        }
     }
   if (new_state_handle)
     {

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -186,6 +186,8 @@ main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
   gboolean success;
 
   cfg->state = persist_state_new(persist_filename);
+  persist_state_set_global_error_handler(cfg->state, (gpointer)main_loop_exit, (gpointer)main_loop_get_instance());
+
   if (!persist_state_start(cfg->state))
     return FALSE;
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -190,9 +190,11 @@ main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
 
   if (!persist_state_start(cfg->state))
     return FALSE;
+  if (!run_id_init(cfg->state))
+    return FALSE;
+  if (!host_id_init(cfg->state))
+    return FALSE;
 
-  run_id_init(cfg->state);
-  host_id_init(cfg->state);
   success = cfg_init(cfg);
 
   if (success)

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -26,6 +26,8 @@
 #include "serialize.h"
 #include "messages.h"
 #include "fdhelpers.h"
+#include "misc.h"
+#include "mainloop.h"
 
 #include <sys/types.h>
 #include <unistd.h>
@@ -33,6 +35,7 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include <string.h>
+#include <signal.h>
 
 typedef struct _PersistFileHeader
 {
@@ -59,6 +62,7 @@ typedef struct _PersistFileHeader
 
 #define PERSIST_FILE_INITIAL_SIZE 16384
 #define PERSIST_STATE_KEY_BLOCK_SIZE 4096
+#define PERSIST_FILE_WATERMARK 4096
 
 /*
  * The syslog-ng persistent state is a set of name-value pairs,
@@ -174,6 +178,26 @@ _wait_until_map_release(PersistState *self)
 }
 
 static gboolean
+_increase_file_size(PersistState *self, guint32 new_size)
+{
+  gboolean result = TRUE;
+  ssize_t length = new_size - self->current_size;
+  gchar *pad_buffer = g_new0(gchar, length);
+  ssize_t rc = pwrite(self->fd, pad_buffer, length, self->current_size);
+  if (rc != length)
+    {
+      msg_error("Can't grow the persist file",
+                evt_tag_int("old_size", self->current_size),
+                evt_tag_int("new_size", new_size),
+                evt_tag_str("error", rc < 0 ? g_strerror(errno) : "short write"),
+                NULL);
+      result = FALSE;
+    }
+  g_free(pad_buffer);
+  return result;
+}
+
+static gboolean
 _grow_store(PersistState *self, guint32 new_size)
 {
   int pgsize = getpagesize();
@@ -188,12 +212,9 @@ _grow_store(PersistState *self, guint32 new_size)
 
   if (new_size > self->current_size)
     {
-      gchar zero = 0;
+      if (!_increase_file_size(self, new_size))
+        goto exit;
 
-      if (lseek(self->fd, new_size - 1, SEEK_SET) < 0)
-        goto exit;
-      if (write(self->fd, &zero, 1) != 1)
-        goto exit;
       if (self->current_map)
         munmap(self->current_map, self->current_size);
       self->current_size = new_size;
@@ -237,6 +258,18 @@ _commit_store(PersistState *self)
   return rename(self->temp_filename, self->committed_filename) >= 0;
 }
 
+static gboolean
+_check_watermark(PersistState *self)
+{
+  return (self->current_ofs + PERSIST_FILE_WATERMARK < self->current_size);
+}
+
+static inline gboolean
+_check_free_space(PersistState *self, guint32 size)
+{
+  return (size + sizeof(PersistValueHeader) +  self->current_ofs) <= self->current_size;
+}
+
 /* "value" layer that handles memory block allocation in the file, without working with keys */
 
 static PersistEntryHandle
@@ -250,11 +283,11 @@ _alloc_value(PersistState *self, guint32 orig_size, gboolean in_use, guint8 vers
   if ((size & 0x7))
     size = ((size >> 3) + 1) << 3;
 
-  if (self->current_ofs + size + sizeof(PersistValueHeader) > self->current_size)
-    {
-      if (!_grow_store(self, self->current_size + sizeof(PersistValueHeader) + size))
-        return 0;
-    }
+  /*
+   * The pre-allocated size should be enough (min PERSIST_FILE_WATERMARK)
+   * if not we should assert here
+   */
+  g_assert(_check_free_space(self, size));
 
   result = self->current_ofs + sizeof(PersistValueHeader);
 
@@ -266,6 +299,15 @@ _alloc_value(PersistState *self, guint32 orig_size, gboolean in_use, guint8 vers
   persist_state_unmap_entry(self, self->current_ofs);
 
   self->current_ofs += size + sizeof(PersistValueHeader);
+
+  if (!_check_watermark(self) && !_grow_store(self, self->current_size + PERSIST_FILE_INITIAL_SIZE))
+    {
+      msg_error("Can't preallocate space for persist file",
+                evt_tag_int("current", self->current_size),
+                evt_tag_int("new_size", self->current_size + PERSIST_FILE_INITIAL_SIZE));
+      main_loop_exit();
+    }
+
   return result;
 }
 

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -295,11 +295,11 @@ _alloc_value(PersistState *self, guint32 orig_size, gboolean in_use, guint8 vers
   if ((size & 0x7))
     size = ((size >> 3) + 1) << 3;
 
-  /*
-   * The pre-allocated size should be enough (min PERSIST_FILE_WATERMARK)
-   * if not we should assert here
-   */
-  g_assert(_check_free_space(self, size));
+  if (!_check_free_space(self, size))
+    {
+      msg_error("No more free space exhausted in persist file", NULL);
+      return 0;
+    }
 
   result = self->current_ofs + sizeof(PersistValueHeader);
 

--- a/lib/persist-state.h
+++ b/lib/persist-state.h
@@ -59,4 +59,7 @@ void persist_state_cancel(PersistState *self);
 PersistState *persist_state_new(const gchar *filename);
 void persist_state_free(PersistState *self);
 
+void persist_state_set_global_error_handler(PersistState *self, void (*handler)(gpointer user_data),
+                                            gpointer user_data);
+
 #endif

--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -26,6 +26,7 @@
 #include "run-id.h"
 #include "persistable-state-header.h"
 #include "str-format.h"
+#include "messages.h"
 
 #define RUN_ID_PERSIST_KEY "run_id"
 
@@ -37,7 +38,7 @@ typedef struct _RunIDState
   gint run_id;
 } RunIDState;
 
-void
+gboolean
 run_id_init(PersistState *state)
 {
   gsize size;
@@ -52,12 +53,20 @@ run_id_init(PersistState *state)
       handle = persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState) );
     }
 
+  if (!handle)
+    {
+      msg_error("run-id: could not allocate persist state");
+      return FALSE;
+    }
+
   run_id_state = persist_state_map_entry(state, handle);
 
   run_id_state->run_id++;
   cached_run_id = run_id_state->run_id;
 
   persist_state_unmap_entry(state, handle);
+
+  return TRUE;
 };
 
 int

--- a/lib/run-id.h
+++ b/lib/run-id.h
@@ -27,7 +27,7 @@
 #define _RUN_ID_H
 #include "persist-state.h"
 
-void run_id_init(PersistState *state);
+gboolean run_id_init(PersistState *state);
 void run_id_deinit(void);
 int run_id_get(void);
 gboolean run_id_is_same_run(gint other_run_id);


### PR DESCRIPTION
Continuing https://github.com/balabit/syslog-ng/pull/717 in a new PR due that I do not have write access to the original PR. Credits for @juhaszviktor for the investigation and putting together the original pr!
Fixes: #716 

As I see the only thing left to do was to inverse the dependency between persist_state and mainloop. This is fixed here.

However, I ran into another problem while testing: 
Test: created a small tmpfs mountpoint for the persist state. Setting wildcard-file source and creating a lot of files with very long names, waiting for crash.

It turned out syslog-ng crashed for another reason:
```
ERROR:../syslog-ng/lib/persist-state.c:295:_alloc_value: assertion failed: (_check_free_space(self, size))
[1]    22773 abort (core dumped)  ./syslog-ng -Fe -R tmpfs/persist.file
```
The idea was that syslog-ng preallocates a fixed sized space that we ensure it is mapped. When syslog-ng sees that the free space is getting low, (less than 4K), then tries to expand the persist file. But still free space is available in the preallocated space, so we can still return with a **valid** handler. But the problem is syslog-ng is not stopped instantly when calling main_loop_exit() (it is possible that halt can be deferred infinitely), so there can be more persist state allocation requests until syslog-ng stops, filling up the preallocated space, until all space is exhausted, crashing in the assert.

So instead, if there is no free space, I try to return with zero handler, as the original implementation did, which would mean the allocation failed for the caller modules. But until the reserved space exhausted we can still return a return **valid** handler.

Though this led to another kind of crash: due that the caller sites were not ready for such allocation failures. In my specific case:
```
ERROR:../syslog-ng/lib/logproto/logproto-buffered-server.c:47:log_proto_buffered_server_get_state: assertion failed: (self->persist_handle != 0)
```

So a little correction is needed on the caller sites. Please check the last patch for reference. For the run-id and host-id modules: I could not trigger the crash, so I just ended up adding a g_assert for handle. However if you feel the necessity, we can add an in-memory storage for these modules too, something similar that happens with self->persist_state vs self->state1 in LogProtoBufferedServer.

An alternative for the situation could have been that if persist_state could not grow, she could allocate an in-memory-only buffer and return a handler with that. My problem was with it is that it would mean we could not ensure persist_state is persistent any more, which would be strange. Also memory allocation could fail as well. That's why I opted the solution explained above.