### PR TITLE
afamqp: LogTemplateOptions fix

### DIFF
--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -540,13 +540,13 @@ afamqp_worker_publish(AMQPDestDriver *self, LogMessage *msg)
   props.delivery_mode = self->persistent;
   props.headers = table;
 
-  log_template_format(self->routing_key_template, msg, NULL, LTZ_LOCAL,
+  log_template_format(self->routing_key_template, msg, &self->template_options, LTZ_LOCAL,
                       self->super.seq_num,
                       NULL, routing_key);
 
   if (self->body_template)
     {
-      log_template_format(self->body_template, msg, NULL, LTZ_LOCAL,
+      log_template_format(self->body_template, msg, &self->template_options, LTZ_LOCAL,
                           self->super.seq_num,
                           NULL, body);
       body_bytes = amqp_cstring_bytes(body->str);


### PR DESCRIPTION
Fixes issue #1909 . LogTemplateOptions were ignored in the driver because it was not called by log_template_format() function.