### PR TITLE
Password protected ssl keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,12 @@ set(Eventlog_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/eventlog/src")
 
 add_custom_target(style-check  COMMAND ${PROJECT_SOURCE_DIR}/scripts/style-checker.sh check  ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
 add_custom_target(style-format COMMAND ${PROJECT_SOURCE_DIR}/scripts/style-checker.sh format ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
+add_custom_target(check-copyright
+  COMMAND ${PROJECT_SOURCE_DIR}/tests/copyright/check.sh . ${PROJECT_BINARY_DIR} policy
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_target_properties(check-copyright PROPERTIES
+  ADDITIONAL_MAKE_CLEAN_FILES
+  "copyright-run.log;copyright-err.log")
 
 
 include_directories (${PROJECT_BINARY_DIR}/lib)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -302,6 +302,7 @@ target_link_libraries(
     ${OPENSSL_LIBRARIES}
     ${RESOLV_LIBRARIES}
     ${LIBPCRE_LIBRARIES}
+    secret-storage
     )
 
 set_target_properties(syslog-ng

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory(value-pairs)
 add_subdirectory(scanner)
 add_subdirectory(str-repr)
 add_subdirectory(eventlog)
+add_subdirectory(secret-storage)
 
 set(LIB_SUBDIR_HEADERS
     ${COMPAT_HEADERS}

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -18,6 +18,7 @@ include lib/scanner/csv-scanner/Makefile.am
 include lib/scanner/list-scanner/Makefile.am
 include lib/scanner/kv-scanner/Makefile.am
 include lib/str-repr/Makefile.am
+include lib/secret-storage/Makefile.am
 
 LSNG_RELEASE		= $(shell echo @PACKAGE_VERSION@ | cut -d. -f1,2)
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -41,7 +41,7 @@ LSNG_REVISION		= 0
 LSNG_AGE		= 0
 
 lib_LTLIBRARIES				+= lib/libsyslog-ng.la
-lib_libsyslog_ng_la_LIBADD		= @CORE_DEPS_LIBS@ $(libsystemd_LIBS)
+lib_libsyslog_ng_la_LIBADD		= @CORE_DEPS_LIBS@ $(libsystemd_LIBS) $(top_builddir)/lib/secret-storage/libsecret-storage.la
 lib_libsyslog_ng_la_LDFLAGS		= -no-undefined -release ${LSNG_RELEASE} \
 					  -version-info ${LSNG_CURRENT}:${LSNG_REVISION}:${LSNG_AGE}
 

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -41,6 +41,8 @@
 #include "value-pairs/value-pairs.h"
 #include "scratch-buffers.h"
 #include "mainloop.h"
+#include "secret-storage/nondumpable-allocator.h"
+#include "secret-storage/secret-storage.h"
 
 #include <iv.h>
 #include <iv_work.h>
@@ -121,6 +123,12 @@ app_fatal(const char *msg)
 }
 
 void
+nondumpable_allocator_logger(gchar *summary, gchar *reason)
+{
+  msg_fatal(summary, evt_tag_str("reason", reason));
+}
+
+void
 app_startup(void)
 {
   msg_init(FALSE);
@@ -144,6 +152,8 @@ app_startup(void)
   service_management_init();
   scratch_buffers_allocator_init();
   main_loop_thread_resource_init();
+  nondumpable_setlogger(nondumpable_allocator_logger);
+  secret_storage_init();
 }
 
 void
@@ -178,6 +188,7 @@ app_shutdown(void)
 {
   run_application_hook(AH_SHUTDOWN, TRUE);
   main_loop_thread_resource_deinit();
+  secret_storage_deinit();
   scratch_buffers_allocator_deinit();
   scratch_buffers_global_deinit();
   value_pairs_global_deinit();

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -178,7 +178,7 @@ process_credentials_add(GString *result, guint argc, gchar **arguments)
   gchar *id = arguments[2];
   gchar *secret = arguments[3];
 
-  if (secret_storage_store_string(id,secret))
+  if (secret_storage_store_secret(id, secret, strlen(secret)))
     g_string_assign(result,"Credentials stored successfully\n");
   else
     g_string_assign(result,"Error while saving credentials\n");

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -151,7 +151,7 @@ secret_status_to_string(SecretStorageSecretState state)
 }
 
 gboolean
-secret_storage_status_iterator(SecretStatus *status, gpointer user_data)
+secret_storage_status_accumulator(SecretStatus *status, gpointer user_data)
 {
   GString *status_str = (GString *) user_data;
   g_string_append_printf(status_str, "%s\t%s\n", status->key, secret_status_to_string(status->state));
@@ -162,7 +162,7 @@ static GString *
 process_credentials_status(GString *result)
 {
   g_string_assign(result,"Credential storage status:\n");
-  secret_storage_status_foreach(secret_storage_status_iterator, (gpointer) result);
+  secret_storage_status_foreach(secret_storage_status_accumulator, (gpointer) result);
   return result;
 }
 
@@ -202,7 +202,7 @@ process_credentials(GString *command, gpointer user_data)
 
   gchar *subcommand = arguments[1];
 
-  if (strcmp(arguments[1],"status")==0)
+  if (strcmp(subcommand,"status")==0)
     result = process_credentials_status(result);
   else if (g_strcmp0(subcommand,"add") == 0)
     result = process_credentials_add(result, argc, arguments);

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -23,7 +23,7 @@
  */
 #include "control/control.h"
 #include "control/control-main.h"
-#include "lib/secret-storage/secret-storage.h"
+#include "secret-storage/secret-storage.h"
 #include "mainloop.h"
 #include "messages.h"
 #include "apphook.h"

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -131,11 +131,30 @@ control_connection_reopen(GString *command, gpointer user_data)
   return result;
 }
 
+static const gchar *
+secret_status_to_string(SecretStorageSecretState state)
+{
+  switch (state)
+    {
+    case SECRET_STORAGE_STATUS_PENDING:
+      return "PENDING";
+    case SECRET_STORAGE_SUCCESS:
+      return "SUCCESS";
+    case SECRET_STORAGE_STATUS_FAILED:
+      return "FAILED";
+    case SECRET_STORAGE_STATUS_INVALID_PASSWORD:
+      return "INVALID_PASSWORD";
+    default:
+      g_assert_not_reached();
+    }
+  return "SHOULD NOT BE REACHED";
+}
+
 gboolean
 secret_storage_status_iterator(SecretStatus *status, gpointer user_data)
 {
   GString *status_str = (GString *) user_data;
-  g_string_append_printf(status_str, "%s\n", status->key);
+  g_string_append_printf(status_str, "%s\t%s\n", status->key, secret_status_to_string(status->state));
   return TRUE;
 }
 

--- a/lib/control/tests/Makefile.am
+++ b/lib/control/tests/Makefile.am
@@ -6,7 +6,8 @@ check_PROGRAMS				+= ${lib_control_tests_TESTS}
 
 lib_control_tests_test_control_cmds_CFLAGS	= $(TEST_CFLAGS) \
 	-I${top_srcdir}/lib/control/tests
-lib_control_tests_test_control_cmds_LDADD	= $(TEST_LDADD)
+lib_control_tests_test_control_cmds_LDADD	= $(TEST_LDADD) \
+	 -dlpreopen $(top_builddir)/lib/secret-storage/libsecret-storage.la
 lib_control_tests_test_control_cmds_SOURCES	= 		\
 	lib/control/tests/test_control_cmds.c
 

--- a/lib/secret-storage/CMakeLists.txt
+++ b/lib/secret-storage/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(SECRET_STORAGE_SOURCES
-  secret-storage.c)
+  secret-storage.c
+  nondumpable-allocator.c)
 set(SECRET_STORAGE_HEADERS
-  secret-storage.h)
+  secret-storage.h
+  nondumpable-allocator.h)
 
 add_library(secret-storage SHARED ${SECRET_STORAGE_SOURCES})
 target_include_directories(secret-storage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(secret-storage PUBLIC "${GLIB_INCLUDE_DIRS}")
 set_target_properties(secret-storage PROPERTIES C_VISIBILITY_PRESET hidden)
+target_link_libraries(secret-storage syslog-ng)
 
 install(TARGETS secret-storage LIBRARY DESTINATION lib)
 install(FILES ${SECRET_STORAGE_HEADERS} DESTINATION include/syslog-ng)

--- a/lib/secret-storage/CMakeLists.txt
+++ b/lib/secret-storage/CMakeLists.txt
@@ -6,9 +6,9 @@ set(SECRET_STORAGE_HEADERS
 add_library(secret-storage SHARED ${SECRET_STORAGE_SOURCES})
 target_include_directories(secret-storage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(secret-storage PUBLIC "${GLIB_INCLUDE_DIRS}")
+set_target_properties(secret-storage PROPERTIES C_VISIBILITY_PRESET hidden)
 
 install(TARGETS secret-storage LIBRARY DESTINATION lib)
 install(FILES ${SECRET_STORAGE_HEADERS} DESTINATION include/syslog-ng)
-
 
 add_subdirectory(tests)

--- a/lib/secret-storage/CMakeLists.txt
+++ b/lib/secret-storage/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(SECRET_STORAGE_SOURCES
+  secret-storage.c)
+set(SECRET_STORAGE_HEADERS
+  secret-storage.h)
+
+add_library(secret-storage SHARED ${SECRET_STORAGE_SOURCES})
+target_include_directories(secret-storage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(secret-storage PUBLIC "${GLIB_INCLUDE_DIRS}")
+
+install(TARGETS secret-storage LIBRARY DESTINATION lib)
+install(FILES ${SECRET_STORAGE_HEADERS} DESTINATION include/syslog-ng)
+
+
+add_subdirectory(tests)

--- a/lib/secret-storage/CMakeLists.txt
+++ b/lib/secret-storage/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(secret-storage SHARED ${SECRET_STORAGE_SOURCES})
 target_include_directories(secret-storage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(secret-storage PUBLIC "${GLIB_INCLUDE_DIRS}")
 set_target_properties(secret-storage PROPERTIES C_VISIBILITY_PRESET hidden)
-target_link_libraries(secret-storage syslog-ng)
 
 install(TARGETS secret-storage LIBRARY DESTINATION lib)
 install(FILES ${SECRET_STORAGE_HEADERS} DESTINATION include/syslog-ng)

--- a/lib/secret-storage/Makefile.am
+++ b/lib/secret-storage/Makefile.am
@@ -1,0 +1,13 @@
+lib_LTLIBRARIES += lib/secret-storage/libsecret-storage.la
+
+lib_secret_storageincludedir = $(pkgincludedir)
+
+lib_secret_storageinclude_HEADERS =     \
+  lib/secret-storage/secret-storage.h
+
+lib_secret_storage_libsecret_storage_la_SOURCES =             \
+  lib/secret-storage/secret-storage.c
+
+lib_secret_storage_libsecret_storage_la_CFLAGS = $(AM_CFLAGS)
+
+include lib/secret-storage/tests/Makefile.am

--- a/lib/secret-storage/Makefile.am
+++ b/lib/secret-storage/Makefile.am
@@ -3,10 +3,12 @@ lib_LTLIBRARIES += lib/secret-storage/libsecret-storage.la
 lib_secret_storageincludedir = $(pkgincludedir)
 
 lib_secret_storageinclude_HEADERS =     \
-  lib/secret-storage/secret-storage.h
+  lib/secret-storage/secret-storage.h	\
+  lib/secret-storage/nondumpable-allocator.h
 
 lib_secret_storage_libsecret_storage_la_SOURCES =             \
-  lib/secret-storage/secret-storage.c
+  lib/secret-storage/secret-storage.c	\
+  lib/secret-storage/nondumpable-allocator.c
 
 lib_secret_storage_libsecret_storage_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 

--- a/lib/secret-storage/Makefile.am
+++ b/lib/secret-storage/Makefile.am
@@ -8,6 +8,6 @@ lib_secret_storageinclude_HEADERS =     \
 lib_secret_storage_libsecret_storage_la_SOURCES =             \
   lib/secret-storage/secret-storage.c
 
-lib_secret_storage_libsecret_storage_la_CFLAGS = $(AM_CFLAGS)
+lib_secret_storage_libsecret_storage_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 
 include lib/secret-storage/tests/Makefile.am

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <sys/mman.h>
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "messages.h"
+#include "nondumpable-allocator.h"
+
+#define ALLOCATION_HEADER_SIZE offsetof(Allocation, user_data)
+#define BUFFER_TO_ALLOCATION(buffer) (buffer - ALLOCATION_HEADER_SIZE)
+
+typedef struct
+{
+  gsize alloc_size;
+  gsize data_len;
+  guint8 user_data[];
+} Allocation;
+
+static gpointer
+_mmap(gsize len)
+{
+  gpointer area = mmap(NULL, len, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+  if (!area)
+    {
+      msg_fatal("secret storage: cannot mmap buffer",
+                evt_tag_int("len", len),
+                evt_tag_errno("errno", errno));
+      return NULL;
+    }
+
+#if defined(MADV_DONTDUMP)
+  if (madvise(area, len, MADV_DONTDUMP) < 0)
+    {
+      msg_fatal("secret storage: cannot madvisebuffer",
+                evt_tag_errno("errno", errno));
+      goto err_munmap;
+    }
+#endif
+
+  if (mlock(area, len) < 0)
+    {
+      msg_fatal("secret storage: cannot lock buffer",
+                evt_tag_int("len", len),
+                evt_tag_errno("errno", errno));
+      goto err_munmap;
+    }
+
+  return area;
+err_munmap:
+  munmap(area, len);
+  return NULL;
+}
+
+static gsize
+round_to_nearest(gsize number, gsize base)
+{
+  return number + (base - (number % base));
+}
+
+gpointer
+nondumpable_buffer_alloc(gsize len)
+{
+  gsize minimum_size = len + ALLOCATION_HEADER_SIZE;
+  gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
+  gsize alloc_size = round_to_nearest(minimum_size, PAGESIZE);
+
+  Allocation *buffer = _mmap(alloc_size);
+  if (!buffer)
+    return NULL;
+
+  buffer->alloc_size = alloc_size;
+  buffer->data_len = len;
+  return buffer->user_data;
+}
+
+void
+nondumpable_buffer_free(gpointer buffer)
+{
+  Allocation *allocation = BUFFER_TO_ALLOCATION(buffer);
+  memset(allocation->user_data, 0, allocation->data_len);
+  munmap(allocation, allocation->alloc_size);
+}
+
+gpointer
+nondumpable_buffer_realloc(gpointer buffer, gsize len)
+{
+  Allocation *allocation = BUFFER_TO_ALLOCATION(buffer);
+  if (allocation->alloc_size >= len + ALLOCATION_HEADER_SIZE)
+    {
+      allocation->data_len = len;
+      return allocation->user_data;
+    }
+
+  gpointer new_buffer = nondumpable_buffer_alloc(len);
+  memmove(new_buffer, allocation->user_data, allocation->data_len);
+  nondumpable_buffer_free(buffer);
+  return new_buffer;
+}

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -116,7 +116,21 @@ nondumpable_buffer_realloc(gpointer buffer, gsize len)
     }
 
   gpointer new_buffer = nondumpable_buffer_alloc(len);
-  memmove(new_buffer, allocation->user_data, allocation->data_len);
+  nondumpable_memcpy(new_buffer, allocation->user_data, allocation->data_len);
   nondumpable_buffer_free(buffer);
   return new_buffer;
+}
+
+/* glibc implementation of memcpy can use stack, exposing parts of the secrets */
+gpointer
+nondumpable_memcpy(gpointer dest, gpointer src, gsize len)
+{
+  gchar *_dest = dest;
+  gchar *_src = src;
+  for (int i = 0; i < len; i++)
+    {
+      _dest[i] = _src[i];
+    }
+
+  return dest;
 }

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -26,12 +26,20 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+#include <stdio.h>
 
-#include "messages.h"
 #include "nondumpable-allocator.h"
 
 #define ALLOCATION_HEADER_SIZE offsetof(Allocation, user_data)
 #define BUFFER_TO_ALLOCATION(buffer) (buffer - ALLOCATION_HEADER_SIZE)
+
+void(*logger)(gchar *summary, gchar *reason) INTERNAL;
+
+void
+nondumpable_setlogger(void(*_logger)(gchar *summary, gchar *reason))
+{
+  logger = _logger;
+}
 
 typedef struct
 {
@@ -46,26 +54,37 @@ _mmap(gsize len)
   gpointer area = mmap(NULL, len, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
   if (!area)
     {
-      msg_fatal("secret storage: cannot mmap buffer",
-                evt_tag_int("len", len),
-                evt_tag_errno("errno", errno));
+      if (logger)
+        {
+          char reason[32] = { 0 };
+          snprintf(reason, sizeof(reason), "len: %lu, errno: %d\n", len, errno);
+          logger("secret storage: cannot mmap buffer", reason);
+        }
       return NULL;
     }
 
 #if defined(MADV_DONTDUMP)
   if (madvise(area, len, MADV_DONTDUMP) < 0)
     {
-      msg_fatal("secret storage: cannot madvisebuffer",
-                evt_tag_errno("errno", errno));
+      if (logger)
+        {
+          char reason[32] = { 0 };
+          snprintf(reason, sizeof(reason), "errno: %d\n", errno);
+          logger("secret storage: cannot madvisebuffer", reason);
+        }
       goto err_munmap;
     }
 #endif
 
   if (mlock(area, len) < 0)
     {
-      msg_fatal("secret storage: cannot lock buffer",
-                evt_tag_int("len", len),
-                evt_tag_errno("errno", errno));
+      if (logger)
+        {
+          char reason[200] = { 0 };
+          gchar *hint = (errno == ENOMEM) ? ". Maybe RLIMIT_MEMLOCK is too small?" : "";
+          snprintf(reason, sizeof(reason), "len: %lu, errno: %d%s\n", len, errno, hint);
+          logger("secret storage: cannot lock buffer", reason);
+        }
       goto err_munmap;
     }
 

--- a/lib/secret-storage/nondumpable-allocator.h
+++ b/lib/secret-storage/nondumpable-allocator.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef NONDUMPABLE_ALLOCATOR_H_INCLUDED
+#define NONDUMPABLE_ALLOCATOR_H_INCLUDED
+
+#include "lib/compat/glib.h"
+
+#define PUBLIC __attribute__ ((visibility ("default")))
+#define INTERNAL __attribute__ ((visibility ("hidden")))
+
+gpointer nondumpable_buffer_alloc(gsize len) PUBLIC;
+void nondumpable_buffer_free(gpointer buffer) PUBLIC;
+gpointer nondumpable_buffer_realloc(gpointer buffer, gsize len) PUBLIC;
+
+#endif

--- a/lib/secret-storage/nondumpable-allocator.h
+++ b/lib/secret-storage/nondumpable-allocator.h
@@ -33,5 +33,6 @@ gpointer nondumpable_buffer_alloc(gsize len) PUBLIC;
 void nondumpable_buffer_free(gpointer buffer) PUBLIC;
 gpointer nondumpable_buffer_realloc(gpointer buffer, gsize len) PUBLIC;
 gpointer nondumpable_memcpy(gpointer dest, gpointer src, gsize len) PUBLIC;
+void nondumpable_setlogger(void(*logger)(gchar *summary, gchar *reason)) PUBLIC;
 
 #endif

--- a/lib/secret-storage/nondumpable-allocator.h
+++ b/lib/secret-storage/nondumpable-allocator.h
@@ -32,5 +32,6 @@
 gpointer nondumpable_buffer_alloc(gsize len) PUBLIC;
 void nondumpable_buffer_free(gpointer buffer) PUBLIC;
 gpointer nondumpable_buffer_realloc(gpointer buffer, gsize len) PUBLIC;
+gpointer nondumpable_memcpy(gpointer dest, gpointer src, gsize len) PUBLIC;
 
 #endif

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -111,7 +111,7 @@ realloc_and_write_secret(SecretStorage *secret_storage, const gchar *key, gchar 
 static SecretStorage *
 update_storage_with_secret(SecretStorage *secret_storage, const gchar *key, gchar *secret, gsize len)
 {
-  gboolean fits_into_storage = secret_storage->secret.len > len;
+  gboolean fits_into_storage = (len <= secret_storage->secret.len);
   if (fits_into_storage)
     return overwrite_secret(secret_storage, secret, len);
   else

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -159,7 +159,7 @@ secret_storage_store_secret(const gchar *key, gchar *secret, gsize len)
   if (!secret)
     len = 0;
   else if (len == -1)
-    len = strlen(secret);
+    len = strlen(secret) + 1;
 
   SecretStorage *secret_storage;
   secret_storage = g_hash_table_lookup(secret_manager, key);

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -98,7 +98,7 @@ overwrite_secret(SecretStorage *storage, gchar *secret, gsize len)
 }
 
 static SecretStorage *
-realloc_and_write_secret(SecretStorage *secret_storage, gchar *key, gchar *secret, gsize len)
+realloc_and_write_secret(SecretStorage *secret_storage, const gchar *key, gchar *secret, gsize len)
 {
   SecretStorage *maybe_new_storage = nondumpable_buffer_realloc(secret_storage, len);
   write_secret(maybe_new_storage, secret, len);
@@ -108,7 +108,7 @@ realloc_and_write_secret(SecretStorage *secret_storage, gchar *key, gchar *secre
 }
 
 static SecretStorage *
-update_storage_with_secret(SecretStorage *secret_storage, gchar *key, gchar *secret, gsize len)
+update_storage_with_secret(SecretStorage *secret_storage, const gchar *key, gchar *secret, gsize len)
 {
   gboolean fits_into_storage = secret_storage->secret.len > len;
   if (fits_into_storage)
@@ -118,7 +118,7 @@ update_storage_with_secret(SecretStorage *secret_storage, gchar *key, gchar *sec
 }
 
 static SecretStorage *
-create_secret_storage_with_secret(gchar *key, gchar *secret, gsize len)
+create_secret_storage_with_secret(const gchar *key, gchar *secret, gsize len)
 {
   SecretStorage *secret_storage = secret_storage_new(len);
   if (!secret_storage)
@@ -132,7 +132,7 @@ create_secret_storage_with_secret(gchar *key, gchar *secret, gsize len)
 }
 
 static void
-run_callbacks_initiate(gchar *key, GArray *subscriptions)
+run_callbacks_initiate(const gchar *key, GArray *subscriptions)
 {
   static gboolean initiated = FALSE;
 
@@ -151,7 +151,7 @@ run_callbacks_initiate(gchar *key, GArray *subscriptions)
 }
 
 gboolean
-secret_storage_store_secret(gchar *key, gchar *secret, gsize len)
+secret_storage_store_secret(const gchar *key, gchar *secret, gsize len)
 {
   if (!secret)
     len = 0;
@@ -174,7 +174,7 @@ secret_storage_store_secret(gchar *key, gchar *secret, gsize len)
 }
 
 gboolean
-secret_storage_store_string(gchar *key, gchar *secret)
+secret_storage_store_string(const gchar *key, gchar *secret)
 {
   return secret_storage_store_secret(key, secret, -1);
 }
@@ -190,7 +190,7 @@ Secret *secret_storage_clone_secret(Secret *self)
 }
 
 Secret *
-secret_storage_get_secret_by_name(gchar *key)
+secret_storage_get_secret_by_name(const gchar *key)
 {
   SecretStorage *secret_storage = g_hash_table_lookup(secret_manager, key);
   if (!secret_storage)
@@ -205,7 +205,7 @@ secret_storage_put_secret(Secret *self)
 }
 
 void
-secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data)
+secret_storage_with_secret(const gchar *key, SecretStorageCB func, gpointer user_data)
 {
   Secret *secret = secret_storage_get_secret_by_name(key);
   if (!secret)
@@ -215,13 +215,13 @@ secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data)
 }
 
 static gboolean
-insert_empty_secret_storage(gchar *key)
+insert_empty_secret_storage(const gchar *key)
 {
   return secret_storage_store_string(key, NULL);
 }
 
 gboolean
-secret_storage_subscribe_for_key(gchar *key, SecretStorageCB func, gpointer user_data)
+secret_storage_subscribe_for_key(const gchar *key, SecretStorageCB func, gpointer user_data)
 {
 
   SecretStorage *secret_storage;
@@ -248,10 +248,10 @@ typedef struct
 } SecretCallBackAction;
 
 static gboolean
-run_callback_for_status(gpointer key, gpointer value, gpointer user_data)
+run_callback_for_status(const gpointer key, gpointer value, gpointer user_data)
 {
   SecretCallBackAction *action = (SecretCallBackAction *)user_data;
-  gchar *key_with_obscured_location = g_strdup(key);
+  gchar *key_with_obscured_location = g_strdup((const gchar *)key);
   SecretStatus secret_status = {.key = key_with_obscured_location};
   gboolean should_continue = !action->func(&secret_status, action->user_data);
   g_free(key_with_obscured_location);

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "secret-storage.h"
+
+#define SECRET_HEADER_SIZE offsetof(Secret, data)
+#define SECRET_STORAGE_INITIAL_SIZE 2048
+
+typedef struct
+{
+  Secret secret;
+} SecretStorage;
+
+SecretStorage *secret_storage INTERNAL;
+volatile gint secret_storage_uninitialized INTERNAL = 1;
+
+
+static SecretStorage *
+secret_storage_new(gsize len)
+{
+  g_assert(len > 0);
+  SecretStorage *storage = malloc(len + SECRET_HEADER_SIZE);
+  return storage;
+}
+
+static void
+secret_storage_free(SecretStorage *self)
+{
+  free(self);
+}
+
+void
+secret_storage_init()
+{
+  if (g_atomic_int_dec_and_test(&secret_storage_uninitialized))
+    {
+      secret_storage = secret_storage_new(SECRET_STORAGE_INITIAL_SIZE);
+      g_assert(secret_storage);
+    }
+  else
+    g_assert_not_reached();
+}
+
+void
+secret_storage_deinit()
+{
+  g_assert(!secret_storage_uninitialized);
+  secret_storage_free(secret_storage);
+}
+
+gboolean
+secret_storage_store_secret(gchar *key, gchar *secret, gsize len)
+{
+  if (len == -1)
+    len = strlen(secret) + 1;
+
+  if (len > SECRET_STORAGE_INITIAL_SIZE)
+    return FALSE;
+
+  Secret *stored_secret = (Secret *)&secret_storage->secret;
+  stored_secret->len = len;
+  memcpy(&stored_secret->data, secret, len);
+
+  return TRUE;
+}
+
+gboolean
+secret_storage_store_string(gchar *key, gchar *secret)
+{
+  return secret_storage_store_secret(key, secret, -1);
+}
+
+Secret *secret_storage_clone_secret(Secret *self)
+{
+  Secret *copy = malloc(self->len + SECRET_HEADER_SIZE);
+  copy->len = self->len;
+  memcpy(copy->data, self->data, self->len);
+  return copy;
+}
+
+Secret *
+secret_storage_get_secret_by_name(gchar *key)
+{
+  Secret *secret = (Secret *)&secret_storage->secret;
+  return secret_storage_clone_secret(secret);
+}
+
+void
+secret_storage_put_secret(Secret *self)
+{
+  free(self);
+}
+
+void
+secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data)
+{
+  Secret *secret = secret_storage_get_secret_by_name(key);
+  func(secret, user_data);
+  secret_storage_put_secret(secret);
+}

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -241,6 +241,30 @@ secret_storage_subscribe_for_key(const gchar *key, SecretStorageCB func, gpointe
   return TRUE;
 }
 
+void
+secret_storage_unsubscribe(const gchar *key, SecretStorageCB func, gpointer user_data)
+{
+  SecretStorage *secret_storage;
+  if (!g_hash_table_contains(secret_manager, key))
+    return;
+
+  secret_storage = g_hash_table_lookup(secret_manager, key);
+  if (!secret_storage->subscriptions)
+    return;
+
+  GArray *subscriptions = secret_storage->subscriptions;
+
+  for (gsize i = 0; i < subscriptions->len; i++)
+    {
+      Subscription sub = g_array_index(subscriptions, Subscription, i);
+      if (sub.func == func && sub.user_data == user_data)
+        {
+          secret_storage->subscriptions = g_array_remove_index(subscriptions, i);
+          break;
+        }
+    }
+}
+
 typedef struct
 {
   SecretStatusCB func;

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -305,3 +305,10 @@ secret_storage_update_status(const gchar *key, SecretStorageSecretState state)
 
   secret_storage->state = state;
 }
+
+gboolean
+secret_storage_contains_key(const gchar *key)
+{
+  SecretStorage *secret_storage = g_hash_table_lookup(secret_manager, key);
+  return (secret_storage != NULL);
+}

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -159,7 +159,7 @@ secret_storage_store_secret(const gchar *key, gchar *secret, gsize len)
   if (!secret)
     len = 0;
   else if (len == -1)
-    len = strlen(secret) + 1;
+    len = strlen(secret);
 
   SecretStorage *secret_storage;
   secret_storage = g_hash_table_lookup(secret_manager, key);

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -39,7 +39,6 @@ typedef struct
 SecretStorage *secret_storage INTERNAL;
 volatile gint secret_storage_uninitialized INTERNAL = 1;
 
-
 static SecretStorage *
 secret_storage_new(gsize len)
 {

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -146,7 +146,8 @@ run_callbacks_initiate(const gchar *key, GArray *subscriptions)
       Subscription sub = g_array_index(subscriptions, Subscription, i);
       secret_storage_with_secret(key, sub.func, sub.user_data);
     }
-  g_array_remove_range(subscriptions, 0, original_length);
+  if (original_length)
+    g_array_remove_range(subscriptions, 0, original_length);
   initiated = FALSE;
 }
 

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -230,3 +230,28 @@ secret_storage_subscribe_for_key(gchar *key, SecretStorageCB func, gpointer user
 
   return TRUE;
 }
+
+typedef struct
+{
+  SecretStatusCB func;
+  gpointer user_data;
+} SecretCallBackAction;
+
+static gboolean
+run_callback_for_status(gpointer key, gpointer value, gpointer user_data)
+{
+  SecretCallBackAction *action = (SecretCallBackAction *)user_data;
+  gchar *key_with_obscured_location = g_strdup(key);
+  SecretStatus secret_status = {.key = key_with_obscured_location};
+  gboolean should_continue = !action->func(&secret_status, action->user_data);
+  g_free(key_with_obscured_location);
+
+  return should_continue;
+}
+
+void
+secret_storage_status_foreach(SecretStatusCB cb, gpointer user_data)
+{
+  SecretCallBackAction action = {.func = cb, .user_data = user_data};
+  g_hash_table_find(secret_manager, run_callback_for_status, &action);
+}

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -24,8 +24,8 @@
 #include <errno.h>
 #include <string.h>
 #include <stddef.h>
-#include <stdlib.h>
 
+#include "nondumpable-allocator.h"
 #include "secret-storage.h"
 
 #define SECRET_HEADER_SIZE offsetof(Secret, data)
@@ -43,14 +43,14 @@ static SecretStorage *
 secret_storage_new(gsize len)
 {
   g_assert(len > 0);
-  SecretStorage *storage = malloc(len + SECRET_HEADER_SIZE);
+  SecretStorage *storage = nondumpable_buffer_alloc(len + SECRET_HEADER_SIZE);
   return storage;
 }
 
 static void
 secret_storage_free(SecretStorage *self)
 {
-  free(self);
+  nondumpable_buffer_free(self);
 }
 
 void
@@ -96,7 +96,7 @@ secret_storage_store_string(gchar *key, gchar *secret)
 
 Secret *secret_storage_clone_secret(Secret *self)
 {
-  Secret *copy = malloc(self->len + SECRET_HEADER_SIZE);
+  Secret *copy = nondumpable_buffer_alloc(self->len + SECRET_HEADER_SIZE);
   copy->len = self->len;
   memcpy(copy->data, self->data, self->len);
   return copy;
@@ -112,7 +112,7 @@ secret_storage_get_secret_by_name(gchar *key)
 void
 secret_storage_put_secret(Secret *self)
 {
-  free(self);
+  nondumpable_buffer_free(self);
 }
 
 void

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -104,7 +104,7 @@ realloc_and_write_secret(SecretStorage *secret_storage, const gchar *key, gchar 
   SecretStorage *maybe_new_storage = nondumpable_buffer_realloc(secret_storage, len);
   write_secret(maybe_new_storage, secret, len);
   if (secret_storage != maybe_new_storage)
-    g_hash_table_insert(secret_manager, strdup(key), maybe_new_storage);
+    g_hash_table_insert(secret_manager, g_strdup(key), maybe_new_storage);
   return maybe_new_storage;
 }
 
@@ -126,7 +126,7 @@ create_secret_storage_with_secret(const gchar *key, gchar *secret, gsize len)
     return NULL;
   secret_storage->secret.len = len;
   nondumpable_memcpy(&secret_storage->secret.data, secret, len);
-  g_hash_table_insert(secret_manager, strdup(key), secret_storage);
+  g_hash_table_insert(secret_manager, g_strdup(key), secret_storage);
   secret_storage->subscriptions = g_array_new(FALSE, FALSE, sizeof(Subscription));
   secret_storage->state = SECRET_STORAGE_STATUS_PENDING;
 
@@ -248,11 +248,8 @@ void
 secret_storage_unsubscribe(const gchar *key, SecretStorageCB func, gpointer user_data)
 {
   SecretStorage *secret_storage;
-  if (!g_hash_table_contains(secret_manager, key))
-    return;
-
   secret_storage = g_hash_table_lookup(secret_manager, key);
-  if (!secret_storage->subscriptions)
+  if (!secret_storage || !secret_storage->subscriptions)
     return;
 
   GArray *subscriptions = secret_storage->subscriptions;

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -182,6 +182,8 @@ secret_storage_store_string(gchar *key, gchar *secret)
 Secret *secret_storage_clone_secret(Secret *self)
 {
   Secret *copy = nondumpable_buffer_alloc(self->len + SECRET_HEADER_SIZE);
+  if (!copy)
+    return NULL;
   copy->len = self->len;
   nondumpable_memcpy(copy->data, self->data, self->len);
   return copy;
@@ -206,6 +208,8 @@ void
 secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data)
 {
   Secret *secret = secret_storage_get_secret_by_name(key);
+  if (!secret)
+    return;
   func(secret, user_data);
   secret_storage_put_secret(secret);
 }

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -87,7 +87,7 @@ secret_storage_store_secret(gchar *key, gchar *secret, gsize len)
     return FALSE;
 
   secret_storage->secret.len = len;
-  memcpy(&secret_storage->secret.data, secret, len);
+  nondumpable_memcpy(&secret_storage->secret.data, secret, len);
   g_hash_table_insert(secret_manager, strdup(key), secret_storage);
 
   return TRUE;
@@ -103,7 +103,7 @@ Secret *secret_storage_clone_secret(Secret *self)
 {
   Secret *copy = nondumpable_buffer_alloc(self->len + SECRET_HEADER_SIZE);
   copy->len = self->len;
-  memcpy(copy->data, self->data, self->len);
+  nondumpable_memcpy(copy->data, self->data, self->len);
   return copy;
 }
 

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -49,4 +49,12 @@ void secret_storage_put_secret(Secret *self) PUBLIC;
 Secret *secret_storage_clone_secret(Secret *self) PUBLIC;
 
 gboolean secret_storage_subscribe_for_key(gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
+
+typedef struct
+{
+  gchar *key;
+} SecretStatus;
+typedef gboolean (*SecretStatusCB)(SecretStatus *secret_status, gpointer user_data);
+void secret_storage_status_foreach(SecretStatusCB cb, gpointer user_data) PUBLIC;
+
 #endif

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -49,12 +49,23 @@ void secret_storage_put_secret(Secret *self) PUBLIC;
 Secret *secret_storage_clone_secret(Secret *self) PUBLIC;
 
 gboolean secret_storage_subscribe_for_key(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
-
 void secret_storage_unsubscribe(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
+
+typedef
+enum
+{
+  SECRET_STORAGE_STATUS_PENDING = 0,
+  SECRET_STORAGE_SUCCESS,
+  SECRET_STORAGE_STATUS_FAILED,
+  SECRET_STORAGE_STATUS_INVALID_PASSWORD
+} SecretStorageSecretState;
+
+void secret_storage_update_status(const gchar *key, SecretStorageSecretState state) PUBLIC;
 
 typedef struct
 {
   gchar *key;
+  SecretStorageSecretState state;
 } SecretStatus;
 typedef gboolean (*SecretStatusCB)(SecretStatus *secret_status, gpointer user_data);
 void secret_storage_status_foreach(SecretStatusCB cb, gpointer user_data) PUBLIC;

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -37,15 +37,15 @@ typedef struct
 
 typedef void(*SecretStorageCB)(Secret *secret, gpointer user_data);
 
-void secret_storage_init(void);
-void secret_storage_deinit(void);
+void secret_storage_init(void) PUBLIC;
+void secret_storage_deinit(void) PUBLIC;
 
-gboolean secret_storage_store_string(gchar *key, gchar *secret);
-gboolean secret_storage_store_secret(gchar *key, gchar *secret, gsize len);
+gboolean secret_storage_store_string(gchar *key, gchar *secret) PUBLIC;
+gboolean secret_storage_store_secret(gchar *key, gchar *secret, gsize len) PUBLIC;
 
-void secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data);
-Secret *secret_storage_get_secret_by_name(gchar *key);
-void secret_storage_put_secret(Secret *self);
-Secret *secret_storage_clone_secret(Secret *self);
+void secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
+Secret *secret_storage_get_secret_by_name(gchar *key) PUBLIC;
+void secret_storage_put_secret(Secret *self) PUBLIC;
+Secret *secret_storage_clone_secret(Secret *self) PUBLIC;
 
 #endif

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -48,4 +48,5 @@ Secret *secret_storage_get_secret_by_name(gchar *key) PUBLIC;
 void secret_storage_put_secret(Secret *self) PUBLIC;
 Secret *secret_storage_clone_secret(Secret *self) PUBLIC;
 
+gboolean secret_storage_subscribe_for_key(gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
 #endif

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -70,4 +70,6 @@ typedef struct
 typedef gboolean (*SecretStatusCB)(SecretStatus *secret_status, gpointer user_data);
 void secret_storage_status_foreach(SecretStatusCB cb, gpointer user_data) PUBLIC;
 
+gboolean secret_storage_contains_key(const gchar *key) PUBLIC;
+
 #endif

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -50,6 +50,8 @@ Secret *secret_storage_clone_secret(Secret *self) PUBLIC;
 
 gboolean secret_storage_subscribe_for_key(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
 
+void secret_storage_unsubscribe(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
+
 typedef struct
 {
   gchar *key;

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SECRET_STORAGE_H_INCLUDED
+#define SECRET_STORAGE_H_INCLUDED
+
+#include "lib/compat/glib.h"
+
+#define PUBLIC __attribute__ ((visibility ("default")))
+#define INTERNAL __attribute__ ((visibility ("hidden")))
+
+typedef struct
+{
+  gsize len;
+  gchar data[];
+} Secret;
+
+typedef void(*SecretStorageCB)(Secret *secret, gpointer user_data);
+
+void secret_storage_init(void);
+void secret_storage_deinit(void);
+
+gboolean secret_storage_store_string(gchar *key, gchar *secret);
+gboolean secret_storage_store_secret(gchar *key, gchar *secret, gsize len);
+
+void secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data);
+Secret *secret_storage_get_secret_by_name(gchar *key);
+void secret_storage_put_secret(Secret *self);
+Secret *secret_storage_clone_secret(Secret *self);
+
+#endif

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -40,15 +40,15 @@ typedef void(*SecretStorageCB)(Secret *secret, gpointer user_data);
 void secret_storage_init(void) PUBLIC;
 void secret_storage_deinit(void) PUBLIC;
 
-gboolean secret_storage_store_string(gchar *key, gchar *secret) PUBLIC;
-gboolean secret_storage_store_secret(gchar *key, gchar *secret, gsize len) PUBLIC;
+gboolean secret_storage_store_string(const gchar *key, gchar *secret) PUBLIC;
+gboolean secret_storage_store_secret(const gchar *key, gchar *secret, gsize len) PUBLIC;
 
-void secret_storage_with_secret(gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
-Secret *secret_storage_get_secret_by_name(gchar *key) PUBLIC;
+void secret_storage_with_secret(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
+Secret *secret_storage_get_secret_by_name(const gchar *key) PUBLIC;
 void secret_storage_put_secret(Secret *self) PUBLIC;
 Secret *secret_storage_clone_secret(Secret *self) PUBLIC;
 
-gboolean secret_storage_subscribe_for_key(gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
+gboolean secret_storage_subscribe_for_key(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
 
 typedef struct
 {

--- a/lib/secret-storage/tests/CMakeLists.txt
+++ b/lib/secret-storage/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(CRITERION TARGET test_secret_storage DEPENDS secret-storage)

--- a/lib/secret-storage/tests/CMakeLists.txt
+++ b/lib/secret-storage/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(CRITERION TARGET test_secret_storage DEPENDS secret-storage)
+add_unit_test(CRITERION TARGET test_nondumpable_allocator DEPENDS secret-storage)

--- a/lib/secret-storage/tests/Makefile.am
+++ b/lib/secret-storage/tests/Makefile.am
@@ -1,0 +1,15 @@
+if ENABLE_CRITERION
+
+lib_secret_storage_tests_TESTS			= \
+	lib/secret-storage/tests/test_secret_storage
+
+check_PROGRAMS					+= ${lib_secret_storage_tests_TESTS}
+
+lib_secret_storage_tests_test_secret_storage_CFLAGS	= $(TEST_CFLAGS) \
+	-I$(top_srcdir)/lib/secret-storage
+
+lib_secret_storage_tests_test_secret_storage_LDADD	= \
+	$(TEST_LDADD) \
+	$(PREOPEN_SYSLOGFORMAT) -dlpreopen $(top_builddir)/lib/secret-storage/libsecret-storage.la
+
+endif

--- a/lib/secret-storage/tests/Makefile.am
+++ b/lib/secret-storage/tests/Makefile.am
@@ -1,7 +1,8 @@
 if ENABLE_CRITERION
 
 lib_secret_storage_tests_TESTS			= \
-	lib/secret-storage/tests/test_secret_storage
+	lib/secret-storage/tests/test_secret_storage \
+	lib/secret-storage/tests/test_nondumpable_allocator
 
 check_PROGRAMS					+= ${lib_secret_storage_tests_TESTS}
 
@@ -9,6 +10,13 @@ lib_secret_storage_tests_test_secret_storage_CFLAGS	= $(TEST_CFLAGS) \
 	-I$(top_srcdir)/lib/secret-storage
 
 lib_secret_storage_tests_test_secret_storage_LDADD	= \
+	$(TEST_LDADD) \
+	$(PREOPEN_SYSLOGFORMAT) -dlpreopen $(top_builddir)/lib/secret-storage/libsecret-storage.la
+
+lib_secret_storage_tests_test_nondumpable_allocator_CFLAGS	= $(TEST_CFLAGS) \
+	-I$(top_srcdir)/lib/secret-storage
+
+lib_secret_storage_tests_test_nondumpable_allocator_LDADD	= \
 	$(TEST_LDADD) \
 	$(PREOPEN_SYSLOGFORMAT) -dlpreopen $(top_builddir)/lib/secret-storage/libsecret-storage.la
 

--- a/lib/secret-storage/tests/test_nondumpable_allocator.c
+++ b/lib/secret-storage/tests/test_nondumpable_allocator.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <unistd.h>
+#include <criterion/criterion.h>
+
+#include "nondumpable-allocator.h"
+
+Test(nondumpableallocator, malloc_realloc_free)
+{
+  char test_string[] = "test_string";
+  gpointer buffer = nondumpable_buffer_alloc(strlen(test_string));
+  strcpy(buffer, test_string);
+  cr_assert_str_eq(buffer, test_string);
+
+  const gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
+  gpointer buffer_realloc = nondumpable_buffer_realloc(buffer, 2*PAGESIZE);
+  cr_assert_str_eq(buffer_realloc, test_string);
+  ((gchar *)buffer_realloc)[2*PAGESIZE] = 'a';
+
+  nondumpable_buffer_free(buffer_realloc);
+}
+
+Test(nondumpableallocator, two_malloc)
+{
+  char test_string1[] = "test_string2";
+  gpointer buffer1 = nondumpable_buffer_alloc(strlen(test_string1));
+  strcpy(buffer1, test_string1);
+
+  char test_string2[] = "test_string2";
+  gpointer buffer2 = nondumpable_buffer_alloc(strlen(test_string2));
+  strcpy(buffer2, test_string2);
+
+  cr_assert_str_eq(buffer1, test_string1);
+  cr_assert_str_eq(buffer2, test_string2);
+
+  nondumpable_buffer_free(buffer1);
+  nondumpable_buffer_free(buffer2);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -72,3 +72,12 @@ Test(secretstorage, read_nonexistent_secret)
   Secret *secret = secret_storage_get_secret_by_name("key");
   cr_assert_eq(secret, NULL);
 }
+
+Test(secretstorage, store_secret_with_embedded_zero)
+{
+  secret_storage_store_secret("key", "a\0b", 4);
+  Secret *secret = secret_storage_get_secret_by_name("key");
+  gint result = memcmp(secret->data, "a\0b", 4);
+  cr_assert_eq(result, 0);
+  secret_storage_put_secret(secret);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -22,10 +22,34 @@
  */
 
 #include <criterion/criterion.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <unistd.h>
 
 #include "secret-storage.h"
+#include "nondumpable-allocator.h"
 
-TestSuite(secretstorage, .init = secret_storage_init, .fini = secret_storage_deinit);
+void
+logger(char *summary, char *reason)
+{
+  fprintf(stderr, "%s : reason=%s", summary, reason);
+}
+
+void
+secret_storage_testsuite_init()
+{
+  secret_storage_init();
+  nondumpable_setlogger(logger);
+}
+
+void
+secret_storage_testsuite_deinit()
+{
+  secret_storage_deinit();
+}
+
+
+TestSuite(secretstorage, .init = secret_storage_testsuite_init, .fini = secret_storage_testsuite_deinit);
 
 Test(secretstorage, simple_store_get)
 {
@@ -232,3 +256,27 @@ Test(secretstorage, subscribe_until_success)
   secret_storage_store_string("key", "good_password");
   cr_assert(test_variable);
 }
+
+#if (SYSLOG_NG_ENABLE_FORCED_SERVER_MODE)
+Test(secretstorage, test_rlimit)
+{
+  struct rlimit locked_limit;
+  cr_assert(!getrlimit(RLIMIT_MEMLOCK, &locked_limit));
+  locked_limit.rlim_cur = MIN(locked_limit.rlim_max, 64 * 1024);
+  cr_assert(!setrlimit(RLIMIT_MEMLOCK, &locked_limit));
+  const gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
+
+  gchar *key_fmt = g_strdup("keyXXX");
+  int i = 0;
+  int for_limit = locked_limit.rlim_cur/PAGESIZE;
+  for (; i < for_limit; i++)
+    {
+      sprintf(key_fmt, "key%03d", i);
+      cr_assert(secret_storage_store_string(key_fmt, "value"), "offending_key: %s, for_limit: %d", key_fmt, for_limit);
+    }
+
+  sprintf(key_fmt, "key%03d", i);
+  cr_assert_not(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
+  cr_assert(secret_storage_subscribe_for_key("key000", secret_checker, "value"));
+}
+#endif

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "secret-storage.h"
+
+TestSuite(secretstorage, .init = secret_storage_init, .fini = secret_storage_deinit);
+
+Test(secretstorage, simple_store_get)
+{
+  secret_storage_store_secret("key1", "value1", -1);
+  Secret *secret = secret_storage_get_secret_by_name("key1");
+  cr_assert_str_eq(secret->data, "value1");
+  secret_storage_put_secret(secret);
+}
+
+void secret_checker(Secret *secret, gpointer expected)
+{
+  cr_assert_str_eq(expected, secret->data);
+}
+
+Test(secretstorage, simple_store_with)
+{
+  secret_storage_store_secret("key1", "value1", -1);
+  secret_storage_with_secret("key1", secret_checker, "value1");
+}
+
+Test(secretstorage, simple_store_single_string)
+{
+  secret_storage_store_string("key1", "value1");
+  Secret *secret = secret_storage_get_secret_by_name("key1");
+  cr_assert_str_eq(secret->data, "value1");
+  secret_storage_put_secret(secret);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -280,3 +280,23 @@ Test(secretstorage, test_rlimit)
   cr_assert(secret_storage_subscribe_for_key("key000", secret_checker, "value"));
 }
 #endif
+
+static void
+update_state_callback(Secret *secret, gpointer user_data)
+{
+  secret_storage_update_status("key", SECRET_STORAGE_STATUS_INVALID_PASSWORD);
+}
+
+static gboolean
+assert_invalid_password_state(SecretStatus *secret_status, gpointer user_data)
+{
+  cr_assert_eq(secret_status->state, SECRET_STORAGE_STATUS_INVALID_PASSWORD);
+  return FALSE;
+}
+
+Test(secretstorage, test_state_update)
+{
+  secret_storage_subscribe_for_key("key", update_state_callback, NULL);
+  secret_storage_store_string("key", "wrong_password");
+  secret_storage_status_foreach(assert_invalid_password_state, NULL);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -141,3 +141,29 @@ Test(secretstorage, subscribe_cb_check_secret)
   secret_storage_subscribe_for_key("key", check_secret, "secret");
   secret_storage_store_string("key", "secret");
 }
+
+Test(secretstorage, multiple_subscriptions_for_same_key)
+{
+  gboolean key1_test_variable = FALSE;
+  gboolean key2_test_variable = FALSE;
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &key1_test_variable);
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &key2_test_variable);
+  cr_assert_not(key1_test_variable);
+  cr_assert_not(key2_test_variable);
+
+  secret_storage_store_string("key", "secret");
+  cr_assert(key1_test_variable);
+  cr_assert(key2_test_variable);
+}
+
+Test(secretstorage, subscription_reset_after_called)
+{
+  gboolean key_test_variable = FALSE;
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &key_test_variable);
+  secret_storage_store_string("key", "secret");
+  cr_assert(key_test_variable);
+
+  key_test_variable = FALSE;
+  secret_storage_store_string("key", "secret");
+  cr_assert_not(key_test_variable);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -53,3 +53,22 @@ Test(secretstorage, simple_store_single_string)
   cr_assert_str_eq(secret->data, "value1");
   secret_storage_put_secret(secret);
 }
+
+Test(secretstorage, store_multiple_secrets)
+{
+  secret_storage_store_string("key1", "value1");
+  secret_storage_store_string("key2", "value2");
+  Secret *secret1 = secret_storage_get_secret_by_name("key1");
+  cr_assert_str_eq(secret1->data, "value1");
+  Secret *secret2 = secret_storage_get_secret_by_name("key2");
+  cr_assert_str_eq(secret2->data, "value2");
+
+  secret_storage_put_secret(secret1);
+  secret_storage_put_secret(secret2);
+}
+
+Test(secretstorage, read_nonexistent_secret)
+{
+  Secret *secret = secret_storage_get_secret_by_name("key");
+  cr_assert_eq(secret, NULL);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -167,3 +167,47 @@ Test(secretstorage, subscription_reset_after_called)
   secret_storage_store_string("key", "secret");
   cr_assert_not(key_test_variable);
 }
+
+typedef struct
+{
+  gpointer user_data;
+  gpointer evidence;
+} UserDataWithEvidence;
+
+gboolean
+check_status_callback(SecretStatus *secret_status, gpointer user_data)
+{
+  cr_assert_str_eq(secret_status->key, ((UserDataWithEvidence *)user_data)->user_data);
+  gboolean *evidence = ((UserDataWithEvidence *)user_data)->evidence;
+  *evidence = TRUE;
+  return TRUE;
+}
+
+Test(secretstorage, check_secret_status)
+{
+  gboolean test_variable = FALSE;
+  secret_storage_store_string("key", "secret");
+  UserDataWithEvidence user_data = {.user_data = "key", .evidence = &test_variable};
+  secret_storage_status_foreach(check_status_callback, &user_data);
+  cr_assert(test_variable);
+}
+
+gboolean
+stop_in_the_middle_callback(SecretStatus *secret_status, gpointer user_data)
+{
+  gint *test_variable = user_data;
+  gboolean should_continue = (1 != *test_variable);
+  (*test_variable)++;
+  return should_continue;
+}
+
+Test(secretstorage, secret_status_can_stop_in_the_middle)
+{
+  gint test_variable = 0;
+  secret_storage_store_string("key1", "secret");
+  secret_storage_store_string("key2", "secret");
+  secret_storage_store_string("key3", "secret");
+  secret_storage_store_string("key4", "secret");
+  secret_storage_status_foreach(stop_in_the_middle_callback, &test_variable);
+  cr_assert_eq(test_variable, 2);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -103,3 +103,41 @@ Test(secretstorage, subscribe_after_store)
   secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &test_variable);
   cr_assert(test_variable);
 }
+
+Test(secretstorage, subscriptions_per_keys)
+{
+  gboolean key1_test_variable = FALSE;
+  gboolean key2_test_variable = FALSE;
+  secret_storage_subscribe_for_key("key1", set_variable_to_true_cb, &key1_test_variable);
+  secret_storage_subscribe_for_key("key2", set_variable_to_true_cb, &key2_test_variable);
+  cr_assert_not(key1_test_variable);
+  cr_assert_not(key2_test_variable);
+
+  secret_storage_store_string("key1", "secret");
+  cr_assert(key1_test_variable);
+  cr_assert_not(key2_test_variable);
+
+  secret_storage_store_string("key2", "secret");
+  cr_assert(key1_test_variable);
+  cr_assert(key2_test_variable);
+}
+
+Test(secretstorage, two_subscribe_without_store)
+{
+  gboolean test_variable = FALSE;
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &test_variable);
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &test_variable);
+  cr_assert_not(test_variable);
+}
+
+void
+check_secret(Secret *secret, gpointer user_data)
+{
+  cr_assert_str_eq(secret->data, user_data);
+}
+
+Test(secretstorage, subscribe_cb_check_secret)
+{
+  secret_storage_subscribe_for_key("key", check_secret, "secret");
+  secret_storage_store_string("key", "secret");
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -81,3 +81,25 @@ Test(secretstorage, store_secret_with_embedded_zero)
   cr_assert_eq(result, 0);
   secret_storage_put_secret(secret);
 }
+
+void set_variable_to_true_cb(Secret *secret, gpointer user_data)
+{
+  *((gboolean *)user_data) = TRUE;
+}
+
+Test(secretstorage, subscribe_before_store)
+{
+  gboolean test_variable = FALSE;
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &test_variable);
+  cr_assert_not(test_variable);
+  secret_storage_store_string("key", "secret");
+  cr_assert(test_variable);
+}
+
+Test(secretstorage, subscribe_after_store)
+{
+  gboolean test_variable = FALSE;
+  secret_storage_store_string("key", "secret");
+  secret_storage_subscribe_for_key("key", set_variable_to_true_cb, &test_variable);
+  cr_assert(test_variable);
+}

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -211,3 +211,24 @@ Test(secretstorage, secret_status_can_stop_in_the_middle)
   secret_storage_status_foreach(stop_in_the_middle_callback, &test_variable);
   cr_assert_eq(test_variable, 2);
 }
+
+void
+subscribe_until_success(Secret *secret, gpointer user_data)
+{
+  if (strcmp(secret->data, "good_password"))
+    {
+      secret_storage_subscribe_for_key("key", subscribe_until_success, user_data);
+      return;
+    }
+  *((gboolean *)user_data) = TRUE;
+}
+
+Test(secretstorage, subscribe_until_success)
+{
+  gboolean test_variable = FALSE;
+  secret_storage_subscribe_for_key("key", subscribe_until_success, &test_variable);
+  secret_storage_store_string("key", "wrong_password");
+  cr_assert_not(test_variable);
+  secret_storage_store_string("key", "good_password");
+  cr_assert(test_variable);
+}

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -54,6 +54,13 @@ typedef enum
   TSO_NOTLSv12=0x0010,
 } TLSSslOptions;
 
+typedef enum
+{
+  TLS_CONTEXT_SETUP_OK,
+  TLS_CONTEXT_SETUP_ERROR,
+  TLS_CONTEXT_SETUP_BAD_PASSWORD
+} TLSContextSetupResult;
+
 typedef gint (*TLSSessionVerifyFunc)(gint ok, X509_STORE_CTX *ctx, gpointer user_data);
 typedef struct _TLSContext TLSContext;
 
@@ -81,7 +88,7 @@ void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, 
                             GDestroyNotify verify_destroy);
 void tls_session_free(TLSSession *self);
 
-gboolean tls_context_setup_context(TLSContext *self);
+TLSContextSetupResult tls_context_setup_context(TLSContext *self);
 TLSSession *tls_context_setup_session(TLSContext *self);
 void tls_session_set_trusted_fingerprints(TLSContext *self, GList *fingerprints);
 void tls_session_set_trusted_dn(TLSContext *self, GList *dns);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -108,6 +108,7 @@ void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);
+const gchar *tls_context_get_key_file(TLSContext *self);
 
 void tls_log_certificate_validation_progress(int ok, X509_STORE_CTX *ctx);
 gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -551,6 +551,9 @@ _finalize_init(gpointer arg)
     }
 
   afsocket_sd_start_watches(self);
+  char buf[256];
+  msg_info("Accepting connections",
+           evt_tag_str("addr", g_sockaddr_format(self->bind_addr, buf, sizeof(buf), GSA_FULL)));
   return TRUE;
 }
 

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -169,12 +169,12 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
   if (!self->tls_context)
     return func(func_args);
 
-  TLSContextSetupResult r = tls_context_setup_context(self->tls_context);
+  TLSContextSetupResult tls_ctx_setup_res = tls_context_setup_context(self->tls_context);
 
-  if (r == TLS_CONTEXT_SETUP_OK)
+  if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_OK)
     return func(func_args);
 
-  if (r == TLS_CONTEXT_SETUP_BAD_PASSWORD)
+  if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_BAD_PASSWORD)
     {
       const gchar *key = tls_context_get_key_file(self->tls_context);
       msg_error("Error setting up TLS context",
@@ -184,12 +184,12 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
       args->func = func;
       args->func_args = func_args;
       self->secret_store_cb_data = args;
-      gboolean r = secret_storage_subscribe_for_key(key, _call_finalize_init, args);
-      if (r)
+      gboolean subscribe_res = secret_storage_subscribe_for_key(key, _call_finalize_init, args);
+      if (subscribe_res)
         msg_info("Waiting for password", evt_tag_str("keyfile", key));
       else
         msg_error("Failed to subscribe for key", evt_tag_str("keyfile", key));
-      return r;
+      return subscribe_res;
     }
 
   return FALSE;

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -107,7 +107,7 @@ transport_mapper_inet_init(TransportMapper *s)
 {
   TransportMapperInet *self = (TransportMapperInet *) s;
 
-  if (self->tls_context && !tls_context_setup_context(self->tls_context))
+  if (self->tls_context && (tls_context_setup_context(self->tls_context) != TLS_CONTEXT_SETUP_OK))
     return FALSE;
 
   return TRUE;
@@ -121,7 +121,7 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
   if (!self->tls_context)
     return func(func_args);
 
-  if (!tls_context_setup_context(self->tls_context))
+  if (tls_context_setup_context(self->tls_context) != TLS_CONTEXT_SETUP_OK)
     return FALSE;
 
   return func(func_args);

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -113,6 +113,20 @@ transport_mapper_inet_init(TransportMapper *s)
   return TRUE;
 }
 
+static gboolean
+transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB func, gpointer func_args)
+{
+  TransportMapperInet *self = (TransportMapperInet *)s;
+
+  if (!self->tls_context)
+    return func(func_args);
+
+  if (!tls_context_setup_context(self->tls_context))
+    return FALSE;
+
+  return func(func_args);
+}
+
 void
 transport_mapper_inet_free_method(TransportMapper *s)
 {
@@ -130,6 +144,7 @@ transport_mapper_inet_init_instance(TransportMapperInet *self, const gchar *tran
   self->super.apply_transport = transport_mapper_inet_apply_transport_method;
   self->super.construct_log_transport = transport_mapper_inet_construct_log_transport;
   self->super.init = transport_mapper_inet_init;
+  self->super.async_init = transport_mapper_inet_async_init;
   self->super.free_fn = transport_mapper_inet_free_method;
   self->super.address_family = AF_INET;
 }

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -139,6 +139,7 @@ _call_finalize_init(Secret *secret, gpointer user_data)
     {
       msg_error("Error setting up TLS context",
                 evt_tag_str("keyfile", key));
+      secret_storage_update_status(key, SECRET_STORAGE_STATUS_FAILED);
       return;
     }
     case TLS_CONTEXT_SETUP_BAD_PASSWORD:
@@ -150,9 +151,13 @@ _call_finalize_init(Secret *secret, gpointer user_data)
         msg_error("Failed to subscribe for key", evt_tag_str("keyfile", key));
       else
         msg_debug("Re-subscribe for key", evt_tag_str("keyfile", key));
+
+      secret_storage_update_status(key, SECRET_STORAGE_STATUS_INVALID_PASSWORD);
+
       return;
     }
     default:
+      secret_storage_update_status(key, SECRET_STORAGE_SUCCESS);
       if (!args->func(args->func_args))
         {
           msg_error("Error finalize initialization",

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -177,7 +177,12 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
   TLSContextSetupResult tls_ctx_setup_res = tls_context_setup_context(self->tls_context);
 
   if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_OK)
-    return func(func_args);
+    {
+      const gchar *key = tls_context_get_key_file(self->tls_context);
+      if (secret_storage_contains_key(key))
+        secret_storage_update_status(key, SECRET_STORAGE_SUCCESS);
+      return func(func_args);
+    }
 
   if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_BAD_PASSWORD)
     {

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -37,6 +37,7 @@ typedef struct _TransportMapperInet
   TLSContext *tls_context;
   TLSSessionVerifyFunc tls_verify_callback;
   gpointer tls_verify_data;
+  gpointer secret_store_cb_data;
 } TransportMapperInet;
 
 static inline gint

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -29,6 +29,7 @@
 #include "gsockaddr.h"
 
 typedef struct _TransportMapper TransportMapper;
+typedef gboolean (*TransportMapperAsyncInitCB)(gpointer arg);
 
 struct _TransportMapper
 {
@@ -48,6 +49,7 @@ struct _TransportMapper
   gboolean (*apply_transport)(TransportMapper *self, GlobalConfig *cfg);
   LogTransport *(*construct_log_transport)(TransportMapper *self, gint fd);
   gboolean (*init)(TransportMapper *self);
+  gboolean (*async_init)(TransportMapper *self, TransportMapperAsyncInitCB func, gpointer arg);
   void (*free_fn)(TransportMapper *self);
 };
 
@@ -88,4 +90,14 @@ transport_mapper_init(TransportMapper *self)
   return TRUE;
 }
 
+static inline gboolean
+transport_mapper_async_init(TransportMapper *self, TransportMapperAsyncInitCB func, gpointer arg)
+{
+  if (self->async_init)
+    {
+      return self->async_init(self, func, arg);
+    }
+
+  return FALSE;
+}
 #endif

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -98,6 +98,6 @@ transport_mapper_async_init(TransportMapper *self, TransportMapperAsyncInitCB fu
       return self->async_init(self, func, arg);
     }
 
-  return FALSE;
+  return func(arg);
 }
 #endif

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -76,21 +76,34 @@ _is_response_empty(GString *response)
   return (response == NULL || g_str_equal(response->str, ""));
 }
 
+static void
+clear_and_free(GString *str)
+{
+  if (str)
+    {
+      memset(str->str, 0, str->len);
+      g_string_free(str, TRUE);
+    }
+}
+
 static gint
 _dispatch_command(const gchar *cmd)
 {
+  gint retval = 0;
   gchar *dispatchable_command = g_strdup_printf("%s\n", cmd);
   GString *rsp = slng_run_command(dispatchable_command);
 
   if (_is_response_empty(rsp))
-    return 1;
+    retval = 1;
+  else
+    printf("%s\n", rsp->str);
 
-  printf("%s\n", rsp->str);
+  clear_and_free(rsp);
 
-  g_string_free(rsp, TRUE);
+  memset(dispatchable_command, 0, strlen(dispatchable_command));
   g_free(dispatchable_command);
 
-  return 0;
+  return retval;
 }
 
 static gchar *verbose_set = NULL;

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -546,23 +546,37 @@ _is_help(gchar *cmd)
   return g_str_equal(cmd, "--help");
 }
 
-
 static CommandDescriptor *
-find_active_mode(const gchar *mode_string, CommandDescriptor descriptors[])
+find_active_mode(CommandDescriptor descriptors[], gint *argc, char **argv, GString *cmdname_accumulator)
 {
-  for (gint mode = 0; modes[mode].mode; mode++)
-    if (strcmp(modes[mode].mode, mode_string) == 0)
-      return &descriptors[mode];
+  const gchar *mode_string = get_mode(argc, &argv);
+  if (!mode_string)
+    {
+      print_usage(cmdname_accumulator->str, descriptors);
+      exit(1);
+    }
+
+  for (gint mode = 0; descriptors[mode].mode; mode++)
+    if (strcmp(descriptors[mode].mode, mode_string) == 0)
+      {
+        if (descriptors[mode].main)
+          return &descriptors[mode];
+
+        g_assert(descriptors[mode].subcommands);
+        g_string_append_printf(cmdname_accumulator, " %s", mode_string);
+        return find_active_mode(descriptors[mode].subcommands, argc, argv, cmdname_accumulator);
+      }
+
   return NULL;
 }
 
 static GOptionContext *
-setup_help_context(const gchar *mode_string, CommandDescriptor *active_mode)
+setup_help_context(const gchar *cmdname, CommandDescriptor *active_mode)
 {
   if (!active_mode)
     return NULL;
 
-  GOptionContext *ctx = g_option_context_new(mode_string);
+  GOptionContext *ctx = g_option_context_new(cmdname);
 #if GLIB_CHECK_VERSION (2, 12, 0)
   g_option_context_set_summary(ctx, active_mode->description);
 #endif
@@ -575,7 +589,6 @@ setup_help_context(const gchar *mode_string, CommandDescriptor *active_mode)
 int
 main(int argc, char *argv[])
 {
-  const gchar *mode_string;
   GError *error = NULL;
   int result;
 
@@ -589,15 +602,9 @@ main(int argc, char *argv[])
       exit(0);
     }
 
-  mode_string = get_mode(&argc, &argv);
-  if (!mode_string)
-    {
-      print_usage(argv[0], modes);
-      exit(1);
-    }
-
-  CommandDescriptor *active_mode = find_active_mode(mode_string, modes);
-  GOptionContext *ctx = setup_help_context(mode_string, active_mode);
+  GString *cmdname_accumulator = g_string_new(argv[0]);
+  CommandDescriptor *active_mode = find_active_mode(modes, &argc, argv, cmdname_accumulator);
+  GOptionContext *ctx = setup_help_context(cmdname_accumulator->str, active_mode);
 
   if (!ctx)
     {
@@ -615,8 +622,7 @@ main(int argc, char *argv[])
     }
 
   control_client = control_client_new(control_name);
-
-  result = modes[mode].main(argc, argv, modes[mode].mode);
+  result = active_mode->main(argc, argv, active_mode->mode, ctx);
   g_option_context_free(ctx);
   control_client_free(control_client);
   return result;

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -401,7 +401,7 @@ set_console_echo(gboolean new_state)
 }
 
 static void
-get_password_from_stdin(gchar *buffer, gulong *length)
+read_password_from_stdin(gchar *buffer, gsize *length)
 {
   printf("enter password:");
   set_console_echo(FALSE);
@@ -422,7 +422,7 @@ is_syslog_ng_running()
 }
 
 static gchar *
-fetch_next_remaining(gchar **remaining, gint *available_index)
+consume_next_from_remaining(gchar **remaining, gint *available_index)
 {
   if (!remaining)
     return NULL;
@@ -438,7 +438,7 @@ slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 
 
   if (!credentials_key)
-    credentials_key = fetch_next_remaining(credentials_remaining, &remaining_unused_index);
+    credentials_key = consume_next_from_remaining(credentials_remaining, &remaining_unused_index);
 
   if (!credentials_key)
     {
@@ -452,7 +452,7 @@ slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
     return 1;
 
   if (!credentials_secret)
-    credentials_secret = fetch_next_remaining(credentials_remaining, &remaining_unused_index);
+    credentials_secret = consume_next_from_remaining(credentials_remaining, &remaining_unused_index);
 
   gchar *secret_to_store;
   if (credentials_secret)
@@ -463,12 +463,12 @@ slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
     }
   else
     {
-      gulong buff_size = 256;
+      gsize buff_size = 256;
       secret_to_store = g_malloc0(buff_size);
       if (!secret_to_store)
         g_assert_not_reached();
 
-      get_password_from_stdin(secret_to_store, &buff_size);
+      read_password_from_stdin(secret_to_store, &buff_size);
     }
 
   gint retval = asprintf(&answer, "PWD %s %s %s", "add", credentials_key, secret_to_store);

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -380,6 +380,9 @@ static GOptionEntry no_options[] =
 static void
 set_console_echo(gboolean new_state)
 {
+  if (!isatty(STDIN_FILENO))
+    return;
+
   struct termios t;
 
   if (tcgetattr(STDIN_FILENO, &t))

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -404,6 +404,7 @@ get_password_from_stdin(gchar *buffer, gulong *length)
   set_console_echo(FALSE);
   if (-1 == getline(&buffer, length, stdin))
     {
+      set_console_echo(TRUE);
       fprintf(stderr, "error while reading password from terminal: %s", strerror(errno));
       g_assert_not_reached();
     }
@@ -414,10 +415,7 @@ get_password_from_stdin(gchar *buffer, gulong *length)
 static gboolean
 is_syslog_ng_running()
 {
-  if (control_client_connect(control_client))
-    return TRUE;
-  else
-    return FALSE;
+  return control_client_connect(control_client);
 }
 
 static gchar *

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -50,7 +50,7 @@ cmake
 sub-configure\.sh$
 configure\.ac$
 Makefile\.am$
-lib/(compat|str-repr|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|logmsg|value-pairs|[^/]*$)
+lib/(compat|str-repr|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|logmsg|value-pairs|secret-storage|[^/]*$)
 lib/scanner/(csv-scanner|list-scanner|kv-scanner|[^/]*$)
 libtest
 syslog-ng(-ctl)?
@@ -68,4 +68,3 @@ scl
 scripts
  GPLv2+_SSL,non-balabit
 modules/http
-


### PR DESCRIPTION
# Support password protected SSL keys

## Concept
The solution has three key parts
 * need to store the secret keys somewhere, possible in a non-dumpable memory area (credential store)
 * inject secret into syslog-ng with syslog-ng-ctl (syslog-ng-ctl)
 * afsocket:
   * network source
     * make it possible to disable client connections until a valid password is not provided by the user, and open connections when the password is available
   * network destination
     * try to reconnect to destination until a valid password is not available


### Technical details

#### Network source & destination (afsocket)
In case of TCP network source, we call a `TransportMapper` init as part of the main init. This `TransportMapper::init` is responsible for setting up the `TLSContext`.
In the original implementation, when someone uses a password protected SSL key, OpenSSL will ask for the password (from stdin as we did not set the default password callback) and entire syslog-ng blocks until the password is not set.
One of our goal was to avoid blocking the entire syslog-ng instance in such case.
We can do this by splitting the init logic:
 * first part is responsible for allocating resources (socket and bind system calls)
 * second part is to start accepting client connections(listen & accept system calls)

As `TransportMapper` initializes the `TLSContext`, it has the knowledge whether we can finalize the Source driver init or not, so we added an asynchronous TransportMapper init method.
The async init requires a callback which is responsible for finishing the Source initialization (it calls the finalize init method which then calls the listen&accept).

#### Callback-hell
Finalize callback (which is passed to `TransportMapper::async_init`, `_finalize_init` in `afsocket-source.c`) is not the only one callback we have to use.
OpenSSL uses a password callback on its own: this callback is responsible for filling up a buffer with the password.
This callback (`_pem_passwd_callback` in `tlscontext.c`) has a user data argument which is used for passing the key parameter for secret store in our implementation.
Based on the key we can get the stored password.

The third callback is used with secret store. Secret store handles a kind of hashtable which stores the keys and callbacks. Absolute path of the PEM files are used as keys, and
when the user injects a password for a specific key, the registered callback will be called.

#### How it works together?
* When a tcp source is configured, asynchronous transportmapper init method will be called. When tls is not used, it just call the finalize callback and start accepting client connections.
* When tls is used and the pem file is not protected by password, tls context setup will be created successfully, callback is called immediately, source driver is accepting client connections.
* When tls is used and the pem file is protected by password, tls context setup will fail, another callback(secret-store-callback) is registered(`secret_storage_subscribe_for_key`) in secret-storage with
key = pem file name. Source driver init returns successfully but won't be able to receive client connections as it is not listening.
When user inputs the password for the key, the registered function is called: it will try to setup tls context. The tls setup context method will trigger OpenSSL to call its own password callback(with
userdata=pem file), which will get the password from the secret store. If the password is not valid, we re-register the callback in secret-store (and display error message and change status in secret-storage).
When the password is fine, and the tls context setup is succeeded, we call the callback passed to `TransportMapper::async_init` which then calls listen and accept, so the source driver is ready
for accepting client connections.

#### Sequence diagram: source
![network-source](https://user-images.githubusercontent.com/5908786/36303088-288f1396-130b-11e8-929c-3bbc1db70c11.png)

#### Destination
We use the same `TransportMapper::async_init`, the only difference is that the finalize init callback calls the `afsocket_dd_try_connect`.
So we handle invalid/unavailable password as it would be a connection error.

#### syslog-ng-ctl
Operators can use `syslog-ng-ctl` to inject secrets to the secret storage.

* The already stored secrets together with their status can be queried by `syslog-ng-ctl credentials status`.

* Secrets can be added to the secret storage by `syslog-ng-ctl credentials add id secret` command.

From ssl passhprase point of view the `id` in `syslog-ng-ctl` must be the exact string written in the configuration for the location of the encrypted key. If not the exact string is used, the unlock will not work. If full path is used inside the configuration, the same full path must be used in `syslog-ng-ctl`. If relative path is used, the same relative path must be used in `syslog-ng-ctl`. The reason is technical: the subscription happens with the string used inside the configuration, and the same key is used by `syslog-ng-ctl` to store the secret.

This behaviour is a counter-intuitive, but there are plans to resolve it in the future.

For sake of convenience, users can either add credentials with `-i/--id, -s/--secret` options, but also with positional parameters. In case an option is missing, `syslog-ng-ctl` tries to fill the data from the positional parameter. If the options could not be filled either way, error will be reported, and a help text is emitted about the options. For sake of the latter: a little refactor was necessary in syslog-ng-ctl: the `GOptionContext` needs to be passed to the callbacks as well.

`syslog-ng-ctl credentials` is a command that has two subcommands: `add` and `status`. So to support this feature, the description of subcommands is extended: now subcommands can also have subcommands. The command descriptor table therefore is now represented as a tree. To find the appropriate command and callback, the tree needs to be traversed from now on, collecting the nodes in the meantime: `find_active_mode`. Once the correct leaf is found, the callback is invoked with the appropriate arguments.

#### secret-storage
The secret-storage module is responsible for storing the credentials - provided by syslog-ng-ctl -, and callbacks - registered by drivers.

Secret-storage is a hashtable with a special memory allocator. The hashtable is indexed by the keys provided by either `syslog-ng-ctl` or `TransportMapper`. An entry is a secret together with some callbacks and a secret status. The values are stored on a specially allocated memory area, that is locked into memory (not written into swap), and not written to a core file.

There is an ulimit for `RLIMIT_MEMLOCK` (total size of locked memory). This restricts the number of secrets handled by syslog-ng in parallel. The memory allocator can allocate only larger chunks than pagesize, which is typically 4k. The default ulimit for `RLIMIT_MEMOLOCK` is 64k, meaning only 16 secrets can be handled only at a time, depending the size of the secrets, including the secrets cloned internally.

Secret storage is a core functionality, but due to a technical limitation, it is shipped as a separate shared library. The reason is that the symbols of the secret storage is set to hidden visibility by default (which we did not want to change in libsyslog-ng.so), meaning a specially crafted syslog-ng module cannot use secret-storage symbols, unless secret-storage explicitely allows it. Specially: the hash table of secrets is also hidden. As a side effect, users of the secret-storage need to explicitely link to libsecret-storage.so. This feature alone does not add much to security, because for now any driver can query any secrets using `secret_storage_get_secret_by_name`, though there are plans to add some level of authentication for drivers in the future.

Any time a driver works with a secret, secret-storage first clones the secret, and provides only a copy for the driver. As a result, the different drivers cannot accidentally modify the secret for each other.

The status of a secret is initialized to `PENDING` when the first subscription comes from `TransportMapper`. After that only the drivers update the status of the secrets.

There is a function added to loop through the secret status: `secret_store_status_foreach`. This is used by `syslog-ng-ctl` to list the stored secrets with status.

#### nondumpable-allocator
A special memory allocator added to store the secrets in memory. The difference between a malloc-ed memory and a nondumpable-memory is the latter is not written to swap, and not written to core file. During deallocation, the area is zeroed out as well.

The allocator works on mapped anonymous pages, calling `mlock` and `madvise` on the pages. Each allocated memory contains a buffer provided for the user, and some metadata about the allocation: the allocated and available size. The available size is used for zeroing during deallocation.

The layout of buffer and metadata tries to imitate the malloc implementation in glibc: the metadata is stored right before the user buffer in memory: i. e. the allocated anonymous map starts with the metadata, however the pointer returned by the allocator is the location of the user buffer inside the anonymous memory. Hence the deallocator can easily find the metadata by a simple substraction from the location provided by the user.

There is an ulimit for locking memory: `RLIMIT_MEMLOCK`, which is usually 64k. As the allocation happens in pages, usually 4k, the number of parallel allocations is very limited by default.

### Future improvements
 * Use crendential store for SQL , mongodb, and amqp destinations (->any other sources, destinations where credential can be set by users).
