### PR TITLE
strtok and value_pairs test to criterion

### DIFF
--- a/lib/compat/tests/CMakeLists.txt
+++ b/lib/compat/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST TARGET test_strtok_r)
+add_unit_test(CRITERION TARGET test_strtok_r)

--- a/lib/value-pairs/tests/CMakeLists.txt
+++ b/lib/value-pairs/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_unit_test(TARGET test_value_pairs DEPENDS syslogformat)
-add_unit_test(LIBTEST TARGET test_value_pairs_walk)
+add_unit_test(CRITERION TARGET test_value_pairs DEPENDS syslogformat)
+add_unit_test(CRITERION TARGET test_value_pairs_walk DEPENDS syslogformat)

--- a/modules/xml/tests/CMakeLists.txt
+++ b/modules/xml/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST CRITERION TARGET test_xml_parser DEPENDS xml)
+add_unit_test(CRITERION TARGET test_xml_parser DEPENDS xml syslog-ng)

--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -22,7 +22,6 @@
 
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
-#include "msg_parse_lib.h"
 #include "xml.h"
 #include "apphook.h"
 #include "scratch-buffers.h"


### PR DESCRIPTION
* Converts the strtok and value_pairs unit test from libtest to criterion.
* Remove not required include from xml parser test.