### PR TITLE
Fix compile issue #1901 on freebsd

### DIFF
--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -32,7 +32,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <locale.h>
-#include <sgtty.h>
 #include <termios.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
sgtty.h doesn't need and cause compile error on freebsd.
closes #1901 
Signed-off-by: norberttakacs <norbert.takacs@balabit.com>