### PR TITLE
scratchbuffers: fixing unit test crash

### DIFF
--- a/lib/tests/test_scratch_buffers.c
+++ b/lib/tests/test_scratch_buffers.c
@@ -167,6 +167,7 @@ setup(void)
 static void
 teardown(void)
 {
+  scratch_buffers_explicit_gc();
   scratch_buffers_allocator_deinit();
   scratch_buffers_global_deinit();
   stats_destroy();


### PR DESCRIPTION
If scratch_buffers_explicit_gc() is not called at all, a warning would be
emitted by the scratchbuffers module. However the messages module is
not initialized in the unit tests, hence all unit test crashes.

This patch calls garbage collection explicitely during teardown,
avoiding the crash. The alternative would have been to call msg_init(TRUE); during startup, though that would couple the scratchbuffers unit test with messages module, that I wanted to avoid.

Criterion does not signal error, if crash happens during teardown, that's why this crash could go undetected:
```
$ ./lib/tests/test_scratch_buffers
[----] Warning! The test `scratch_buffers::reclaim_marked_allocs` crashed during its setup or teardown.
[----] Warning! The test `scratch_buffers::alloc_returns_a_gstring_instance` crashed during its setup or teardown.
[----] Warning! The test `scratch_buffers::reclaim_up_to_a_marked_alloc` crashed during its setup or teardown.
[----] Warning! The test `scratch_buffers::local_usage_metrics_measure_allocs` crashed during its setup or teardown.
[----] Warning! The test `scratch_buffers::stats_counters_are_updated` crashed during its setup or teardown.
[====] Synthesis: Tested: 6 | Passing: 6 | Failing: 0 | Crashing: 0 
```

But a core file is still generated, hence make distcheck fails if ran under ulimit -c unlimited.