### PR TITLE
grammar: Make sure that nonnegative and positive integers fit into 32 bits

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -971,6 +971,7 @@ nonnegative_integer
         : LL_NUMBER
           {
             CHECK_ERROR(($1 >= 0), @1, "It cannot be negative");
+            CHECK_ERROR((($1 >= G_MININT32) && ($1 <= G_MAXINT32)), @1, "Must fit into 32 bits!");
           }
         ;
 
@@ -978,6 +979,7 @@ positive_integer
         : LL_NUMBER
           {
             CHECK_ERROR(($1 > 0), @1, "Must be positive");
+            CHECK_ERROR((($1 >= G_MININT32) && ($1 <= G_MAXINT32)), @1, "Must fit into 32 bits!");
           }
         ;
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -443,7 +443,9 @@ DNSCacheOptions *last_dns_cache_options;
 %type   <num> level_string
 
 %type   <num> positive_integer
+%type   <num> positive_integer64
 %type   <num> nonnegative_integer
+%type   <num> nonnegative_integer64
 
 /* END_DECLS */
 
@@ -967,19 +969,31 @@ dnsmode
 	| KW_PERSIST_ONLY                       { $$ = 2; }
 	;
 
-nonnegative_integer
+nonnegative_integer64
         : LL_NUMBER
           {
             CHECK_ERROR(($1 >= 0), @1, "It cannot be negative");
-            CHECK_ERROR((($1 >= G_MININT32) && ($1 <= G_MAXINT32)), @1, "Must fit into 32 bits!");
+          }
+        ;
+
+nonnegative_integer
+        : nonnegative_integer64
+          {
+            CHECK_ERROR(($1 <= G_MAXINT32), @1, "Must be smaller than 2^31");
+          }
+        ;
+
+positive_integer64
+        : LL_NUMBER
+          {
+            CHECK_ERROR(($1 > 0), @1, "Must be positive");
           }
         ;
 
 positive_integer
-        : LL_NUMBER
+        : positive_integer64
           {
-            CHECK_ERROR(($1 > 0), @1, "Must be positive");
-            CHECK_ERROR((($1 >= G_MININT32) && ($1 <= G_MAXINT32)), @1, "Must fit into 32 bits!");
+            CHECK_ERROR(($1 <= G_MAXINT32), @1, "Must be smaller than 2^31");
           }
         ;
 

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -64,12 +64,20 @@ DiskQueueOptions *last_options;
 %token KW_QOUT_SIZE
 %token KW_DIR
 
+%type <num> nonnegative_integer64
 
 %%
 
 start
 	: LL_CONTEXT_INNER_DEST dest_diskq { YYACCEPT; }
 	;
+
+nonnegative_integer64
+  : LL_NUMBER
+    {
+      CHECK_ERROR(($1 >= 0), @1, "It cannot be negative");
+    }
+  ;
 
 dest_diskq
         : KW_DISK_BUFFER
@@ -90,7 +98,7 @@ dest_diskq_option
         : KW_RELIABLE '(' yesno ')'            { disk_queue_options_reliable_set(last_options, $3); }
         | KW_MEM_BUF_SIZE '(' nonnegative_integer ')'    { disk_queue_options_mem_buf_size_set(last_options, $3); }
         | KW_MEM_BUF_LENGTH '(' nonnegative_integer ')'  { disk_queue_options_mem_buf_length_set(last_options, $3); }
-        | KW_DISK_BUF_SIZE '(' nonnegative_integer ')'   { disk_queue_options_disk_buf_size_set(last_options, $3); }
+        | KW_DISK_BUF_SIZE '(' nonnegative_integer64 ')'   { disk_queue_options_disk_buf_size_set(last_options, $3); }
         | KW_QOUT_SIZE '(' nonnegative_integer ')'       { disk_queue_options_qout_size_set(last_options, $3); }
         | KW_DIR '(' string ')'                { disk_queue_options_set_dir(last_options, $3); free($3); }
         ;

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -64,20 +64,12 @@ DiskQueueOptions *last_options;
 %token KW_QOUT_SIZE
 %token KW_DIR
 
-%type <num> nonnegative_integer64
 
 %%
 
 start
 	: LL_CONTEXT_INNER_DEST dest_diskq { YYACCEPT; }
 	;
-
-nonnegative_integer64
-  : LL_NUMBER
-    {
-      CHECK_ERROR(($1 >= 0), @1, "It cannot be negative");
-    }
-  ;
 
 dest_diskq
         : KW_DISK_BUFFER


### PR DESCRIPTION
Every time `nonnegative_integer` or `positive_integer` is used in the grammar, the numbers end up being stored on 32 bits (except for `disk-buf-size`, which is 64-bit wide). Not properly bounds-checking these numbers can result in us ending up with a negative value.

Seeing as there is only one exception, this patch changes `nonnegative_integer` and `positive_integer` to do proper bounds checking too, and error out if the value does not fit. For `disk-buf-size`, we introduce `nonnegative_integer64`, local to that part of the grammar.

Fixes #1820.
