### PR TITLE
Style check exclude dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,9 @@ set(CORE_INCLUDE_DIRS
     ${LIBPCRE_INCLUDE_DIRS}
 )
 
+add_custom_target(style-check  COMMAND ${PROJECT_SOURCE_DIR}/scripts/style-checker.sh check  ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
+add_custom_target(style-format COMMAND ${PROJECT_SOURCE_DIR}/scripts/style-checker.sh format ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
+
 
 include_directories (${PROJECT_BINARY_DIR}/lib)
 include_directories (${PROJECT_BINARY_DIR})

--- a/scripts/style-checker.sh
+++ b/scripts/style-checker.sh
@@ -24,6 +24,7 @@
 
 action="$1"
 root_dir="$2"
+exclude_dir="$3"
 
 function setup_root_dir
 {
@@ -34,7 +35,7 @@ function setup_root_dir
 
 function astyle_c_check
 {
-    astyle --options="$root_dir/.astylerc" --dry-run "$root_dir/*.h" "$root_dir/*.c" | grep "Formatted" | tee badly-formatted-files.list | wc -l | while read badly_formatted_c_files
+    astyle --options="$root_dir/.astylerc" --exclude="$exclude_dir" --dry-run "$root_dir/*.h" "$root_dir/*.c" | grep "Formatted" | tee badly-formatted-files.list | wc -l | while read badly_formatted_c_files
     do
         echo "Number of badly formatted files: $badly_formatted_c_files"
         if [ "$badly_formatted_c_files" == "0" ]; then
@@ -48,17 +49,23 @@ function astyle_c_check
 
 function astyle_c_format
 {
-    astyle --options="$root_dir/.astylerc" "$root_dir/*.h" "$root_dir/*.c" | grep "Formatted"
+    astyle --options="$root_dir/.astylerc" --exclude="$exclude_dir" "$root_dir/*.h" "$root_dir/*.c" | grep "Formatted"
     exit 0
 }
 
 function print_help
 {
+    echo
     echo "Format C source files to comply with coding standards of syslog-ng"
+    echo "${0} ACTION [ROOT_DIR] [EXCLUDE_DIR]"
     echo "Possible actions:"
     echo "    check    Check the format of sources in current directory"
     echo "    format   Format sources in current directory"
     echo "    help     Print this message"
+    echo
+    echo "Additional options:"
+    echo "  ROOT_DIR     Path for the source and .astylerc (default: current directory)"
+    echo "  EXCLUDE_DIR  Path for the build directory (excluded from style-check)  (default: '')"
 }
 
 function run_checker


### PR DESCRIPTION
A new option for the `style-check` script to exclude directories, which could be used for `cmake` or in git commit hook to exclude the build directory.

The `autotools` provides the `$(top_buildir)` that contains `.` that `astyle` cannot interpret:
> Directory  ../*.c
Exclude  build/lib/jsonc
Exclude  build/lib/ivykis
Exclude  build/modules/afamqp/rabbitmq-c
Exclude  build/modules/afmongodb/mongo-c-driver
Exclude  lib/jsonc
Exclude  lib/ivykis
Exclude  modules/afamqp/rabbitmq-c
Exclude  modules/afmongodb/mongo-c-driver
Exclude (unmatched)  .

