### PR TITLE
global config: add three global options needed for logstore

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -236,6 +236,11 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_JVM_OPTIONS                 10303
 %token KW_READ_OLD_RECORDS            10304
 
+/* logstore options */
+%token KW_LGS_JOURNAL_SHMEM_THRESHOLD               10305
+%token KW_TIMESTAMP_URL               10306
+%token KW_TIMESTAMP_POLICY            10307
+
 /* log statement options */
 %token KW_FLAGS                       10190
 
@@ -926,6 +931,9 @@ options_item
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
 	| KW_RECV_TIME_ZONE '(' string ')'      { configuration->recv_time_zone = g_strdup($3); free($3); }
   | KW_JVM_OPTIONS '(' string ')' {configuration->jvm_options = g_strdup($3); free($3);}
+  | KW_LGS_JOURNAL_SHMEM_THRESHOLD '(' positive_integer ')'		{ configuration->logstore_journal_shmem_threshold = $3; }
+  | KW_TIMESTAMP_URL '(' string ')' {configuration->timestamp_url = g_strdup($3); free($3);}
+  | KW_TIMESTAMP_POLICY '(' string ')' {configuration->timestamp_policy = g_strdup($3); free($3);}
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -133,6 +133,10 @@ static CfgLexerKeyword main_keywords[] =
   { "throttle",           KW_THROTTLE },
   { "jvm_options",        KW_JVM_OPTIONS },
 
+  { "logstore_journal_shmem_threshold", KW_LGS_JOURNAL_SHMEM_THRESHOLD },
+  { "timestamp_url",      KW_TIMESTAMP_URL },
+  { "timestamp_policy",   KW_TIMESTAMP_POLICY },
+
   { "create_dirs",        KW_CREATE_DIRS },
   { "optional",           KW_OPTIONAL },
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -447,6 +447,10 @@ cfg_new(gint version)
   self->use_uniqid = FALSE;
   self->jvm_options = NULL;
 
+  self->logstore_journal_shmem_threshold = 536870912;
+  self->timestamp_url = NULL;
+  self->timestamp_policy = NULL;
+
   stats_options_defaults(&self->stats_options);
 
   cfg_tree_init_instance(&self->tree, self);
@@ -596,6 +600,18 @@ cfg_free(GlobalConfig *self)
   log_template_unref(self->proto_template);
   log_template_options_destroy(&self->template_options);
   host_resolve_options_destroy(&self->host_resolve_options);
+
+  if (self->timestamp_url)
+    {
+      g_free(self->timestamp_url);
+      self->timestamp_url = NULL;
+    }
+
+  if (self->timestamp_policy)
+    {
+      g_free(self->timestamp_policy);
+      self->timestamp_policy = NULL;
+    }
 
   if (self->bad_hostname_compiled)
     regfree(&self->bad_hostname);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -447,7 +447,7 @@ cfg_new(gint version)
   self->use_uniqid = FALSE;
   self->jvm_options = NULL;
 
-  self->logstore_journal_shmem_threshold = 536870912;
+  self->logstore_journal_shmem_threshold = 512 * 1024 *1024;
   self->timestamp_url = NULL;
   self->timestamp_policy = NULL;
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -111,6 +111,10 @@ struct _GlobalConfig
 
   gchar *jvm_options;
 
+  gint64  logstore_journal_shmem_threshold;
+  gchar *timestamp_url;
+  gchar *timestamp_policy;
+
   LogTemplate *file_template;
   LogTemplate *proto_template;
 


### PR DESCRIPTION
This PR is about add three global options.
Signed-off-by: norberttakacs <norbert.takacs@balabit.com>