### PR TITLE
configuration language support

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -100,6 +100,7 @@ set (LIB_HEADERS
     persistable-state-header.h
     persistable-state-presenter.h
     plugin.h
+    plugin-mapper.h
     plugin-types.h
     poll-events.h
     poll-fd-events.h
@@ -186,6 +187,7 @@ set(LIB_SOURCES
     pathutils.c
     persist-state.c
     plugin.c
+    plugin-mapper.c
     poll-events.c
     poll-fd-events.c
     pragma-parser.c

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -50,11 +50,14 @@ static CfgLexerKeyword main_keywords[] =
 {
   /* statements */
   { "source",             KW_SOURCE },
+  { "forrás",             KW_SOURCE },
   { "filter",             KW_FILTER },
   { "parser",             KW_PARSER },
   { "rewrite",            KW_REWRITE },
   { "destination",        KW_DESTINATION },
+  { "célállomás",         KW_DESTINATION },
   { "log",                KW_LOG },
+  { "farönk",             KW_LOG },
   { "junction",           KW_JUNCTION },
   { "channel",            KW_CHANNEL },
   { "options",            KW_OPTIONS },

--- a/lib/plugin-mapper.c
+++ b/lib/plugin-mapper.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "plugin-mapper.h"
+
+static void
+_free_fn(PluginMapper *s)
+{
+  SimplePluginMapper *self = (SimplePluginMapper *)s;
+
+  g_hash_table_destroy(self->map);
+  g_free(self);
+}
+
+static gchar *
+_map(PluginMapper *s, const gint plugin_type, const gchar *plugin_name)
+{
+  SimplePluginMapper *self = (SimplePluginMapper *)s;
+
+  gchar *new_name = (gchar *)g_hash_table_lookup(self->map, plugin_name);
+
+  return new_name;
+}
+
+PluginMapper *simple_plugin_mapper_new()
+{
+  SimplePluginMapper *self = g_new0(SimplePluginMapper,1);
+
+  self->map = g_hash_table_new(g_str_hash, g_str_equal);
+  self->super.free_fn = _free_fn;
+  self->super.map     = _map;
+
+  return (PluginMapper *)self;
+}
+
+void
+simple_plugin_mapper_add_alternative_name(SimplePluginMapper *self, gchar *new_name, gchar *original_name)
+{
+  g_hash_table_insert(self->map, new_name, original_name);
+}
+
+PluginMapper *hu_plugin_mapper_new()
+{
+  HuPluginMapper *self = simple_plugin_mapper_new();
+
+  simple_plugin_mapper_add_alternative_name(self, "fájl", "file");
+  simple_plugin_mapper_add_alternative_name(self, "rendszerd-napló", "systemd-journal");
+  simple_plugin_mapper_add_alternative_name(self, "rugalmaskeresés2", "elasticsearch2");
+  simple_plugin_mapper_add_alternative_name(self, "hálózat", "network");
+
+  return (PluginMapper *)self;
+}

--- a/lib/plugin-mapper.h
+++ b/lib/plugin-mapper.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PLUGIN_MAPPAR_H_INCLUDED
+#define PLUGIN_MAPPAR_H_INCLUDED
+
+#include "compat/glib.h"
+
+typedef struct _PluginMapper PluginMapper;
+
+struct _PluginMapper
+{
+  gchar *(*map)(PluginMapper *self, const gint plugin_type, const gchar *plugin_name);
+  void (*free_fn)(PluginMapper *self);
+};
+
+static inline gchar *
+plugin_mapper_map(PluginMapper *self, const gint plugin_type, const gchar *plugin_name)
+{
+  if (self->map)
+    return self->map(self, plugin_type, plugin_name);
+
+  return g_strdup(plugin_name);
+};
+
+static inline void
+plugin_mapper_free(PluginMapper *self)
+{
+  if (self->free_fn)
+    self->free_fn(self);
+  else
+    g_assert_not_reached();
+};
+
+typedef struct _SimplePluginMapper
+{
+  PluginMapper super;
+  GHashTable *map;
+} SimplePluginMapper;
+
+PluginMapper *simple_plugin_mapper_new();
+
+void simple_plugin_mapper_add_alternative_name(SimplePluginMapper *self, gchar *new_name, gchar *original_name);
+
+typedef SimplePluginMapper HuPluginMapper;
+
+PluginMapper *hu_plugin_mapper_new();
+
+#endif

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -625,6 +625,31 @@ plugin_context_init_instance(PluginContext *context)
 {
   memset(context, 0, sizeof(*context));
   plugin_context_set_module_path(context, resolvedConfigurablePaths.initial_module_path);
+  context->mapper = NULL;
+}
+
+gboolean
+plugin_context_set_plugin_mapper(PluginContext *context, gchar *mapper_name)
+{
+  PluginMapper *pm = NULL;
+  if (0 == strcmp(mapper_name, "simple"))
+    {
+      pm = simple_plugin_mapper_new();
+    }
+  else if (0 == strcmp(mapper_name, "hu"))
+    {
+      pm = hu_plugin_mapper_new();
+    }
+
+  if (!pm)
+    return FALSE;
+
+  if (context->mapper)
+    plugin_mapper_free(context->mapper);
+
+  context->mapper = pm;
+
+  return TRUE;
 }
 
 void
@@ -633,6 +658,9 @@ plugin_context_deinit_instance(PluginContext *context)
   plugin_free_plugins(context);
   _free_candidate_plugin_list(context->candidate_plugins);
   context->candidate_plugins = NULL;
+
+  if (context->mapper)
+    plugin_mapper_free(context->mapper);
 
   g_free(context->module_path);
 }

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -27,6 +27,8 @@
 
 #include "cfg-parser.h"
 
+#include "plugin-mapper.h"
+
 typedef struct _PluginFailureInfo
 {
   gconstpointer aux_data;
@@ -92,6 +94,7 @@ struct _PluginContext
   GList *plugins;
   GList *candidate_plugins;
   gchar *module_path;
+  PluginMapper *mapper;
 };
 
 /* instantiate a new plugin */
@@ -111,5 +114,6 @@ void plugin_load_candidate_modules(PluginContext *context);
 void plugin_context_set_module_path(PluginContext *context, const gchar *module_path);
 void plugin_context_init_instance(PluginContext *context);
 void plugin_context_deinit_instance(PluginContext *context);
+gboolean plugin_context_set_plugin_mapper(PluginContext *context, gchar *mapper_name);
 
 #endif

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -44,6 +44,7 @@
 %token KW_VERSION
 %token KW_DEFINE
 %token KW_MODULE
+%token KW_LANG
 
 %code {
 
@@ -90,6 +91,7 @@ pragma_stmt
         : KW_VERSION ':' string_or_number               { configuration->parsed_version = __process_version_string($3); free($3); }
 	| define_stmt
         | module_stmt
+        | lang_stmt
 	;
 
 include_stmt
@@ -105,6 +107,8 @@ define_stmt
                                                                             evt_tag_str("define", $2),
                                                                             evt_tag_str("value", $3));
 								  cfg_args_set(configuration->globals, $2, $3); free($2); free($3); }
+lang_stmt
+	: KW_LANG LL_IDENTIFIER { if (!plugin_context_set_plugin_mapper(&configuration->plugin_context, $2)) { free($2); YYERROR; } free($2); }
 
 module_stmt
 	: KW_MODULE string { last_module_args = cfg_args_new(); } module_params

--- a/lib/pragma-parser.c
+++ b/lib/pragma-parser.c
@@ -34,6 +34,7 @@ static CfgLexerKeyword pragma_keywords[] =
   { "include",            KW_INCLUDE, },
   { "module",             KW_MODULE, },
   { "define",             KW_DEFINE, },
+  { "lang",               KW_LANG, },
   { CFG_KEYWORD_STOP },
 };
 

--- a/lib/pragma-parser.c
+++ b/lib/pragma-parser.c
@@ -31,10 +31,12 @@ int pragma_parse(CfgLexer *lexer, gpointer *result, gpointer arg);
 static CfgLexerKeyword pragma_keywords[] =
 {
   { "version",            KW_VERSION, },
+  { "verzió",             KW_VERSION, },
   { "include",            KW_INCLUDE, },
   { "module",             KW_MODULE, },
   { "define",             KW_DEFINE, },
   { "lang",               KW_LANG, },
+  { "nyelv",              KW_LANG, },
   { CFG_KEYWORD_STOP },
 };
 


### PR DESCRIPTION
This is the first step to make it possible to translate the configuration for other languages.
The configuration file right now is only written in english.

The following configuration might be difficult to understand for a person whom does not know english well:
```
@version: 3.14

log {
	source{ systemd-journal(); };
	destination{ file(/tmp/a.txt); };
};
```

The following configuration would be much easier to understand:

```
@verzió: 3.14

@nyelv hu

farönk {
	forrás{ rendszerd-napló(); };
	célállomás{ fájl(/tmp/a.txt); };
};
```

Task to complete:
- [ ] Create a plugin from the different language support
- [ ] Support internal log translation
- [ ] Additional language support (german, klingon, ...)
- [ ] Provide a way to map all the keywords
- [ ] Translate all of the keywords


