### PR TITLE
Mainloop refactor

### DIFF
--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -194,9 +194,8 @@ main_loop_worker_thread_stop(void)
 
   g_mutex_lock(&workers_running_lock);
   main_loop_workers_running--;
-  g_mutex_unlock(&workers_running_lock);
-
   g_cond_signal(&thread_halt_cond);
+  g_mutex_unlock(&workers_running_lock);
 }
 
 void

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -103,7 +103,8 @@ _release_thread_id(void)
   g_static_mutex_lock(&main_loop_workers_idmap_lock);
   if (main_loop_worker_id)
     {
-      main_loop_workers_idmap[main_loop_worker_type] &= ~(1 << (main_loop_worker_id - 1));
+      const gint id = main_loop_worker_id & (sizeof(guint64) * CHAR_BIT - 1);
+      main_loop_workers_idmap[main_loop_worker_type] &= ~(1 << (id - 1));
       main_loop_worker_id = 0;
     }
   g_static_mutex_unlock(&main_loop_workers_idmap_lock);


### PR DESCRIPTION
1. Prevent undefined behavior - [Shift-pass-bitwidth](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
2. Holding lock on condition variable signaling. See [glibc document](https://developer.gnome.org/glib/stable/glib-Threads.html#g-cond-signal).