### PR TITLE
valgrind support for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ include (ExternalProject)
 include (external_or_find_package)
 include (add_tests)
 
+SET (CTEST_ENVIRONMENT
+  "G_SLICE=always-malloc,debug-blocks"
+  "G_DEBUG=fatal-warnings,fatal-criticals,gc-friendly"
+  )
+set(MEMORYCHECK_SUPPRESSIONS_FILE "${CMAKE_SOURCE_DIR}/tests/valgrind/unit-test-leak.supp")
+set(MEMORYCHECK_COMMAND_OPTIONS "--num-callers=30 --sim-hints=no-nptl-pthread-stackcache --gen-suppressions=all --leak-check=full --freelist-vol=200000000 --freelist-big-blocks=10000000 --malloc-fill=55 --free-fill=AA")
 
 file (STRINGS "${CMAKE_SOURCE_DIR}/VERSION" VERSION_FROM_FILE)
 set (SYSLOG_NG_VERSION "${VERSION_FROM_FILE}")

--- a/Makefile.am
+++ b/Makefile.am
@@ -173,5 +173,17 @@ include dbld/Makefile.am
 TEST_EXTENSIONS = .sh
 @VALGRIND_CHECK_RULES@
 
-VALGRIND_SUPPRESSIONS_FILES = $(top_srcdir)/syslog-ng.supp
+VALGRIND_SUPPRESSIONS_FILES = $(top_srcdir)/tests/valgrind/unit-test-leak.supp
 EXTRA_DIST += syslog-ng.supp
+
+VALGRIND_FLAGS = \
+  --num-callers=30 \
+  --sim-hints=no-nptl-pthread-stackcache \
+  --gen-suppressions=all
+
+VALGRIND_memcheck_FLAGS = \
+  --leak-check=full \
+  --freelist-vol=200''000''000 \
+  --freelist-big-blocks=10''000''000 \
+  --malloc-fill=55 \
+  --free-fill=AA

--- a/lib/logmsg/logmsg-serialize.c
+++ b/lib/logmsg/logmsg-serialize.c
@@ -76,6 +76,7 @@ _deserialize_sdata(LogMessage *self, SerializeArchive *sa)
   if (!serialize_read_uint8(sa, &self->alloc_sdata))
     return FALSE;
 
+  g_assert(!self->sdata);
   self->sdata = (NVHandle *) g_malloc(sizeof(NVHandle)*self->alloc_sdata);
   serialize_read_uint32_array(sa, (guint32 *) self->sdata, self->num_sdata);
   return TRUE;

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -249,18 +249,18 @@ test_deserialization_performance(void)
   GString *stream = g_string_sized_new(512);
   SerializeArchive *sa = _serialize_message_for_test(stream);
   const int iterations = 100000;
-  LogMessage *msg = log_msg_new_empty();
+  LogMessage *msg;
 
   start_stopwatch();
   for (int i = 0; i < iterations; i++)
     {
       serialize_string_archive_reset(sa);
-      log_msg_clear(msg);
+      msg = log_msg_new_empty();
       log_msg_deserialize(msg, sa);
+      log_msg_unref(msg);
     }
   stop_stopwatch_and_display_result(iterations, "serializing %d times took", iterations);
   serialize_archive_free(sa);
-  log_msg_unref(msg);
   g_string_free(stream, TRUE);
 }
 

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -89,8 +89,11 @@ rewrite_template_content
 	    GError *error = NULL;
 
 	    $$ = log_template_new(configuration, $1);
-	    CHECK_ERROR_GERROR(log_template_compile($$, $1, &error), @1, error, "error compiling replacement");
+	    gboolean ok = log_template_compile($$, $1, &error);
         free($1);
+	    if (!ok)
+	      log_template_unref($$);
+	    CHECK_ERROR_GERROR(ok, @1, error, "error compiling replacement");
 	  }
 	;
 

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -126,7 +126,7 @@ _initialize_counter_hash(void)
 
   const CounterHashContent single_cluster_counters[] =
   {
-    {SCS_GLOBAL, NULL, "guba", SC_TYPE_SINGLE_VALUE}
+    {SCS_GLOBAL, "", "guba", SC_TYPE_SINGLE_VALUE}
   };
 
   app_startup();

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -205,11 +205,11 @@ Test(value_pairs, test_transformers)
   g_ptr_array_free(transformers, TRUE);
 }
 
+GlobalConfig *cfg;
+
 void
 setup(void)
 {
-  GlobalConfig *cfg;
-
   app_startup();
   putenv("TZ=MET-1METDST");
   tzset();
@@ -224,8 +224,8 @@ setup(void)
 void
 teardown(void)
 {
+  cfg_free(cfg);
   app_shutdown();
 }
 
 TestSuite(value_pairs, .init = setup, .fini = teardown);
-

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -499,7 +499,8 @@ tf_binary_free_state(gpointer s)
 {
   TFBinaryState *state = (TFBinaryState *) s;
 
-  g_string_free(state->octets, TRUE);
+  if (state->octets)
+    g_string_free(state->octets, TRUE);
   tf_simple_func_free_state(&state->super);
 }
 

--- a/tests/valgrind/unit-test-leak.supp
+++ b/tests/valgrind/unit-test-leak.supp
@@ -1,0 +1,7 @@
+{
+   nvtable-uninitialized: https://github.com/balabit/syslog-ng/issues/946
+   Memcheck:Param
+   pwrite64(buf)
+   ...
+   fun:log_queue_push_tail
+}


### PR DESCRIPTION
This pull request is the continuation of https://github.com/balabit/syslog-ng/pull/1080. Thank you @bkil-syslogng for the investigation and putting together the original pull request.

I moved most of the commits from the original pull request here. One notable exception is the travis part. Unfortunately the valgrind execution of the unit test set is too long to execute in travis.

Besides autotools, cmake support is added as well.

Usage:
- autotools
  - configure with --enable-valgrind option
  - make check-valgrind-tool #optionally add VALGRIND_TOOL=memcheck

- cmake
After the usual compile: one can execute
  - ctest -T memcheck