### PR TITLE
globalconfig: plugin support for global options

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -934,7 +934,6 @@ options_item
           {
             Plugin *p;
             gint context = LL_CONTEXT_OPTIONS;
-            gpointer result;
 
             p = cfg_find_plugin(configuration, context, $1);
             CHECK_ERROR(p, @1, "%s plugin %s not found", cfg_lexer_lookup_context_name_by_type(context), $1);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1129,6 +1129,7 @@ static const gchar *lexer_contexts[] =
   [LL_CONTEXT_INNER_SRC] = "inner-src",
   [LL_CONTEXT_CLIENT_PROTO] = "client-proto",
   [LL_CONTEXT_SERVER_PROTO] = "server-proto",
+  [LL_CONTEXT_OPTIONS] = "options",
 };
 
 gint

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -131,7 +131,6 @@ static CfgLexerKeyword main_keywords[] =
   { "program_override",   KW_PROGRAM_OVERRIDE },
   { "host_override",      KW_HOST_OVERRIDE },
   { "throttle",           KW_THROTTLE },
-  { "jvm_options",        KW_JVM_OPTIONS },
 
   { "create_dirs",        KW_CREATE_DIRS },
   { "optional",           KW_OPTIONAL },

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -445,7 +445,6 @@ cfg_new(gint version)
   self->keep_timestamp = TRUE;
 
   self->use_uniqid = FALSE;
-  self->jvm_options = NULL;
 
   stats_options_defaults(&self->stats_options);
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -109,8 +109,6 @@ struct _GlobalConfig
   gchar *file_template_name;
   gchar *proto_template_name;
 
-  gchar *jvm_options;
-
   LogTemplate *file_template;
   LogTemplate *proto_template;
 

--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -10,6 +10,8 @@ set (NATIVE_SOURCES
     native/java-parser.c
     native/java-parser.h
     native/java-plugin.c
+    native/java-config.c
+    native/java-config.h
     ${CMAKE_CURRENT_BINARY_DIR}/java-grammar.c
     ${CMAKE_CURRENT_BINARY_DIR}/java-grammar.h
 )

--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -86,6 +86,8 @@ modules_java_libmod_java_la_SOURCES = \
     modules/java/native/java_machine.c \
     modules/java/native/java_machine.h \
     modules/java/native/java-destination.h \
+		modules/java/native/java-config.c \
+		modules/java/native/java-config.h \
     modules/java/proxies/java-destination-proxy.c \
     modules/java/proxies/java-destination-proxy.h \
     modules/java/proxies/java-logmsg-proxy.c \

--- a/modules/java/native/java-config.c
+++ b/modules/java/native/java-config.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "java-config.h"
+#include "cfg.h"
+
+#define MODULE_CONFIG_KEY "java"
+
+static gboolean
+java_config_init(ModuleConfig *s, GlobalConfig *cfg)
+{
+  return TRUE;
+}
+
+static void
+java_config_free(ModuleConfig *s)
+{
+  JavaConfig *self = (JavaConfig *) s;
+
+  if (self->jvm_options)
+    g_free(self->jvm_options);
+  self->jvm_options = NULL;
+
+  module_config_free_method(s);
+}
+
+JavaConfig *
+java_config_new(void)
+{
+  JavaConfig *self = g_new0(JavaConfig, 1);
+
+  self->super.init = java_config_init;
+  self->super.free_fn = java_config_free;
+  return self;
+}
+
+JavaConfig *
+java_config_get(GlobalConfig *cfg)
+{
+  JavaConfig *jc = g_hash_table_lookup(cfg->module_config, MODULE_CONFIG_KEY);
+  if (!jc)
+    {
+      jc = java_config_new();
+      g_hash_table_insert(cfg->module_config, g_strdup(MODULE_CONFIG_KEY), jc);
+    }
+  return jc;
+}
+
+void
+java_config_set_jvm_options(GlobalConfig *cfg, gchar *jvm_options)
+{
+  JavaConfig *jc = java_config_get(cfg);
+  jc -> jvm_options = jvm_options;
+}
+
+gchar *
+java_config_get_jvm_options(GlobalConfig *cfg)
+{
+  JavaConfig *jc = java_config_get(cfg);
+  return (jc -> jvm_options);
+}

--- a/modules/java/native/java-config.h
+++ b/modules/java/native/java-config.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef JAVA_GLOBALS_H_INCLUDED
+#define JAVA_GLOBALS_H_INCLUDED
+
+#include "module-config.h"
+
+typedef struct _JavaConfig
+{
+  ModuleConfig super;
+  gchar *jvm_options;
+} JavaConfig;
+
+JavaConfig *java_config_get(GlobalConfig *cfg);
+void        java_config_set_jvm_options(GlobalConfig *cfg, gchar *jvm_options);
+gchar      *java_config_get_jvm_options(GlobalConfig *cfg);
+
+#endif
+

--- a/modules/java/native/java-config.h
+++ b/modules/java/native/java-config.h
@@ -1,17 +1,18 @@
 /*
  * Copyright (c) 2018 Balabit
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -28,6 +28,7 @@
 #include "logqueue.h"
 #include "driver.h"
 #include "str-utils.h"
+#include "java-config.h"
 
 #include <stdio.h>
 
@@ -130,8 +131,9 @@ java_dd_init(LogPipe *s)
       return FALSE;
     }
 
+  const gchar *jvm_options = java_config_get_jvm_options(cfg);
   self->proxy = java_destination_proxy_new(self->class_name, self->class_path->str, self, self->template,
-                                           &self->super.seq_num, cfg->jvm_options);
+                                           &self->super.seq_num, jvm_options);
   if (!self->proxy)
     return FALSE;
 

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -32,6 +32,7 @@
 
 #include "cfg-parser.h"
 #include "cfg-grammar.h"
+#include "java-config.h"
 #include "plugin.h"
 
 }
@@ -49,6 +50,7 @@
 %token KW_CLASS_PATH
 %token KW_CLASS_NAME
 %token KW_OPTION
+%token KW_JVM_OPTIONS
 
 %%
 
@@ -58,6 +60,7 @@ start
             last_driver = *instance = java_dd_new(configuration);
           }
           '(' java_dest_options ')'		{ YYACCEPT; }
+        | LL_CONTEXT_OPTIONS java_global_option { YYACCEPT; }
         ;
 
 java_dest_options
@@ -91,6 +94,9 @@ java_dest_custom_options
 java_dest_custom_option
   : string string_or_number { java_dd_set_option(last_driver, $1, $2); free($1); free($2); }
 
+java_global_option
+        : KW_JVM_OPTIONS '(' string ')' {java_config_set_jvm_options(configuration, g_strdup($3)); free($3);}
+	;
 /* INCLUDE_RULES */
 
 %%

--- a/modules/java/native/java-parser.c
+++ b/modules/java/native/java-parser.c
@@ -33,6 +33,8 @@ static CfgLexerKeyword java_keywords[] =
   { "class_path",  KW_CLASS_PATH},
   { "class_name",  KW_CLASS_NAME},
   { "option",      KW_OPTION},
+
+  { "jvm_options", KW_JVM_OPTIONS},
   { NULL }
 };
 

--- a/modules/java/native/java-plugin.c
+++ b/modules/java/native/java-plugin.c
@@ -38,6 +38,11 @@ extern CfgParser java_parser;
 static Plugin java_plugins[] =
 {
   {
+    .type = LL_CONTEXT_OPTIONS,
+    .name = "jvm_options",
+    .parser = &java_parser,
+  },
+  {
     .type = LL_CONTEXT_DESTINATION,
     .name = "java",
     .parser = &java_parser,


### PR DESCRIPTION
This extends the `ModuleConfig` with automatic module load. A module (like `java`) is able to declare a module specific global option(s).