### PR TITLE
scratchbuffers: crash in test_context_info_db: missing explicit_gc()

### DIFF
--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -37,7 +37,8 @@ function (add_unit_test)
   set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND PROPERTY LINK_FLAGS "-Wl,--no-as-needed")
 
   if (${ADD_UNIT_TEST_CRITERION})
-    target_link_libraries(${ADD_UNIT_TEST_TARGET} criterion)
+    target_link_libraries(${ADD_UNIT_TEST_TARGET} ${CRITERION_LIBRARIES})
+    target_include_directories(${ADD_UNIT_TEST_TARGET} PUBLIC ${CRITERION_INCLUDE_DIRS})
     set_property(TARGET ${ADD_UNIT_TEST_TARGET} PROPERTY POSITION_INDEPENDENT_CODE FALSE)
   endif()
 

--- a/lib/value-pairs/tests/Makefile.am
+++ b/lib/value-pairs/tests/Makefile.am
@@ -6,7 +6,8 @@ check_PROGRAMS				+= \
 	${lib_value_pairs_tests_TESTS}
 
 lib_value_pairs_tests_test_value_pairs_LDADD	= $(TEST_LDADD)
+lib_value_pairs_tests_test_value_pairs_CFLAGS	= $(TEST_CFLAGS)
 lib_value_pairs_tests_test_value_pairs_LDFLAGS	= $(PREOPEN_SYSLOGFORMAT)
 
-lib_value_pairs_tests_test_value_pairs_walk_LDADD	= \
-	$(TEST_LDADD)
+lib_value_pairs_tests_test_value_pairs_walk_LDADD = $(TEST_LDADD)
+lib_value_pairs_tests_test_value_pairs_walk_CFLAGS = $(TEST_CFLAGS)

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -21,7 +21,7 @@
  */
 
 #include "context-info-db.h"
-#include "scratch-buffers.h"
+#include "apphook.h"
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
 #include <stdio.h>
@@ -29,7 +29,7 @@
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
-TestSuite(add_contextual_data, .init=scratch_buffers_allocator_init, .fini=scratch_buffers_allocator_deinit);
+TestSuite(add_contextual_data, .init=app_startup, .fini=app_shutdown);
 
 static void
 _count_records(gpointer arg, const ContextualDataRecord *record)

--- a/modules/csvparser/tests/test_csvparser_perf.c
+++ b/modules/csvparser/tests/test_csvparser_perf.c
@@ -22,9 +22,9 @@
  */
 
 #include "csvparser.h"
+#include "apphook.h"
 #include "logmsg/logmsg.h"
 #include "string-list.h"
-#include "scratch-buffers.h"
 
 LogParser *
 _construct_parser(gint max_columns, gint dialect, gchar *delimiters, gchar *quotes, gchar *null_value,
@@ -145,11 +145,8 @@ test_escaped_parsers(void)
 int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
-  stats_init();
-  scratch_buffers_allocator_init();
-  log_msg_global_init();
+  app_startup();
   test_escaped_parsers();
-  log_msg_global_deinit();
-  stats_destroy();
+  app_shutdown();
   return 0;
 }

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -23,6 +23,7 @@ unit_test_extra_modules			= \
 
 tests_unit_test_logwriter_LDADD		= \
 	$(TEST_LDADD) $(unit_test_extra_modules)
+tests_unit_test_logwriter_CFLAGS	= $(TEST_CFLAGS)
 
 tests_unit_test_logqueue_CFLAGS		= $(TEST_CFLAGS)
 tests_unit_test_logqueue_LDADD		= \
@@ -66,6 +67,7 @@ tests_unit_test_hostid_LDADD		= \
 
 tests_unit_test_zone_LDADD		= \
 	$(TEST_LDADD) $(unit_test_extra_modules)
+tests_unit_test_zone_CFLAGS		= $(TEST_CFLAGS)
 
 tests_unit_test_pathutils_CFLAGS	= $(TEST_CFLAGS)
 tests_unit_test_pathutils_LDADD	= \


### PR DESCRIPTION
The root cause is the same as in: #1872 
As garbage collection is not explicitely called, unit test tries to write an internal message (warning) about possible leak. Though the internal messaging is not initialized, hence there is a crash.
For now I created the same fix as in #1872, calling garbage collection explicitely. Though I am starting to feel this is not the correct way to handle these issues.

Another problem is with test_context_info_db testcase is that scratchbuffers is not used at all by the test code, still the test code needs to deal with the lifecycle of scratchbuffers. It is unfortunate that the test code needs to know the internal mechanics of memory management of the tested module.

I am not sure about the alternatives though.

We can cut the dependency between scratchbuffers and messages, if we create a logger class inside scratchbuffers with a public method that can set the logger to use msg_warning. scratch_buffer_alloc_init might initialize logger to fprintf stderr. In case of unit tests, warning on stderr can be ignored, and will be ignored by the test driver.

Though the problem is the unit test still needs to initialize scratchbuffers, even without using it. It would be great if we could lazily initialize scratchbuffers on the first use, but I am not sure if it is possible without performance hit (without a memory barrier for each scratch_buffers_alloc()).

And the scratch_buffers_allocator_deinit() still needs to be called somewhere.

What are your opinions? Do you feel this is a problem we should deal, or it is fine if unit tests take care of the proper intialization/deinitialization for either or both problems?