### PR TITLE
Diskq: Fix crash when corrupt disk-queue is read (during move)

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1852,6 +1852,8 @@ log_msg_lookup_time_stamp_name(const gchar *name)
 
 gssize log_msg_get_size(LogMessage *self)
 {
+  if(!self) return 0;
+
   return
     sizeof(LogMessage) + // msg.static fields
     + self->alloc_sdata * sizeof(self->sdata[0]) +

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -102,8 +102,11 @@ _get_next_message(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
   if (qdisk_get_length (self->super.qdisk) > 0)
     {
       result = self->super.read_message(&self->super, path_options);
-      stats_counter_add(self->super.super.memory_usage, log_msg_get_size(result));
-      path_options->ack_needed = FALSE;
+      if(result)
+        {
+          stats_counter_add(self->super.super.memory_usage, log_msg_get_size(result));
+          path_options->ack_needed = FALSE;
+        }
     }
   else if (self->qoverflow->length > 0)
     {


### PR DESCRIPTION
After fixing the restart functionality of disk-queue (see PR #1886) our test cases found another bug in non-reliable disk-queue.

After a successful message pop from disk-queue (either from qout or from overflow buffer or from the disk itself) we call a `move_disk` function to move the messages between the different queues.
Order of moving messages:
qout <-- qdisk <-- qoverflow.

In this `move_disk` function there is a lack of error handling when reading from the disk which results in a crash when `log_msg_get_size` is called with passing a NULL pointer to it.

Note that reliable disk-buffer is not affected.

Question:
* When will the invalid read reported to the user of disk-queue? `_move_disk()` is a void function.

