### PR TITLE
Fix message corruption caused by a bug in the subst() rewrite rule

### DIFF
--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -547,13 +547,19 @@ log_matcher_pcre_re_feed_backrefs(LogMatcher *s, LogMessage *msg, gint value_han
 
   for (i = 0; i < (RE_MAX_MATCHES) && i < match_num; i++)
     {
+      gint begin_index = matches[2 * i];
+      gint end_index = matches[2 * i + 1];
+
+      if (begin_index < 0 || end_index < 0)
+        continue;
+
       if (indirect)
         {
-          log_msg_set_match_indirect(msg, i, value_handle, 0, matches[2 * i], matches[2 * i + 1] - matches[2 * i]);
+          log_msg_set_match_indirect(msg, i, value_handle, 0, begin_index, end_index - begin_index);
         }
       else
         {
-          log_msg_set_match(msg, i, &value[matches[2 * i]], matches[2 * i + 1] - matches[2 * i]);
+          log_msg_set_match(msg, i, &value[begin_index], end_index - begin_index);
         }
     }
 }
@@ -583,7 +589,13 @@ log_matcher_pcre_re_feed_named_substrings(LogMatcher *s, LogMessage *msg, int *m
       for (i = 0; i < namecount; i++)
         {
           int n = (tabptr[0] << 8) | tabptr[1];
-          log_msg_set_value_by_name(msg, tabptr + 2, value + matches[2*n], matches[2*n+1] - matches[2*n]);
+          gint begin_index = matches[2 * n];
+          gint end_index = matches[2 * n + 1];
+
+          if (begin_index < 0 || end_index < 0)
+            continue;
+
+          log_msg_set_value_by_name(msg, tabptr + 2, value + begin_index, end_index - begin_index);
           tabptr += name_entry_size;
         }
     }

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -157,6 +157,20 @@ void test_subst_field_exist_and_substring_substituted(void)
   rewrite_teardown(msg);
 }
 
+void test_subst_pcre_unused_subpattern(void)
+{
+  LogRewrite *test_rewrite =
+    create_rewrite_rule("subst('(a|(z))(bc)', '.', value('field1') type(pcre) flags('store-matches'));");
+  LogMessage *msg = create_message_with_fields("field1", "abc", NULL);
+  invoke_rewrite_rule(test_rewrite, msg);
+  assert_msg_field_equals(msg, "field1", ".", -1, ASSERTION_ERROR("Couldn't subst message field with literal"));
+  assert_msg_field_equals(msg, "0", "abc", -1, ASSERTION_ERROR("Invalid subpattern match"));
+  assert_msg_field_equals(msg, "1", "a", -1, ASSERTION_ERROR("Invalid subpattern match"));
+  assert_msg_field_equals(msg, "2", "", -1, ASSERTION_ERROR("Invalid subpattern match"));
+  assert_msg_field_equals(msg, "3", "bc", -1, ASSERTION_ERROR("Invalid subpattern match"));
+  rewrite_teardown(msg);
+}
+
 void test_subst_field_exist_and_substring_substituted_with_template(void)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"$field2\" value(\"field1\") );");
@@ -337,6 +351,7 @@ main(int argc, char **argv)
   test_set_field_not_exist_and_set_literal_string();
   test_set_field_exist_and_set_template_string();
   test_subst_field_exist_and_substring_substituted();
+  test_subst_pcre_unused_subpattern();
   test_subst_field_exist_and_substring_substituted_with_template();
   test_subst_field_exist_and_substring_substituted_only_once_without_global();
   test_subst_field_exist_and_substring_substituted_every_occurence_with_global();


### PR DESCRIPTION
In case of `LogMatcherPcreRe`, the `matches` array may contain -1 values.

https://www.pcre.org/original/doc/html/pcreapi.html

>  It is possible for capturing subpattern number n+1 to match some part of the subject when subpattern n has not been used at all. For example, if the string "abc" is matched against the pattern (a|(z))(bc) the return from the function is 4, and subpatterns 1 and 3 are matched, but 2 is not. When this happens, both values in the offset pairs corresponding to unused subpatterns are set to -1.

> Offset values that correspond to unused subpatterns at the end of the expression are also set to -1. For example, if the string "abc" is matched against the pattern (abc)(x(yz)?)? subpatterns 2 and 3 are not matched. The return from the function is 2, because the highest used capturing subpattern number is 1, and the offsets for for the second and third capturing subpatterns (assuming the vector is large enough, of course) are set to -1. 

### Reproduction

#### Config
```
rewrite r_indirect {
    set("indirect: ${MSG}", value(".indirect"));
};

rewrite r_test {
    subst('(a|(((((((((z))))))))))(bc)', ".", value(".indirect") type(pcre));
};

source s_s { file("/dev/stdin"); };
destination d_d { file ("/dev/stdout" template("${.indirect}")); };

log {
    source(s_s);
    rewrite(r_indirect);
    rewrite(r_test);
    destination(d_d);
};
```

#### Input
```
test: abc padding padding padding padding padding padding padding padding padding
```

#### Invalid indirect values (ofs, len)
```
Setting indirect value; msg='0x7de3ec0', name='2', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='3', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='4', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='5', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='6', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='7', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='8', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='9', ref_handle='388', ofs='65535', len='0'
Setting indirect value; msg='0x7de3ec0', name='10', ref_handle='388', ofs='65535', len='0'
```

#### Valgrind output
```
Invalid read of size 2
   at 0x4C32720: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x5194FE0: g_string_insert_len (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
   by 0x4E7AF03: log_matcher_pcre_re_replace (logmatcher.c:754)
   by 0x4EBB123: log_matcher_replace (logmatcher.h:91)
   by 0x4EBB219: log_rewrite_subst_process (rewrite-subst.c:61)
   by 0x4EBA5E0: log_rewrite_queue (rewrite-expr.c:49)
   by 0x4EBA4BA: log_pipe_queue (logpipe.h:340)
   by 0x4EBA356: log_pipe_forward_msg (logpipe.h:303)
   by 0x4EBA6E0: log_rewrite_queue (rewrite-expr.c:60)
   by 0x4E7B531: log_pipe_queue (logpipe.h:340)
   by 0x4E7B3CD: log_pipe_forward_msg (logpipe.h:303)
   by 0x4E7B54A: log_pipe_queue (logpipe.h:344)
 Address 0x7de5f22 is 514 bytes inside a block of size 872 free'd
   at 0x4C2FD5F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x51797D7: g_realloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
   by 0x4ED41FA: nv_table_realloc (nvtable.c:698)
   by 0x4ECE30C: log_msg_set_value_indirect (logmsg.c:633)
   by 0x4ECE54A: log_msg_set_match_indirect (logmsg.c:669)
   by 0x4E7A81C: log_matcher_pcre_re_feed_backrefs (logmatcher.c:552)
   by 0x4E7AEAC: log_matcher_pcre_re_replace (logmatcher.c:748)
   by 0x4EBB123: log_matcher_replace (logmatcher.h:91)
   by 0x4EBB219: log_rewrite_subst_process (rewrite-subst.c:61)
   by 0x4EBA5E0: log_rewrite_queue (rewrite-expr.c:49)
   by 0x4EBA4BA: log_pipe_queue (logpipe.h:340)
   by 0x4EBA356: log_pipe_forward_msg (logpipe.h:303)
```