### PR TITLE
libsyslog-ng: missing dependency libsecret-storage

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -47,7 +47,7 @@ lib_libsyslog_ng_la_LDFLAGS		= -no-undefined -release ${LSNG_RELEASE} \
 
 lib_test_subdirs			= lib_filter lib_logproto lib_parser lib_rewrite lib_template lib_stats lib_control
 
-lib_libsyslog_ng_la_DEPENDENCIES	= lib/eventlog/src/libevtlog.la
+lib_libsyslog_ng_la_DEPENDENCIES       = lib/eventlog/src/libevtlog.la lib/secret-storage/libsecret-storage.la
 
 if IVYKIS_INTERNAL
 lib_libsyslog_ng_la_DEPENDENCIES	+= lib/ivykis/src/libivykis.la


### PR DESCRIPTION
See details in the issue.

Fixes #1949 