### PR TITLE
add-contextual-data: mocked license added for test

### DIFF
--- a/modules/add-contextual-data/tests/CMakeLists.txt
+++ b/modules/add-contextual-data/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_unit_test(CRITERION TARGET test_context_info_db DEPENDS add_contextual_data)
 add_unit_test(CRITERION TARGET test_selector DEPENDS add_contextual_data)
-add_unit_test(CRITERION TARGET test_selector_filter DEPENDS add_contextual_data)
+add_unit_test(CRITERION LIBTEST TARGET test_selector_filter DEPENDS add_contextual_data)

--- a/modules/add-contextual-data/tests/test_selector_filter.c
+++ b/modules/add-contextual-data/tests/test_selector_filter.c
@@ -22,6 +22,7 @@
 #include "add-contextual-data-filter-selector.h"
 #include "logmsg/logmsg.h"
 #include "template/macros.h"
+#include "license_module_mock.h"
 #include "cfg.h"
 #include "apphook.h"
 #include <criterion/criterion.h>
@@ -70,6 +71,7 @@ setup(void)
 {
   app_startup();
   /* Force to link the libtest library */
+  license_module_init(NULL,NULL);
   test_filter_conf = NULL;
 }
 


### PR DESCRIPTION
Mocked license added to the `test_selector_filter` test.