### PR TITLE
JessieDocker: Update automake in Jessie dev-dependencies

### DIFF
--- a/dbld/images/jessie/dev-dependencies.txt
+++ b/dbld/images/jessie/dev-dependencies.txt
@@ -1,7 +1,7 @@
 # required for autogen
 autoconf
 autoconf-archive
-automake1.11
+automake
 libtool
 pkg-config
 # required for configure


### PR DESCRIPTION
* Updated jsonc module needed a newer (v.1.14) automake

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>