### PR TITLE
cmake: fixing different naming of getent between autotools and cmake

### DIFF
--- a/modules/getent/CMakeLists.txt
+++ b/modules/getent/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 set(GETENT_SOURCES
   tfgetent.c)
 
-add_library(getent SHARED ${GETENT_SOURCES})
-target_link_libraries(getent PRIVATE syslog-ng)
+add_library(tfgetent SHARED ${GETENT_SOURCES})
+target_link_libraries(tfgetent PRIVATE syslog-ng)
 
-install(TARGETS getent LIBRARY DESTINATION lib/syslog-ng/ COMPONENT getent)
+install(TARGETS tfgetent LIBRARY DESTINATION lib/syslog-ng/ COMPONENT tfgetent)


### PR DESCRIPTION
In autotools, the getent module is called tfgetent. In cmake, it is
called just getent. This fails the getent-related e2e tests in the cmake version. 

The cmake version is aligned to the autotools version.
