### PR TITLE
Error reporting on misspelled block args

### DIFF
--- a/lib/cfg-args.c
+++ b/lib/cfg-args.c
@@ -30,46 +30,25 @@ struct _CfgArgs
 {
   gint ref_cnt;
   GHashTable *args;
+  gboolean accept_varargs;
 };
 
-/* token block args */
-
-static void
-cfg_args_validate_callback(gpointer k, gpointer v, gpointer user_data)
+gboolean
+cfg_args_is_accepting_varargs(CfgArgs *self)
 {
-  CfgArgs *defs = ((gpointer *) user_data)[0];
-  gchar **bad_key = (gchar **) &((gpointer *) user_data)[1];
-  gchar **bad_value = (gchar **) &((gpointer *) user_data)[2];
+  return self->accept_varargs;
+}
 
-  if ((*bad_key == NULL) && (!defs || cfg_args_get(defs, k) == NULL))
-    {
-      *bad_key = k;
-      *bad_value = v;
-    }
+void
+cfg_args_accept_varargs(CfgArgs *self)
+{
+  self->accept_varargs = TRUE;
 }
 
 void
 cfg_args_foreach(CfgArgs *self, GHFunc func, gpointer user_data)
 {
   g_hash_table_foreach(self->args, func, user_data);
-}
-
-gboolean
-cfg_args_validate(CfgArgs *self, CfgArgs *defs, const gchar *context)
-{
-  gpointer validate_params[] = { defs, NULL, NULL };
-
-  cfg_args_foreach(self, cfg_args_validate_callback, validate_params);
-
-  if (validate_params[1])
-    {
-      msg_error("Unknown argument",
-                evt_tag_str("context", context),
-                evt_tag_str("arg", validate_params[1]),
-                evt_tag_str("value", validate_params[2]));
-      return FALSE;
-    }
-  return TRUE;
 }
 
 static void

--- a/lib/cfg-args.h
+++ b/lib/cfg-args.h
@@ -30,11 +30,12 @@
 typedef struct _CfgArgs CfgArgs;
 
 /* argument list for a block generator */
-gboolean cfg_args_validate(CfgArgs *self, CfgArgs *defs, const gchar *context);
 gchar *cfg_args_format_varargs(CfgArgs *self, CfgArgs *defaults);
 void cfg_args_set(CfgArgs *self, const gchar *name, const gchar *value);
 const gchar *cfg_args_get(CfgArgs *self, const gchar *name);
 void cfg_args_foreach(CfgArgs *self, GHFunc func, gpointer user_data);
+void cfg_args_accept_varargs(CfgArgs *self);
+gboolean cfg_args_is_accepting_varargs(CfgArgs *self);
 
 CfgArgs *cfg_args_new(void);
 CfgArgs *cfg_args_ref(CfgArgs *self);

--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -35,9 +35,10 @@ cfg_block_generator_format_name_method(CfgBlockGenerator *self, gchar *buf, gsiz
 }
 
 gboolean
-cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result)
+cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+                             const gchar *reference)
 {
-  return self->generate(self, cfg, args, result);
+  return self->generate(self, cfg, args, result, reference);
 }
 
 void

--- a/lib/cfg-block-generator.h
+++ b/lib/cfg-block-generator.h
@@ -45,7 +45,8 @@ struct _CfgBlockGenerator
   gchar *name;
   gboolean suppress_backticks;
   const gchar *(*format_name)(CfgBlockGenerator *self, gchar *buf, gsize buf_len);
-  gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result);
+  gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+                       const gchar *reference);
   void (*free_fn)(CfgBlockGenerator *self);
 };
 
@@ -55,7 +56,8 @@ cfg_block_generator_format_name(CfgBlockGenerator *self, gchar *buf, gsize buf_l
   return self->format_name(self, buf, buf_len);
 }
 
-gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result);
+gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+                                      const gchar *reference);
 void cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const gchar *name);
 void cfg_block_generator_free_instance(CfgBlockGenerator *self);
 void cfg_block_generator_free(CfgBlockGenerator *self);

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -61,6 +61,50 @@ cfg_block_format_name(CfgBlockGenerator *s, gchar *buf, gsize buf_len)
   return buf;
 }
 
+/* token block args */
+
+static void
+_validate_args_callback(gpointer k, gpointer v, gpointer user_data)
+{
+  CfgArgs *defs = ((gpointer *) user_data)[0];
+  const gchar *reference = ((gpointer *) user_data)[1];
+  gboolean *problem_found = ((gpointer *) user_data)[2];
+
+  if ((!defs || cfg_args_get(defs, k) == NULL))
+    {
+      if (cfg_args_is_accepting_varargs(defs))
+        {
+          msg_verbose("Unknown argument, adding it to __VARARGS__",
+                      evt_tag_str("argument", k),
+                      evt_tag_str("value", v),
+                      evt_tag_str("reference", reference));
+        }
+      else
+        {
+          msg_error("Unknown argument specified to block reference",
+                    evt_tag_str("argument", k),
+                    evt_tag_str("value", v),
+                    evt_tag_str("reference", reference));
+          *problem_found = TRUE;
+        }
+    }
+}
+
+static gboolean
+_validate_args(CfgArgs *self, CfgArgs *defs, const gchar *reference)
+{
+  gboolean problem_found = FALSE;
+  gpointer validate_params[] = { defs, (gchar *) reference, &problem_found };
+
+  cfg_args_foreach(self, _validate_args_callback, validate_params);
+
+  if (problem_found)
+    return FALSE;
+
+  return TRUE;
+}
+
+
 /*
  * cfg_block_generate:
  *
@@ -75,15 +119,19 @@ cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GStri
   gchar *value;
   gsize length;
   GError *error = NULL;
+  gchar buf[256];
 
-  cfg_args_set(args, "__VARARGS__", cfg_args_format_varargs(args, self->arg_defs));
+  if (!_validate_args(args, self->arg_defs, reference))
+    return FALSE;
+
+  if (cfg_args_is_accepting_varargs(self->arg_defs))
+    cfg_args_set(args, "__VARARGS__", cfg_args_format_varargs(args, self->arg_defs));
 
   value = cfg_lexer_subst_args_in_input(cfg->globals, self->arg_defs, args, self->content, -1, &length, &error);
   if (!value)
     {
       msg_warning("Syntax error while resolving backtick references in block",
-                  evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(self->super.context)),
-                  evt_tag_str("block", self->super.name),
+                  evt_tag_str("block_definition", cfg_block_generator_format_name(s, buf, sizeof(buf))),
                   evt_tag_str("error", error->message),
                   NULL);
       g_clear_error(&error);

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -69,7 +69,7 @@ cfg_block_format_name(CfgBlockGenerator *s, gchar *buf, gsize buf_len)
  * for the lexer.
  */
 gboolean
-cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result)
+cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result, const gchar *reference)
 {
   CfgBlock *self = (CfgBlock *) s;
   gchar *value;

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -53,11 +53,11 @@ cfg_block_format_name(CfgBlockGenerator *s, gchar *buf, gsize buf_len)
 {
   CfgBlock *self = (CfgBlock *) s;
 
-  g_snprintf(buf, buf_len, "block %s %s (at %s:%d:%d)",
+  g_snprintf(buf, buf_len, "block %s %s() at %s:%d",
              cfg_lexer_lookup_context_name_by_type(self->super.context),
              self->super.name,
              self->filename ? : "#buffer",
-             self->line, self->column);
+             self->line);
   return buf;
 }
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -310,16 +310,17 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_ENDIF                       10411
 
 %token LL_DOTDOT                      10420
+%token LL_DOTDOTDOT                   10421
 
-%token <cptr> LL_IDENTIFIER           10421
-%token <num>  LL_NUMBER               10422
-%token <fnum> LL_FLOAT                10423
-%token <cptr> LL_STRING               10424
-%token <token> LL_TOKEN               10425
-%token <cptr> LL_BLOCK                10426
-%token LL_PRAGMA                      10427
-%token LL_EOL                         10428
-%token LL_ERROR                       10429
+%token <cptr> LL_IDENTIFIER           10422
+%token <num>  LL_NUMBER               10423
+%token <fnum> LL_FLOAT                10424
+%token <cptr> LL_STRING               10425
+%token <token> LL_TOKEN               10426
+%token <cptr> LL_BLOCK                10427
+%token LL_PRAGMA                      10428
+%token LL_EOL                         10429
+%token LL_ERROR                       10430
 
 %destructor { free($$); } <cptr>
 
@@ -892,7 +893,7 @@ block_stmt
         : KW_BLOCK
           { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_DEF, block_def_keywords, "block definition"); }
           LL_IDENTIFIER LL_IDENTIFIER
-          '(' { last_block_args = cfg_args_new(); } block_args ')'
+          '(' { last_block_args = cfg_args_new(); } block_definition ')'
           { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "block content"); }
           LL_BLOCK
           {
@@ -913,6 +914,11 @@ block_stmt
             free($10);
             last_block_args = NULL;
           }
+        ;
+
+block_definition
+        : block_args
+        | block_args LL_DOTDOTDOT			{ cfg_args_accept_varargs(last_block_args); }
         ;
 
 block_args

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -193,6 +193,7 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
                            }
 {white}+		   ;
 \.\.                       { return LL_DOTDOT; }
+\.\.\.                     { return LL_DOTDOTDOT; }
 (-|\+)?{digit}+\.{digit}+  { yylval->fnum = strtod(yytext, NULL); return LL_FLOAT; }
 0x{xdigit}+ 		   { yylval->num = strtoll(yytext + 2, NULL, 16); return LL_NUMBER; }
 0{odigit}+		   { yylval->num = strtoll(yytext + 1, NULL, 8); return LL_NUMBER; }

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -947,6 +947,12 @@ relex:
           free(yylval->cptr);
           cfg_args_unref(args);
 
+          if (!success)
+            {
+              g_string_free(result, TRUE);
+              return LL_ERROR;
+            }
+
           cfg_block_generator_format_name(gen, buf, sizeof(buf));
 
           if (gen->suppress_backticks)
@@ -955,17 +961,17 @@ relex:
             success = cfg_lexer_include_buffer(self, buf, result->str, result->len);
           g_string_free(result, TRUE);
 
-          if (success)
-            {
-              goto relex;
-            }
+          if (!success)
+            return LL_ERROR;
+
+          goto relex;
         }
       else
         {
           free(yylval->cptr);
           self->preprocess_suppress_tokens--;
+          return LL_ERROR;
         }
-      return LL_ERROR;
     }
 
   if (self->ignore_pragma || self->cfg == NULL)

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -941,7 +941,8 @@ relex:
           level->lloc.first_line = saved_line;
           level->lloc.first_column = saved_column;
           self->preprocess_suppress_tokens--;
-          success = cfg_block_generator_generate(gen, self->cfg, args, result);
+          success = cfg_block_generator_generate(gen, self->cfg, args, result,
+                                                 cfg_lexer_format_location(self, &level->lloc, buf, sizeof(buf)));
 
           free(yylval->cptr);
           cfg_args_unref(args);

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1107,7 +1107,7 @@ cfg_tree_compile_node(CfgTree *self, LogExprNode *node,
   gboolean result = FALSE;
   static gint indent = -1;
 
-  if (debug_flag)
+  if (trace_flag)
     {
       gchar buf[128];
       gchar compile_message[256];

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -144,7 +144,7 @@ _generate_empty_frame(AppParserGenerator *self)
 }
 
 static gboolean
-_parse_auto_parse_arg(AppParserGenerator *self, CfgArgs *args)
+_parse_auto_parse_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "auto-parse");
 
@@ -156,7 +156,7 @@ _parse_auto_parse_arg(AppParserGenerator *self, CfgArgs *args)
 }
 
 static gboolean
-_parse_auto_parse_exclude_arg(AppParserGenerator *self, CfgArgs *args)
+_parse_auto_parse_exclude_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "auto-parse-exclude");
   if (!v)
@@ -166,7 +166,7 @@ _parse_auto_parse_exclude_arg(AppParserGenerator *self, CfgArgs *args)
 }
 
 static gboolean
-_parse_auto_parse_include_arg(AppParserGenerator *self, CfgArgs *args)
+_parse_auto_parse_include_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "auto-parse-include");
   if (!v)
@@ -176,40 +176,41 @@ _parse_auto_parse_include_arg(AppParserGenerator *self, CfgArgs *args)
 }
 
 static gboolean
-_parse_topic_arg(AppParserGenerator *self, CfgArgs *args)
+_parse_topic_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   self->topic = cfg_args_get(args, "topic");
   if (!self->topic)
     {
-      msg_error("app-parser() requires a topic() argument");
+      msg_error("app-parser() requires a topic() argument",
+                evt_tag_str("reference", reference));
       return FALSE;
     }
   return TRUE;
 }
 
 static gboolean
-_parse_arguments(AppParserGenerator *self, CfgArgs *args)
+_parse_arguments(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   g_assert(args != NULL);
 
-  if (!_parse_topic_arg(self, args))
+  if (!_parse_topic_arg(self, args, reference))
     return FALSE;
-  if (!_parse_auto_parse_arg(self, args))
+  if (!_parse_auto_parse_arg(self, args, reference))
     return FALSE;
-  if (!_parse_auto_parse_exclude_arg(self, args))
+  if (!_parse_auto_parse_exclude_arg(self, args, reference))
     return FALSE;
-  if (!_parse_auto_parse_include_arg(self, args))
+  if (!_parse_auto_parse_include_arg(self, args, reference))
     return FALSE;
   return TRUE;
 }
 
 static gboolean
-_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result)
+_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result, const gchar *reference)
 {
   AppParserGenerator *self = (AppParserGenerator *) s;
   AppModelContext *appmodel = appmodel_get_context(cfg);
 
-  if (!_parse_arguments(self, args))
+  if (!_parse_arguments(self, args, reference))
     return FALSE;
 
   self->block = result;

--- a/modules/appmodel/tests/test_app_parser_generator.c
+++ b/modules/appmodel/tests/test_app_parser_generator.c
@@ -81,7 +81,7 @@ static void
 _app_parser_generate_with_args(const gchar *topic, CfgArgs *args)
 {
   cfg_args_set(args, "topic", topic);
-  cfg_block_generator_generate(app_parser, configuration, args, result);
+  cfg_block_generator_generate(app_parser, configuration, args, result, "dummy-reference");
   cfg_args_unref(args);
 }
 

--- a/modules/confgen/confgen-plugin.c
+++ b/modules/confgen/confgen-plugin.c
@@ -55,7 +55,7 @@ typedef struct _ConfgenExec
 } ConfgenExec;
 
 gboolean
-confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result)
+confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result, const gchar *reference)
 {
   ConfgenExec *self = (ConfgenExec *) s;
   FILE *out;
@@ -72,6 +72,7 @@ confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GS
   if (!out)
     {
       msg_error("confgen: Error executing generator program",
+                evt_tag_str("reference", reference),
                 evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(self->super.context)),
                 evt_tag_str("block", self->super.name),
                 evt_tag_str("exec", self->exec),
@@ -88,6 +89,7 @@ confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GS
   if (res != 0)
     {
       msg_error("confgen: Generator program returned with non-zero exit code",
+                evt_tag_str("reference", reference),
                 evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(self->super.context)),
                 evt_tag_str("block", self->super.name),
                 evt_tag_str("exec", self->exec),

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -341,7 +341,8 @@ system_generate_app_parser(GlobalConfig *cfg, GString *sysblock, CfgArgs *args)
 }
 
 static gboolean
-system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *sysblock)
+system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *sysblock,
+                       const gchar *reference)
 {
   gboolean result = FALSE;
 

--- a/scl/default-network-drivers/plugin.conf
+++ b/scl/default-network-drivers/plugin.conf
@@ -29,7 +29,8 @@ block source default-network-drivers(
 	log-msg-size(65536)
 	flags()
 	tls()
-	hook-commands()) {
+	hook-commands()
+	...) {
 
 	channel {
 		source {

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -35,6 +35,7 @@ block destination elasticsearch(
   resource("")
   client_lib_dir("")
   concurrent_requests("1")
+  ...
 )
 {
   java(
@@ -79,6 +80,7 @@ block destination elasticsearch2(
   http_auth_type_basic_username("")
   http_auth_type_basic_password("")
   time_zone("UTC")
+  ...
 )
 {
   java(

--- a/scl/ewmm/ewmm.conf
+++ b/scl/ewmm/ewmm.conf
@@ -58,7 +58,7 @@ block parser ewmm-parser() {
 
 template-function "format-ewmm" "<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --leave-initial-dot --scope all-nv-pairs --exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* --exclude 6* --exclude 7* --exclude 8* --exclude 9* --exclude SOURCE --exclude .SDATA.* ._TAGS=${TAGS})\n";
 
-block destination syslog-ng(server('127.0.0.1') transport(tcp) port(514)) {
+block destination syslog-ng(server('127.0.0.1') transport(tcp) port(514) ...) {
         network("`server`" transport(`transport`) port(`port`)
                 template("$(format-ewmm)")
                 frac-digits(3)

--- a/scl/graphite/plugin.conf
+++ b/scl/graphite/plugin.conf
@@ -25,7 +25,8 @@
 
 block destination graphite(
       host("localhost") port(2003)
-      payload("")) {
+      payload("")
+      ...) {
   network("`host`" port(`port`) transport(tcp)
           template("$(graphite-output `payload`)") `__VARARGS__`);
 };

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -33,6 +33,7 @@ block destination hdfs(
   kerberos_keytab_file("")
   template("")
   hdfs_append_enabled("")
+  ...
 )
 {
   java(

--- a/scl/kafka/plugin.conf
+++ b/scl/kafka/plugin.conf
@@ -28,6 +28,7 @@ block destination kafka(
   properties_file("")
   sync_send("")
   client_lib_dir("")
+  ...
 )
 {
   java(

--- a/scl/loadbalancer/plugin.conf
+++ b/scl/loadbalancer/plugin.conf
@@ -23,7 +23,7 @@
 @module confgen context(destination) name(genlb) exec("`scl-root`/loadbalancer/gen-loadbalancer.sh")
 
 
-block destination network-load-balancer(targets()) {
+block destination network-load-balancer(targets() ...) {
   genlb(
       targets(`targets`)
       parameters(`__VARARGS__`)

--- a/scl/loggly/loggly.conf
+++ b/scl/loggly/loggly.conf
@@ -69,7 +69,7 @@ block destination loggly(token(TOKEN)
                          tag("tag")
                          host('logs-01.loggly.com')
                          port(514)
-                         template("$MSG")) {
+                         template("$MSG") ...) {
     tcp("`host`" port(`port`)
         template("<${PRI}>1 ${ISODATE} ${HOST} ${PROGRAM} ${PID} ${MSGID} [`token`@41058 tag=\"`tag`\"] `template`\n")
 	template_escape(no)

--- a/scl/logmatic/logmatic.conf
+++ b/scl/logmatic/logmatic.conf
@@ -62,7 +62,7 @@
 
 @requires json-plugin
 
-block destination logmatic(token(TOKEN) host('api.logmatic.io') port(10514) template("$MSG")) {
+block destination logmatic(token(TOKEN) host('api.logmatic.io') port(10514) template("$MSG") ...) {
     tcp("`host`" port(`port`)
         template("`token` <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} `template`\n")
 	template_escape(no)

--- a/scl/nodejs/plugin.conf
+++ b/scl/nodejs/plugin.conf
@@ -21,7 +21,7 @@
 #############################################################################
 
 
-block source nodejs(localip(0.0.0.0) port(9003)) {
+block source nodejs(localip(0.0.0.0) port(9003) ...) {
         channel {
                 log {
                         source { network(transport(tcp) localip(`localip`) port(`port`) flags(no-parse) `__VARARGS__`); };

--- a/scl/osquery/plugin.conf
+++ b/scl/osquery/plugin.conf
@@ -33,7 +33,7 @@ template t_osquery {
   template_escape(no);
 };
 
-block destination osquery(pipe("/var/osquery/syslog_pipe")) {
+block destination osquery(pipe("/var/osquery/syslog_pipe") ...) {
   channel {
     rewrite {
       set("$MESSAGE", value("ESCAPED_MESSAGE"));

--- a/scl/pacct/plugin.conf
+++ b/scl/pacct/plugin.conf
@@ -21,7 +21,7 @@
 #############################################################################
 
 
-block source pacct(file("/var/log/account/pacct") follow-freq(1)) {
+block source pacct(file("/var/log/account/pacct") follow-freq(1) ...) {
 @module pacctformat
         file("`file`" follow-freq(`follow-freq`) format("pacct") tags(".pacct") `__VARARGS__`);
 };

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -24,6 +24,7 @@ block source snmptrap(
   filename("")
   prefix(".snmp.")
   set-message-macro(yes)
+  ...
 )
 {
   channel {


### PR DESCRIPTION
This branch makes the __VARARGS__ functionality in SCL blocks explicit, as currently it is very easy to mis-spell an argument, which is not logged in any way. It changes the syntax slightly:

```
block source something(foo() bar() ...) {
};
```

The ... at the end of the argument list tells syslog-ng that this macro indeed wants to accept __VARARGS__, thus any name-value pair can be passed without validation.
