### PR TITLE
Added g_list_free_full in lib/compat/glib & configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -860,7 +860,7 @@ LDFLAGS="$LDFLAGS $GLIB_LIBS"
 
 old_LIBS=$LIBS
 LIBS="$LIBS $GLIB_LIBS"
-AC_CHECK_FUNCS(g_mapped_file_unref g_list_copy_deep g_queue_free_full)
+AC_CHECK_FUNCS(g_mapped_file_unref g_list_copy_deep g_queue_free_full g_list_free_full)
 LIBS=$old_LIBS
 
 AC_CACHE_CHECK(sanity checking Glib headers,

--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -55,6 +55,7 @@ g_list_copy_deep(GList     *list,
 
   return new_list;
 }
+
 #endif
 
 #if !SYSLOG_NG_HAVE_G_QUEUE_FREE_FULL
@@ -67,3 +68,15 @@ g_queue_free_full(GQueue *queue, GDestroyNotify free_func)
 }
 
 #endif
+
+#if !SYSLOG_NG_HAVE_G_LIST_FREE_FULL
+
+void
+g_list_free_full (GList *list, GDestroyNotify free_func)
+{
+  g_list_foreach (list, (GFunc) free_func, NULL);
+  g_list_free (list);
+}
+
+#endif
+

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -60,4 +60,8 @@ GList *g_list_copy_deep (GList *list, GCopyFunc func, gpointer user_data);
 void g_queue_free_full(GQueue *queue, GDestroyNotify free_func);
 #endif
 
+#if !SYSLOG_NG_HAVE_G_LIST_FREE_FULL
+void g_list_free_full (GList *list, GDestroyNotify free_func);
+#endif
+
 #endif

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -226,9 +226,8 @@ insert_empty_secret_storage(const gchar *key)
 gboolean
 secret_storage_subscribe_for_key(const gchar *key, SecretStorageCB func, gpointer user_data)
 {
-
   SecretStorage *secret_storage;
-  if (!g_hash_table_contains(secret_manager, key))
+  if (!g_hash_table_lookup(secret_manager, key))
     if (!insert_empty_secret_storage(key))
       return FALSE;
 


### PR DESCRIPTION
Fixes issue #1270  
SLES 11 has glib version <=2-26, in which g_list_free_full function is not present.
Added compat : glib patch to fix the issue.