### PR TITLE
App parser kill switch

### DIFF
--- a/lib/cfg-args.h
+++ b/lib/cfg-args.h
@@ -31,6 +31,7 @@ typedef struct _CfgArgs CfgArgs;
 
 /* argument list for a block generator */
 gboolean cfg_args_validate(CfgArgs *self, CfgArgs *defs, const gchar *context);
+gchar *cfg_args_format_varargs(CfgArgs *self, CfgArgs *defaults);
 void cfg_args_set(CfgArgs *self, const gchar *name, const gchar *value);
 const gchar *cfg_args_get(CfgArgs *self, const gchar *name);
 void cfg_args_foreach(CfgArgs *self, GHFunc func, gpointer user_data);

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -46,29 +46,6 @@ struct _CfgBlock
   CfgArgs *arg_defs;
 };
 
-static void
-_resolve_unknown_blockargs_as_varargs(gpointer key, gpointer value, gpointer user_data)
-{
-  CfgArgs *defs = ((gpointer *) user_data)[0];
-  GString *varargs = ((gpointer *) user_data)[1];
-
-  if (cfg_args_get(defs, key) == NULL)
-    {
-      g_string_append_printf(varargs, "%s(%s) ", (gchar *)key, (gchar *)value);
-    }
-}
-
-static void
-_fill_varargs(CfgBlock *block, CfgArgs *args)
-{
-  GString *varargs = g_string_new("");
-  gpointer user_data[] = { block->arg_defs, varargs };
-
-  cfg_args_foreach(args, _resolve_unknown_blockargs_as_varargs, user_data);
-  cfg_args_set(args, "__VARARGS__", varargs->str);
-  g_string_free(varargs, TRUE);
-}
-
 /*
  * cfg_block_generate:
  *
@@ -84,7 +61,7 @@ cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GStri
   gsize length;
   GError *error = NULL;
 
-  _fill_varargs(self, args);
+  cfg_args_set(args, "__VARARGS__", cfg_args_format_varargs(args, self->arg_defs));
 
   value = cfg_lexer_subst_args_in_input(cfg->globals, self->arg_defs, args, self->content, -1, &length, &error);
   if (!value)

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -26,6 +26,7 @@
 #include "cfg-grammar.h"
 
 #include <string.h>
+#include <stdlib.h>
 
 extern int main_debug;
 
@@ -364,5 +365,13 @@ cfg_process_flag(CfgFlagHandler *handlers, gpointer base, const gchar *flag_)
             }
         }
     }
+  return FALSE;
+}
+
+gboolean
+cfg_process_yesno(const gchar *yesno)
+{
+  if (strcasecmp(yesno, "yes") == 0 || atoi(yesno) > 0)
+    return TRUE;
   return FALSE;
 }

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -65,8 +65,8 @@ typedef struct _CfgFlagHandler
   guint32 mask;
 } CfgFlagHandler;
 
-gboolean
-cfg_process_flag(CfgFlagHandler *handlers, gpointer base, const gchar *flag);
+gboolean cfg_process_flag(CfgFlagHandler *handlers, gpointer base, const gchar *flag);
+gboolean cfg_process_yesno(const gchar *yesno);
 
 
 extern CfgParser main_parser;

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -32,6 +32,9 @@ typedef struct _AppParserGenerator
   CfgBlockGenerator super;
   GString *block;
   const gchar *topic;
+  const gchar *included_apps;
+  const gchar *excluded_apps;
+  gboolean is_parsing_enabled;
 } AppParserGenerator;
 
 static const gchar *
@@ -75,12 +78,35 @@ _generate_action(AppParserGenerator *self, Application *app)
   g_string_append(self->block, "    flags(final);\n");
 }
 
+static gboolean
+_is_application_included(AppParserGenerator *self, Application *app)
+{
+  /* include everything if we don't have the option */
+  if (!self->included_apps)
+    return TRUE;
+  return strstr(self->included_apps, app->name) != NULL;
+}
+
+static gboolean
+_is_application_excluded(AppParserGenerator *self, Application *app)
+{
+  if (!self->excluded_apps)
+    return FALSE;
+  return strstr(self->excluded_apps, app->name) != NULL;
+}
+
 static void
 _generate_application(Application *app, Application *base_app, gpointer user_data)
 {
   AppParserGenerator *self = (AppParserGenerator *) user_data;
 
   if (strcmp(self->topic, app->topic) != 0)
+    return;
+
+  if (!_is_application_included(self, app))
+    return;
+
+  if (_is_application_excluded(self, app))
     return;
 
   g_string_append(self->block, "channel {\n");
@@ -97,16 +123,6 @@ _generate_applications(AppParserGenerator *self, AppModelContext *appmodel)
   appmodel_context_iter_applications(appmodel, _generate_application, self);
 }
 
-static gboolean
-_is_parsing_enabled(CfgArgs *args)
-{
-  const gchar *v = cfg_args_get(args, "auto-parse");
-
-  if (!v)
-    return TRUE;
-
-  return cfg_process_yesno(v);
-}
 
 static void
 _generate_framing(AppParserGenerator *self, AppModelContext *appmodel)
@@ -128,21 +144,76 @@ _generate_empty_frame(AppParserGenerator *self)
 }
 
 static gboolean
-_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result)
+_parse_auto_parse_arg(AppParserGenerator *self, CfgArgs *args)
 {
-  AppParserGenerator *self = (AppParserGenerator *) s;
-  AppModelContext *appmodel = appmodel_get_context(cfg);
+  const gchar *v = cfg_args_get(args, "auto-parse");
 
-  g_assert(args != NULL);
+  if (v)
+    self->is_parsing_enabled = cfg_process_yesno(v);
+  else
+    self->is_parsing_enabled = TRUE;
+  return TRUE;
+}
+
+static gboolean
+_parse_auto_parse_exclude_arg(AppParserGenerator *self, CfgArgs *args)
+{
+  const gchar *v = cfg_args_get(args, "auto-parse-exclude");
+  if (!v)
+    return TRUE;
+  self->excluded_apps = g_strdup(v);
+  return TRUE;
+}
+
+static gboolean
+_parse_auto_parse_include_arg(AppParserGenerator *self, CfgArgs *args)
+{
+  const gchar *v = cfg_args_get(args, "auto-parse-include");
+  if (!v)
+    return TRUE;
+  self->included_apps = g_strdup(v);
+  return TRUE;
+}
+
+static gboolean
+_parse_topic_arg(AppParserGenerator *self, CfgArgs *args)
+{
   self->topic = cfg_args_get(args, "topic");
   if (!self->topic)
     {
       msg_error("app-parser() requires a topic() argument");
       return FALSE;
     }
+  return TRUE;
+}
+
+static gboolean
+_parse_arguments(AppParserGenerator *self, CfgArgs *args)
+{
+  g_assert(args != NULL);
+
+  if (!_parse_topic_arg(self, args))
+    return FALSE;
+  if (!_parse_auto_parse_arg(self, args))
+    return FALSE;
+  if (!_parse_auto_parse_exclude_arg(self, args))
+    return FALSE;
+  if (!_parse_auto_parse_include_arg(self, args))
+    return FALSE;
+  return TRUE;
+}
+
+static gboolean
+_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result)
+{
+  AppParserGenerator *self = (AppParserGenerator *) s;
+  AppModelContext *appmodel = appmodel_get_context(cfg);
+
+  if (!_parse_arguments(self, args))
+    return FALSE;
 
   self->block = result;
-  if (_is_parsing_enabled(args))
+  if (self->is_parsing_enabled)
     _generate_framing(self, appmodel);
   else
     _generate_empty_frame(self);

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -317,19 +317,23 @@ system_generate_system_transports(GString *sysblock)
 }
 
 static void
-system_generate_app_parser(GlobalConfig *cfg, GString *sysblock)
+system_generate_app_parser(GlobalConfig *cfg, GString *sysblock, CfgArgs *args)
 {
-  g_string_append(sysblock,
-                  "channel {\n"
-                  "  channel {\n"
-                  "    parser {\n"
-                  "      app-parser(topic(system-unix));\n"
-                  "      app-parser(topic(syslog));\n"
-                  "    };\n"
-                  "    flags(final);\n"
-                  "  };\n"
-                  "  channel { flags(final); };\n"
-                  "};\n");
+  gchar *varargs = cfg_args_format_varargs(args, NULL);
+
+  g_string_append_printf(sysblock,
+                         "channel {\n"
+                         "  channel {\n"
+                         "    parser {\n"
+                         "      app-parser(topic(system-unix) %s);\n"
+                         "      app-parser(topic(syslog) %s);\n"
+                         "    };\n"
+                         "    flags(final);\n"
+                         "  };\n"
+                         "  channel { flags(final); };\n"
+                         "};\n",
+                         varargs, varargs);
+  g_free(varargs);
 }
 
 static gboolean
@@ -348,7 +352,7 @@ system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args
 
   g_string_append(sysblock, "    }; # source\n");
 
-  system_generate_app_parser(cfg, sysblock);
+  system_generate_app_parser(cfg, sysblock, args);
 
   g_string_append(sysblock, "}; # channel\n");
   result = TRUE;

--- a/scl/default-network-drivers/plugin.conf
+++ b/scl/default-network-drivers/plugin.conf
@@ -41,7 +41,7 @@ block source default-network-drivers(
 				flags(no-parse, `flags`));
 		};
 		channel {
-			parser { app-parser(topic(syslog-raw)); };
+			parser { app-parser(topic(syslog-raw) `__VARARGS__`); };
 			flags(final);
 		};
 		channel {
@@ -53,7 +53,7 @@ block source default-network-drivers(
 				flags(final);
 			};
 			channel {
-				parser { app-parser(topic(syslog)); };
+				parser { app-parser(topic(syslog) `__VARARGS__`); };
 				flags(final);
 			};
 			channel {
@@ -76,7 +76,7 @@ block source default-network-drivers(
 	                       log-msg-size(`log-msg-size`));
 		};
 		channel {
-			parser { app-parser(topic(syslog)); };
+			parser { app-parser(topic(syslog) `__VARARGS__`); };
 			flags(final);
 		};
 		channel {


### PR DESCRIPTION
This patch implements auto-parse(yes/no) option into

- the app-paser()
- and through the use of __VARARGS__ system() and default-network-drivers()

this was requested by @czanik 
