### PR TITLE
README.md:compile from source -> add missing step [skip-ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,13 @@ Releases and tarballs ready to compile are are made available at [GitHub][github
 
  [github-repo]: https://github.com/balabit/syslog-ng/releases
 
-To generate the configure script and compile from source:
-
-    $ ./autogen.sh
-
 After that, the usual drill applies (assuming you have
 the required dependencies):
 
     $ ./configure && make && make install
+
+If you don't have a configure script (because of cloning from git, for example),
+run `./autogen.sh` to generate it.
 
 Some of the functionality is compiled only in case the required
 development libraries are present. The configure script displays a

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Releases and tarballs ready to compile are are made available at [GitHub][github
 
  [github-repo]: https://github.com/balabit/syslog-ng/releases
 
-After that, the usual drill applies (assuming you have
+To compile from source, the usual drill applies (assuming you have
 the required dependencies):
 
     $ ./configure && make && make install

--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ Releases and tarballs ready to compile are are made available at [GitHub][github
 
  [github-repo]: https://github.com/balabit/syslog-ng/releases
 
-To compile from source, the usual drill applies (assuming you have
+To generate the configure script and compile from source:
+
+    $ ./autogen.sh
+
+After that, the usual drill applies (assuming you have
 the required dependencies):
 
     $ ./configure && make && make install


### PR DESCRIPTION
./autogen.sh needs to be run before trying to execute the configure
script. I mention it in this patch.

    Signed-off-by: Andy Alt
    <andy400-dev@yahoo.com>