### PR TITLE
Properly declare main_loop_workers_running extern

### DIFF
--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -48,6 +48,8 @@
 #include <iv_signal.h>
 #include <iv_event.h>
 
+volatile gint main_loop_workers_running;
+
 /**
  * Processing model
  * ================

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -27,7 +27,7 @@
 #include "syslog-ng.h"
 #include "thread-utils.h"
 
-volatile gint main_loop_workers_running;
+extern volatile gint main_loop_workers_running;
 
 typedef struct _MainLoop MainLoop;
 


### PR DESCRIPTION
This resolves the following build error on OSX 10.13:
```
:info:build   CCLD     lib/libsyslog-ng.la
:info:build clang: warning: argument unused during compilation: '-pthread'
:info:build clang: warning: argument unused during compilation: '-pthread'
:info:build ld: warning: option -noall_load is obsolete and being ignored
:info:build ld: warning: option -noall_load is obsolete and being ignored
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-apphook.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-cfg.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-cfg-lexer.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-cfg-lexer-subst.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-cfg-parser.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-logqueue-fifo.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-logreader.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-logthrdestdrv.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-logwriter.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-mainloop.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-mainloop-call.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-mainloop-worker.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-mainloop-io-worker.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-ml-batched-timer.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-msg-format.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-plugin.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-cfg-lex.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/.libs/lib_libsyslog_ng_la-cfg-grammar.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/logproto/.libs/lib_libsyslog_ng_la-logproto-client.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/logproto/.libs/lib_libsyslog_ng_la-logproto-server.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/logproto/.libs/lib_libsyslog_ng_la-logproto-builtins.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/filter/.libs/lib_libsyslog_ng_la-filter-expr-grammar.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/parser/.libs/lib_libsyslog_ng_la-parser-expr-grammar.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/rewrite/.libs/lib_libsyslog_ng_la-rewrite-expr-grammar.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/template/.libs/lib_libsyslog_ng_la-templates.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/template/.libs/lib_libsyslog_ng_la-simple-function.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/template/.libs/lib_libsyslog_ng_la-repr.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/template/.libs/lib_libsyslog_ng_la-compiler.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/template/.libs/lib_libsyslog_ng_la-user-function.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/stats/.libs/lib_libsyslog_ng_la-stats-control.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/control/.libs/lib_libsyslog_ng_la-control-commands.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/control/.libs/lib_libsyslog_ng_la-control-main.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/debugger/.libs/lib_libsyslog_ng_la-debugger.o
:info:build duplicate symbol _main_loop_workers_running in:
:info:build     lib/.libs/lib_libsyslog_ng_la-afinter.o
:info:build     lib/debugger/.libs/lib_libsyslog_ng_la-debugger-main.o
:info:build ld: 34 duplicate symbols for architecture x86_64
:info:build clang: error: linker command failed with exit code 1 (use -v to see invocation)
:info:build make[2]: *** [lib/libsyslog-ng.la] Error 1
:info:build make[1]: *** [all-recursive] Error 1
:info:build make: *** [all] Error 2
```