### PR TITLE
debian: Drop the syslog-ng-abi-* virtual package

### DIFF
--- a/packaging/debian/README.source
+++ b/packaging/debian/README.source
@@ -56,27 +56,12 @@ to maintain the whole.
 
 Upstream builds a `libsyslog-ng-$MAJOR.so.$N` shared library, which we
 ship in `syslog-ng-core`, because it is not a general purpose library.
-We also want third party modules (like the ones in the Incubator) to
-not have overly strict dependencies on the syslog-ng version they were
-compiled against. Having to rebuild the Incubator on every syslog-ng
-upload would be a disaster.
-
-For this reason, `syslog-ng-core` provides
-`syslog-ng-abi-$MAJOR-$ABI`, where **$MAJOR** is the major version,
-and **$ABI** is the ABI version: the **$N** part of
-`libsyslog-ng-$MAJOR.so.$N`. Whenever upstream bumps the version, the
-**$ABI** variable in `debian/rules` needs to be bumped too.
-
-If upstream forgets to bump the version, but introduces an
-ABI-incompatible change, it should be bumped anyway, and dependent
-modules will need to be rebuilt.
 
 ### Control variables
 
 We have three custom control variables, which are referenced by
-`debian/control`: **${sng:CoreModules}**, **${sng:Modules}** and
-**${sng:ABI}}**. The first two will be used for dependencies, and last
-one will be used to provide an ABI version.
+`debian/control`: **${sng:CoreModules}**, and **${sng:Modules}**. They will be
+used for dependencies.
 
 The `syslog-ng` meta package has to depend on core modules, because at
 some point in the past, they were part of the monolithic `syslog-ng`
@@ -91,13 +76,7 @@ starting with `syslog-ng-mod-`.
 
 We use the `debian/tools/list-modules.sh` script to construct these
 lists for us, and in `debian/rules`, we override `dh_gencontrol` to
-pass these along, along with **${sng:ABI}**.
-
-The **${sng:ABI}** is used for module dependencies. To have a looser
-dependency for modules, so that third party (and Incubator) modules do
-not have to get recompiled for every single syslog-ng update, we track
-the ABI with a `Provides` field. Whenever the version of
-`libsyslog-ng.so` changes, the ABI version should be updated too.
+pass these along.
 
  -- Gergely Nagy <algernon@madhouse-project.org>  Fri, 07 Nov 2014 08:44:36 +0100
 

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -129,8 +129,7 @@ Multi-Arch: foreign
 Depends: ${shlibs:Depends}, ${misc:Depends}, util-linux (>= 2.12-10), lsb-base (>= 3.0-6)
 Recommends: logrotate
 Suggests: ${sng:CoreModules}, ${sng:Modules}
-Provides: system-log-daemon, linux-kernel-log-daemon, libsyslog-ng-dev,
- syslog-ng-abi-${sng:ABI}
+Provides: system-log-daemon, linux-kernel-log-daemon
 Conflicts: system-log-daemon, linux-kernel-log-daemon
 Replaces: syslog-ng (<< 3.3.0~), libsyslog-ng-dev
 Breaks: syslog-ng (<< 3.3.0~), libsyslog-ng-dev

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -36,11 +36,6 @@ endif
 # it out from the changelog instead.
 UMAJOR		   = $(shell dpkg-parsechangelog | sed -n '/^Version:/s/^Version: //p' | cut -d. -f1,2)
 
-# To better support the Incubator, and have looser dependencies, we
-# track the ABI version here. Whenever the soname of libsyslog-ng
-# changes, up this one too!
-ABI_VERSION	   = 3.13-0
-
 export DH_OPTIONS += -O-Bdebian/build-tree --dbg-package=syslog-ng-dbg
 
 CFLAGS		?= $(shell dpkg-buildflags --get CFLAGS)
@@ -163,16 +158,8 @@ override_dh_installlogcheck:
 # directory. On the other hand, we do want correct dependencies on
 # anything that build-depends on syslog-ng-dev, so lets make a correct
 # shlibs file for that, shall we?
-#
-# See the comment at the top of this file about ABI_VERSION, which
-# explains how the dependency is calculated.
 override_dh_makeshlibs:
-ifneq (,$(filter syslog-ng-core,$(shell dh_listpackages)))
-	dh_makeshlibs -V "syslog-ng-abi-${ABI_VERSION}" \
-		      -n -Xusr/lib/syslog-ng/${UMAJOR}
-else
 	dh_makeshlibs -n -Xusr/lib/syslog-ng/${UMAJOR}
-endif
 
 # Since syslog-ng depends on all the modules, and syslog-ng-core
 # suggests the same set, and modules can come and go as new versions
@@ -182,8 +169,7 @@ endif
 # part of syslog-ng (or it depended on them) previously, in 3.3.
 override_dh_gencontrol:
 	dh_gencontrol -- -Vsng:Modules=$(shell debian/tools/list-modules.sh optional) \
-			 -Vsng:CoreModules=$(shell debian/tools/list-modules.sh core) \
-			 -Vsng:ABI=${ABI_VERSION}
+			 -Vsng:CoreModules=$(shell debian/tools/list-modules.sh core)
 
 # Sadly, dh_python2 barfs on --dbg-package=, so we work it around by
 # clearing DH_OPTIONS here.


### PR DESCRIPTION
As the Incubator is being phased out, and there are no other third party modules of note, the virtual package was becoming not only unnecessary, but a burden too.

This drops it completely, re-introducing a tight dependency between syslog-ng-core and modules.
