### PR TITLE
logproto-client: make the logproto_client_get_id to a virtual function

### DIFF
--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -49,11 +49,18 @@ log_proto_client_free(LogProtoClient *s)
   g_free(s);
 }
 
+gint
+_get_id(LogProtoClient *self)
+{
+  return log_transport_get_id(self->transport);
+}
+
 void
 log_proto_client_init(LogProtoClient *self, LogTransport *transport, const LogProtoClientOptions *options)
 {
   self->validate_options = log_proto_client_validate_options_method;
   self->free_fn = log_proto_client_free_method;
+  self->get_id  = _get_id;
   self->options = options;
   self->transport = transport;
 }

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -65,6 +65,7 @@ struct _LogProtoClient
   gboolean (*prepare)(LogProtoClient *s, gint *fd, GIOCondition *cond);
   LogProtoStatus (*post)(LogProtoClient *s, guchar *msg, gsize msg_len, gboolean *consumed);
   LogProtoStatus (*flush)(LogProtoClient *s);
+  gint (*get_id)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
   void (*free_fn)(LogProtoClient *s);
   LogProtoClientFlowControlFuncs flow_control_funcs;
@@ -119,10 +120,12 @@ log_proto_client_post(LogProtoClient *s, guchar *msg, gsize msg_len, gboolean *c
 }
 
 static inline gint
-log_proto_client_get_fd(LogProtoClient *s)
+log_proto_client_get_id(LogProtoClient *s)
 {
-  /* FIXME: Layering violation */
-  return s->transport->fd;
+  if (s->get_id)
+    return s->get_id(s);
+
+  return -1;
 }
 
 static inline void

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -215,8 +215,8 @@ log_writer_work_finished(gpointer s)
       if (self->proto)
         {
           log_writer_suspend(self);
-          msg_notice("Suspending write operation because of an I/O error",
-                     evt_tag_int("fd", log_proto_client_get_fd(self->proto)),
+          msg_notice("Suspending write operation because of write error",
+                     evt_tag_int("id", log_proto_client_get_id(self->proto)),
                      evt_tag_int("time_reopen", self->options->time_reopen));
         }
       goto exit;
@@ -272,7 +272,7 @@ log_writer_io_error(gpointer s)
   if (self->fd_watch.handler_out == NULL && self->fd_watch.handler_in == NULL)
     {
       msg_debug("POLLERR occurred while idle",
-                evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
+                evt_tag_int("id", log_proto_client_get_id(self->proto)));
       log_writer_broken(self, NC_WRITE_ERROR);
       return;
     }
@@ -291,7 +291,7 @@ log_writer_io_check_eof(gpointer s)
   LogWriter *self = (LogWriter *) s;
 
   msg_error("EOF occurred while idle",
-            evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
+            evt_tag_int("id", log_proto_client_get_id(self->proto)));
   log_writer_broken(self, NC_CLOSE);
 }
 
@@ -302,7 +302,7 @@ log_writer_error_suspend_elapsed(gpointer s)
 
   self->suspended = FALSE;
   msg_notice("Error suspend timeout has elapsed, attempting to write again",
-             evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
+             evt_tag_int("id", log_proto_client_get_id(self->proto)));
   log_writer_start_watches(self);
 }
 

--- a/lib/transport/logtransport.c
+++ b/lib/transport/logtransport.c
@@ -38,12 +38,19 @@ log_transport_free_method(LogTransport *s)
     }
 }
 
+static gint
+_get_id(LogTransport *self)
+{
+  return self->fd;
+}
+
 void
 log_transport_init_instance(LogTransport *self, gint fd)
 {
   self->fd = fd;
   self->cond = 0;
   self->free_fn = log_transport_free_method;
+  self->get_id  = _get_id;
 }
 
 void

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -36,6 +36,7 @@ struct _LogTransport
   GIOCondition cond;
   gssize (*read)(LogTransport *self, gpointer buf, gsize count, LogTransportAuxData *aux);
   gssize (*write)(LogTransport *self, const gpointer buf, gsize count);
+  gint (*get_id)(LogTransport *self);
   void (*free_fn)(LogTransport *self);
 };
 
@@ -49,6 +50,15 @@ static inline gssize
 log_transport_read(LogTransport *self, gpointer buf, gsize count, LogTransportAuxData *aux)
 {
   return self->read(self, buf, count, aux);
+}
+
+static inline gint
+log_transport_get_id(LogTransport *self)
+{
+  if (self->get_id)
+    return self->get_id(self);
+
+  return -1;
 }
 
 void log_transport_init_instance(LogTransport *s, gint fd);


### PR DESCRIPTION
* The `LogProtoClient` provides an interface, that should alone does not have knowledge about the underlying transport's fd.
* The `log_proto_client_get_fd` renamed to `log_proto_client_get_id`, because I think that name describes better, what this function should do. In this case it shows that possible the `fd` is not the only information we could have here.

Does it also okay for the `LogTransport` to have this `log_transport_get_id` function ?