### PR TITLE
autotools: small fixes related to --disable-all-modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1735,6 +1735,7 @@ AM_CONDITIONAL(ENABLE_EXTRA_WARNINGS, [test "$enable_extra_warnings" = "yes"])
 AM_CONDITIONAL(ENABLE_LEGACY_MONGODB_OPTIONS, [test x"$enable_legacy_mongodb_options" != x"no"])
 AM_CONDITIONAL(ENABLE_CRITERION, [test "$with_criterion" != "no"])
 AM_CONDITIONAL([HAVE_INOTIFY], [test x$ac_cv_func_inotify_init = xyes])
+AM_CONDITIONAL(ENABLE_IPV6, [test $enable_ipv6 = yes])
 
 AC_SUBST(timezonedir)
 AC_SUBST(pidfiledir)

--- a/configure.ac
+++ b/configure.ac
@@ -349,7 +349,8 @@ if test "x$enable_all_modules" != "xauto"; then
    state="$enable_all_modules"
 
    MODULES="spoof_source sun_streams sql pacct mongodb json amqp stomp \
-            redis systemd geoip geoip2 riemann ipv6 smtp native python java java_modules"
+            redis systemd geoip geoip2 riemann ipv6 smtp native python java java_modules \
+            http"
    for mod in ${MODULES}; do
        modstate=$(eval echo \$enable_${mod})
        if test "x$modstate" = "xauto"; then

--- a/lib/filter/tests/Makefile.am
+++ b/lib/filter/tests/Makefile.am
@@ -1,7 +1,10 @@
 lib_filter_tests_TESTS		 =              \
     lib/filter/tests/test_filters               \
-    lib/filter/tests/test_filters_in_list       \
-    lib/filter/tests/test_filters_netmask6
+    lib/filter/tests/test_filters_in_list
+
+if ENABLE_IPV6
+lib_filter_tests_TESTS += lib/filter/tests/test_filters_netmask6
+endif
 
 check_PROGRAMS				+= ${lib_filter_tests_TESTS}
 
@@ -17,10 +20,12 @@ lib_filter_tests_test_filters_in_list_CFLAGS     = $(TEST_CFLAGS) \
 lib_filter_tests_test_filters_in_list_LDADD      = $(TEST_LDADD)  \
 	$(PREOPEN_SYSLOGFORMAT)
 
+if ENABLE_IPV6
 lib_filter_tests_test_filters_netmask6_CFLAGS    = $(TEST_CFLAGS) \
     -I${top_srcdir}/lib/filter/tests
 lib_filter_tests_test_filters_netmask6_LDADD     = $(TEST_LDADD)  \
     $(PREOPEN_SYSLOGFORMAT)
+endif
 
 if ENABLE_CRITERION
 lib_filter_tests_TESTS += lib/filter/tests/test_filters_statistics

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -20,7 +20,7 @@ libtest_libsyslog_ng_test_a_SOURCES =   \
 	libtest/proto_lib.h		\
 	libtest/persist_lib.h		\
 	libtest/persist_lib.c		\
-	libtest/mock-transport.c	\		
+	libtest/mock-transport.c	\
 	libtest/mock-transport.h        \
 	libtest/config_parse_lib.c      \
 	libtest/config_parse_lib.h      \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -60,12 +60,13 @@ BUILT_SOURCES					+= \
 	modules/python/python-grammar.h
 
 modules/python mod-python: modules/python/libmod-python.la
+
+include modules/python/tests/Makefile.am
 else
 modules/python mod-python:
 endif
 
 include modules/python/pylib/Makefile.am
-include modules/python/tests/Makefile.am
 
 EXTRA_DIST					+= \
 	modules/python/compat/compat-python-v2.c   \


### PR DESCRIPTION
This patchset fixes
- python unit test should not be compiled if python is disabled
- if ipv6 support is disabled, test_filter_netmask6 should not be compiled
- There was a whitespace in libtest makefile after backslash, causing autotools warning
- The compile of http module was unaffected by --enable/disable-all-modules, even though the default detection state was auto