### PR TITLE
Syslog ng debun improvements

### DIFF
--- a/contrib/README.syslog-ng-debun
+++ b/contrib/README.syslog-ng-debun
@@ -49,7 +49,7 @@ usage examples:
 	* start system's syslog-ng
 	* stops packet capturing
 
-# syslog-ng-debun -r -W /var/tmp -P /usr/local
+# syslog-ng-debun -r -W /var/tmp -R /usr/local
 	Collect debug info, but the temporary files, and the result will be
 	in /var/tmp instead of /tmp and don't try to search syslog-ng in
 	/opt/syslog-ng, it will search in /usr/local

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -7,7 +7,7 @@
 ### This software may be used and distributed according to the terms of GNU GPLv2
 ### http://www.gnu.org/licenses/gpl-2.0.html
 
-version="0.3.10.20180114"
+version="0.3.10.20180119"
 
 ### Check for "local" variable support
 if type local >/dev/null; then
@@ -203,6 +203,8 @@ fi
 [ -n "$privacy_mode" ] && [ "x$debug_params" = "x$default_debug_params" ] && debug_params="$default_ldebug_params"
 
 syslogbin=${binprefix}/sbin/syslog-ng
+syslogngctlbin=${binprefix}/sbin/syslog-ng-ctl
+syslogngquerybin=${binprefix}/sbin/syslog-ng-query
 vardir=${binprefix}/var
 piddir=${vardir}/run
 confdir=${binprefix}/etc
@@ -684,17 +686,17 @@ acquire_syslog_stats () {
 	#handy-dandy delay magic, triggered when we'd step on our own foot
 	[ -f ${tmpdir}/syslog.stats.${tsdata} ] && sleep 5 && tsdata=$( timestamp )
 
-	${syslogbin}-ctl stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
-	echo ${syslogbin}-ctl stats
+	${syslogngctlbin} stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
+	echo ${syslogngctlbin} stats
 	tsdata=$( timestamp )
-	${syslogbin}-ctl query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
-	echo ${syslogbin}-ctl query get "*"
-	if [ -x ${syslogbin}-query ]; then
+	${syslogngctlbin} query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+	echo ${syslogngctlbin} query get "*"
+	if [ -x ${syslogngquerybin} ]; then
 		#if we reach this brach, then syslog.query.all - as generated above - will not contain any meaningful data
 		rm ${tmpdir}/syslog.query.all.${tsdata}
 		tsdata=$( timestamp )
-		${syslogbin}-query sum "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
-		echo ${syslogbin}-query sum "*"
+		${syslogngquerybin} sum "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+		echo ${syslogngquerybin} sum "*"
 	fi
 }
 
@@ -706,10 +708,10 @@ acquire_syslog_info () {
 
 	acquire_syslog_stats
 
-	if ${syslogbin}-ctl show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
-		${syslogbin}-ctl show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
+	if ${syslogngctlbin} show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
+		${syslogngctlbin} show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
 	fi
-	echo ${syslogbin}-ctl show-license-info
+	echo ${syslogngctlbin} show-license-info
 	for i in ${sngallpids} ; do
 		is_available ${lsof%% *} && $lsof $i >${tmpdir}/syslog.$i.lsof 2>/dev/null || echo "No lsof in path." >${tmpdir}/syslog.$i.lsof
 		myplimit $i >${tmpdir}/syslog.$i.limits
@@ -850,6 +852,8 @@ fhs_set_linux () {
 	vardir=/var/lib/syslog-ng
 	piddir=/var/lib/syslog-ng
 	syslogbin=/usr/sbin/syslog-ng
+	syslogngctlbin=/usr/sbin/syslog-ng-ctl
+	syslogngquerybin=/usr/sbin/syslog-ng-query
 	syslogrealbin=/usr/sbin/syslog-ng
 }
 

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -716,10 +716,13 @@ acquire_syslog_var () {
 			find . |grep -v run\\/syslog-ng.ctl$ | cpio -pd ${tmpdir}/var
 		else
 			printf "Size of ${vardir} is larger than $varlimit kilobytes.\n"
-			printf "Do you really want to copy its contents? Type 'YES' with all capitals: "
+			printf "Do you really want to copy all of its contents? Type 'YES' with all capitals: "
 			read ans
 			if [ "$ans" = "YES" ]; then
 				find . | grep -v "syslog-ng*\.ctl" | cpio -pd ${tmpdir}/var
+			else
+				printf "Only copying most important files on user request.\n"
+				find . \( -name "*.persist" -o -name "*.pid" \) | grep -v "syslog-ng.*\.ctl" | cpio -pd ${tmpdir}/var
 			fi
 		fi
 	else

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -7,7 +7,7 @@
 ### This software may be used and distributed according to the terms of GNU GPLv2
 ### http://www.gnu.org/licenses/gpl-2.0.html
 
-version="0.3.8.20170926"
+version="0.3.10.20180114"
 
 ### Check for "local" variable support
 if type local >/dev/null; then
@@ -70,6 +70,7 @@ pcapifparm=-i
 w=w
 vmstat=vmstat
 dmesg=dmesg
+timestamp () { date +%s ; }
 tcpdumpcmd="tcpdump"
 tcpdumpopts="-p -s 1500 -w"
 opensslmajor=0
@@ -285,6 +286,11 @@ debun_generate_hashes () {
 debun_final() {
 	debun_finish_debug
 	[ -n "$service_status" ] && $service_status >${tmpdir}/svc.post
+
+	# Generating stats again for the EPS counter
+	printf 'Generating second batch of statistics\n'
+	acquire_syslog_stats
+
 	printf "\nGenerating hashes..."
 	debun_generate_hashes
 	printf " done.\nDebug Bundle generation: Done.\n"
@@ -672,20 +678,34 @@ acquire_syslog_pids () {
 	[ -n "$service_status" ] && $service_status >${tmpdir}/svc.pre
 }
 
+acquire_syslog_stats () {
+	local tsdata
+	tsdata=$( timestamp )
+	#handy-dandy delay magic, triggered when we'd step on our own foot
+	[ -f ${tmpdir}/syslog.stats.${tsdata} ] && sleep 5 && tsdata=$( timestamp )
+
+	${syslogbin}-ctl stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
+	echo ${syslogbin}-ctl stats
+	tsdata=$( timestamp )
+	${syslogbin}-ctl query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+	echo ${syslogbin}-ctl query get "*"
+	if [ -x ${syslogbin}-query ]; then
+		#if we reach this brach, then syslog.query.all - as generated above - will not contain any meaningful data
+		rm ${tmpdir}/syslog.query.all.${tsdata}
+		tsdata=$( timestamp )
+		${syslogbin}-query sum "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+		echo ${syslogbin}-query sum "*"
+	fi
+}
+
 acquire_syslog_info () {
 	ls -la "${binprefix}" > ${tmpdir}/syslog.lsl.install_dir 2>&1
 	printf "Syslog-ng's exact version: "
 	$syslogbin --version > ${tmpdir}/syslog.version
 	head -1 ${tmpdir}/syslog.version
-	${syslogbin}-ctl stats > ${tmpdir}/syslog.stats 2>&1
-	echo ${syslogbin}-ctl stats
-	${syslogbin}-ctl query get "*" > ${tmpdir}/syslog.query.all 2>/dev/null
-	echo ${syslogbin}-ctl query get "*"
-	if [ -x ${syslogbin}-query ]; then
-		#if we reach this brach, then syslog.query.all - as generated above - will not contain any meaningful data
-		${syslogbin}-query sum "*" > ${tmpdir}/syslog.query.all 2>/dev/null
-		echo ${syslogbin}-query sum "*"
-	fi
+
+	acquire_syslog_stats
+
 	if ${syslogbin}-ctl show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
 		${syslogbin}-ctl show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
 	fi
@@ -1235,6 +1255,7 @@ setup_env_solaris () {
 	unset -f distpkgstatus
 	unset -f is_available
 	unset -f os_hash_helper
+	unset -f timestamp
 
 	is_available () { which "$1" | $grepq "no $1 in" && return 1 || return 0 ; }
 	mypidof () { $pseao pid,comm | while read pid bin ; do [ "$bin" = "$1" ] && echo $pid ; done ; }
@@ -1243,6 +1264,7 @@ setup_env_solaris () {
 	netstatlunp () { netstat -P udp -na ; }
 	myplimit () { plimit $1 ; }
 	free () { prtconf | grep Mem ; printf Pagesize:\  ; pagesize -a ; }
+	timestamp () { perl -e 'print time, "\n";' ; }
 	distpkgoffile () {
 		FILE="$1"
 		if [ -L "/lib/64" ]; then

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -86,7 +86,7 @@ service_status="${initfile} status"
 #for reference: http://pubs.opengroup.org/onlinepubs/009695399/functions/kill.html
 checkpid () { [ -n "$1" ] && kill -0 "$1" 2>/dev/null ; }
 #mywait () { jobs -p >${tmpdir}/sdn.jobs ; for i in `grep -v "\<$tailpid\>" ${tmpdir}/sdn.jobs` ; do wait $i ; done ; }
-mywait () { jobs -p >${tmpdir}/sdn.jobs ; for i in `grep -v "^$tailpid\$" ${tmpdir}/sdn.jobs` ; do wait $i ; done ; }
+mywait () { jobs -p >${tmpdir}/sdn.jobs ; for i in $( grep -v "^$tailpid\$" ${tmpdir}/sdn.jobs ) ; do wait $i ; done ; }
 is_available () { which "$1" >/dev/null 2>&1; }
 distpkgoffile_cleanup () { : ; }
 
@@ -213,8 +213,8 @@ fi
 
 debun_init () {
 	#Create temp dir, to place files into
-	host=`uname -n`
-	date=`date '+%Y-%m-%d_%H-%M'`
+	host=$( uname -n )
+	date=$( date '+%Y-%m-%d_%H-%M' )
 	tmpdir=${workdir}/syslog.debun.${host}.${date}.$$
 	( umask 077 ; mkdir ${tmpdir} )
 	[ -d "$tmpdir" ] || { printf "Could not create a temp directory\n" >&2 ; exit 1 ; }
@@ -335,12 +335,12 @@ getchilds () {
 getallchilds () {
 	local childs
 	local subchilds
-	childs="`getchilds $1`"
+	childs=$( getchilds ${1} )
 	local i
 	# Default value, learned after getchilds()'s forkbomb case
 	unset subchilds
 	for i in ${childs} ; do
-		subchilds="${subchilds}${subchilds:+ }`getallchilds $i`"
+		subchilds="${subchilds}${subchilds:+ }$(getallchilds $i)"
 	done
 	echo ${childs} ${subchilds}
 }
@@ -649,22 +649,22 @@ acquire_syslog_pids () {
 	echo 'Old "getsyslogpids":' >${tmpdir}/syslog.pids
 	getsyslogpids >>${tmpdir}/syslog.pids
 	if [ -r "${piddir}/syslog-ng.pid" ]; then
-		sngpid=`cat ${piddir}/syslog-ng.pid`
+		sngpid=$( cat ${piddir}/syslog-ng.pid )
 	else
 		# Handle when fhs is "linux"-like
-		sngpid=`cat ${piddir}/syslog-ng.pid`
+		sngpid=$( cat ${piddir}/syslog-ng.pid )
 	fi
-	ppid=`getparent $sngpid`
-	sngallpids="`getallchilds $sngpid`"
+	ppid=$( getparent $sngpid )
+	sngallpids="$( getallchilds $sngpid )"
 	echo "SVpid: $ppid SNGpid: $sngpid Chpids: ${sngallpids}" >>${tmpdir}/syslog.pids
 	tail -1 ${tmpdir}/syslog.pids
 	if [ -n "$ppid" ]; then
 		sngallpids="$ppid $sngpid ${sngallpids}"
 	else
-		sngallpids="` getsyslogpids `"
+		sngallpids="$( getsyslogpids )"
 	fi
 	# drop out the unneeded white spaces, since that disturb the ps command
-	sngallpids=`echo ${sngallpids}`
+	sngallpids=$( echo ${sngallpids} )
 	if [ -n "${sngallpids}" ]; then
 		printf 'ps -l -f -p "%s"\n' "${sngallpids}" >>${tmpdir}/syslog.pids
 		ps -l -f -p "${sngallpids}" >>${tmpdir}/syslog.pids
@@ -749,13 +749,13 @@ format_ldd_output () {
 acquire_syslog_ldinfo () {
 	$lddcmd $syslogrealbin |grep -v needs >${tmpdir}/syslog.ldd
 	format_ldd_output <${tmpdir}/syslog.ldd >${tmpdir}/syslog.ldfiles
-	for i in `cat ${tmpdir}/syslog.ldfiles ` ; do
+	for i in $( cat ${tmpdir}/syslog.ldfiles ) ; do
 		distpkgoffile $i >>${tmpdir}/syslog.ldpkg
 	done
 	distpkgoffile_cleanup
 	sort <${tmpdir}/syslog.ldpkg | uniq >${tmpdir}/syslog.ldpkg.u
 	mv ${tmpdir}/syslog.ldpkg.u ${tmpdir}/syslog.ldpkg
-	for i in `cat ${tmpdir}/syslog.ldpkg ` ; do
+	for i in $( cat ${tmpdir}/syslog.ldpkg ) ; do
 		distpkgstatus $i >>${tmpdir}/syslog.ldinfos
 	done
 }
@@ -1018,7 +1018,7 @@ debun_aix () {
 detect_env_linux () {
 	if is_available lsb_release ; then
 		lsb_release -a | tee ${tmpdir}/lsb.all
-		dist=`lsb_release -si`
+		dist=$( lsb_release -si )
 	elif [ -r /etc/debian_version ]; then
 		dist="Debian"
 	elif [ -r /etc/redhat-release ]; then
@@ -1048,7 +1048,7 @@ detect_env () {
 		echo "No syslog-ng detected"
 	fi
 
-	os=`uname -s`
+	os=$( uname -s )
 	if [ "$os" = "Linux" ]; then
 		detect_env_linux
 	fi
@@ -1569,9 +1569,9 @@ run_debug () {
 		echo "Waiting ${waitforit} secs before stop system's syslog-ng, and restart in debug mode."
 		pad=''
 		bs=''
-		for i in `seq 1 ${#waitforit}`; do pad="${pad} " ; bs="\b${bs}" ; done
+		for i in $( seq 1 ${#waitforit} ); do pad="${pad} " ; bs="\b${bs}" ; done
 		printf "Start countdown: ${pad}" >&3
-		for i in `seq ${waitforit} -1 1 `; do printf "${bs}${pad:${#i}}$i" >&3 ; sleep 1 ; done
+		for i in $( seq ${waitforit} -1 1 ); do printf "${bs}${pad:${#i}}$i" >&3 ; sleep 1 ; done
 		print "0\n">&3
 		touch ${tmpdir}/syslog.debug
 	fi
@@ -1585,7 +1585,7 @@ run_debug () {
 				${trace} -o ${tmpdir}/trace.dbg.txt ${syslogbin} ${debug_params} >>${tmpdir}/syslog.debug 2>&1 &
 				i=${!}
 				tracepids="${i}"
-				debugpid="`getchilds ${i}`"
+				debugpid="$( getchilds ${i} )"
 				echo "Trace: ${i} Debug: ${debugpid}"
 			else
 				echo "Tracing was requested but ${trace%% *} was not available!"


### PR DESCRIPTION
Details:

-  cosmetic changes to remove backtick-style code invokations in favor of dollarsign+parentheses
-  gather the persist file even when vardir is too big
-  gather two sets of syslog-ng stats, with Unix timestamps to allow EPS counting based on the diffs