### PR TITLE
file source filename corruption in case of missing path

### DIFF
--- a/lib/file-perms.h
+++ b/lib/file-perms.h
@@ -55,9 +55,9 @@ void file_perm_options_global_defaults(FilePermOptions *self);
 void file_perm_options_inherit_from(FilePermOptions *self, const FilePermOptions *from);
 void file_perm_options_inherit_dont_change(FilePermOptions *self);
 
-gboolean file_perm_options_apply_file(const FilePermOptions *self, gchar *name);
-gboolean file_perm_options_apply_dir(const FilePermOptions *self, gchar *name);
+gboolean file_perm_options_apply_file(const FilePermOptions *self, const gchar *name);
+gboolean file_perm_options_apply_dir(const FilePermOptions *self, const gchar *name);
 gboolean file_perm_options_apply_fd(const FilePermOptions *self, gint fd);
-gboolean file_perm_options_create_containing_directory(const FilePermOptions *self, gchar *name);
+gboolean file_perm_options_create_containing_directory(const FilePermOptions *self, const gchar *name);
 
 #endif

--- a/modules/affile/file-opener.c
+++ b/modules/affile/file-opener.c
@@ -94,7 +94,7 @@ _is_path_spurious(const gchar *name)
 }
 
 static inline gboolean
-_obtain_capabilities(FileOpener *self, gchar *name, cap_t *act_caps)
+_obtain_capabilities(FileOpener *self, const gchar *name, cap_t *act_caps)
 {
   if (self->options->needs_privileges)
     {
@@ -143,7 +143,7 @@ _open(FileOpener *self, const gchar *name, gint open_flags)
 }
 
 gboolean
-file_opener_open_fd(FileOpener *self, gchar *name, FileDirection dir, gint *fd)
+file_opener_open_fd(FileOpener *self, const gchar *name, FileDirection dir, gint *fd)
 {
   cap_t saved_caps;
 

--- a/modules/affile/file-opener.h
+++ b/modules/affile/file-opener.h
@@ -78,7 +78,7 @@ file_opener_construct_dst_proto(FileOpener *self, LogTransport *transport, LogPr
   return self->construct_dst_proto(self, transport, proto_options);
 }
 
-gboolean file_opener_open_fd(FileOpener *self, gchar *name, FileDirection dir, gint *fd);
+gboolean file_opener_open_fd(FileOpener *self, const gchar *name, FileDirection dir, gint *fd);
 
 void file_opener_set_options(FileOpener *self, FileOpenerOptions *options);
 void file_opener_init_instance(FileOpener *self);


### PR DESCRIPTION
The file source checks if the provided path exists, and in case of the path does not exists it has a side effect to put a terminating zero, thus corrupting the passed filename argument. That parameter should be read only.
Because of this I also modified the rest of the `file_perm_*` functions, where it did not cause any issue.

* Does it okay to `memcpy` the `name` paramater from performance point of view? (Does it have per message performance penalty?!)

Fixes #1934