### PR TITLE
Remove the last leftover of the eventlog package

### DIFF
--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -14,6 +14,6 @@ ivykis=@with_ivykis@
 Name: syslog-ng-dev
 Description: Dev package for syslog-ng module
 Version: @PACKAGE_VERSION@
-Requires: glib-2.0 eventlog
+Requires: glib-2.0
 Libs: -L${libdir} @GLIB_LIBS@ -lsyslog-ng
 Cflags: -I${includedir}/syslog-ng @INTERNAL_IVYKIS_CFLAGS@


### PR DESCRIPTION
This remaining reference to the evenetlog package prevents compiling the syslog-ng-incubator.