### PR TITLE
Filter logging improvements

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -80,7 +80,7 @@ endif
 
 if JSON_INTERNAL
 lib/jsonc/libjson-c.la:
-	${MAKE} -C lib/jsonc
+	${MAKE} CFLAGS="${CFLAGS} -Wno-error" -C lib/jsonc
 
 CLEAN_SUBDIRS				+= @JSON_SUBDIRS@
 endif

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -44,6 +44,7 @@
 # include <syslog.h>
 #endif
 #include <stdarg.h>
+#include <arpa/inet.h>
 
 #include "evtmaps.h"
 
@@ -145,6 +146,8 @@ EVTTAG *evt_tag_int(const char *tag, int value);
 EVTTAG *evt_tag_long(const char *tag, long value);
 EVTTAG *evt_tag_errno(const char *tag, int err);
 EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) EVT_GNUC_PRINTF_FUNC(2, 3);
+EVTTAG *evt_tag_inaddr(const char *tag, const struct in_addr *addr);
+EVTTAG *evt_tag_inaddr6(const char *tag, const struct in6_addr *addr);
 
 /**
  * evt_format:

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -118,3 +118,28 @@ evt_tag_printf(const char *tag, const char *format, ...)
   va_end(ap);
   return evt_tag_str(tag, buf);
 }
+
+EVTTAG *
+evt_tag_inaddr(const char *tag, const struct in_addr *addr)
+{
+  char buf[64];
+
+  if (addr)
+    inet_ntop(AF_INET, addr, buf, sizeof(buf));
+  else
+    strncpy(buf, "none", sizeof(buf));
+
+  return evt_tag_str(tag, buf);
+}
+
+EVTTAG *
+evt_tag_inaddr6(const char *tag, const struct in6_addr *addr)
+{
+  char buf[128];
+
+  if (addr)
+    inet_ntop(AF_INET6, addr, buf, sizeof(buf));
+  else
+    strncpy(buf, "none", sizeof(buf));
+  return evt_tag_str(tag, buf);
+}

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -49,6 +49,11 @@ filter_call_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     stats_counter_inc(self->super.not_matched);
 
+  msg_debug("  filter() evaluation result",
+            filter_result_tag(res),
+            evt_tag_str("called-rule", self->rule),
+            evt_tag_printf("msg", "%p", msgs[num_msg - 1]));
+
   return res ^ s->comp;
 }
 

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -85,6 +85,13 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       result = self->cmp_op & FCMP_GT || self->cmp_op == 0;
     }
 
+  msg_debug("  cmp() evaluation result",
+            filter_result_tag(result),
+            evt_tag_str("left", left_buf->str),
+            evt_tag_str("operator", self->super.type),
+            evt_tag_str("right", right_buf->str),
+            evt_tag_printf("msg", "%p", msgs[num_msg - 1]));
+
   scratch_buffers_reclaim_marked(marker);
   return result ^ s->comp;
 }

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -49,10 +49,6 @@ filter_expr_eval_with_context(FilterExprNode *self, LogMessage **msg, gint num_m
   g_assert(num_msg > 0);
 
   res = self->eval(self, msg, num_msg);
-  msg_debug("Filter node evaluation result",
-            evt_tag_printf("msg", "%p", *msg),
-            evt_tag_str("result", res ? "match" : "not-match"),
-            evt_tag_str("type", self->type));
   return res;
 }
 
@@ -96,4 +92,10 @@ filter_expr_unref(FilterExprNode *self)
         self->free_fn(self);
       g_free(self);
     }
+}
+
+EVTTAG *
+filter_result_tag(gboolean res)
+{
+  return evt_tag_str("result", res ? "MATCH" : "UNMATCHED");
 }

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -53,6 +53,8 @@ filter_expr_init(FilterExprNode *self, GlobalConfig *cfg)
     self->init(self, cfg);
 }
 
+EVTTAG *filter_result_tag(gboolean res);
+
 gboolean filter_expr_eval(FilterExprNode *self, LogMessage *msg);
 gboolean filter_expr_eval_with_context(FilterExprNode *self, LogMessage **msgs, gint num_msg);
 gboolean filter_expr_eval_root(FilterExprNode *self, LogMessage **msg, const LogPathOptions *path_options);

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -49,13 +49,13 @@ filter_in_list_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   value = log_msg_get_value(msg, self->value_handle, &len);
   APPEND_ZERO(value, value, len);
 
-  gboolean result = (g_tree_lookup(self->tree, value) != NULL) ^ s->comp;
-  msg_debug("Filter in-list node evaluation result",
-            evt_tag_printf("msg", "%p", msg),
+  gboolean result = (g_tree_lookup(self->tree, value) != NULL);
+  msg_debug("  in-list() evaluation result",
+            filter_result_tag(result),
             evt_tag_str("value", value),
-            evt_tag_str("result", result ? "match" : "not-match"));
+            evt_tag_printf("msg", "%p", msg));
 
-  return result;
+  return result ^ s->comp;
 }
 
 static void

--- a/lib/filter/filter-netmask6.h
+++ b/lib/filter/filter-netmask6.h
@@ -28,6 +28,6 @@
 #include "filter-expr.h"
 
 FilterExprNode *filter_netmask6_new(gchar *cidr);
-void get_network_address(unsigned char *ipv6, int prefix, struct in6_addr *network);
+void get_network_address(const struct in6_addr *address, int prefix, struct in6_addr *network);
 
 #endif

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -55,17 +55,17 @@ log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   LogFilterPipe *self = (LogFilterPipe *) s;
   gboolean res;
 
-  msg_debug("Filter rule evaluation begins",
-            evt_tag_printf("msg", "%p", msg),
+  msg_debug(">>>>>> filter rule evaluation begin",
             evt_tag_str("rule", self->name),
-            log_pipe_location_tag(s));
+            log_pipe_location_tag(s),
+            evt_tag_printf("msg", "%p", msg));
 
   res = filter_expr_eval_root(self->expr, &msg, path_options);
-  msg_debug("Filter rule evaluation result",
-            evt_tag_printf("msg", "%p", msg),
-            evt_tag_str("result", res ? "match" : "not-match"),
+  msg_debug("<<<<<< filter rule evaluation result",
+            filter_result_tag(res),
             evt_tag_str("rule", self->name),
-            log_pipe_location_tag(s));
+            log_pipe_location_tag(s),
+            evt_tag_printf("msg", "%p", msg));
   if (res)
     {
       log_pipe_forward_msg(s, msg, path_options);

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -36,12 +36,14 @@ filter_re_eval_string(FilterExprNode *s, LogMessage *msg, gint value_handle, con
 
   if (str_len < 0)
     str_len = strlen(str);
-  result = log_matcher_match(self->matcher, msg, value_handle, str, str_len) ^ self->super.comp;
-  msg_debug("Filter regexp node evaluation result",
-            evt_tag_printf("msg", "%p", msg),
+  result = log_matcher_match(self->matcher, msg, value_handle, str, str_len);
+  msg_debug("  match() evaluation result",
+            filter_result_tag(result),
             evt_tag_str("input", str),
-            evt_tag_str("result", result ? "match" : "not-match"));
-  return result;
+            evt_tag_str("pattern", self->matcher->pattern),
+            evt_tag_str("value", log_msg_get_value_name(value_handle, NULL)),
+            evt_tag_printf("msg", "%p", msg));
+  return result ^ s->comp;
 }
 
 static gboolean

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -37,15 +37,28 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 {
   FilterTags *self = (FilterTags *)s;
   LogMessage *msg = msgs[num_msg - 1];
+  gboolean res;
   gint i;
 
   for (i = 0; i < self->tags->len; i++)
     {
-      if (log_msg_is_tag_by_id(msg, g_array_index(self->tags, LogTagId, i)))
-        return TRUE ^ s->comp;
+      LogTagId tag_id = g_array_index(self->tags, LogTagId, i);
+      if (log_msg_is_tag_by_id(msg, tag_id))
+        {
+          res = TRUE;
+          msg_debug("  tags() evaluation result",
+                    filter_result_tag(res),
+                    evt_tag_str("tag", log_tags_get_by_id(tag_id)),
+                    evt_tag_printf("msg", "%p", msg));
+          return res ^ s->comp;
+        }
     }
 
-  return FALSE ^ s->comp;
+  res = FALSE;
+  msg_debug("  tags() evaluation result",
+            filter_result_tag(res),
+            evt_tag_printf("msg", "%p", msg));
+  return res ^ s->comp;
 }
 
 void

--- a/lib/filter/tests/test_filters_netmask6.c
+++ b/lib/filter/tests/test_filters_netmask6.c
@@ -53,7 +53,7 @@ calculate_network6(const gchar *ipv6, int prefix, gchar *calculated_network)
   memset(&network, 0, sizeof(struct in6_addr));
 
   inet_pton(AF_INET6, ipv6, &address);
-  get_network_address((unsigned char *)&address, prefix, &network);
+  get_network_address(&address, prefix, &network);
   inet_ntop(AF_INET6, &network, calculated_network, INET6_ADDRSTRLEN);
   _replace_last_zero_with_wildcard(calculated_network);
   return calculated_network;

--- a/lib/logmatcher.h
+++ b/lib/logmatcher.h
@@ -64,6 +64,7 @@ struct _LogMatcher
 {
   gint ref_cnt;
   gint flags;
+  gchar *pattern;
   gboolean (*compile)(LogMatcher *s, const gchar *re, GError **error);
   /* value_len can be -1 to indicate unknown length */
   gboolean (*match)(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len);

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -83,16 +83,18 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   gboolean success;
 
   success = log_parser_process_message(self, &msg, path_options);
-  msg_debug("Message parsing complete",
-            evt_tag_int("result", success),
-            evt_tag_str("rule", self->name),
-            log_pipe_location_tag(s));
   if (success)
     {
+      msg_debug("Message parsing successful",
+                evt_tag_str("rule", self->name),
+                log_pipe_location_tag(s));
       log_pipe_forward_msg(s, msg, path_options);
     }
   else
     {
+      msg_debug("Message parsing failed, dropping message",
+                evt_tag_str("rule", self->name),
+                log_pipe_location_tag(s));
       if (path_options->matched)
         (*path_options->matched) = FALSE;
       log_msg_drop(msg, path_options, AT_PROCESSED);

--- a/modules/afstreams/afstreams-grammar.ym
+++ b/modules/afstreams/afstreams-grammar.ym
@@ -51,8 +51,8 @@ extern LogDriver *last_driver;
 
 /* INCLUDE_DECLS */
 
-%token KW_DOOR                        10020
-%token KW_SUN_STREAMS                 10021
+%token KW_DOOR
+%token KW_SUN_STREAMS
 
 
 %type	<ptr> source_afstreams

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -142,8 +142,17 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
                                 csv_scanner_get_current_value_len(&scanner));
     }
 
+  gboolean result = csv_scanner_is_scan_finished(&scanner);
   csv_scanner_deinit(&scanner);
-  return csv_scanner_is_scan_finished(&scanner);
+
+  if (!result)
+    {
+      msg_debug("csv-parser() failed to parse all columns from the message, and drop-invalid flag is specified",
+                evt_tag_str("input", input),
+                log_pipe_location_tag(&s->super),
+                evt_tag_printf("msg", "%p", msg));
+    }
+  return result;
 }
 
 static LogPipe *

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -189,10 +189,19 @@ date_parser_process(LogParser *s,
    */
 
   APPEND_ZERO(input, input, input_len);
-  return _convert_timestamp_to_logstamp(self,
-                                        msg->timestamps[LM_TS_RECVD].tv_sec,
-                                        &msg->timestamps[self->time_stamp],
-                                        input);
+  gboolean res = _convert_timestamp_to_logstamp(self,
+                                                msg->timestamps[LM_TS_RECVD].tv_sec,
+                                                &msg->timestamps[self->time_stamp],
+                                                input);
+
+  if (!res)
+    {
+      msg_debug("date-parser() failed to parse its input",
+                evt_tag_str("input", input),
+                log_pipe_location_tag(&s->super),
+                evt_tag_printf("msg", "%p", msg));
+    }
+  return res;
 }
 
 static LogPipe *

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -216,6 +216,13 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
         matched = pattern_db_process(self->db, *pmsg);
     }
 
+  if (self->drop_unmatched && !matched)
+    {
+      msg_debug("db-parser() failed to parse its input and drop-unmatched flag was specified",
+                evt_tag_str("input", input),
+                log_pipe_location_tag(&s->super),
+                evt_tag_printf("msg", "%p", *pmsg));
+    }
   if (!self->drop_unmatched)
     matched = TRUE;
   return matched;

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -229,7 +229,7 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   jso = json_tokener_parse_ex(tok, input, input_len);
   if (tok->err != json_tokener_success || !jso)
     {
-      msg_error("Unparsable JSON stream encountered",
+      msg_debug("Unparsable JSON stream encountered",
                 evt_tag_str ("input", input),
                 tok->err != json_tokener_success ? evt_tag_str ("error", json_tokener_error_desc(tok->err)) : NULL);
       json_tokener_free (tok);


### PR DESCRIPTION
This branch dramatically improves readability of the logs generated by filter/parser evaluation, which makes it much easier to troubleshoot configuration issues.

There are a couple of unrelated fixes as well.

NOTE: I am splitting up a larger branch into smaller, more manageably pieces. This is the first part of that series.