### PR TITLE
template: remove unneeded name argument from call sites

### DIFF
--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -44,7 +44,7 @@ tf_graphite_set_timestamp(const gchar *option_name, const gchar *value,
 {
   TFGraphiteArgumentsUserData *args = (TFGraphiteArgumentsUserData *) data;
 
-  args->state->timestamp_template = log_template_new(args->cfg, "graphite_timestamp_template");
+  args->state->timestamp_template = log_template_new(args->cfg, NULL);
   log_template_compile(args->state->timestamp_template, value, NULL);
   return TRUE;
 };
@@ -92,7 +92,7 @@ tf_graphite_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
 
   if (!state->timestamp_template)
     {
-      state->timestamp_template = log_template_new(parent->cfg, "graphite_timestamp_template");
+      state->timestamp_template = log_template_new(parent->cfg, NULL);
       log_template_compile(state->timestamp_template, "$R_UNIXTIME", NULL);
     }
 

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -280,7 +280,7 @@ java_dd_new(GlobalConfig *cfg)
   self->super.format.stats_instance = java_dd_format_stats_instance;
   self->super.stats_source = SCS_JAVA;
 
-  self->template = log_template_new(cfg, "java_dd_template");
+  self->template = log_template_new(cfg, NULL);
   self->class_path = g_string_new(".");
 
   java_dd_set_template_string(&self->super.super.super, "$ISODATE $HOST $MSGHDR$MSG\n");


### PR DESCRIPTION
The LogTemplate->name member is used to store the name of the template
statement, so it is not needed in case we are creating inline template
instances. Get rid off that parameter from everywhere.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>