### PR TITLE
dnscache: Disable the DNS cache if use-dns(no) is used

### DIFF
--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -394,6 +394,14 @@ host_resolve_options_global_defaults(HostResolveOptions *options)
 static void
 _init_options(HostResolveOptions *options)
 {
+  if (options->use_dns == 0)
+    {
+      if (options->use_dns_cache != 0)
+        {
+          msg_warning("WARNING: With use-dns(no), use-dns-cache() will be forced to 'no' too!");
+        }
+      options->use_dns_cache = 0;
+    }
 }
 
 void


### PR DESCRIPTION
Fully disabling DNS should also disable the DNS cache. To this end, when the configuration parser sees an `use-dns()` option, set `use-dns-cache()` to the same value too, unless it is `persist-only` (in which case the dns cache settings are not touched).