### PR TITLE
eventlog: avoid linking to old system libevtlog libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
       libdbd-sqlite3
       libdbi0-dev
       libesmtp-dev
-      libevtlog-dev
       libgeoip-dev
       libglib2.0-dev
       libhiredis-dev
@@ -167,7 +166,6 @@ matrix:
             autoconf-archive
             binutils
             bison
-            eventlog
             geoip
             geoipupdate
             glib

--- a/configure.ac
+++ b/configure.ac
@@ -754,11 +754,11 @@ dnl ***************************************************************************
 AC_CHECK_FUNCS([inotify_init])
 
 dnl ***************************************************************************
-dnl libevtlog headers/libraries
+dnl libevtlog headers/libraries (remove after relicensing libevtlog)
 dnl ***************************************************************************
 
-EVTLOG_LIBS="-Wl,${WHOLE_ARCHIVE_OPT} -L\$(top_builddir)/lib/eventlog/src -levtlog -Wl,${NO_WHOLE_ARCHIVE_OPT}"
-EVTLOG_NO_LIBTOOL_LIBS="-Wl,${WHOLE_ARCHIVE_OPT} -L\$(top_builddir)/lib/eventlog/src/.libs -levtlog -Wl,${NO_WHOLE_ARCHIVE_OPT}"
+EVTLOG_LIBS="\$(top_builddir)/lib/eventlog/src/libevtlog.la"
+EVTLOG_NO_LIBTOOL_LIBS="\$(top_builddir)/lib/eventlog/src/.libs/libevtlog.la"
 EVTLOG_CFLAGS="-I\$(top_srcdir)/lib/eventlog/src -I\$(top_builddir)/lib/eventlog/src"
 
 dnl ***************************************************************************


### PR DESCRIPTION
`eventlog` is not an external library anymore.
Instead of adding an `-levtlog` ld flag, this patch adds the internal `libevtlog` explicitly as a dependency.