### PR TITLE
Templates: Change ref_cnt type to GAtomic

### DIFF
--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -227,7 +227,7 @@ log_template_new(GlobalConfig *cfg, const gchar *name)
   LogTemplate *self = g_new0(LogTemplate, 1);
 
   log_template_set_name(self, name);
-  self->ref_cnt = 1;
+  g_atomic_counter_set(&self->ref_cnt, 1);
   self->cfg = cfg;
   g_static_mutex_init(&self->arg_lock);
   return self;
@@ -256,8 +256,8 @@ log_template_ref(LogTemplate *s)
 {
   if (s)
     {
-      g_assert(s->ref_cnt > 0);
-      s->ref_cnt++;
+      g_assert(g_atomic_counter_get(&s->ref_cnt) > 0);
+      g_atomic_counter_inc(&s->ref_cnt);
     }
   return s;
 }
@@ -267,8 +267,8 @@ log_template_unref(LogTemplate *s)
 {
   if (s)
     {
-      g_assert(s->ref_cnt > 0);
-      if (--s->ref_cnt == 0)
+      g_assert(g_atomic_counter_get(&s->ref_cnt) > 0);
+      if (g_atomic_counter_dec_and_test(&s->ref_cnt))
         log_template_free(s);
     }
 }

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -29,6 +29,7 @@
 #include "common-template-typedefs.h"
 #include "timeutils.h"
 #include "type-hinting.h"
+#include "atomic.h"
 
 #define LTZ_LOCAL 0
 #define LTZ_SEND  1
@@ -56,7 +57,7 @@ typedef enum
 /* structure that represents an expandable syslog-ng template */
 typedef struct _LogTemplate
 {
-  gint ref_cnt;
+  GAtomicCounter ref_cnt;
   gchar *name;
   gchar *template;
   GList *compiled_template;


### PR DESCRIPTION
 * The variable was changed twice between unref and ref

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>

ref_cnt in templates.c was used in non-atomic way, this can cause the crash in #1773. 
Thanks the tip for @MrAnno 

Investigation:
 * With the following modification I discover how the ref_cnt changed in log_template_ref() and log_template_unref() during the reproduction from #1773 
 * modification
```
--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -28,6 +28,9 @@
 #include "template/escaping.h"
 #include "cfg.h"
 
+#include <sys/types.h>
+#include <sys/syscall.h>
+
 static void
 log_template_reset_compiled(LogTemplate *self)
 {
@@ -256,8 +259,11 @@ log_template_ref(LogTemplate *s)
 {
   if (s)
     {
+      pid_t thread_id = syscall(__NR_gettid);
+      printf("log_template_ref - before inc, ref_cnt: %d, %s, %d\n", s->ref_cnt, s->template, thread_id);
       g_assert(s->ref_cnt > 0);
       s->ref_cnt++;
+      printf("log_template_ref - after inc, ref_cnt: %d, %s, %d\n", s->ref_cnt, s->template, thread_id);
     }
   return s;
 }
@@ -267,7 +273,9 @@ log_template_unref(LogTemplate *s)
 {
   if (s)
     {
+      pid_t thread_id = syscall(__NR_gettid);
       g_assert(s->ref_cnt > 0);
+      printf("log_template_unref - before dec, ref_cnt: %d, %s, %d\n", s->ref_cnt, s->template, thread_id);
       if (--s->ref_cnt == 0)
         log_template_free(s);
     }
```
 * result, shows that between log_template_unref() and log_template_ref() the ref_cnt variable changed twice: 2<->0
```
...
log_template_ref - after inc, ref_cnt: 2, ${MESSAGE}, 26112
log_template_unref - before dec, ref_cnt: 2, ${MESSAGE}, 26112
log_template_ref - before inc, ref_cnt: 1, ${MESSAGE}, 26112
log_template_ref - after inc, ref_cnt: 2, ${MESSAGE}, 26112
log_template_unref - before dec, ref_cnt: 2, ${MESSAGE}, 26112
log_template_ref - after inc, ref_cnt: 2, ${MESSAGE}, 26114
log_template_ref - before inc, ref_cnt: 1, ${MESSAGE}, 26112
log_template_ref - after inc, ref_cnt: 2, ${MESSAGE}, 26112
log_template_unref - before dec, ref_cnt: 1, ${MESSAGE}, 26114
log_template_unref - before dec, ref_cnt: 2, ${MESSAGE}, 26112
log_template_ref - before inc, ref_cnt: 0, , , 26112
**
ERROR:../lib/template/templates.c:264:log_template_ref: assertion failed: (s->ref_cnt > 0)
```

