### PR TITLE
File destination (time-reap) crash under immense load

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -111,7 +111,7 @@ affile_dw_format_persist_name(AFFileDestWriter *self)
   return persist_name;
 }
 
-static void affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw);
+static gboolean affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw);
 
 static void
 affile_dw_arm_reaper(AFFileDestWriter *self)
@@ -136,20 +136,8 @@ affile_dw_reap(gpointer s)
       return;
     }
 
-  g_static_mutex_lock(&self->owner->lock);
-  if (!self->queue_pending)
-    {
-      msg_verbose("Destination timed out, reaping",
-                  evt_tag_str("template", self->owner->filename_template->template),
-                  evt_tag_str("filename", self->filename));
-      affile_dd_reap_writer(self->owner, self);
-      g_static_mutex_unlock(&self->owner->lock);
-    }
-  else
-    {
-      g_static_mutex_unlock(&self->owner->lock);
-      affile_dw_arm_reaper(self);
-    }
+  if (!affile_dd_reap_writer(self->owner, self))
+    affile_dw_arm_reaper(self);
 }
 
 static gboolean
@@ -424,13 +412,21 @@ affile_dd_format_persist_name(const LogPipe *s)
   return persist_name;
 }
 
-/* DestDriver lock must be held before calling this function */
-static void
+static gboolean
 affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw)
 {
-  LogWriter *writer = (LogWriter *)dw->writer;
-
   main_loop_assert_main_thread();
+
+  g_static_mutex_lock(&self->lock);
+  if (dw->queue_pending)
+    {
+      g_static_mutex_unlock(&self->lock);
+      return FALSE;
+    }
+
+  msg_verbose("Destination timed out, reaping",
+              evt_tag_str("template", self->filename_template->template),
+              evt_tag_str("filename", dw->filename));
 
   if (self->filename_is_a_template)
     {
@@ -443,10 +439,14 @@ affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw)
       self->single_writer = NULL;
     }
 
-  LogQueue *queue = log_writer_get_queue(writer);
+  LogQueue *queue = log_writer_get_queue(dw->writer);
   log_pipe_deinit(&dw->super);
   log_dest_driver_release_queue(&self->super, queue);
   log_pipe_unref(&dw->super);
+
+  g_static_mutex_unlock(&self->lock);
+
+  return TRUE;
 }
 
 

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -119,7 +119,7 @@ affile_dw_arm_reaper(AFFileDestWriter *self)
   /* not yet reaped, set up the next callback */
   iv_validate_now();
   self->reap_timer.expires = iv_now;
-  timespec_add_msec(&self->reap_timer.expires, self->owner->time_reap * 1000 / 2);
+  timespec_add_msec(&self->reap_timer.expires, self->owner->time_reap * 1000);
   iv_timer_register(&self->reap_timer);
 }
 
@@ -131,9 +131,7 @@ affile_dw_reap(gpointer s)
   main_loop_assert_main_thread();
 
   g_static_mutex_lock(&self->lock);
-  if (!log_writer_has_pending_writes(self->writer) &&
-      !self->queue_pending &&
-      (cached_g_current_time_sec() - self->last_msg_stamp) >= self->owner->time_reap)
+  if (!log_writer_has_pending_writes(self->writer) && !self->queue_pending)
     {
       g_static_mutex_unlock(&self->lock);
       msg_verbose("Destination timed out, reaping",

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -687,9 +687,9 @@ affile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
 
   if (!self->filename_is_a_template)
     {
-      /* no need to lock the check below, the worst case that happens is
-       * that we go to the mainloop to return the same information, but this
-       * is not fast path anyway */
+
+      /* we need to lock single_writer in order to get a reference and
+       * make sure it is not a stale pointer by the time we ref it */
 
       g_static_mutex_lock(&self->lock);
       if (!self->single_writer)
@@ -699,8 +699,6 @@ affile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
         }
       else
         {
-          /* we need to lock single_writer in order to get a reference and
-           * make sure it is not a stale pointer by the time we ref it */
           next = self->single_writer;
           next->queue_pending = TRUE;
           log_pipe_ref(&next->super);


### PR DESCRIPTION
The race is in the file destination between our queueing mechanism (`affile_dd_queue()`) and `time-reap()` (`affile_dd_reap_writer()`).
Basically, `time-reap()` could deinitialize the writer while the queue (and the writer) was being used.

An example schedule:
1. In the main thread, reap is called (timer); the queue seems to be empty, so we "start reaping".
2. Context switch
3. In a worker thread, a new message arrives; the `next` writer is selected with the help of a mutex:
https://github.com/balabit/syslog-ng/blob/e07700c463fe905b66e1ffa95a6fb378fcdeae1e/modules/affile/affile-dest.c#L716-L730
4. The mutex is unlocked.
5. Context switch
6. The writer (and the queue) is deinitialized without any locks. `log_pipe_deinit` is the problem here, `log_pipe_unref` is protected (see below):
https://github.com/balabit/syslog-ng/blob/e07700c463fe905b66e1ffa95a6fb378fcdeae1e/modules/affile/affile-dest.c#L445-L447
7. Context switch
8. Main thread, syslog-ng tries to use the writer without a lock (it would be really expensive to lock a mutex here):
https://github.com/balabit/syslog-ng/blob/e07700c463fe905b66e1ffa95a6fb378fcdeae1e/modules/affile/affile-dest.c#L739

### Reproduction steps

1. Apply the following patch to trigger the race easily (immense load is required otherwise):

```diff
+++ b/modules/affile/affile-dest.c
@@ -735,6 +735,7 @@ affile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
     }
   if (next)
     {
+      sleep(1);
       log_msg_add_ack(msg, path_options);
       log_pipe_queue(&next->super, log_msg_ref(msg), path_options);
       next->queue_pending = FALSE;
```

2. Use the config below, send messages with loggen:

```
options {
	time-reap(1);
};

log {
	source {
		network(port(4444) log-fetch-limit(1) flags(no-parse));
	};

	destination {
		file("/tmp/$SEC.log", flush-lines(1));
	};
};
```

```
$ bin/loggen --syslog-proto --active-connections 10 localhost 4444
...
ERROR:../lib/logpipe.h:314:log_pipe_queue: assertion failed: ((s->flags & PIF_INITIALIZED) != 0)

This is the LogWriter instance in affile_dd_queue:
(gdb) print next->super.flags
$1 = 0
```
