### PR TITLE
Fix scratch-buffer memory usage in threaded destinations

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -25,6 +25,7 @@
 #include "stats/stats-cluster-logpipe.h"
 #include "logthrdestdrv.h"
 #include "seqnum.h"
+#include "scratch-buffers.h"
 
 #define MAX_RETRIES_OF_FAILED_INSERT_DEFAULT 3
 
@@ -154,7 +155,10 @@ log_threaded_dest_driver_do_insert(LogThrDestDriver *self)
       msg_set_context(msg);
       log_msg_refcache_start_consumer(msg, &path_options);
 
+      ScratchBuffersMarker mark;
+      scratch_buffers_mark(&mark);
       result = self->worker.insert(self, msg);
+      scratch_buffers_reclaim_marked(mark);
 
       switch (result)
         {

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -25,7 +25,6 @@
 #include "mainloop-worker.h"
 #include "mainloop-call.h"
 #include "logqueue.h"
-#include "scratch-buffers.h"
 
 /************************************************************************************
  * I/O worker threads
@@ -52,7 +51,7 @@ _work(MainLoopIOWorkerJob *self)
 {
   self->work(self->user_data);
   main_loop_worker_invoke_batch_callbacks();
-  scratch_buffers_explicit_gc();
+  main_loop_worker_run_gc();
 }
 
 /* NOTE: runs in the main thread */


### PR DESCRIPTION
There is an explicit scratch_buffer_gc call in `log_threaded_dest_driver_do_work()`
(see `main_loop_worker_run_gc`), 
but the insert() method can be called several times in one do_work call.
If `scratch_buffers_alloc()` is used in the insert method and have been called several times then the memory usage will be increased.

With this patch the used scratch buffers will be reclaimed after each insert() call.

Question:
- Why should the current `main_loop_worker_run_gc` remain in do_work() function?