### PR TITLE
Disk queue directory change in configuration

### DIFF
--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -91,6 +91,17 @@ disk_queue_options_check_plugin_settings(DiskQueueOptions *self)
     }
 }
 
+gchar *
+_normalize_path(const gchar *path)
+{
+  const int length = strlen(path);
+
+  if ('/' == path[length-1] || '\\' == path[length-1])
+    return g_path_get_dirname(path);
+
+  return g_strdup(path);
+}
+
 void
 disk_queue_options_set_dir(DiskQueueOptions *self, const gchar *dir)
 {
@@ -98,7 +109,8 @@ disk_queue_options_set_dir(DiskQueueOptions *self, const gchar *dir)
     {
       g_free(self->dir);
     }
-  self->dir = g_strdup(dir);
+
+  self->dir = _normalize_path(dir);
 }
 
 void


### PR DESCRIPTION
When the `disk-buffer` directory is changed, but the destination already has a disk buffer file, syslog-ng continues to use the old path without any warning.
This modification aims to notify the user about the fact that disk queue is not changed.
Solves first part of the #1851.