### PR TITLE
python3 has no function raw_input

### DIFF
--- a/modules/python/pylib/syslogng/debuggercli/__init__.py
+++ b/modules/python/pylib/syslogng/debuggercli/__init__.py
@@ -26,4 +26,8 @@ from syslogng.debuggercli.readline import setup_readline
 
 def fetch_command():
     setup_readline()
-    return raw_input("(syslog-ng) ")
+    try:
+        input_function = raw_input
+    except NameError:
+        input_function = input
+    return input_function("(syslog-ng) ")


### PR DESCRIPTION
But both python2 and python3 has the function input.
The difference between the two implementation that
in python2 input can return with other type than
string.