### PR TITLE
afprog: Smarter child restart in the destination

### DIFF
--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -392,6 +392,25 @@ afprogram_dd_reopen(AFProgramDestDriver *self)
   return TRUE;
 }
 
+static gboolean
+afprogram_dd_is_command_not_found(int status)
+{
+  /*
+   * Status here is a 16-bit int, the real exit status is the 8 least
+   * significant bits of it, and an exit status of 127 from the shell is
+   * supposed to signal a command-not-found case. The other 8 bits are one bit
+   * to signal if the child dumped core, the other 7 the signal - if any - with
+   * which it exited.
+   *
+   * In our case, we want to make sure that the other 8 bits are all empty (no
+   * core dump; and normal exit, not one due to a signal), hence the second part
+   * of the check.
+   *
+   * See wait(2) for more information.
+   */
+  return (status >> 8) == 127 && ((status & 0x00ff) == 0);
+}
+
 static void
 afprogram_dd_exit(pid_t pid, int status, gpointer s)
 {
@@ -402,7 +421,7 @@ afprogram_dd_exit(pid_t pid, int status, gpointer s)
    * handling restarting the command before this handler is run. */
   if (self->process_info.pid != -1 && self->process_info.pid == pid)
     {
-      if ((status >> 8) == 127 && ((status & 0x00ff) == 0))
+      if (afprogram_dd_is_command_not_found(status))
         {
           msg_error("Child program exited with command not found, stopping the destination.",
                     evt_tag_str("cmdline", self->process_info.cmdline->str),


### PR DESCRIPTION
The problem this fixes is that when the destination tries to use a program that does not exist, we end up trying to restart it endlessly, forever, without logging anything about it on a reasonable log level. This spams the logs, and is very unhelpful anyway.

Instead, this patch changes the restart logic, so it is not always immediate. On a write error, we'll defer restart to the child manager, which will have access to the exit status. We check this exit status, and if it is 127, with no core dump, and the child did not die due to a signal, we can be pretty certain that this is a command-not-found error. As such, in this case, we delay the restart, and use a `time-reopen`-long delay, after logging the fact. In every other case, the restart is silent below verbose level, and happens immediately.