### PR TITLE
Fixes for 3.14 release

### DIFF
--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -257,7 +257,6 @@ Test(secretstorage, subscribe_until_success)
   cr_assert(test_variable);
 }
 
-#if (SYSLOG_NG_ENABLE_FORCED_SERVER_MODE)
 Test(secretstorage, test_rlimit)
 {
   struct rlimit locked_limit;
@@ -276,10 +275,18 @@ Test(secretstorage, test_rlimit)
     }
 
   sprintf(key_fmt, "key%03d", i);
-  cr_assert_not(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
-  cr_assert(secret_storage_subscribe_for_key("key000", secret_checker, "value"));
+
+  /* root is not restricted by rlimit */
+  if (geteuid() == 0)
+    {
+      cr_assert(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
+      cr_assert(secret_storage_subscribe_for_key("key000", secret_checker, "value"));
+    }
+  else
+    {
+      cr_assert_not(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
+    }
 }
-#endif
 
 static void
 update_state_callback(Secret *secret, gpointer user_data)

--- a/packaging/debian/syslog-ng-core.install
+++ b/packaging/debian/syslog-ng-core.install
@@ -5,6 +5,7 @@ usr/bin/*
 usr/sbin/*
 usr/lib/syslog-ng/libsyslog-ng-*.so.*
 usr/lib/syslog-ng/libevtlog-*.so.*
+usr/lib/syslog-ng/libsecret-storage.so.*
 usr/lib/syslog-ng/*/libsdjournal.so
 usr/lib/syslog-ng/*/libaffile.so
 usr/lib/syslog-ng/*/libafprog.so


### PR DESCRIPTION
- Unit test needed to be branched based on executor user id. Please see commit message for details.

- Add missing libsecret-storage.so to deb packaging.
@lbudai this one was tricky because we used lib_LTLIBRARIES instead of module_LTLIBRARIES, meaning the generated so file will be something like libsecret-storage.so.0.0.0 instead of the usual libsecret-storage.so, thats why libsecret-storage.so.* needed to be used in the install file. Probably the same hack will be necessary in obs. Thanks for @algernon helping me in the fix.