### PR TITLE
Statistics static assert for module_names

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -23,6 +23,7 @@
  */
 #include "stats/stats-cluster.h"
 
+#include <assert.h>
 #include <string.h>
 
 static StatsClusterKey *
@@ -79,7 +80,7 @@ stats_cluster_get_type_name(StatsCluster *self, gint type)
 static const gchar *
 _get_module_name(gint source)
 {
-  static const gchar *module_names[SCS_MAX] =
+  static const gchar *module_names[] =
   {
     "none",
     "file",
@@ -121,8 +122,12 @@ _get_module_name(gint source)
     "python",
     "filter",
     "parser",
-    "monitoring"
+    "monitoring",
+    "stdin",
   };
+#if defined(static_assert)
+  static_assert(sizeof(module_names)/sizeof(module_names[0])==SCS_MAX, "The module_names must match the SCS_ items.");
+#endif
   return module_names[source & SCS_SOURCE_MASK];
 }
 

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -74,7 +74,7 @@ enum
   SCS_FILTER         = 38,
   SCS_PARSER         = 39,
   SCS_MONITORING     = 40,
-  SCS_STDIN      = 41,
+  SCS_STDIN          = 41,
   SCS_MAX,
   SCS_SOURCE_MASK    = 0xff
 };


### PR DESCRIPTION
The `module_names` must match the list of `SCS_` items defined in the header.

Should the `static_assert` defined in compat layer instead of not doing the check if not exists ?
