### PR TITLE
wildcard file source: fixing various crashes

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -38,6 +38,7 @@
 #define NC_FILE_MOVED  4
 #define NC_FILE_EOF    5
 #define NC_REOPEN_REQUIRED 6
+#define NC_FILE_MISSING 7
 
 /* indicates that the LogPipe was initialized */
 #define PIF_INITIALIZED       0x0001

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -177,9 +177,8 @@ static void
 _wait_until_map_release(PersistState *self)
 {
   g_mutex_lock(self->mapped_lock);
-  if (self->mapped_counter != 0)
+  while (self->mapped_counter)
     g_cond_wait(self->mapped_release_cond, self->mapped_lock);
-  g_assert(self->mapped_counter == 0);
 }
 
 static gboolean

--- a/modules/affile/directory-monitor-inotify.c
+++ b/modules/affile/directory-monitor-inotify.c
@@ -102,10 +102,17 @@ directory_monitor_inotify_new(const gchar *dir, guint recheck_time)
   DirectoryMonitorInotify *self = g_new0(DirectoryMonitorInotify, 1);
   directory_monitor_init_instance(&self->super, dir, recheck_time);
 
+  IV_INOTIFY_INIT(&self->inotify);
+  if (iv_inotify_register(&self->inotify))
+    {
+      msg_error("directory-monitor-inotify: could not create inotify object", evt_tag_errno("errno", errno));
+      directory_monitor_free(&self->super);
+      return NULL;
+    }
+
   self->super.start_watches = _start_watches;
   self->super.stop_watches = _stop_watches;
   self->super.free_fn = _free;
-  IV_INOTIFY_INIT(&self->inotify);
-  iv_inotify_register(&self->inotify);
+
   return &self->super;
 }

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -43,6 +43,7 @@ typedef struct _FileReader
   FileOpener *opener;
   LogReader *reader;
   gboolean is_pipe;
+  void (*missing_cb)(struct _FileReader *self, gpointer user_data);
 } FileReader;
 
 static inline LogProtoFileReaderOptions *

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -131,6 +131,8 @@ poll_file_changes_check_file(gpointer s)
         {
           msg_verbose("Follow mode file still does not exist",
                       evt_tag_str("filename", self->follow_filename));
+          log_pipe_notify(self->control, NC_FILE_MISSING, self);
+          return;
         }
     }
 reschedule:

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -208,6 +208,13 @@ _add_directory_monitor(WildcardSourceDriver *self, const gchar *directory)
     .method = self->monitor_method
   };
   DirectoryMonitor *monitor = create_directory_monitor(&options);
+  if (!monitor)
+    {
+      msg_error("Wildcard source: could not create directory monitoring object! Possible message loss",
+                evt_tag_str("dir", directory),
+                log_pipe_location_tag(&self->super.super.super));
+      return;
+    }
 
   directory_monitor_set_callback(monitor, _on_directory_monitor_changed, self);
   directory_monitor_start(monitor);


### PR DESCRIPTION
This patchset fixes 3 independent crashes in wildcard file source.

- in persist state, g_cond_wait was not checked in a while loop, though it is possible to it returns early, without g_cond_signal. This resulted in an assert. I could trigger this with creating and deleting non-empty files in busy loop, while reloading syslog-ng, also in a busy loop.

- When a file is deleted wildcard source deinits the reader in the main thread, but in the meantime it was possible the worker threads try to post message to the pipe element, resulting in an assert. The deinit of the reader is moved to another part of the code: it is handled together with the other reader notifications. Those are synchronized with the pipe post mechanism, eliminating the crash.

- Missing check for directory monitoring creation results in a crash. In case too many files were open, due to missing error checking, syslog-ng thought the watches are started successfully. During deinit, syslog-ng tries to stop the watches, resulting in an abort in ivykis about the not tracked fd to be untracked. Only "inotify" version of polling is affected.

Fixes: https://github.com/balabit/syslog-ng/issues/1855