### PR TITLE
filter: fix memory leak with multiple call on FilterCall's init

### DIFF
--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -58,6 +58,10 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
   FilterCall *self = (FilterCall *) s;
   LogExprNode *rule;
 
+  /* skip initialize if filter_call_init already called. */
+  if (self->filter_expr)
+    return;
+
   rule = cfg_tree_get_object(&cfg->tree, ENC_FILTER, self->rule);
   if (rule)
     {


### PR DESCRIPTION
if `filter_call_init` being called twice or more, `filter_expr_ref(self->filter_expr)` will trigger each time, but `filter_call_free` -> `filter_expr_unref(self->filter_expr)` will only trigger once, so `self->filter_expr` will leak.

This commit prevent furthermore initialization when `self->filter_expr` has value.

Signed-off-by: Shen-Ta Hsieh <ibmibmibm.tw@gmail.com>