### PR TITLE
Disk-buffer save queue in qdisk write chunks instead whole buffer

### DIFF
--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -356,12 +356,6 @@ timespec_add_msec(struct timespec *ts, glong msec)
 }
 
 glong
-timspec_diff_msec(struct timespec *t1, struct timespec *t2)
-{
-  return (t1->tv_sec - t2->tv_sec) * 1e3 + (t1->tv_nsec - t2->tv_nsec) / 1e6;
-}
-
-glong
 timespec_diff_nsec(struct timespec *t1, struct timespec *t2)
 {
   return (t1->tv_sec - t2->tv_sec) * 1e9 + (t1->tv_nsec - t2->tv_nsec);

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -45,7 +45,6 @@ gboolean check_nanosleep(void);
 int format_zone_info(gchar *buf, size_t buflen, long gmtoff);
 glong g_time_val_diff(GTimeVal *t1, GTimeVal *t2);
 void timespec_add_msec(struct timespec *ts, glong msec);
-glong timespec_diff_msec(struct timespec *t1, struct timespec *t2);
 glong timespec_diff_nsec(struct timespec *t1, struct timespec *t2);
 gint determine_year_for_month(gint month, const struct tm *now);
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -552,6 +552,28 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
   return TRUE;
 }
 
+#define STRING_BUFFER_MEMORY_LIMIT (8 * 1024)
+static inline gboolean
+string_reached_memory_limit(GString *string)
+{
+  return (string->len >= STRING_BUFFER_MEMORY_LIMIT);
+}
+
+static gboolean
+qdisk_write_serialized_string_to_file(QDisk *self, GString const *serialized, gint64 *offset)
+{
+  *offset = lseek(self->fd, 0, SEEK_END);
+  if (!pwrite_strict(self->fd, serialized->str, serialized->len, *offset))
+    {
+      msg_error("Error writing in-memory buffer of disk-queue to disk",
+                evt_tag_str("filename", self->filename),
+                evt_tag_errno("error", errno),
+                NULL);
+      return FALSE;
+    }
+  return TRUE;
+}
+
 static gboolean
 _save_queue(QDisk *self, GQueue *q, gint64 *q_ofs, gint32 *q_len)
 {
@@ -559,6 +581,10 @@ _save_queue(QDisk *self, GQueue *q, gint64 *q_ofs, gint32 *q_len)
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   SerializeArchive *sa;
   GString *serialized;
+  gint64  current_offset = 0;
+  gint64  queue_start_position = 0;
+  gint32  written_bytes = 0;
+  gboolean success = FALSE;
 
   if (q->length == 0)
     {
@@ -581,20 +607,32 @@ _save_queue(QDisk *self, GQueue *q, gint64 *q_ofs, gint32 *q_len)
       log_msg_serialize(msg, sa);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);
+      if (string_reached_memory_limit(serialized))
+        {
+          if (!qdisk_write_serialized_string_to_file(self, serialized, &current_offset))
+            goto error;
+          if(!queue_start_position)
+            queue_start_position = current_offset;
+          written_bytes += serialized->len;
+          g_string_truncate(serialized, 0);
+        }
     }
-  serialize_archive_free(sa);
-  *q_ofs = lseek(self->fd, 0, SEEK_END);
-  if (!pwrite_strict(self->fd, serialized->str, serialized->len, *q_ofs))
+  if(serialized->len)
     {
-      msg_error("Error writing in-memory buffer of disk-queue to disk",
-                evt_tag_str("filename", self->filename),
-                evt_tag_errno("error", errno));
-      g_string_free(serialized, TRUE);
-      return FALSE;
+      if (!qdisk_write_serialized_string_to_file(self, serialized, &current_offset))
+        goto error;
+      if(!queue_start_position)
+        queue_start_position = current_offset;
+      written_bytes += serialized->len;
     }
-  *q_len = serialized->len;
+
+  *q_len = written_bytes;
+  *q_ofs = queue_start_position;
+  success = TRUE;
+error:
   g_string_free(serialized, TRUE);
-  return TRUE;
+  serialize_archive_free(sa);
+  return success;
 }
 
 gboolean

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -420,7 +420,7 @@ _load_queue(QDisk *self, GQueue *q, gint64 q_ofs, gint32 q_len, gint32 q_count)
             }
           else
             {
-              msg_error("Error reading message from disk-queue file (maybe currupted file) some messages will be lost",
+              msg_error("Error reading message from disk-queue file (maybe corrupted file) some messages will be lost",
                         evt_tag_str("filename", self->filename),
                         evt_tag_int("lost messages", q_count - i));
               log_msg_unref(msg);


### PR DESCRIPTION
In the past qdisk_save_queue only wrote the serialized data to the diskq when all messages have been popped from the queue and serialized.
During serialization each serialized message is appended to the same string buffer which could lead to huge memory usage (proportional to the log-fifo-size).

With this patch we define an internal memory limit of the string buffer.
When the limit is reached, we write the serialized messages to the disk-buffer and truncate the buffer.