### PR TITLE
dbld: add manpages to tarball

### DIFF
--- a/dbld/tarball
+++ b/dbld/tarball
@@ -7,7 +7,7 @@ VERSION=`cat VERSION`
 ./autogen.sh
 
 cd /build
-/source/configure
+/source/configure --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
 make dist
 
 echo "Your tarball is in /build, also available on the host in \$(top_srcdir)/dbld/build"


### PR DESCRIPTION
Fixes #1793

@czanik: Could you try it? ( `dbld/rules tarball` ) 

list of files in `doc/man`:
```
dqtool.1
dqtool.1.xml
loggen.1
loggen.1.xml
pdbtool.1
pdbtool.1.xml
syslog-ng.8
syslog-ng.8.xml
syslog-ng.conf.5
syslog-ng.conf.5.xml
syslog-ng-ctl.1
syslog-ng-ctl.1.xml
syslog-ng-debun.1
syslog-ng-debun.1.xml
```

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>