### PR TITLE
[TEST][WIP] LogPipe destruction

### DIFF
--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -24,6 +24,7 @@
 
 #include "logpipe.h"
 #include "cfg-tree.h"
+#include "mainloop-call.h"
 
 gboolean (*pipe_single_step_hook)(LogPipe *pipe, LogMessage *msg, const LogPathOptions *path_options);
 
@@ -95,7 +96,7 @@ log_pipe_unref(LogPipe *self)
 
   if (self && (g_atomic_counter_dec_and_test(&self->ref_cnt)))
     {
-      _free(self);
+      main_loop_call((MainLoopTaskFunc) _free, self, TRUE);
     }
 }
 


### PR DESCRIPTION
This is just a test PR trying to force the LogPipe destruction to run in the main thread.

Calling `new()`, `init()`, `deinit()`, `free()` on a LogPipe instance is, by convention, only valid in the main thread. There are places in our codebase where `log_pipe_unref()` is called from worker threads (for example: `LateAckTracker`). This may result in use-after-free or other problems that cause crashes.

Work in progress, this is NOT the final fix.