### PR TITLE
Improve error reporting

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -23,6 +23,16 @@
  */
 
 #include "cfg-block-generator.h"
+#include "cfg-lexer.h"
+
+const gchar *
+cfg_block_generator_format_name_method(CfgBlockGenerator *self, gchar *buf, gsize buf_len)
+{
+  g_snprintf(buf, buf_len, "%s generator %s",
+             cfg_lexer_lookup_context_name_by_type(self->context),
+             self->name);
+  return buf;
+}
 
 gboolean
 cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result)
@@ -35,6 +45,7 @@ cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const g
 {
   self->context = context;
   self->name = g_strdup(name);
+  self->format_name = cfg_block_generator_format_name_method;
   self->free_fn = cfg_block_generator_free_instance;
 }
 

--- a/lib/cfg-block-generator.h
+++ b/lib/cfg-block-generator.h
@@ -44,9 +44,16 @@ struct _CfgBlockGenerator
   gint context;
   gchar *name;
   gboolean suppress_backticks;
+  const gchar *(*format_name)(CfgBlockGenerator *self, gchar *buf, gsize buf_len);
   gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result);
   void (*free_fn)(CfgBlockGenerator *self);
 };
+
+static inline const gchar *
+cfg_block_generator_format_name(CfgBlockGenerator *self, gchar *buf, gsize buf_len)
+{
+  return self->format_name(self, buf, buf_len);
+}
 
 gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result);
 void cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const gchar *name);

--- a/lib/cfg-block.h
+++ b/lib/cfg-block.h
@@ -30,6 +30,7 @@
 
 /* user defined configuration block */
 
-CfgBlockGenerator *cfg_block_new(gint context, const gchar *name, const gchar *content, CfgArgs *arg_defs, YYLTYPE *yylloc);
+CfgBlockGenerator *cfg_block_new(gint context, const gchar *name, const gchar *content, CfgArgs *arg_defs,
+                                 YYLTYPE *yylloc);
 
 #endif

--- a/lib/cfg-block.h
+++ b/lib/cfg-block.h
@@ -26,9 +26,10 @@
 #define CFG_BLOCK_H_INCLUDED 1
 
 #include "cfg-block-generator.h"
+#include "cfg-lexer.h"
 
 /* user defined configuration block */
 
-CfgBlockGenerator *cfg_block_new(gint context, const gchar *name, const gchar *content, CfgArgs *arg_defs);
+CfgBlockGenerator *cfg_block_new(gint context, const gchar *name, const gchar *content, CfgArgs *arg_defs, YYLTYPE *yylloc);
 
 #endif

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -903,7 +903,7 @@ block_stmt
             gint context_type = cfg_lexer_lookup_context_type_by_name($3);
             CHECK_ERROR(context_type, @3, "unknown context \"%s\"", $3);
 
-            block = cfg_block_new(context_type, $4, $10, last_block_args);
+            block = cfg_block_new(context_type, $4, $10, last_block_args, &@1);
             cfg_lexer_register_generator_plugin(&configuration->plugin_context, block);
             free($3);
             free($4);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -920,14 +920,20 @@ relex:
       (gen = cfg_lexer_find_generator(self, self->cfg, cfg_lexer_get_context_type(self), yylval->cptr)))
     {
       CfgArgs *args;
+      CfgIncludeLevel *level = &self->include_stack[self->include_depth];
 
       self->preprocess_suppress_tokens++;
+
+      gint saved_line = level->lloc.first_line;
+      gint saved_column = level->lloc.first_column;
       if (cfg_parser_parse(&block_ref_parser, self, (gpointer *) &args, NULL))
         {
           gboolean success;
           gchar buf[256];
           GString *result = g_string_sized_new(256);
 
+          level->lloc.first_line = saved_line;
+          level->lloc.first_column = saved_column;
           self->preprocess_suppress_tokens--;
           success = cfg_block_generator_generate(gen, self->cfg, args, result);
 

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -243,6 +243,7 @@ cfg_lexer_clear_include_level(CfgLexer *self, CfgIncludeLevel *level)
   else if (level->include_type == CFGI_BUFFER)
     {
       g_free(level->buffer.content);
+      g_free(level->buffer.original_content);
     }
   memset(level, 0, sizeof(*level));
 }
@@ -300,7 +301,10 @@ cfg_lexer_start_next_include(CfgLexer *self)
       g_free(level->name);
 
       if (level->include_type == CFGI_BUFFER)
-        g_free(level->buffer.content);
+        {
+          g_free(level->buffer.content);
+          g_free(level->buffer.original_content);
+        }
 
       memset(level, 0, sizeof(*level));
 
@@ -660,6 +664,7 @@ cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self, const gch
   level->include_type = CFGI_BUFFER;
   level->buffer.content = lexer_buffer;
   level->buffer.content_length = lexer_buffer_len;
+  level->buffer.original_content = g_strdup(lexer_buffer);
   level->name = g_strdup(name);
 
   return cfg_lexer_start_next_include(self);
@@ -1088,6 +1093,7 @@ cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
 
   level = &self->include_stack[0];
   level->include_type = CFGI_BUFFER;
+  level->buffer.original_content = g_strdup(buffer);
   level->buffer.content = g_malloc(length + 2);
   memcpy(level->buffer.content, buffer, length);
   level->buffer.content[length] = 0;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -939,9 +939,8 @@ relex:
 
           free(yylval->cptr);
           cfg_args_unref(args);
-          g_snprintf(buf, sizeof(buf), "%s generator %s",
-                     cfg_lexer_lookup_context_name_by_type(gen->context),
-                     gen->name);
+
+          cfg_block_generator_format_name(gen, buf, sizeof(buf));
 
           if (gen->suppress_backticks)
             success = cfg_lexer_include_buffer_without_backtick_substitution(self, buf, result->str, result->len);

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -106,6 +106,9 @@ struct _CfgIncludeLevel
     } file;
     struct
     {
+      /* the lexer mutates content, so save it for error reporting */
+      gchar *original_content;
+      /* buffer for the lexer */
       gchar *content;
       gsize content_length;
     } buffer;

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -244,7 +244,7 @@ _print_underlined_source_block(YYLTYPE *yylloc, gchar **lines, gint error_index)
 
           _print_underline(line, yylloc->first_column - 1,
                            multi_line ? strlen(&line[yylloc->first_column]) + 1
-                                      : yylloc->last_column - yylloc->first_column);
+                           : yylloc->last_column - yylloc->first_column);
         }
       else if (line_ndx >= error_index + CONTEXT)
         break;
@@ -282,7 +282,7 @@ _report_file_location(const gchar *filename, YYLTYPE *yylloc)
     }
   _print_underlined_source_block(yylloc, (gchar **) context->pdata, error_index);
 
- exit:
+exit:
   g_ptr_array_foreach(context, (GFunc) g_free, NULL);
   g_ptr_array_free(context, TRUE);
 }
@@ -305,7 +305,7 @@ _report_buffer_location(const gchar *buffer_content, YYLTYPE *yylloc)
     }
   _print_underlined_source_block(yylloc, &lines[start], error_index);
 
- exit:
+exit:
   g_strfreev(lines);
 }
 


### PR DESCRIPTION
This patch vastly improves error reporting in case a syntax error happens in the configuration. It is in a way doing something similar to what #1931 does with Python exceptions.

Should make troubleshooting config issues a lot simpler.
