### PR TITLE
Fixing KVParser rare crash in race condition

### DIFF
--- a/lib/scanner/kv-scanner/kv-scanner.c
+++ b/lib/scanner/kv-scanner/kv-scanner.c
@@ -344,19 +344,3 @@ kv_scanner_init(KVScanner *self, gchar value_separator, const gchar *pair_separa
   self->is_valid_key_character = _is_valid_key_character;
   self->stop_char = 0;
 }
-
-KVScanner *
-kv_scanner_new(gchar value_separator, const gchar *pair_separator, gboolean extract_stray_words)
-{
-  KVScanner *self = g_new0(KVScanner, 1);
-
-  kv_scanner_init(self, value_separator, pair_separator, extract_stray_words);
-  return self;
-}
-
-void
-kv_scanner_free(KVScanner *self)
-{
-  kv_scanner_deinit(self);
-  g_free(self);
-}

--- a/lib/scanner/kv-scanner/kv-scanner.h
+++ b/lib/scanner/kv-scanner/kv-scanner.h
@@ -107,7 +107,5 @@ kv_scanner_set_stop_character(KVScanner *self, gchar stop_char)
 }
 
 gboolean kv_scanner_scan_next(KVScanner *self);
-KVScanner *kv_scanner_new(gchar value_separator, const gchar *pair_separator, gboolean extract_stray_words);
-void kv_scanner_free(KVScanner *self);
 
 #endif

--- a/lib/scanner/kv-scanner/tests/test_kv_scanner.c
+++ b/lib/scanner/kv-scanner/tests/test_kv_scanner.c
@@ -139,12 +139,19 @@ typedef struct Testcase_t
   KVContainer expected;
 } Testcase;
 
-KVScanner *
-create_kv_scanner(const ScannerConfig config)
+static KVScanner *
+create_kv_scanner(const ScannerConfig *config)
 {
-  KVScanner *scanner = kv_scanner_new(config.kv_separator, config.pair_separator, config.extract_stray_words);
-  scanner->transform_value = config.transform_value;
+  KVScanner *scanner = g_new(KVScanner, 1);
+  kv_scanner_init(scanner, config->kv_separator, config->pair_separator, config->extract_stray_words);
+  kv_scanner_set_transform_value(scanner, config->transform_value);
   return scanner;
+}
+
+static inline void
+kv_scanner_free(KVScanner *scanner)
+{
+  g_free(scanner);
 }
 
 #define VARARG_STRUCT(VARARG_STRUCT_cont, VARARG_STRUCT_elem, ...) \
@@ -189,7 +196,7 @@ _expect_kvq_triplets(KVScanner *scanner, KVQContainer args, gchar **error)
 
 #define _IMPL_EXPECT_KVQ(SCANNER_config, TEST_KV_SCAN_input, ...) \
   do { \
-    KVScanner *scanner = create_kv_scanner(SCANNER_config); \
+    KVScanner *scanner = create_kv_scanner(&SCANNER_config); \
     gchar *error = NULL; \
     \
     kv_scanner_input(scanner, TEST_KV_SCAN_input);            \
@@ -210,7 +217,7 @@ _expect_kvq_triplets(KVScanner *scanner, KVQContainer args, gchar **error)
 
 #define _IMPL_EXPECT_KV(TEST_KV_SCAN_config, TEST_KV_SCAN_input, ...) \
   do { \
-    KVScanner *scanner = create_kv_scanner(TEST_KV_SCAN_config); \
+    KVScanner *scanner = create_kv_scanner(&TEST_KV_SCAN_config); \
     gchar *error = NULL; \
     \
     kv_scanner_input(scanner, TEST_KV_SCAN_input);            \
@@ -236,7 +243,7 @@ _expect_kvq_triplets(KVScanner *scanner, KVQContainer args, gchar **error)
 
 #define _EXPECT_KV_AND_STRAY_WORDS(INPUT, STRAY, ...) \
   do { \
-    KVScanner *scanner = create_kv_scanner(((ScannerConfig) {     \
+    KVScanner *scanner = create_kv_scanner(&((ScannerConfig) {     \
       .kv_separator = '=',              \
       .extract_stray_words=TRUE})); \
     gchar *error = NULL; \

--- a/modules/kvformat/kv-parser.h
+++ b/modules/kvformat/kv-parser.h
@@ -35,7 +35,6 @@ struct _KVParser
   gchar *prefix;
   gchar *stray_words_value_name;
   gsize prefix_len;
-  GString *formatted_key;
   void (*init_scanner)(KVParser *self, KVScanner *kv_scanner);
 };
 

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -23,48 +23,47 @@
 #include "apphook.h"
 #include "testutils.h"
 
-#define kv_scanner_testcase_begin(func, args)             \
+#define kv_scanner_testcase_begin(func, args) \
   do                                                            \
     {                                                           \
       testcase_begin("%s(%s)", func, args);                     \
-      kv_scanner = kv_scanner_new('=', 0, FALSE);      \
-      kv_scanner_set_transform_value(kv_scanner, parse_linux_audit_style_hexdump); \
+      kv_scanner_init(&kv_scanner, '=', 0, FALSE);              \
+      kv_scanner_set_transform_value(&kv_scanner, parse_linux_audit_style_hexdump); \
     }                                                           \
   while (0)
 
-#define kv_scanner_testcase_end()                           \
+#define kv_scanner_testcase_end() \
   do                                                            \
     {                                                           \
-      kv_scanner_free(kv_scanner);                              \
       testcase_end();                                           \
     }                                                           \
   while (0)
 
 #define KV_SCANNER_TESTCASE(x, ...) \
   do {                                                          \
-      kv_scanner_testcase_begin(#x, #__VA_ARGS__);      \
+      kv_scanner_testcase_begin(#x, #__VA_ARGS__);              \
       x(__VA_ARGS__);                                           \
       kv_scanner_testcase_end();                                \
   } while(0)
 
-KVScanner *kv_scanner;
+KVScanner kv_scanner;
 
 static void
 assert_no_more_tokens(void)
 {
-  assert_false(kv_scanner_scan_next(kv_scanner), "kv_scanner is expected to return no more key-value pairs");
+  assert_false(kv_scanner_scan_next(&kv_scanner), "kv_scanner is expected to return no more key-value pairs");
 }
 
 static void
 scan_next_token(void)
 {
-  assert_true(kv_scanner_scan_next(kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
+  assert_true(kv_scanner_scan_next(&kv_scanner),  "kv_scanner is expected to return TRUE for scan_next");
 }
 
 static void
 assert_current_key_is(const gchar *expected_key)
 {
-  const gchar *key = kv_scanner_get_current_key(kv_scanner);
+  const gchar *key = kv_scanner_get_current_key(&kv_scanner);
 
   assert_string(key, expected_key, "current key mismatch");
 }
@@ -72,7 +71,7 @@ assert_current_key_is(const gchar *expected_key)
 static void
 assert_current_value_is(const gchar *expected_value)
 {
-  const gchar *value = kv_scanner_get_current_value(kv_scanner);
+  const gchar *value = kv_scanner_get_current_value(&kv_scanner);
 
   assert_string(value, expected_value, "current value mismatch");
 }
@@ -95,28 +94,28 @@ static void
 test_linux_audit_scanner_audit_style_hex_dump_is_decoded(void)
 {
   /* not decoded as no characters to be escaped, kernel only escapes stuff below 0x21, above 0x7e and the quote character */
-  kv_scanner_input(kv_scanner, "proctitle=41607E");
+  kv_scanner_input(&kv_scanner, "proctitle=41607E");
   assert_next_kv_is("proctitle", "41607E");
   assert_no_more_tokens();
 
-  kv_scanner_input(kv_scanner, "proctitle=412042");
+  kv_scanner_input(&kv_scanner, "proctitle=412042");
   assert_next_kv_is("proctitle", "A B");
   assert_no_more_tokens();
 
   /* odd number of chars, not decoded */
-  kv_scanner_input(kv_scanner, "proctitle=41204");
+  kv_scanner_input(&kv_scanner, "proctitle=41204");
   assert_next_kv_is("proctitle", "41204");
   assert_no_more_tokens();
 
-  kv_scanner_input(kv_scanner, "proctitle=C3A17276C3AD7A74C5B172C59174C3BC6BC3B67266C3BA72C3B367C3A970");
+  kv_scanner_input(&kv_scanner, "proctitle=C3A17276C3AD7A74C5B172C59174C3BC6BC3B67266C3BA72C3B367C3A970");
   assert_next_kv_is("proctitle", "árvíztűrőtükörfúrógép");
   assert_no_more_tokens();
 
-  kv_scanner_input(kv_scanner, "proctitle=2F62696E2F7368002D65002F6574632F696E69742E642F706F737466697800737461747573");
+  kv_scanner_input(&kv_scanner, "proctitle=2F62696E2F7368002D65002F6574632F696E69742E642F706F737466697800737461747573");
   assert_next_kv_is("proctitle", "/bin/sh\t-e\t/etc/init.d/postfix\tstatus");
   assert_no_more_tokens();
 
-  kv_scanner_input(kv_scanner, "a1=2F62696E2F7368202D6C");
+  kv_scanner_input(&kv_scanner, "a1=2F62696E2F7368202D6C");
   assert_next_kv_is("a1", "/bin/sh -l");
   assert_no_more_tokens();
 }


### PR DESCRIPTION
In rare conditions KVParser may crash due to concurrent access to the "formatted_key" field.
Solution: Moved formatted_key from KVParser into a _process local variable.

Also splitted the _get_formatted_key function along the "if prefix" logic, because it can be decided in config time. (Function called for each key in _process.)

Question:
- Is it needed to modify the key_formatter function anywhere else than kv_parser_set_prefix?
