### PR TITLE
Diskq: fix restart disk-queue

### DIFF
--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -304,6 +304,8 @@ _restart_diskq(LogQueueDisk *self, gboolean corrupted)
 {
   gchar *filename = g_strdup(qdisk_get_filename(self->qdisk));
   gchar *new_file = NULL;
+  DiskQueueOptions *options = qdisk_get_options(self->qdisk);
+
   qdisk_deinit(self->qdisk);
   if (corrupted)
     {
@@ -311,6 +313,7 @@ _restart_diskq(LogQueueDisk *self, gboolean corrupted)
       rename(filename,new_file);
       g_free(new_file);
     }
+  qdisk_init(self->qdisk, options);
   if (self->start)
     {
       self->start(self, filename);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -786,6 +786,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
       self->hdr->write_head = QDISK_RESERVED_SPACE;
       self->hdr->backlog_head = self->hdr->read_head;
       self->hdr->length = 0;
+      self->file_size = self->hdr->write_head;
 
       if (!qdisk_save_state(self, qout, qbacklog, qoverflow))
         {
@@ -855,6 +856,7 @@ void
 qdisk_init(QDisk *self, DiskQueueOptions *options)
 {
   self->fd = -1;
+  self->file_size = 0;
   self->options = options;
   if (!self->options->reliable)
     self->file_id = "SLQF";

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -83,9 +83,6 @@ struct _QDisk
   gchar *filename;
   gchar *file_id;
   gint fd;
-  gint64 read_qout_ofs; /* the size in bytes between read_head and qout_ofs */
-  gint64 prev_read_head;
-  gint64 prev_length;
   gint64 file_size;
   QDiskFileHeader *hdr;
   DiskQueueOptions *options;
@@ -460,7 +457,6 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
   qoverflow_count = self->hdr->qoverflow_count;
   qoverflow_len = self->hdr->qoverflow_len;
   qoverflow_ofs = self->hdr->qoverflow_ofs;
-  self->read_qout_ofs = qout_ofs;
 
   if ((self->hdr->read_head < QDISK_RESERVED_SPACE) ||
       (self->hdr->write_head < QDISK_RESERVED_SPACE) ||

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -967,6 +967,12 @@ qdisk_reset_file_if_possible(QDisk *self)
     }
 }
 
+DiskQueueOptions *
+qdisk_get_options(QDisk *self)
+{
+  return self->options;
+}
+
 gint64
 qdisk_get_length(QDisk *self)
 {

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -53,6 +53,7 @@ void qdisk_free(QDisk *self);
 
 gboolean qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 
+DiskQueueOptions *qdisk_get_options(QDisk *self);
 gint64 qdisk_get_length(QDisk *self);
 void qdisk_set_length(QDisk *self, gint64 new_value);
 gint64 qdisk_get_size(QDisk *self);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -339,14 +339,6 @@ typedef struct diskq_tester_parameters
   guint32 qout_size;
 } diskq_tester_parameters_t;
 
-
-typedef struct
-{
-  LogQueue *q;
-  guint32 num;
-  guint32 single_msg_size;
-} feed_and_assert_t;
-
 void
 init_statistics(LogQueue *q)
 {

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -42,6 +42,7 @@
 #include <string.h>
 #include <iv.h>
 #include <iv_thread.h>
+#include <sys/stat.h>
 
 #define OVERFLOW_SIZE 10000
 #ifdef PATH_QDISK
@@ -50,6 +51,7 @@
 #define PATH_QDISK "./"
 
 MsgFormatOptions parse_options;
+
 
 static void
 testcase_zero_diskbuf_and_normal_acks(void)
@@ -315,6 +317,72 @@ testcase_with_threads(void)
   fprintf(stderr, "Feed speed: %.2lf\n", (double) TEST_RUNS * MESSAGES_SUM * 1000000 / sum_time);
 }
 
+static void
+testcase_diskbuffer_restart_corrupted(void)
+{
+  typedef struct restart_test_parameters
+  {
+    gchar *filename;
+    LogQueue *(*lqdisk_new_func)(DiskQueueOptions *options, const gchar *persist_name);
+    gboolean reliable;
+  } restart_test_parameters;
+
+  restart_test_parameters parameters[] =
+  {
+    {"test-diskq-restart.qf", log_queue_disk_non_reliable_new, FALSE},
+    {"test-diskq-restart.rqf", log_queue_disk_reliable_new, TRUE},
+  };
+
+  guint64 const original_disk_buf_size = 1000123;
+  gsize number_of_variants = sizeof(parameters)/sizeof(restart_test_parameters);
+  for (gsize i = 0; i < number_of_variants; i++)
+    {
+      DiskQueueOptions options;
+      _construct_options(&options, original_disk_buf_size, 100000, parameters[i].reliable);
+      LogQueue *q = parameters[i].lqdisk_new_func(&options, NULL);
+      log_queue_set_use_backlog(q, FALSE);
+
+      gchar *filename = parameters[i].filename;
+      gchar filename_corrupted_dq[100];
+      g_snprintf(filename_corrupted_dq, 100, "%s.corrupted", filename);
+      unlink(filename);
+      unlink(filename_corrupted_dq);
+
+      log_queue_disk_load_queue(q, filename);
+      fed_messages = 0;
+      feed_some_messages(q, 100, &parse_options);
+      assert_gint(fed_messages, 100, "Failed to push all messages to the disk-queue!\n");
+
+      LogQueueDisk *disk_queue = (LogQueueDisk *)q;
+      disk_queue->restart_corrupted(disk_queue);
+
+      struct stat file_stat;
+      assert_gint(stat(filename, &file_stat), 0,
+                  "New disk-queue file does not exists!!");
+      assert_gint(S_ISREG(file_stat.st_mode), TRUE,
+                  "New disk-queue file expected to be a regular file!! st_mode value=",
+                  (file_stat.st_mode & S_IFMT));
+      stat(filename_corrupted_dq, &file_stat);
+      assert_gint(S_ISREG(file_stat.st_mode), TRUE,
+                  "Corrupted disk-queue file does not exists!!");
+      assert_string(qdisk_get_filename(disk_queue->qdisk), filename,
+                    "New disk-queue file's name should be the same\n");
+      assert_gint(qdisk_get_size(disk_queue->qdisk), original_disk_buf_size,
+                  "Disk-queue option does not match the original configured value!\n");
+      assert_gint(qdisk_get_length(disk_queue->qdisk), 0,
+                  "New disk-queue file should be empty!\n");
+      assert_gint(qdisk_get_writer_head(disk_queue->qdisk), QDISK_RESERVED_SPACE,
+                  "Invalid write pointer!\n");
+      assert_gint(qdisk_get_reader_head(disk_queue->qdisk), QDISK_RESERVED_SPACE,
+                  "Invalid read pointer!\n");
+
+      log_queue_unref(q);
+      unlink(filename);
+      unlink(filename_corrupted_dq);
+      disk_queue_options_destroy(&options);
+    }
+}
+
 static gboolean
 is_valid_msg_size(guint32 one_msg_size)
 {
@@ -524,6 +592,7 @@ main(void)
 
   testcase_zero_diskbuf_alternating_send_acks();
   testcase_zero_diskbuf_and_normal_acks();
+  testcase_diskbuffer_restart_corrupted();
 
   return 0;
 }


### PR DESCRIPTION
If a pop operation fails during reading from the disk-queue file the restart_corrupted method is called.
It has to close the current disk-queue file and rename it to "<filename>.corrupted" then it has to start a new file from scratch.

The function reuses the existing QDisk object after a deinit call, although it forgets to initialize the object properly before use and that causes a crash.

Questions:
* Who creates the DiskQueueOptions object and where is it passed to the QDisk object?
* Is it okay to get a reference of the `options` member?

Probably fixes crash in #1770 (but not the corruption of the disk-queue).