### PR TITLE
Refactor and increase the maximum record length of disk-buffer()

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -46,6 +46,8 @@
 /*pessimistic default for reliable disk queue 10000 x 16 kbyte*/
 #define PESSIMISTIC_MEM_BUF_SIZE 10000 * 16 *1024
 
+#define MAX_RECORD_LENGTH 10 * 1024 * 1024
+
 #define PATH_QDISK              PATH_LOCALSTATEDIR
 
 typedef union _QDiskFileHeader
@@ -294,6 +296,12 @@ qdisk_push_tail(QDisk *self, GString *record)
   return TRUE;
 }
 
+static inline gboolean
+_is_record_length_reached_hard_limit(guint32 record_length)
+{
+  return record_length > MAX_RECORD_LENGTH;
+}
+
 gboolean
 qdisk_pop_head(QDisk *self, GString *record)
 {
@@ -318,7 +326,7 @@ qdisk_pop_head(QDisk *self, GString *record)
         }
 
       n = GUINT32_FROM_BE(n);
-      if (n > 10 * 1024 * 1024)
+      if (_is_record_length_reached_hard_limit(n))
         {
           msg_warning("Disk-queue file contains possibly invalid record-length",
                       evt_tag_int("rec_length", n),

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -46,7 +46,7 @@
 /*pessimistic default for reliable disk queue 10000 x 16 kbyte*/
 #define PESSIMISTIC_MEM_BUF_SIZE 10000 * 16 *1024
 
-#define MAX_RECORD_LENGTH 10 * 1024 * 1024
+#define MAX_RECORD_LENGTH 100 * 1024 * 1024
 
 #define PATH_QDISK              PATH_LOCALSTATEDIR
 


### PR DESCRIPTION
There is a hard-coded limitation in disk-buffer: the length of a record can not be more than 10 mebibyte.
A record consists of multiple fields serialized by `log_msg_serialize()`, so it is just a serialized `LogMessage` object.

The limit is used as a heuristic to detect an incorrect record and to prevent extreme memory usage in case of a corrupt message. Since a record includes structured data (the `NVTable`) and not just a simple serialized message, there is no way to derive an appropriate dynamic limit from the value of the `log-msg-size()` option.

The best would be to remove this limitation, but in that case, a few "consistency guarantees" and/or per-record checksum would be required.