### PR TITLE
Fix TLS-based destinations in case of a missing client key/cert

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -322,7 +322,7 @@ tls_session_free(TLSSession *self)
 }
 
 static gboolean
-file_exists(const gchar *fname)
+_is_file_accessible(const gchar *fname)
 {
   if (!fname)
     return FALSE;
@@ -444,7 +444,7 @@ _is_dh_valid(DH *dh)
 static DH *
 _load_dh_from_file(const gchar *dhparam_file)
 {
-  if (!file_exists(dhparam_file))
+  if (!_is_file_accessible(dhparam_file))
     return NULL;
 
   BIO *bio = BIO_new_file(dhparam_file, "r");
@@ -528,7 +528,7 @@ tls_context_setup_dh(TLSContext *self)
 static PKCS12 *
 _load_pkcs12_file(const gchar *pkcs12_file)
 {
-  if (!file_exists(pkcs12_file))
+  if (!_is_file_accessible(pkcs12_file))
     return NULL;
 
   FILE *p12_file = fopen(pkcs12_file, "rb");
@@ -595,10 +595,10 @@ tls_context_load_pkcs12(TLSContext *self)
 static gboolean
 _are_key_and_cert_files_accessible(TLSContext *self)
 {
-  gboolean key_file_exists = file_exists(self->key_file);
-  gboolean cert_file_exists = file_exists(self->cert_file);
+  gboolean key_file_accessible = _is_file_accessible(self->key_file);
+  gboolean cert_file_accessible = _is_file_accessible(self->cert_file);
 
-  return key_file_exists && cert_file_exists;
+  return key_file_accessible && cert_file_accessible;
 }
 
 static gboolean
@@ -650,10 +650,10 @@ tls_context_setup_context(TLSContext *self)
         goto error;
     }
 
-  if (file_exists(self->ca_dir) && !SSL_CTX_load_verify_locations(self->ssl_ctx, NULL, self->ca_dir))
+  if (_is_file_accessible(self->ca_dir) && !SSL_CTX_load_verify_locations(self->ssl_ctx, NULL, self->ca_dir))
     goto error;
 
-  if (file_exists(self->crl_dir) && !SSL_CTX_load_verify_locations(self->ssl_ctx, NULL, self->crl_dir))
+  if (_is_file_accessible(self->crl_dir) && !SSL_CTX_load_verify_locations(self->ssl_ctx, NULL, self->crl_dir))
     goto error;
 
   if (self->crl_dir)

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -599,9 +599,18 @@ _are_key_and_cert_files_accessible(TLSContext *self)
          file_exists(self->cert_file);
 }
 
+static gboolean
+_client_key_and_cert_files_are_not_specified(TLSContext *self)
+{
+  return self->mode == TM_CLIENT && (!self->key_file && !self->cert_file);
+}
+
 static TLSContextLoadResult
 tls_context_load_key_and_cert(TLSContext *self)
 {
+  if (_client_key_and_cert_files_are_not_specified(self))
+    return TLS_CONTEXT_OK;
+
   if (!_are_key_and_cert_files_accessible(self))
     return TLS_CONTEXT_FILE_ACCES_ERROR;
   if (!SSL_CTX_use_PrivateKey_file(self->ssl_ctx, self->key_file, SSL_FILETYPE_PEM))

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -595,8 +595,10 @@ tls_context_load_pkcs12(TLSContext *self)
 static gboolean
 _are_key_and_cert_files_accessible(TLSContext *self)
 {
-  return file_exists(self->key_file) &&
-         file_exists(self->cert_file);
+  gboolean key_file_exists = file_exists(self->key_file);
+  gboolean cert_file_exists = file_exists(self->cert_file);
+
+  return key_file_exists && cert_file_exists;
 }
 
 static gboolean

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -176,17 +176,17 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
 
   TLSContextSetupResult tls_ctx_setup_res = tls_context_setup_context(self->tls_context);
 
+  const gchar *key = tls_context_get_key_file(self->tls_context);
+
   if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_OK)
     {
-      const gchar *key = tls_context_get_key_file(self->tls_context);
-      if (secret_storage_contains_key(key))
+      if (key && secret_storage_contains_key(key))
         secret_storage_update_status(key, SECRET_STORAGE_SUCCESS);
       return func(func_args);
     }
 
   if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_BAD_PASSWORD)
     {
-      const gchar *key = tls_context_get_key_file(self->tls_context);
       msg_error("Error setting up TLS context",
                 evt_tag_str("keyfile", key));
       call_finalize_init_args *args = g_new0(call_finalize_init_args, 1);


### PR DESCRIPTION
key_file and cert_file are optional (the client cert is not mandatory).

Fixes #1916

Questions:
- `secret-storage` does not work with NULL keys. Should we fix the API to prevent such cases? (Passing NULL causes a crash.)