### PR TITLE
Rewrite/add template-related unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ add_subdirectory(modules)
 add_subdirectory(scripts)
 add_subdirectory(syslog-ng)
 add_subdirectory(syslog-ng-ctl)
-add_subdirectory(libtest)
+add_test_subdirectory(libtest)
 add_subdirectory(tests)
 
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/syslog-ng-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/syslog-ng-config.h)

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,7 @@ endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest $(AM_CFLAGS)
 
-TEST_LDADD		= $(top_builddir)/libtest/libsyslog-ng-test.a \
+TEST_LDADD		= $(LIBTEST_LIBS) \
 			  $(top_builddir)/lib/libsyslog-ng.la \
 			  $(TOOL_DEPS_LIBS)
 
@@ -164,7 +164,9 @@ $(install_moduleLTLIBRARIES): install-libLTLIBRARIES
 
 include Mk/lex-rules.am
 include Mk/Makefile.am
+if ENABLE_TESTING
 include libtest/Makefile.am
+endif
 include lib/Makefile.am
 include modules/Makefile.am
 include syslog-ng/Makefile.am

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -302,4 +302,6 @@ endif
 
 .PHONY: lib/ libsyslog-ng ivykis lib/ivykis/ lib/jsonc/ jsonc
 
+if ENABLE_TESTING
 include lib/tests/Makefile.am
+endif

--- a/lib/template/tests/CMakeLists.txt
+++ b/lib/template/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_unit_test(LIBTEST TARGET test_template_compile)
 add_unit_test(LIBTEST TARGET test_template_on_error)
-add_unit_test(LIBTEST TARGET test_template DEPENDS syslogformat basicfuncs)
-add_unit_test(LIBTEST TARGET test_template_speed DEPENDS syslogformat basicfuncs)
+add_unit_test(LIBTEST CRITERION TARGET test_template DEPENDS syslogformat basicfuncs)
+add_unit_test(LIBTEST CRITERION TARGET test_template_speed DEPENDS syslogformat basicfuncs)

--- a/lib/template/tests/Makefile.am
+++ b/lib/template/tests/Makefile.am
@@ -22,5 +22,7 @@ lib_template_tests_test_template_LDADD		= \
 	$(PREOPEN_SYSLOGFORMAT)		\
 	$(PREOPEN_BASICFUNCS)
 
-lib_template_tests_test_template_speed_LDADD	= \
-	$(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT)
+
+lib_template_tests_test_template_speed_CFLAGS = $(TEST_CFLAGS)
+lib_template_tests_test_template_speed_LDADD = \
+	$(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(PREOPEN_BASICFUNCS)

--- a/lib/template/tests/test_template_speed.c
+++ b/lib/template/tests/test_template_speed.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2014 Balabit
+ * Copyright (c) 2009-2018 Balabit
  * Copyright (c) 2009-2014 Balázs Scheidler <balazs.scheidler@balabit.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -22,27 +22,16 @@
  *
  */
 
+#include <criterion/criterion.h>
+
 #include "syslog-ng.h"
-#include "logmsg/logmsg.h"
-#include "template/templates.h"
 #include "apphook.h"
 #include "cfg.h"
-#include "timeutils.h"
-#include "plugin.h"
-#include "libtest/template_lib.h"
+#include "libtest/cr_template.h"
 #include "libtest/stopwatch.h"
 
-#include <time.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
-gboolean success = TRUE;
-
-int
-main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+Test(template_speed, test_template_speed)
 {
-
   app_startup();
 
   init_template_tests();
@@ -69,8 +58,4 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   perftest_template("$DATE ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} $MSG\n");
 
   app_shutdown();
-
-  if (success)
-    return 0;
-  return 1;
 }

--- a/libtest/CMakeLists.txt
+++ b/libtest/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LIBTEST_HEADERS
     proto_lib.h
     queue_utils_lib.h
     stopwatch.h
-    template_lib.h
+    cr_template.h
     testutils.h
 )
 
@@ -19,12 +19,11 @@ set(LIBTEST_SOURCES
     proto_lib.c
     queue_utils_lib.c
     stopwatch.c
-    template_lib.c
+    cr_template.c
     testutils.c
 )
 
 add_library(libtest STATIC ${LIBTEST_SOURCES})
-target_link_libraries(libtest syslog-ng)
+target_link_libraries(libtest syslog-ng ${CRITERION_LIBRARIES})
 target_include_directories(libtest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/libtest}")
 target_include_directories(libtest PRIVATE "${CORE_INCLUDE_DIRS}")
-

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -14,8 +14,7 @@ libtest_libsyslog_ng_test_a_SOURCES =   \
 	libtest/stopwatch.h		\
 	libtest/msg_parse_lib.c		\
 	libtest/msg_parse_lib.h		\
-	libtest/template_lib.c		\
-	libtest/template_lib.h		\
+	libtest/cr_template.c		\
 	libtest/proto_lib.c		\
 	libtest/proto_lib.h		\
 	libtest/persist_lib.h		\
@@ -30,10 +29,12 @@ libtest_libsyslog_ng_test_a_SOURCES =   \
 libtestinclude_HEADERS		    =	\
 	libtest/testutils.h		\
 	libtest/msg_parse_lib.h		\
-	libtest/template_lib.h		\
+	libtest/cr_template.h		\
 	libtest/proto_lib.h		\
 	libtest/persist_lib.h		\
 	libtest/mock-transport.h
 
 pkgconfig_DATA			   +=	\
 	libtest/syslog-ng-test.pc
+
+LIBTEST_LIBS = $(top_builddir)/libtest/libsyslog-ng-test.a

--- a/libtest/cr_template.h
+++ b/libtest/cr_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2015 Balabit
+ * Copyright (c) 2012-2018 Balabit
  * Copyright (c) 2012 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
@@ -22,12 +22,15 @@
  *
  */
 
-#ifndef LIBTEST_TEMPLATE_LIB_H_INCLUDED
-#define LIBTEST_TEMPLATE_LIB_H_INCLUDED 1
+#ifndef LIBTEST_CR_TEMPLATE_H_INCLUDED
+#define LIBTEST_CR_TEMPLATE_H_INCLUDED 1
 
-#include "testutils.h"
+#include "syslog-ng.h"
 #include "template/templates.h"
+#include "msg-format.h"
 #include <stdarg.h>
+
+MsgFormatOptions parse_options;
 
 void assert_template_format(const gchar *template, const gchar *expected);
 void assert_template_format_msg(const gchar *template,

--- a/modules/basicfuncs/tests/CMakeLists.txt
+++ b/modules/basicfuncs/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST TARGET test_basicfuncs DEPENDS syslogformat basicfuncs)
+add_unit_test(LIBTEST CRITERION TARGET test_basicfuncs DEPENDS syslogformat basicfuncs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2015 Balabit
+ * Copyright (c) 2010-2018 Balabit
  * Copyright (c) 2010-2015 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -21,17 +21,20 @@
  *
  */
 
-#include "template_lib.h"
+#include <criterion/criterion.h>
+
+#include "libtest/cr_template.h"
 #include "apphook.h"
 #include "plugin.h"
 #include "cfg.h"
+#include "logmsg/logmsg.h"
 
 static void
 add_dummy_template_to_configuration(void)
 {
   LogTemplate *dummy = log_template_new(configuration, "dummy");
-  assert_true(log_template_compile(dummy, "dummy template expanded $HOST", NULL),
-              "Unexpected error compiling dummy template");
+  cr_assert(log_template_compile(dummy, "dummy template expanded $HOST", NULL),
+            "Unexpected error compiling dummy template");
   cfg_tree_add_template(&configuration->tree, dummy);
 }
 
@@ -66,7 +69,24 @@ free_log_message_array(GPtrArray *messages)
 }
 
 void
-test_cond_funcs(void)
+setup(void)
+{
+  app_startup();
+  init_template_tests();
+  add_dummy_template_to_configuration();
+  cfg_load_module(configuration, "basicfuncs");
+}
+
+void
+teardown(void)
+{
+  deinit_template_tests();
+  app_shutdown();
+}
+
+TestSuite(basicfuncs, .init = setup, .fini = teardown);
+
+Test(basicfuncs, test_cond_funcs)
 {
   assert_template_format_with_context("$(grep 'facility(local3)' $PID)", "23323,23323");
   assert_template_format_with_context("$(grep -m 1 'facility(local3)' $PID)", "23323");
@@ -107,8 +127,7 @@ test_cond_funcs(void)
   assert_template_format_with_context("$(or)", "");
 }
 
-void
-test_str_funcs(void)
+Test(basicfuncs, test_str_funcs)
 {
   assert_template_format("$(ipv4-to-int $SOURCEIP)", "168496141");
 
@@ -163,8 +182,7 @@ test_str_funcs(void)
   assert_template_format_with_len("$(binary 0xFF 0x00 0x40)", "\xFF\000@", 3);
 }
 
-void
-test_numeric_funcs(void)
+Test(basicfuncs, test_numeric_funcs)
 {
   assert_template_format("$(+ $FACILITY_NUM 1)", "20");
   assert_template_format("$(+ -1 -1)", "-2");
@@ -183,8 +201,7 @@ test_numeric_funcs(void)
   assert_template_format("$(- 10000000000 5000000000)", "5000000000");
 }
 
-void
-test_fname_funcs(void)
+Test(basicfuncs, test_fname_funcs)
 {
   assert_template_format("$(basename foo)", "foo");
   assert_template_format("$(basename /foo/bar)", "bar");
@@ -192,7 +209,7 @@ test_fname_funcs(void)
 
   assert_template_format("$(dirname foo)", ".");
   assert_template_format("$(dirname /foo/bar)", "/foo");
-  assert_template_format("$(dirname /foo/bar/)", "/foo");
+  assert_template_format("$(dirname /foo/bar/)", "/foo/bar");
   assert_template_format("$(dirname /foo/bar/baz)", "/foo/bar");
 }
 
@@ -215,8 +232,7 @@ _test_macros_with_context(const gchar *id, const gchar *numbers[], const MacroAn
   free_log_message_array(messages);
 }
 
-void
-test_numeric_aggregate_simple(void)
+Test(basicfuncs, test_numeric_aggregate_simple)
 {
   _test_macros_with_context(
     "NUMBER", (const gchar *[])
@@ -232,8 +248,7 @@ test_numeric_aggregate_simple(void)
   });
 }
 
-void
-test_numeric_aggregate_invalid_values(void)
+Test(basicfuncs, test_numeric_aggregate_invalid_values)
 {
   _test_macros_with_context(
     "NUMBER", (const gchar *[])
@@ -249,8 +264,7 @@ test_numeric_aggregate_invalid_values(void)
   });
 }
 
-void
-test_numeric_aggregate_full_invalid_values(void)
+Test(basicfuncs, test_numeric_aggregate_full_invalid_values)
 {
   _test_macros_with_context(
     "NUMBER", (const gchar *[])
@@ -266,16 +280,7 @@ test_numeric_aggregate_full_invalid_values(void)
   });
 }
 
-void
-test_numeric_aggregate_funcs(void)
-{
-  test_numeric_aggregate_simple();
-  test_numeric_aggregate_invalid_values();
-  test_numeric_aggregate_full_invalid_values();
-}
-
-void
-test_misc_funcs(void)
+Test(basicfuncs, test_misc_funcs)
 {
   unsetenv("OHHELLO");
   setenv("TEST_ENV", "test-env", 1);
@@ -284,15 +289,13 @@ test_misc_funcs(void)
   assert_template_format("$(env TEST_ENV)", "test-env");
 }
 
-static void
-test_tf_template(void)
+Test(basicfuncs, test_tf_template)
 {
   assert_template_format("foo $(template dummy) bar", "foo dummy template expanded bzorp bar");
   assert_template_failure("foo $(template unknown) bar", "Unknown template function or template \"unknown\"");
 }
 
-static void
-test_list_funcs(void)
+Test(basicfuncs, test_list_funcs)
 {
   assert_template_format("$(list-concat)", "");
   assert_template_format("$(list-concat foo bar baz)", "foo,bar,baz");
@@ -370,8 +373,7 @@ test_list_funcs(void)
   assert_template_format("$(list-count foo,bar,xxx, baz bad)", "5");
 }
 
-void
-test_context_funcs(void)
+Test(basicfuncs, test_context_funcs)
 {
   assert_template_format_with_context("$(context-length)", "2");
 
@@ -382,25 +384,4 @@ test_context_funcs(void)
   assert_template_format_with_context("$(context-values ${PID})", "23323,23323");
   assert_template_format_with_context("$(context-values ${comma_value})",
                                       "\"value,with,a,comma\",\"value,with,a,comma\"");
-}
-
-int
-main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
-{
-  app_startup();
-  init_template_tests();
-  add_dummy_template_to_configuration();
-  cfg_load_module(configuration, "basicfuncs");
-
-  test_cond_funcs();
-  test_str_funcs();
-  test_numeric_funcs();
-  test_numeric_aggregate_funcs();
-  test_misc_funcs();
-  test_tf_template();
-  test_list_funcs();
-  test_context_funcs();
-
-  deinit_template_tests();
-  app_shutdown();
 }

--- a/modules/cef/tests/CMakeLists.txt
+++ b/modules/cef/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST TARGET test-format-cef-extension DEPENDS cef)
+add_unit_test(LIBTEST CRITERION TARGET test-format-cef-extension DEPENDS cef)

--- a/modules/cryptofuncs/tests/CMakeLists.txt
+++ b/modules/cryptofuncs/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST TARGET test_cryptofuncs DEPENDS cryptofuncs)
+add_unit_test(LIBTEST CRITERION TARGET test_cryptofuncs DEPENDS cryptofuncs)

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2015 Balabit
+ * Copyright (c) 2012-2018 Balabit
  * Copyright (c) 2012-2015 Balázs Scheidler <balazs.scheidler@balabit.com>
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -21,12 +21,30 @@
  *
  */
 
-#include "template_lib.h"
+#include <criterion/criterion.h>
+
+#include "libtest/cr_template.h"
 #include "apphook.h"
 #include "cfg.h"
 
 void
-test_hash(void)
+setup(void)
+{
+  app_startup();
+  init_template_tests();
+  cfg_load_module(configuration, "cryptofuncs");
+}
+
+void
+teardown(void)
+{
+  deinit_template_tests();
+  app_shutdown();
+}
+
+TestSuite(cryptofuncs, .init = setup, .fini = teardown);
+
+Test(cryptofuncs, test_hash)
 {
   assert_template_format("$(sha1 foo)", "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
   assert_template_format("$(sha1 bar)", "62cdb7020ff920e5aa642c3d4066950dd1f01f4d");
@@ -48,17 +66,4 @@ test_hash(void)
   assert_template_format("$(sha1 foo bar)", "8843d7f92416211de9ebb963ff4ce28125932878");
   assert_template_format("$(sha1 \"foo bar\")", "3773dea65156909838fa6c22825cafe090ff8030");
   assert_template_format("$(md5 $(sha1 foo) bar)", "196894290a831b2d2755c8de22619a97");
-}
-
-int
-main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
-{
-  app_startup();
-  init_template_tests();
-  cfg_load_module(configuration, "cryptofuncs");
-
-  test_hash();
-
-  deinit_template_tests();
-  app_shutdown();
 }

--- a/modules/graphite/CMakeLists.txt
+++ b/modules/graphite/CMakeLists.txt
@@ -4,8 +4,10 @@ set (GRAPHITE_SOURCES
     graphite-output.c
 )
 
-add_library(graphite MODULE ${GRAPHITE_SOURCES})
+add_library(graphite SHARED ${GRAPHITE_SOURCES})
 target_include_directories (graphite PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(graphite PRIVATE syslog-ng)
 
 install(TARGETS graphite LIBRARY DESTINATION lib/syslog-ng/ COMPONENT graphite)
+
+add_test_subdirectory(tests)

--- a/modules/graphite/Makefile.am
+++ b/modules/graphite/Makefile.am
@@ -21,3 +21,4 @@ modules/graphite mod-graphite: modules/graphite/libgraphite.la
 
 .PHONY: modules/graphite mod-graphite
 
+include modules/graphite/tests/Makefile.am

--- a/modules/graphite/tests/CMakeLists.txt
+++ b/modules/graphite/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(LIBTEST CRITERION TARGET test_graphite_output DEPENDS syslogformat graphite)

--- a/modules/graphite/tests/Makefile.am
+++ b/modules/graphite/tests/Makefile.am
@@ -1,0 +1,11 @@
+modules_graphite_tests_TESTS = \
+  modules/graphite/tests/test_graphite_output
+
+check_PROGRAMS       += ${modules_graphite_tests_TESTS}
+
+modules_graphite_tests_test_graphite_output_CFLAGS = $(TEST_CFLAGS)
+modules_graphite_tests_test_graphite_output_LDADD = $(TEST_LDADD)
+modules_graphite_tests_test_graphite_output_LDFLAGS = \
+  $(PREOPEN_SYSLOGFORMAT) \
+  -dlpreopen $(top_builddir)/modules/graphite/libgraphite.la
+modules_graphite_tests_test_graphite_output_DEPENDENCIES = $(top_builddir)/modules/graphite/libgraphite.la

--- a/modules/graphite/tests/test_graphite_output.c
+++ b/modules/graphite/tests/test_graphite_output.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+
+#include "libtest/cr_template.h"
+#include "apphook.h"
+#include "cfg.h"
+
+void
+setup(void)
+{
+  app_startup();
+  putenv("TZ=UTC");
+  tzset();
+  init_template_tests();
+  cfg_load_module(configuration, "graphite");
+}
+
+void
+teardown(void)
+{
+  deinit_template_tests();
+  app_shutdown();
+}
+
+TestSuite(graphite_output, .init = setup, .fini = teardown);
+
+Test(graphite_output, test_graphite_plaintext_proto_simple)
+{
+  assert_template_format("$(graphite-output local.random.diceroll=4)", "local.random.diceroll 4 1139684315\n");
+}
+
+Test(graphite_output, test_graphite_output_key)
+{
+  assert_template_format("$(graphite-output --key MESSAGE)", "MESSAGE árvíztűrőtükörfúrógép 1139684315\n");
+  assert_template_format("$(graphite-output --key APP.VALUE*)",
+                         "APP.VALUE value 1139684315\n"
+                         "APP.VALUE2 value 1139684315\n"
+                         "APP.VALUE3 value 1139684315\n"
+                         "APP.VALUE4 value 1139684315\n"
+                         "APP.VALUE5 value 1139684315\n"
+                         "APP.VALUE6 value 1139684315\n"
+                         "APP.VALUE7 value 1139684315\n");
+  assert_template_format("$(graphite-output local.value=${APP.VALUE})", "local.value value 1139684315\n");
+}
+
+Test(graphite_output, test_graphite_output_timestamp)
+{
+  assert_template_format("$(graphite-output --timestamp 123 x=y)", "x y 123\n");
+}

--- a/modules/json/tests/CMakeLists.txt
+++ b/modules/json/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_unit_test(LIBTEST TARGET test_format_json
+add_unit_test(LIBTEST CRITERION TARGET test_format_json
   DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})
 if (${JSONC_INTERNAL})
   add_dependencies(test_format_json JSONC)

--- a/modules/kvformat/tests/CMakeLists.txt
+++ b/modules/kvformat/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_unit_test(LIBTEST TARGET test_format_welf DEPENDS syslogformat kvformat)
+add_unit_test(LIBTEST CRITERION TARGET test_format_welf DEPENDS syslogformat kvformat)
 add_unit_test(LIBTEST TARGET test_linux_audit_scanner DEPENDS kvformat)
 add_unit_test(LIBTEST TARGET test_kv_parser DEPENDS kvformat)

--- a/modules/stardate/tests/CMakeLists.txt
+++ b/modules/stardate/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST TARGET test_stardate DEPENDS syslogformat stardate)
+add_unit_test(LIBTEST CRITERION TARGET test_stardate DEPENDS syslogformat stardate)

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -22,11 +22,14 @@
 
 #include <syslog-ng.h>
 #include <logmsg/logmsg.h>
-#include <template_lib.h>
+#include <cr_template.h>
 #include <apphook.h>
 #include <plugin.h>
 
 #include "cfg.h"
+
+#include <criterion/criterion.h>
+#include <stdlib.h>
 
 MsgFormatOptions parse_options;
 
@@ -47,8 +50,25 @@ stardate_assert(const gchar *msg_str, const int precision, const gchar *expected
   log_msg_unref(logmsg);
 }
 
+
 void
-test_stardate(void)
+setup(void)
+{
+  app_startup();
+  init_template_tests();
+  cfg_load_module(configuration, "stardate");
+}
+
+void
+teardown(void)
+{
+  deinit_template_tests();
+  app_shutdown();
+}
+
+TestSuite(stardate, .init = setup, .fini = teardown);
+
+Test(stardate, test_stardate)
 {
   stardate_assert("2012-07-15T00:00:00", 1, "2012.5"); // 2012.01.01 + 365/2 day
   stardate_assert("2013-07-01T00:00:00", 2, "2013.49");
@@ -59,18 +79,4 @@ test_stardate(void)
 
   stardate_assert("2017-01-01T00:00:00", 0, "2017");
   stardate_assert("2018-12-01T00:00:00", 0, "2018"); // No rounding up!
-}
-
-int
-main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
-{
-  app_startup();
-  init_template_tests();
-  cfg_load_module(configuration, "stardate");
-
-  test_stardate();
-
-  deinit_template_tests();
-  app_shutdown();
-  return 0;
 }

--- a/modules/tagsparser/tests/test_tagsparser.c
+++ b/modules/tagsparser/tests/test_tagsparser.c
@@ -25,7 +25,7 @@
 #include "tags-parser.h"
 #include "apphook.h"
 #include "msg_parse_lib.h"
-#include "template_lib.h"
+#include "libtest/cr_template.h"
 
 void
 setup(void)


### PR DESCRIPTION
This PR
- adds unit tests for the `$(graphite-output)` template function
- rewrites all template-related unit tests in Criterion

Resolves #268