### PR TITLE
add hook-commands module

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -58,6 +58,18 @@ typedef struct _ApplicationHookEntry
 static GList *application_hooks = NULL;
 static gint current_state = AH_STARTUP;
 
+gboolean
+app_is_starting_up(void)
+{
+  return current_state < AH_PRE_CONFIG_LOADED;
+}
+
+gboolean
+app_is_shutting_down(void)
+{
+  return current_state >= AH_PRE_SHUTDOWN;
+}
+
 void
 register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data)
 {
@@ -181,6 +193,12 @@ app_post_config_loaded(void)
 {
   run_application_hook(AH_POST_CONFIG_LOADED, TRUE);
   res_init();
+}
+
+void
+app_pre_shutdown(void)
+{
+  run_application_hook(AH_PRE_SHUTDOWN, TRUE);
 }
 
 void

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -34,21 +34,27 @@ enum
   AH_POST_DAEMONIZED,
   AH_PRE_CONFIG_LOADED,
   AH_POST_CONFIG_LOADED,
+  AH_PRE_SHUTDOWN,
   AH_SHUTDOWN,
   AH_REOPEN,
 };
 
 typedef void (*ApplicationHookFunc)(gint type, gpointer user_data);
 
+gboolean app_is_starting_up(void);
+gboolean app_is_shutting_down(void);
 void register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
 void app_startup(void);
 void app_finish_app_startup_after_cfg_init(void);
+
 void app_post_daemonized(void);
 void app_pre_config_loaded(void);
 void app_post_config_loaded(void);
-void app_thread_start(void);
-void app_thread_stop(void);
+void app_pre_shutdown(void);
 void app_shutdown(void);
 void app_reopen(void);
+
+void app_thread_start(void);
+void app_thread_stop(void);
 
 #endif

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1137,7 +1137,11 @@ dest_driver_option
               {
                 YYERROR;
               }
-            log_driver_add_plugin(last_driver, (LogDriverPlugin *) value);
+            if (!log_driver_add_plugin(last_driver, (LogDriverPlugin *) value))
+              {
+                log_driver_plugin_free(value);
+                CHECK_ERROR(TRUE, @1, "Error while registering the plugin %s in this destination", $1);
+              }
           }
         | driver_option
         ;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1112,7 +1112,29 @@ driver_option
 
 /* All source drivers should incorporate this rule, implies driver_option */
 source_driver_option
-        : driver_option
+        : LL_IDENTIFIER
+          {
+            Plugin *p;
+            gint context = LL_CONTEXT_INNER_SRC;
+            gpointer value;
+
+            p = cfg_find_plugin(configuration, context, $1);
+            CHECK_ERROR(p, @1, "%s plugin %s not found", cfg_lexer_lookup_context_name_by_type(context), $1);
+
+            value = cfg_parse_plugin(configuration, p, &@1, last_driver);
+
+            free($1);
+            if (!value)
+              {
+                YYERROR;
+              }
+            if (!log_driver_add_plugin(last_driver, (LogDriverPlugin *) value))
+              {
+                log_driver_plugin_free(value);
+                CHECK_ERROR(TRUE, @1, "Error while registering the plugin %s in this destination", $1);
+              }
+          }
+        | driver_option
         ;
 
 /* implies driver_option */

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1110,6 +1110,11 @@ driver_option
         : KW_PERSIST_NAME '(' string ')' { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
         ;
 
+/* All source drivers should incorporate this rule, implies driver_option */
+source_driver_option
+        : driver_option
+        ;
+
 /* implies driver_option */
 dest_driver_option
         /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
@@ -1160,7 +1165,6 @@ source_option
 	| KW_READ_OLD_RECORDS '(' yesno ')'	{ last_source_options->read_old_records = $3; }
         | KW_TAGS '(' string_list ')'		{ log_source_options_set_tags(last_source_options, $3); }
         | { last_host_resolve_options = &last_source_options->host_resolve_options; } host_resolve_option
-        | driver_option
         ;
 
 /* LogReader related options, implies source_option */
@@ -1182,6 +1186,7 @@ source_reader_option_flags
 	|
 	;
 
+/* LogProtoSource related options */
 source_proto_option
         : KW_ENCODING '(' string ')'
           {

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1189,6 +1189,8 @@ threaded_dest_driver_option
         {
           log_threaded_dest_driver_set_max_retries(last_driver, $3);
         }
+        | dest_driver_option
+        ;
 
 dest_driver_option
         /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
@@ -1213,7 +1215,7 @@ dest_driver_option
               }
             log_driver_add_plugin(last_driver, (LogDriverPlugin *) value);
           }
-    | driver_option
+        | driver_option
         ;
 
 dest_writer_options

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1110,6 +1110,32 @@ driver_option
         : KW_PERSIST_NAME '(' string ')' { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
         ;
 
+/* implies driver_option */
+dest_driver_option
+        /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
+
+	: KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
+	| KW_THROTTLE '(' nonnegative_integer ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
+        | LL_IDENTIFIER
+          {
+            Plugin *p;
+            gint context = LL_CONTEXT_INNER_DEST;
+            gpointer value;
+
+            p = cfg_find_plugin(configuration, context, $1);
+            CHECK_ERROR(p, @1, "%s plugin %s not found", cfg_lexer_lookup_context_name_by_type(context), $1);
+
+            value = cfg_parse_plugin(configuration, p, &@1, last_driver);
+
+            free($1);
+            if (!value)
+              {
+                YYERROR;
+              }
+            log_driver_add_plugin(last_driver, (LogDriverPlugin *) value);
+          }
+        | driver_option
+        ;
 /* LogSource related options */
 source_option
         /* NOTE: plugins need to set "last_source_options" in order to incorporate this rule in their grammar */
@@ -1186,32 +1212,6 @@ threaded_dest_driver_option
           log_threaded_dest_driver_set_max_retries(last_driver, $3);
         }
         | dest_driver_option
-        ;
-
-dest_driver_option
-        /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
-
-	: KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
-	| KW_THROTTLE '(' nonnegative_integer ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
-        | LL_IDENTIFIER
-          {
-            Plugin *p;
-            gint context = LL_CONTEXT_INNER_DEST;
-            gpointer value;
-
-            p = cfg_find_plugin(configuration, context, $1);
-            CHECK_ERROR(p, @1, "%s plugin %s not found", cfg_lexer_lookup_context_name_by_type(context), $1);
-
-            value = cfg_parse_plugin(configuration, p, &@1, last_driver);
-
-            free($1);
-            if (!value)
-              {
-                YYERROR;
-              }
-            log_driver_add_plugin(last_driver, (LogDriverPlugin *) value);
-          }
-        | driver_option
         ;
 
 dest_writer_options

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1136,6 +1136,17 @@ dest_driver_option
           }
         | driver_option
         ;
+
+/* implies dest_driver_option */
+threaded_dest_driver_option
+	: KW_RETRIES '(' positive_integer ')'
+        {
+          log_threaded_dest_driver_set_max_retries(last_driver, $3);
+        }
+        | dest_driver_option
+        ;
+
+
 /* LogSource related options */
 source_option
         /* NOTE: plugins need to set "last_source_options" in order to incorporate this rule in their grammar */
@@ -1205,14 +1216,6 @@ source_reader_option_flags
         | KW_CHECK_HOSTNAME source_reader_option_flags     { log_reader_options_process_flag(last_reader_options, "check-hostname"); }
 	|
 	;
-
-threaded_dest_driver_option
-	: KW_RETRIES '(' positive_integer ')'
-        {
-          log_threaded_dest_driver_set_max_retries(last_driver, $3);
-        }
-        | dest_driver_option
-        ;
 
 dest_writer_options
 	: dest_writer_option dest_writer_options

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1106,6 +1106,10 @@ parser_opt
                                                 }
         ;
 
+driver_option
+        : KW_PERSIST_NAME '(' string ')' { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
+        ;
+
 /* LogSource related options */
 source_option
         /* NOTE: plugins need to set "last_source_options" in order to incorporate this rule in their grammar */
@@ -1175,10 +1179,6 @@ source_reader_option_flags
         | KW_CHECK_HOSTNAME source_reader_option_flags     { log_reader_options_process_flag(last_reader_options, "check-hostname"); }
 	|
 	;
-
-driver_option
-    : KW_PERSIST_NAME '(' string ')' { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
-    ;
 
 threaded_dest_driver_option
 	: KW_RETRIES '(' positive_integer ')'

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1133,10 +1133,6 @@ source_proto_option
 	| KW_LOG_MSG_SIZE '(' positive_integer ')'	{ last_proto_server_options->max_msg_size = $3; }
         ;
 
-source_reader_options
-	: source_reader_option source_reader_options
-	;
-
 host_resolve_option
         : KW_USE_FQDN '(' yesno ')'             { last_host_resolve_options->use_fqdn = $3; }
         | KW_USE_DNS '(' dnsmode ')'            { last_host_resolve_options->use_dns = $3; }

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1340,7 +1340,7 @@ cfg_tree_start(CfgTree *self)
       if (!log_pipe_init(pipe))
         {
           msg_error("Error initializing message pipeline",
-                    evt_tag_str("plugin name", pipe->plugin_name ? pipe->plugin_name : "not a plugin"),
+                    evt_tag_str("plugin_name", pipe->plugin_name ? pipe->plugin_name : "not a plugin"),
                     log_pipe_location_tag(pipe));
           return FALSE;
         }

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -187,7 +187,7 @@ log_src_driver_deinit_method(LogPipe *s)
 }
 
 void
-log_src_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_src_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogSrcDriver *self = (LogSrcDriver *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
@@ -257,7 +257,7 @@ log_dest_driver_release_queue_method(LogDestDriver *self, LogQueue *q)
 }
 
 void
-log_dest_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_dest_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogDestDriver *self = (LogDestDriver *) s;
 

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -146,7 +146,7 @@ struct _LogSrcDriver
 
 gboolean log_src_driver_init_method(LogPipe *s);
 gboolean log_src_driver_deinit_method(LogPipe *s);
-void log_src_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data);
+void log_src_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options);
 void log_src_driver_init_instance(LogSrcDriver *self, GlobalConfig *cfg);
 void log_src_driver_free(LogPipe *s);
 
@@ -201,7 +201,7 @@ log_dest_driver_release_queue(LogDestDriver *self, LogQueue *q)
 
 gboolean log_dest_driver_init_method(LogPipe *s);
 gboolean log_dest_driver_deinit_method(LogPipe *s);
-void log_dest_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data);
+void log_dest_driver_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options);
 
 void log_dest_driver_init_instance(LogDestDriver *self, GlobalConfig *cfg);
 void log_dest_driver_free(LogPipe *s);

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -50,7 +50,7 @@ log_filter_pipe_init(LogPipe *s)
 }
 
 static void
-log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogFilterPipe *self = (LogFilterPipe *) s;
   gboolean res;

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -63,7 +63,7 @@ queue_and_assert_statistics(LogFilterPipe *pipe, gchar *msg, guint32 matched_exp
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   LogMessage *logmsg = log_msg_new(msg, strlen(msg), NULL, &parse_options);
   LogPipe *p = (LogPipe *)pipe;
-  p->queue(p, logmsg, &path_options, NULL);
+  p->queue(p, logmsg, &path_options);
   cr_assert_eq(stats_counter_get(pipe->not_matched), not_matched_expected);
   cr_assert_eq(stats_counter_get(pipe->matched), matched_expected);
 }

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -62,7 +62,7 @@ log_multiplexer_deinit(LogPipe *self)
 }
 
 static void
-log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogMultiplexer *self = (LogMultiplexer *) s;
   gint i;

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -169,11 +169,13 @@
  *   The way to override a method by an external object is as follows:
  *
  *     - it should save the current value of the method address (for
- *       example "queue" for the queue method), and the associated
- *       user_data pointer (queue_data in this case)
+ *       example "queue" for the queue method)
  *
  *     - it should change the pointer pointing to the relevant method to
  *       its own code (e.g. change "queue" in LogPipe)
+ *
+ *     - once the hook is invoked, it should take care about calling the
+ *       original function
  **/
 
 struct _LogPathOptions
@@ -218,10 +220,7 @@ struct _LogPipe
   StatsCounterItem *discarded_messages;
   const gchar *persist_name;
 
-  /* user_data pointer of the "queue" method in case it is overridden
-     by a plugin, see the explanation in the comment on the top. */
-  gpointer queue_data;
-  void (*queue)(LogPipe *self, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data);
+  void (*queue)(LogPipe *self, LogMessage *msg, const LogPathOptions *path_options);
   gchar *plugin_name;
   gboolean (*init)(LogPipe *self);
   gboolean (*deinit)(LogPipe *self);
@@ -340,7 +339,7 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 
   if (s->queue)
     {
-      s->queue(s, msg, path_options, s->queue_data);
+      s->queue(s, msg, path_options);
     }
   else
     {

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -288,7 +288,7 @@ _invoke_mangle_callbacks(LogPipe *s, LogMessage *msg, const LogPathOptions *path
 }
 
 static void
-log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogSource *self = (LogSource *) s;
   gint i;

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -422,8 +422,7 @@ log_threaded_dest_driver_free(LogPipe *s)
 
 static void
 log_threaded_dest_driver_queue(LogPipe *s, LogMessage *msg,
-                               const LogPathOptions *path_options,
-                               gpointer user_data)
+                               const LogPathOptions *path_options)
 {
   LogThrDestDriver *self = (LogThrDestDriver *)s;
   LogPathOptions local_options;
@@ -439,7 +438,7 @@ log_threaded_dest_driver_queue(LogPipe *s, LogMessage *msg,
 
   stats_counter_inc(self->processed_messages);
 
-  log_dest_driver_queue_method(s, msg, path_options, user_data);
+  log_dest_driver_queue_method(s, msg, path_options);
 }
 
 void

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -777,7 +777,7 @@ log_writer_mark_timeout(void *cookie)
 
 /* NOTE: runs in the reader thread */
 static void
-log_writer_queue(LogPipe *s, LogMessage *lm, const LogPathOptions *path_options, gpointer user_data)
+log_writer_queue(LogPipe *s, LogMessage *lm, const LogPathOptions *path_options)
 {
   LogWriter *self = (LogWriter *) s;
   LogPathOptions local_options;

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -361,6 +361,8 @@ main_loop_exit_initiate(gpointer user_data)
   if (main_loop_is_terminating(self))
     return;
 
+  app_pre_shutdown();
+
   msg_notice("syslog-ng shutting down",
              evt_tag_str("version", SYSLOG_NG_VERSION));
 

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -77,7 +77,7 @@ log_parser_process_message(LogParser *self, LogMessage **pmsg, const LogPathOpti
 }
 
 static void
-log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogParser *self = (LogParser *) s;
   gboolean success;

--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -33,7 +33,7 @@ log_rewrite_set_condition(LogRewrite *self, FilterExprNode *condition)
 }
 
 static void
-log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogRewrite *self = (LogRewrite *) s;
   gssize length;

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -43,6 +43,7 @@ include modules/tagsparser/Makefile.am
 include modules/xml/Makefile.am
 include modules/appmodel/Makefile.am
 include modules/openbsd/Makefile.am
+include modules/hook-commands/Makefile.am
 
 SYSLOG_NG_CORE_JAR=$(top_builddir)/modules/java/syslog-ng-core/libs/syslog-ng-core.jar
 

--- a/modules/add-contextual-data/add-contextual-data-filter-selector.c
+++ b/modules/add-contextual-data/add-contextual-data-filter-selector.c
@@ -85,7 +85,7 @@ _filter_store_get_first_matching_name(FilterStore *self, LogMessage *msg)
        filter_it = filter_it->next, name_it = name_it->next)
     {
       filter = (FilterExprNode *) filter_it->data;
-      msg_debug("Evaluating filter", evt_tag_str("filter name", name_it->data));
+      msg_debug("Evaluating filter", evt_tag_str("filter_name", name_it->data));
       if (filter_expr_eval(filter, msg))
         {
           name = (const gchar *) name_it->data;

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -91,7 +91,6 @@ afamqp_option
 	| KW_USERNAME '(' string ')'		{ afamqp_dd_set_user(last_driver, $3); free($3); }
 	| KW_PASSWORD '(' string ')'		{ afamqp_dd_set_password(last_driver, $3); free($3); }
 	| value_pair_option			{ afamqp_dd_set_value_pairs(last_driver, $1); }
-	| dest_driver_option
 	| threaded_dest_driver_option
     | afamqp_tls_option
     | KW_TLS '(' afamqp_tls_options ')'

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -250,7 +250,7 @@ affile_dw_deinit(LogPipe *s)
  * main thread.
  */
 static void
-affile_dw_queue(LogPipe *s, LogMessage *lm, const LogPathOptions *path_options, gpointer user_data)
+affile_dw_queue(LogPipe *s, LogMessage *lm, const LogPathOptions *path_options)
 {
   if (!affile_dw_queue_enabled_for_msg(lm))
     {
@@ -673,7 +673,7 @@ affile_dd_open_writer(gpointer args[])
 }
 
 static void
-affile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+affile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   AFFileDestDriver *self = (AFFileDestDriver *) s;
   AFFileDestWriter *next;
@@ -734,7 +734,7 @@ affile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
       log_pipe_unref(&next->super);
     }
 
-  log_dest_driver_queue_method(s, msg, path_options, user_data);
+  log_dest_driver_queue_method(s, msg, path_options);
 }
 
 static void

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -152,6 +152,7 @@ source_affile_option
 	| multi_line_option
 	| file_perm_option
         | source_reader_option
+	| source_driver_option
         ;
 
 source_wildcard_option
@@ -190,6 +191,7 @@ source_afpipe_option
 	| multi_line_option
 	| file_perm_option
 	| source_reader_option
+	| source_driver_option
 	;
 
 /* NOTE: don't copy this to other drivers blindly, but make it general and

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -76,9 +76,9 @@ affile_sd_format_persist_name(const LogPipe *s)
 }
 
 static void
-affile_sd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+affile_sd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
-  log_src_driver_queue_method(s, msg, path_options, user_data);
+  log_src_driver_queue_method(s, msg, path_options);
 }
 
 static gboolean

--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -114,7 +114,9 @@ resolve_to_absolute_path(const gchar *path, const gchar *basedir)
         }
       else
         {
-          msg_error("Can't resolve to absolute path", evt_tag_str("path", path), evt_tag_errno("error", errno), NULL);
+          msg_error("Can't resolve to absolute path",
+                    evt_tag_str("path", path),
+                    evt_tag_errno("error", errno));
           res = NULL;
         }
     }
@@ -248,7 +250,8 @@ directory_monitor_free(DirectoryMonitor *self)
 {
   if (self)
     {
-      msg_debug("Free directory monitor", evt_tag_str("dir", self->dir));
+      msg_debug("Free directory monitor",
+                evt_tag_str("dir", self->dir));
       if (self->free_fn)
         {
           self->free_fn(self);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -191,7 +191,8 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
   file_opened = file_opener_open_fd(self->opener, self->filename->str, AFFILE_DIR_READ, &fd);
   if (!file_opened && self->options->follow_freq > 0)
     {
-      msg_info("Follow-mode file source not found, deferring open", evt_tag_str("filename", self->filename->str));
+      msg_info("Follow-mode file source not found, deferring open",
+               evt_tag_str("filename", self->filename->str));
       open_deferred = TRUE;
       fd = -1;
     }
@@ -214,7 +215,8 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
       _setup_logreader(s, poll_events, proto, check_immediately);
       if (!log_pipe_init((LogPipe *) self->reader))
         {
-          msg_error("Error initializing log_reader, closing fd", evt_tag_int("fd", fd));
+          msg_error("Error initializing log_reader, closing fd",
+                    evt_tag_int("fd", fd));
           log_pipe_unref((LogPipe *) self->reader);
           self->reader = NULL;
           close(fd);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -281,7 +281,7 @@ _notify(LogPipe *s, gint notify_code, gpointer user_data)
 }
 
 static void
-_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   FileReader *self = (FileReader *)s;
   static NVHandle filename_handle = 0;

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -78,7 +78,8 @@ _create_file_reader(WildcardSourceDriver *self, const gchar *full_path)
   reader->missing_cb = _deleted_cb;
   if (!log_pipe_init(&reader->super))
     {
-      msg_warning("File reader initialization failed", evt_tag_str("filename", full_path),
+      msg_warning("File reader initialization failed",
+                  evt_tag_str("filename", full_path),
                   evt_tag_str("source_driver", self->super.super.group));
       log_pipe_unref(&reader->super);
     }
@@ -104,7 +105,8 @@ _handle_file_created(WildcardSourceDriver *self, const DirectoryMonitorEvent *ev
         {
           if (!log_pipe_init(&reader->super))
             {
-              msg_error("Can not re-initialize reader for file", evt_tag_str("filename", event->full_path));
+              msg_error("Can not re-initialize reader for file",
+                        evt_tag_str("filename", event->full_path));
             }
           msg_debug("Wildcard: file reader reinitialized", evt_tag_str("filename", event->full_path));
         }
@@ -116,7 +118,8 @@ _handle_directory_created(WildcardSourceDriver *self, const DirectoryMonitorEven
 {
   if (self->recursive)
     {
-      msg_debug("Directory created", evt_tag_str("name", event->full_path));
+      msg_debug("Directory created",
+                evt_tag_str("name", event->full_path));
       DirectoryMonitor *monitor = g_hash_table_lookup(self->directory_monitors, event->full_path);
       if (!monitor)
         {
@@ -131,9 +134,11 @@ _handle_deleted(WildcardSourceDriver *self, const DirectoryMonitorEvent *event)
   FileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
 
   if (reader)
-    msg_debug("Monitored file is deleted", evt_tag_str("filename", event->full_path));
+    msg_debug("Monitored file is deleted",
+              evt_tag_str("filename", event->full_path));
   else if (g_hash_table_remove(self->directory_monitors, event->full_path))
-    msg_debug("Monitored directory is deleted", evt_tag_str("directory", event->full_path));
+    msg_debug("Monitored directory is deleted",
+              evt_tag_str("directory", event->full_path));
 }
 
 static void
@@ -310,7 +315,8 @@ wildcard_sd_set_monitor_method(LogDriver *s, const gchar *method)
 
   if (new_method == MM_UNKNOWN)
     {
-      msg_error("Invalid monitor-method", evt_tag_str("monitor-method", method));
+      msg_error("Invalid monitor-method",
+                evt_tag_str("monitor-method", method));
       return FALSE;
     }
   self->monitor_method = new_method;

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -83,7 +83,6 @@ afmongodb_option
         {
             afmongodb_dd_set_value_pairs(last_driver, $1);
         }
-    | dest_driver_option
     | threaded_dest_driver_option
     | { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
     ;

--- a/modules/afmongodb/afmongodb-legacy-uri.c
+++ b/modules/afmongodb/afmongodb-legacy-uri.c
@@ -39,7 +39,8 @@ _parse_addr(const char *str, char **host, gint *port)
   mongoc_uri_t *uri = mongoc_uri_new(proto_str);
   if (!uri)
     {
-      msg_error("Cannot parse MongoDB URI", evt_tag_str("uri", proto_str));
+      msg_error("Cannot parse MongoDB URI",
+                evt_tag_str("uri", proto_str));
       g_free(proto_str);
       return FALSE;
     }
@@ -48,9 +49,11 @@ _parse_addr(const char *str, char **host, gint *port)
   if (!hosts || hosts->next)
     {
       if (hosts)
-        msg_error("Multiple hosts found in MongoDB URI", evt_tag_str("uri", proto_str));
+        msg_error("Multiple hosts found in MongoDB URI",
+                  evt_tag_str("uri", proto_str));
       else
-        msg_error("No host found in MongoDB URI", evt_tag_str("uri", proto_str));
+        msg_error("No host found in MongoDB URI",
+                  evt_tag_str("uri", proto_str));
       g_free(proto_str);
       mongoc_uri_destroy(uri);
       return FALSE;
@@ -60,7 +63,8 @@ _parse_addr(const char *str, char **host, gint *port)
   mongoc_uri_destroy(uri);
   if (!*host)
     {
-      msg_error("NULL hostname", evt_tag_str("uri", proto_str));
+      msg_error("NULL hostname",
+                evt_tag_str("uri", proto_str));
       g_free(proto_str);
       return FALSE;
     }
@@ -219,7 +223,8 @@ _build_uri_from_legacy_options(MongoDBDestDriver *self)
 
   if (!self->recovery_cache)
     {
-      msg_error("Error in host server list", evt_tag_str("driver", self->super.super.super.id));
+      msg_error("Error in host server list",
+                evt_tag_str("driver", self->super.super.super.id));
       return FALSE;
     }
 
@@ -253,8 +258,8 @@ afmongodb_dd_create_uri_from_legacy(MongoDBDestDriver *self)
 
   if (self->uri_str && self->is_legacy)
     {
-      msg_error("Error: either specify a MongoDB URI (and optional collection)"
-                " or only legacy options", evt_tag_str("driver", self->super.super.super.id));
+      msg_error("Error: either specify a MongoDB URI (and optional collection) or only legacy options",
+                evt_tag_str("driver", self->super.super.super.id));
       return FALSE;
     }
   else if (self->is_legacy)

--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -89,6 +89,7 @@ source_afprogram_options
 
 source_afprogram_option
 	: source_reader_option
+	| source_driver_option
 	| KW_INHERIT_ENVIRONMENT '(' yesno ')' { afprogram_set_inherit_environment(&((AFProgramSourceDriver *)last_driver)->process_info, $3); }
 	;
 

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -162,7 +162,6 @@ afsmtp_option
             log_template_unref($4);
           }
         | threaded_dest_driver_option
-        | dest_driver_option
         | { last_template_options = afsmtp_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -409,7 +409,7 @@ afinet_dd_construct_ipv6_packet(AFInetDestDriver *self, LogMessage *msg, GString
 #endif
 
 static void
-afinet_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+afinet_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
 #if SYSLOG_NG_ENABLE_SPOOF_SOURCE
   AFInetDestDriver *self = (AFInetDestDriver *) s;
@@ -467,7 +467,7 @@ afinet_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
       g_static_mutex_unlock(&self->lnet_lock);
     }
 #endif
-  log_dest_driver_queue_method(s, msg, path_options, user_data);
+  log_dest_driver_queue_method(s, msg, path_options);
 }
 
 void

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -266,6 +266,7 @@ source_afunix_option
         : file_perm_option
 	| source_afsocket_stream_params		{}
 	| source_reader_option			{}
+	| source_driver_option
 	| socket_option				{}
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
 	| KW_PASS_UNIX_CREDENTIALS '(' yesno ')'
@@ -322,6 +323,7 @@ source_afinet_option
 	| KW_LOCALPORT '(' string_or_number ')'	{ afinet_sd_set_localport(last_driver, $3); free($3); }
 	| KW_PORT '(' string_or_number ')'	{ afinet_sd_set_localport(last_driver, $3); free($3); }
 	| source_reader_option
+	| source_driver_option
 	| inet_socket_option
 	;
 
@@ -482,6 +484,7 @@ source_systemd_syslog_options
 source_systemd_syslog_option
         : source_reader_option
         | socket_option
+	| source_driver_option
         ;
 
 dest_afunix

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -243,7 +243,7 @@ source_afunix
 source_afunix_dgram_params
 	: string
 	  {
-      create_and_set_unix_dgram_or_systemd_syslog_source($1, configuration);
+            create_and_set_unix_dgram_or_systemd_syslog_source($1, configuration);
 	  }
 	  source_afunix_options			{ $$ = last_driver; free($1); }
 	;
@@ -251,7 +251,7 @@ source_afunix_dgram_params
 source_afunix_stream_params
 	: string
 	  {
-      create_and_set_unix_stream_or_systemd_syslog_source($1, configuration);
+            create_and_set_unix_stream_or_systemd_syslog_source($1, configuration);
 	  }
 	  source_afunix_options			{ $$ = last_driver; free($1); }
 	;

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -148,9 +148,11 @@ _call_finalize_init(Secret *secret, gpointer user_data)
                 evt_tag_str("keyfile", key));
 
       if (!secret_storage_subscribe_for_key(key, _call_finalize_init, args))
-        msg_error("Failed to subscribe for key", evt_tag_str("keyfile", key));
+        msg_error("Failed to subscribe for key",
+                  evt_tag_str("keyfile", key));
       else
-        msg_debug("Re-subscribe for key", evt_tag_str("keyfile", key));
+        msg_debug("Re-subscribe for key",
+                  evt_tag_str("keyfile", key));
 
       secret_storage_update_status(key, SECRET_STORAGE_STATUS_INVALID_PASSWORD);
 
@@ -196,9 +198,11 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
       self->secret_store_cb_data = args;
       gboolean subscribe_res = secret_storage_subscribe_for_key(key, _call_finalize_init, args);
       if (subscribe_res)
-        msg_info("Waiting for password", evt_tag_str("keyfile", key));
+        msg_info("Waiting for password",
+                 evt_tag_str("keyfile", key));
       else
-        msg_error("Failed to subscribe for key", evt_tag_str("keyfile", key));
+        msg_error("Failed to subscribe for key",
+                  evt_tag_str("keyfile", key));
       return subscribe_res;
     }
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1360,7 +1360,7 @@ afsql_dd_deinit(LogPipe *s)
 }
 
 static void
-afsql_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+afsql_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
   LogPathOptions local_options;
@@ -1370,7 +1370,7 @@ afsql_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, 
 
   log_msg_add_ack(msg, path_options);
   log_queue_push_tail(self->queue, log_msg_ref(msg), path_options);
-  log_dest_driver_queue_method(s, msg, path_options, user_data);
+  log_dest_driver_queue_method(s, msg, path_options);
 }
 
 static void

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1184,7 +1184,7 @@ afsql_dd_init(LogPipe *s)
   if (!self->columns || !self->values)
     {
       msg_error("Default columns and values must be specified for database destinations",
-                evt_tag_str("database type", self->type));
+                evt_tag_str("type", self->type));
       return FALSE;
     }
 

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -79,7 +79,6 @@ afstomp_option
         | KW_USERNAME '(' string ')'		{ afstomp_dd_set_user(last_driver, $3); free($3); }
         | KW_PASSWORD '(' string ')'		{ afstomp_dd_set_password(last_driver, $3); free($3); }
         | value_pair_option			{ afstomp_dd_set_value_pairs(last_driver, $1); }
-        | dest_driver_option
         | threaded_dest_driver_option
 	| { last_template_options = afstomp_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/afstreams/afstreams-grammar.ym
+++ b/modules/afstreams/afstreams-grammar.ym
@@ -83,6 +83,7 @@ source_afstreams_options
 
 source_afstreams_option
 	: KW_DOOR '(' string ')'		{ afstreams_sd_set_sundoor(last_driver, $3); free($3); }
+	| source_driver_option
 	;
 
 

--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -95,7 +95,7 @@ _utmp_entry_matches(UtmpEntry *ut, GString *username)
 G_LOCK_DEFINE_STATIC(utmp_lock);
 
 static void
-afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   AFUserDestDriver *self = (AFUserDestDriver *) s;
   gchar buf[8192];
@@ -155,7 +155,7 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
   _close_utmp();
   G_UNLOCK(utmp_lock);
 finish:
-  log_dest_driver_queue_method(s, msg, path_options, user_data);
+  log_dest_driver_queue_method(s, msg, path_options);
 }
 
 void

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -90,7 +90,8 @@ tf_substr(LogMessage *msg, gint argc, GString *argv[], GString *result)
   /* get offset position from second argument */
   if (!parse_number(argv[1]->str, &start))
     {
-      msg_error("$(substr) parsing failed, start could not be parsed", evt_tag_str("start", argv[1]->str));
+      msg_error("$(substr) parsing failed, start could not be parsed",
+                evt_tag_str("start", argv[1]->str));
       return;
     }
 
@@ -99,7 +100,8 @@ tf_substr(LogMessage *msg, gint argc, GString *argv[], GString *result)
     {
       if (!parse_number(argv[2]->str, &len))
         {
-          msg_error("$(substr) parsing failed, length could not be parsed", evt_tag_str("length", argv[2]->str));
+          msg_error("$(substr) parsing failed, length could not be parsed",
+                    evt_tag_str("length", argv[2]->str));
           return;
         }
     }

--- a/modules/dbparser/patternize.c
+++ b/modules/dbparser/patternize.c
@@ -346,12 +346,14 @@ ptz_merge_clusterlists(gpointer _key, gpointer _value, gpointer _target)
 GHashTable *
 ptz_find_clusters_step(Patternizer *self, GPtrArray *logs, guint support, guint num_of_samples)
 {
-  msg_progress("Searching clusters", evt_tag_int("input lines", logs->len));
+  msg_progress("Searching clusters",
+               evt_tag_int("input_lines", logs->len));
   if (self->algo == PTZ_ALGO_SLCT)
     return ptz_find_clusters_slct(logs, support, self->delimiters, num_of_samples);
   else
     {
-      msg_error("Unknown clustering algorithm", evt_tag_int("algo_id", self->algo));
+      msg_error("Unknown clustering algorithm",
+                evt_tag_int("algo_id", self->algo));
       return NULL;
     }
 }
@@ -422,7 +424,8 @@ ptz_find_clusters(Patternizer *self)
       return ret_clusters;
     }
 
-  msg_error("Invalid iteration type", evt_tag_int("iteration_type", self->iterate));
+  msg_error("Invalid iteration type",
+            evt_tag_int("iteration_type", self->iterate));
   return NULL;
 
 }

--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -32,9 +32,9 @@ disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size)
   if (qout_size < 64)
     {
       msg_warning("WARNING: The configured qout size is smaller than the minimum allowed",
-                  evt_tag_int("configured size", qout_size),
-                  evt_tag_int("minimum allowed size", 64),
-                  evt_tag_int("new size", 64));
+                  evt_tag_int("configured_size", qout_size),
+                  evt_tag_int("minimum_allowed_size", 64),
+                  evt_tag_int("new_size", 64));
       qout_size = 64;
     }
   self->qout_size = qout_size;
@@ -46,9 +46,9 @@ disk_queue_options_disk_buf_size_set(DiskQueueOptions *self, gint64 disk_buf_siz
   if (disk_buf_size < MIN_DISK_BUF_SIZE)
     {
       msg_warning("WARNING: The configured disk buffer size is smaller than the minimum allowed",
-                  evt_tag_int("configured size", disk_buf_size),
-                  evt_tag_int("minimum allowed size", MIN_DISK_BUF_SIZE),
-                  evt_tag_int("new size", MIN_DISK_BUF_SIZE));
+                  evt_tag_int("configured_size", disk_buf_size),
+                  evt_tag_int("minimum_allowed_size", MIN_DISK_BUF_SIZE),
+                  evt_tag_int("new_size", MIN_DISK_BUF_SIZE));
       disk_buf_size = MIN_DISK_BUF_SIZE;
     }
   self->disk_buf_size = disk_buf_size;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -246,7 +246,8 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
       serialize_archive_free(sa);
       log_msg_unref(*msg);
       *msg = NULL;
-      msg_error("Can't read correct message from disk-queue file",evt_tag_str("filename",qdisk_get_filename(self->qdisk)));
+      msg_error("Can't read correct message from disk-queue file",
+                evt_tag_str("filename", qdisk_get_filename(self->qdisk)));
       return TRUE;
     }
 
@@ -269,7 +270,7 @@ _read_message(LogQueueDisk *self, LogPathOptions *path_options)
       if (!_pop_disk (self, &msg))
         {
           msg_error("Error reading from disk-queue file, dropping disk queue",
-                    evt_tag_str ("filename", qdisk_get_filename (self->qdisk)));
+                    evt_tag_str("filename", qdisk_get_filename(self->qdisk)));
           self->restart_corrupted(self);
           if (msg)
             log_msg_unref (msg);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -97,9 +97,9 @@ pwrite_strict(gint fd, const void *buf, size_t count, off_t offset)
     {
       if (written != -1)
         {
-          msg_error("Short written",
-                    evt_tag_int("Number of bytes want to write", count),
-                    evt_tag_int("Number of bytes written", written));
+          msg_error("Short write while writing disk buffer",
+                    evt_tag_int("bytes_to_write", count),
+                    evt_tag_int("bytes_written", written));
           errno = ENOSPC;
         }
       result = FALSE;
@@ -207,8 +207,8 @@ _truncate_file(QDisk *self, gint64 new_size)
       msg_error("Error truncating disk-queue file",
                 evt_tag_errno("error", errno),
                 evt_tag_str("filename", self->filename),
-                evt_tag_int("newsize",self->hdr->write_head),
-                evt_tag_int("fd",self->fd));
+                evt_tag_int("newsize", self->hdr->write_head),
+                evt_tag_int("fd", self->fd));
     }
 
   return success;
@@ -419,7 +419,7 @@ _load_queue(QDisk *self, GQueue *q, gint64 q_ofs, gint32 q_len, gint32 q_count)
             {
               msg_error("Error reading message from disk-queue file (maybe corrupted file) some messages will be lost",
                         evt_tag_str("filename", self->filename),
-                        evt_tag_int("lost messages", q_count - i));
+                        evt_tag_int("lost_messages", q_count - i));
               log_msg_unref(msg);
               break;
             }
@@ -767,8 +767,9 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
       memset(&tmp, 0, sizeof(tmp));
       if (!pwrite_strict(self->fd, &tmp, sizeof(tmp), 0))
         {
-          msg_error("Error occurred while initalizing the new queue file",evt_tag_str("filename",self->filename),
-                    evt_tag_errno("error",errno));
+          msg_error("Error occurred while initalizing the new queue file",
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_errno("error", errno));
           munmap((void *)self->hdr, sizeof(QDiskFileHeader));
           self->hdr = NULL;
           close(self->fd);

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -187,13 +187,13 @@ geoip_parser_init(LogPipe *s)
   if (is_country_type(self->gi->databaseType))
     {
       msg_debug("geoip: country type database detected",
-                evt_tag_int("database type", self->gi->databaseType));
+                evt_tag_int("database_type", self->gi->databaseType));
       self->add_geoip_result = add_geoip_country_code;
     }
   else
     {
       msg_debug("geoip: city type database detected",
-                evt_tag_int("database type", self->gi->databaseType));
+                evt_tag_int("database_type", self->gi->databaseType));
       self->add_geoip_result = add_geoip_record;
     }
   return log_parser_init_method(s);

--- a/modules/geoip/tfgeoip.c
+++ b/modules/geoip/tfgeoip.c
@@ -80,13 +80,13 @@ tf_geoip_init(TFGeoIPState *state)
   if (is_country_type(state->gi->databaseType))
     {
       msg_debug("geoip: country type database detected",
-                evt_tag_int("database type", state->gi->databaseType));
+                evt_tag_int("database_type", state->gi->databaseType));
       state->add_geoip_result = add_geodata_from_geocountry;
     }
   else
     {
       msg_debug("geoip: city type database detected",
-                evt_tag_int("database type", state->gi->databaseType));
+                evt_tag_int("database_type", state->gi->databaseType));
       state->add_geoip_result = add_geodata_from_geocity;
     }
   return TRUE;

--- a/modules/hook-commands/Makefile.am
+++ b/modules/hook-commands/Makefile.am
@@ -1,0 +1,27 @@
+module_LTLIBRARIES += modules/hook-commands/libhook-commands.la
+
+modules_hook_commands_libhook_commands_la_SOURCES = \
+  modules/hook-commands/hook-commands.c \
+  modules/hook-commands/hook-commands.h \
+  modules/hook-commands/hook-commands-grammar.y \
+  modules/hook-commands/hook-commands-parser.c \
+  modules/hook-commands/hook-commands-parser.h \
+  modules/hook-commands/hook-commands-plugin.c
+
+BUILT_SOURCES += \
+  modules/hook-commands/hook-commands-grammar.y \
+  modules/hook-commands/hook-commands-grammar.c \
+  modules/hook-commands/hook-commands-grammar.h
+
+EXTRA_DIST += modules/hook-commands/hook-commands-grammar.ym
+
+modules_hook_commands_libhook_commands_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/hook-commands -I$(top_builddir)/modules/hook-commands
+modules_hook_commands_libhook_commands_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_hook_commands_libhook_commands_la_LDFLAGS = $(MODULE_LDFLAGS)
+modules_hook_commands_libhook_commands_la_DEPENDENCIES = $(MODULE_DEPS_LIBS)
+
+modules/hook-commands modules/hook-commands/ mod-hook-commands: modules/hook-commands/libhook-commands.la
+
+#include modules/hook-commands/tests/Makefile.am
+
+.PHONY: modules/hook-commands/ mod-hook-commands

--- a/modules/hook-commands/hook-commands-grammar.ym
+++ b/modules/hook-commands/hook-commands-grammar.ym
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "hook-commands-parser.h"
+#include "driver.h"
+#include "cfg-lexer.h"
+
+}
+
+
+%code {
+
+#pragma GCC diagnostic ignored "-Wswitch-default"
+
+#include "cfg-parser.h"
+#include "syslog-names.h"
+#include "messages.h"
+#include "hook-commands.h"
+
+#include <string.h>
+
+HookCommandsPlugin *last_hook_commands;
+
+}
+
+%name-prefix "hook_commands_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogDriverPlugin **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_HOOK_COMMANDS
+%token KW_STARTUP
+%token KW_SETUP
+%token KW_TEARDOWN
+%token KW_SHUTDOWN
+
+%%
+
+start
+	: LL_CONTEXT_INNER_SRC hook_invocation		{ YYACCEPT; }
+	| LL_CONTEXT_INNER_DEST hook_invocation		{ YYACCEPT; }
+	;
+
+hook_invocation
+        : KW_HOOK_COMMANDS '('
+	  {
+	    last_hook_commands = hook_commands_plugin_new();
+	    *instance = (LogDriverPlugin *) last_hook_commands;
+	  }
+	  hook_options ')'
+        ;
+
+hook_options
+	: hook_option hook_options
+	|
+	;
+
+hook_option
+	: KW_STARTUP '(' string ')'		{ hook_commands_plugin_set_startup(last_hook_commands, $3); free($3); }
+	| KW_SETUP '(' string ')'		{ hook_commands_plugin_set_setup(last_hook_commands, $3); free($3); }
+	| KW_TEARDOWN '(' string ')'		{ hook_commands_plugin_set_teardown(last_hook_commands, $3); free($3); }
+	| KW_SHUTDOWN '(' string ')'		{ hook_commands_plugin_set_shutdown(last_hook_commands, $3); free($3); }
+	;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/hook-commands/hook-commands-parser.c
+++ b/modules/hook-commands/hook-commands-parser.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2016 Balabit
+ * Copyright (c) 2016 Viktor Juhasz <viktor.juhasz@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "hook-commands.h"
+#include "cfg-parser.h"
+#include "hook-commands-grammar.h"
+
+extern int hook_commands_debug;
+int hook_commands_parse(CfgLexer *lexer, LogDriverPlugin **instance, gpointer arg);
+
+static CfgLexerKeyword hook_commands_keywords[] =
+{
+  { "hook_commands",   KW_HOOK_COMMANDS },
+  { "startup",         KW_STARTUP },
+  { "setup",           KW_SETUP },
+  { "teardown",        KW_TEARDOWN },
+  { "shutdown",        KW_SHUTDOWN },
+  { NULL }
+};
+
+CfgParser hook_commands_parser =
+{
+#if SYSLOG_NG_ENABLE_DEBUG
+  .debug_flag = &hook_commands_debug,
+#endif
+  .name = "hook_commands",
+  .keywords = hook_commands_keywords,
+  .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer arg)) hook_commands_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(hook_commands_, LogDriverPlugin **)

--- a/modules/hook-commands/hook-commands-parser.h
+++ b/modules/hook-commands/hook-commands-parser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HOOK_COMMANDS_PARSER_H_INCLUDED
+#define HOOK_COMMANDS_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "driver.h"
+
+extern CfgParser hook_commands_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(hook_commands_, LogDriverPlugin **)
+
+#endif

--- a/modules/hook-commands/hook-commands-plugin.c
+++ b/modules/hook-commands/hook-commands-plugin.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-parser.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser hook_commands_parser;
+
+static Plugin hook_commands_plugins[] =
+{
+  {
+    .type = LL_CONTEXT_INNER_DEST,
+    .name = "hook-commands",
+    .parser = &hook_commands_parser,
+  },
+  {
+    .type = LL_CONTEXT_INNER_SRC,
+    .name = "hook-commands",
+    .parser = &hook_commands_parser,
+  },
+};
+
+#ifndef STATIC
+const ModuleInfo module_info =
+{
+  .canonical_name = "hook-commands",
+  .version = SYSLOG_NG_VERSION,
+  .description = "This module provides setup/teardown commands for sources/destinations",
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
+  .plugins = hook_commands_plugins,
+  .plugins_len = G_N_ELEMENTS(hook_commands_plugins),
+};
+#endif
+
+gboolean
+hook_commands_module_init(PluginContext *context, CfgArgs *args)
+{
+  plugin_register(context, hook_commands_plugins, G_N_ELEMENTS(hook_commands_plugins));
+  return TRUE;
+}

--- a/modules/hook-commands/hook-commands.c
+++ b/modules/hook-commands/hook-commands.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "hook-commands.h"
+#include "apphook.h"
+
+#include <stdlib.h>
+
+#define HOOK_COMMANDS_PLUGIN "hook-commands"
+
+void
+hook_commands_plugin_set_startup(HookCommandsPlugin *self, const gchar *startup)
+{
+  g_free(self->startup);
+  self->startup = g_strdup(startup);
+}
+
+void
+hook_commands_plugin_set_setup(HookCommandsPlugin *self, const gchar *setup)
+{
+  g_free(self->setup);
+  self->setup = g_strdup(setup);
+}
+
+void
+hook_commands_plugin_set_teardown(HookCommandsPlugin *self, const gchar *teardown)
+{
+  g_free(self->teardown);
+  self->teardown = g_strdup(teardown);
+}
+
+void
+hook_commands_plugin_set_shutdown(HookCommandsPlugin *self, const gchar *shutdown)
+{
+  g_free(self->shutdown);
+  self->shutdown = g_strdup(shutdown);
+}
+
+static gboolean
+_run_hook(LogDriver *driver, const gchar *hook, const gchar *cmd)
+{
+  gint rc;
+
+  if (!cmd)
+    return TRUE;
+
+  msg_debug("About to execute a hook command",
+            evt_tag_str("driver", driver->id),
+            log_pipe_location_tag(&driver->super),
+            evt_tag_str("hook", hook),
+            evt_tag_str("command", cmd));
+  rc = system(cmd);
+  if (rc != 0)
+    {
+      msg_error("Hook command returned with failure, aborting initialization",
+                evt_tag_str("driver", driver->id),
+                log_pipe_location_tag(&driver->super),
+                evt_tag_str("hook", hook),
+                evt_tag_str("command", cmd),
+                evt_tag_int("rc", rc));
+    }
+  return rc == 0;
+}
+
+/* this is running in the context of the LogDriver, e.g.  LogPipe *s points
+ * to the driver we were plugged into */
+static gboolean
+_init_hook(LogPipe *s)
+{
+  LogDriver *driver = (LogDriver *) s;
+  HookCommandsPlugin *self = log_driver_get_plugin(driver, HookCommandsPlugin, HOOK_COMMANDS_PLUGIN);
+
+  if (app_is_starting_up() && !_run_hook(driver, "startup", self->startup))
+    return FALSE;
+
+  if (!_run_hook(driver, "setup", self->setup))
+    return FALSE;
+  return self->saved_init(s);
+}
+
+static gboolean
+_deinit_hook(LogPipe *s)
+{
+  LogDriver *driver = (LogDriver *) s;
+  HookCommandsPlugin *self = log_driver_get_plugin(driver, HookCommandsPlugin, HOOK_COMMANDS_PLUGIN);
+
+  _run_hook(driver, "teardown", self->teardown);
+
+  if (app_is_shutting_down())
+    _run_hook(driver, "shutdown", self->shutdown);
+
+  /* NOTE: we call deinit() even if teardown failed, there's not much we can
+   * do apart from reporting the failure, which we already did in
+   * _run_hook()
+   * */
+
+  return self->saved_deinit(s);
+}
+
+static gboolean
+_attach(LogDriverPlugin *s, LogDriver *driver)
+{
+  HookCommandsPlugin *self = (HookCommandsPlugin *) s;
+
+  self->saved_init = driver->super.init;
+  driver->super.init = _init_hook;
+
+  self->saved_deinit = driver->super.deinit;
+  driver->super.deinit = _deinit_hook;
+  return TRUE;
+}
+
+static void
+_free(LogDriverPlugin *s)
+{
+  HookCommandsPlugin *self = (HookCommandsPlugin *) s;
+
+  g_free(self->setup);
+  g_free(self->teardown);
+  log_driver_plugin_free_method(s);
+}
+
+HookCommandsPlugin *
+hook_commands_plugin_new(void)
+{
+  HookCommandsPlugin *self = g_new0(HookCommandsPlugin, 1);
+
+  log_driver_plugin_init_instance(&self->super, HOOK_COMMANDS_PLUGIN);
+  self->super.attach = _attach;
+  self->super.free_fn = _free;
+  return self;
+}

--- a/modules/hook-commands/hook-commands.h
+++ b/modules/hook-commands/hook-commands.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HOOK_COMMANDS_H_INLCUDED
+#define HOOK_COMMANDS_H_INLCUDED 1
+
+#include "driver.h"
+
+typedef struct _HookCommandsPlugin
+{
+  LogDriverPlugin super;
+  gchar *startup;
+  gchar *setup;
+  gchar *teardown;
+  gchar *shutdown;
+  gboolean (*saved_init)(LogPipe *s);
+  gboolean (*saved_deinit)(LogPipe *s);
+} HookCommandsPlugin;
+
+void hook_commands_plugin_set_startup(HookCommandsPlugin *s, const gchar *command);
+void hook_commands_plugin_set_setup(HookCommandsPlugin *s, const gchar *command);
+void hook_commands_plugin_set_teardown(HookCommandsPlugin *s, const gchar *command);
+void hook_commands_plugin_set_shutdown(HookCommandsPlugin *s, const gchar *command);
+HookCommandsPlugin *hook_commands_plugin_new(void);
+
+#endif

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -109,7 +109,6 @@ http_option
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
-    | dest_driver_option
     | threaded_dest_driver_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -82,7 +82,6 @@ java_dest_option
         | KW_TEMPLATE '(' string ')' { java_dd_set_template_string(last_driver, $3); free($3); }
         | KW_OPTION '(' java_dest_custom_options ')'
         | threaded_dest_driver_option
-        | dest_driver_option
         | { last_template_options = java_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/java/proxies/java-destination-proxy.c
+++ b/modules/java/proxies/java-destination-proxy.c
@@ -137,7 +137,8 @@ __load_destination_object(JavaDestinationProxy *self, const gchar *class_name, c
   self->dest_impl.mi_is_opened = CALL_JAVA_FUNCTION(java_env, GetMethodID, self->loaded_class, "isOpenedProxy", "()Z");
   if (!self->dest_impl.mi_is_opened)
     {
-      msg_error("Can't find method in class", evt_tag_str("class_name", class_name),
+      msg_error("Can't find method in class",
+                evt_tag_str("class_name", class_name),
                 evt_tag_str("method", "boolean isOpened()"));
     }
 

--- a/modules/openbsd/openbsd-grammar.ym
+++ b/modules/openbsd/openbsd-grammar.ym
@@ -67,12 +67,22 @@ start
 
 
 source_openbsd
-	: KW_OPENBSD '(' ')'
+	: KW_OPENBSD '(' source_openbsd_options ')'
 	  {
 	    last_driver = *instance = openbsd_sd_new(configuration);
 	  }
 
 	;
+
+source_openbsd_options
+	: source_openbsd_option source_openbsd_options
+	|
+	;
+
+source_openbsd_option
+	: source_driver_option
+	;
+
 /* INCLUDE_RULES */
 
 %%

--- a/modules/openbsd/openbsd-grammar.ym
+++ b/modules/openbsd/openbsd-grammar.ym
@@ -59,11 +59,11 @@
 %%
 
 start
-  : LL_CONTEXT_SOURCE source_openbsd
-    {
-      YYACCEPT;
-    }
-  ;
+        : LL_CONTEXT_SOURCE source_openbsd
+          {
+            YYACCEPT;
+          }
+        ;
 
 
 source_openbsd

--- a/modules/pseudofile/pseudofile.c
+++ b/modules/pseudofile/pseudofile.c
@@ -156,7 +156,7 @@ _suspend_output(PseudoFileDestDriver *self, time_t now)
 }
 
 static void
-pseudofile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+pseudofile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   PseudoFileDestDriver *self = (PseudoFileDestDriver *) s;
   GString *formatted_message = scratch_buffers_alloc();
@@ -176,7 +176,7 @@ pseudofile_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_opti
     _suspend_output(self, now);
 
 finish:
-  log_dest_driver_queue_method(s, msg, path_options, user_data);
+  log_dest_driver_queue_method(s, msg, path_options);
 }
 
 static gboolean

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -98,7 +98,6 @@ python_dd_option
           {
             python_dd_set_value_pairs(last_driver, $1);
           }
-        | dest_driver_option
         | { last_template_options = python_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -91,7 +91,6 @@ redis_option
             free($3);
           }
         | dest_driver_option
-        | threaded_dest_driver_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -140,7 +140,6 @@ riemann_option
           {
             riemann_dd_set_flush_lines(last_driver,  $3);
           }
-        | dest_driver_option
         | threaded_dest_driver_option
         | KW_TLS '(' riemann_tls_options ')'
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -74,9 +74,9 @@ source_systemd_journal
 source_systemd_journal_params
 	:
 	  {
-	    last_driver = *instance = systemd_journal_sd_new(configuration);
-      last_journal_reader_options = systemd_journal_get_reader_options(last_driver);
-	    last_source_options = &last_journal_reader_options->super;
+            last_driver = *instance = systemd_journal_sd_new(configuration);
+            last_journal_reader_options = systemd_journal_get_reader_options(last_driver);
+            last_source_options = &last_journal_reader_options->super;
 	  }
 	  source_systemd_journal_options		{ $$ = last_driver; }
 	;
@@ -87,43 +87,43 @@ source_systemd_journal_options
 	;
 
 source_systemd_journal_option
-  : KW_DEFAULT_LEVEL '(' level_string ')'
-    {
-      if (last_journal_reader_options->default_pri == 0xFFFF)
-        last_journal_reader_options->default_pri = LOG_USER;
-      last_journal_reader_options->default_pri = (last_journal_reader_options->default_pri & ~7) | $3;
-    }
-  | KW_DEFAULT_FACILITY '(' facility_string ')'
-    {
-      if (last_journal_reader_options->default_pri == 0xFFFF)
-        last_journal_reader_options->default_pri = LOG_NOTICE;
-      last_journal_reader_options->default_pri = (last_journal_reader_options->default_pri & 7) | $3;
-    }
-  | KW_TIME_ZONE '(' string ')'
-    {
-      if (last_journal_reader_options->recv_time_zone)
-        free(last_journal_reader_options->recv_time_zone);
-      last_journal_reader_options->recv_time_zone = strdup($3);
-      free($3);
-    }
+        : KW_DEFAULT_LEVEL '(' level_string ')'
+          {
+            if (last_journal_reader_options->default_pri == 0xFFFF)
+              last_journal_reader_options->default_pri = LOG_USER;
+            last_journal_reader_options->default_pri = (last_journal_reader_options->default_pri & ~7) | $3;
+          }
+        | KW_DEFAULT_FACILITY '(' facility_string ')'
+          {
+            if (last_journal_reader_options->default_pri == 0xFFFF)
+              last_journal_reader_options->default_pri = LOG_NOTICE;
+            last_journal_reader_options->default_pri = (last_journal_reader_options->default_pri & 7) | $3;
+          }
+        | KW_TIME_ZONE '(' string ')'
+          {
+            if (last_journal_reader_options->recv_time_zone)
+              free(last_journal_reader_options->recv_time_zone);
+            last_journal_reader_options->recv_time_zone = strdup($3);
+            free($3);
+          }
 
-  | KW_PREFIX '(' string ')'
-    {
-      if (last_journal_reader_options->prefix)
-        free(last_journal_reader_options->prefix);
-      last_journal_reader_options->prefix = strdup($3);
-      free($3);
-    }
-  | KW_MAX_FIELD_SIZE '(' positive_integer ')'
-    {
-      last_journal_reader_options->max_field_size = $3;
-    }
-  | KW_LOG_FETCH_LIMIT '(' positive_integer ')'
-    {
-      last_journal_reader_options->fetch_limit = $3;
-    }
-  | source_option
-  ;
+        | KW_PREFIX '(' string ')'
+          {
+            if (last_journal_reader_options->prefix)
+              free(last_journal_reader_options->prefix);
+            last_journal_reader_options->prefix = strdup($3);
+            free($3);
+          }
+        | KW_MAX_FIELD_SIZE '(' positive_integer ')'
+          {
+            last_journal_reader_options->max_field_size = $3;
+          }
+        | KW_LOG_FETCH_LIMIT '(' positive_integer ')'
+          {
+            last_journal_reader_options->fetch_limit = $3;
+          }
+        | source_option
+        ;
 
 
 /* INCLUDE_RULES */

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -123,6 +123,7 @@ source_systemd_journal_option
             last_journal_reader_options->fetch_limit = $3;
           }
         | source_option
+	| source_driver_option
         ;
 
 

--- a/modules/systemd-journal/tests/test-source.c
+++ b/modules/systemd-journal/tests/test-source.c
@@ -76,7 +76,7 @@ __free(LogPipe *s)
 }
 
 static void
-__queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options, gpointer user_data)
+__queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   TestSource *self = (TestSource *)s;
   if (self->current_test_case && self->current_test_case->checker)

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -100,7 +100,8 @@ start_element_cb(GMarkupParseContext  *context,
 
   if (tag_matches_patterns(state->parser->exclude_patterns, tag_length, element_name, reversed))
     {
-      msg_debug("xml: subtree skipped", evt_tag_str("tag", element_name));
+      msg_debug("xml: subtree skipped",
+                evt_tag_str("tag", element_name));
       state->pop_next_time = 1;
       g_markup_parse_context_push(context, &skip, NULL);
       g_free(reversed);
@@ -229,7 +230,8 @@ xml_parser_process(LogParser *s, LogMessage **pmsg,
   return TRUE;
 
 err:
-  msg_error("xml: error", evt_tag_str("str", error->message));
+  msg_error("xml: error",
+            evt_tag_str("str", error->message));
   g_error_free(error);
   g_markup_parse_context_free(xml_ctx);
   return self->forward_invalid;

--- a/scl/default-network-drivers/plugin.conf
+++ b/scl/default-network-drivers/plugin.conf
@@ -28,14 +28,16 @@ block source default-network-drivers(
 	rfc5424-tcp-port(601)
 	log-msg-size(65536)
 	flags()
-	tls()) {
+	tls()
+	hook-commands()) {
 
 	channel {
 		source {
 			network(transport(tcp)
 				port(`tcp-port`)
 				log-msg-size(`log-msg-size`)
-				flags(no-parse, `flags`));
+				flags(no-parse, `flags`)
+				hook-commands(`hook-commands`));
 			network(transport(udp)
 				port(`udp-port`)
 				log-msg-size(`log-msg-size`)

--- a/tests/copyright/check.sh
+++ b/tests/copyright/check.sh
@@ -479,6 +479,7 @@ prune_ignored_paths() {
    s~$~(/.*)?$~
   " |
   cat > "$IGNORE"
+  echo "*~" >> "$IGNORE"
  fi
 
  grep --invert-match --extended-regexp --file "$IGNORE"

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -63,7 +63,7 @@ tests
 modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|geoip2|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|snmptrapd-parser|xml|openbsd|[^/]*$)
-modules/(add-contextual-data|tagsparser|map-value-pairs|appmodel|[^/]*$)
+modules/(add-contextual-data|tagsparser|map-value-pairs|hook-commands|appmodel|[^/]*$)
 scl
 scripts
  GPLv2+_SSL,non-balabit


### PR DESCRIPTION

This module adds a new plugin that is capable of injecting itself into both
source and destination drivers.  It makes it possible to execute external
programs when they are initialized or torn down.
    
Here's an example that opens an iptables port automatically as syslog-ng is
started/stopped.
    
Assumption: the LOGCHAIN chain is part of a larger ruleset that routes
traffic to it.  Whenever the syslog-ng created rule is there, packets can
flow, otherwise the port is closed.  This is a silly example, but I think
you get the idea.
```
source {
  network(transport(udp)
              hook-commands(setup("iptables -I LOGCHAIN 1 -p udp --dport 514 -j ACCEPT")
                          teardown("iptables -D LOGCHAIN 1")));
};
```    
It might even be combined with something like salt for using more
declarative actions instead of simply coding add/remove transactions which
might break if syslog-ng dies.
