### PR TITLE
pragma module-dependency for optional include

### DIFF
--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -46,6 +46,7 @@
 %token KW_VERSION
 %token KW_DEFINE
 %token KW_MODULE
+%token KW_REQUIRES
 
 %code {
 
@@ -92,6 +93,7 @@ pragma_stmt
         : KW_VERSION ':' string_or_number               { configuration->parsed_version = __process_version_string($3); free($3); }
 	| define_stmt
         | module_stmt
+        | requires_stmt
 	;
 
 include_stmt
@@ -115,6 +117,31 @@ module_stmt
             free($2);
             cfg_args_unref(last_module_args);
             last_module_args = NULL;
+          }
+	;
+
+requires_stmt
+	: KW_REQUIRES string
+          {
+            if (!plugin_load_module(&configuration->plugin_context, $2, NULL))
+              {
+                if (0 == lexer->include_depth)
+                  {
+                    msg_error("Cannot load required module ",
+                                evt_tag_str("module", $2),
+                                cfg_lexer_format_location_tag(lexer,&@1));
+                    free($2);
+                    YYERROR;
+                  }
+                else
+                  {
+                    msg_warning("Included file was skipped because of a missing module",
+                                evt_tag_str("module", $2),
+                                cfg_lexer_format_location_tag(lexer,&@1));
+                    cfg_lexer_start_next_include(lexer);
+                  }
+              }
+            free($2);
           }
 	;
 

--- a/lib/pragma-parser.c
+++ b/lib/pragma-parser.c
@@ -34,6 +34,7 @@ static CfgLexerKeyword pragma_keywords[] =
   { "include",            KW_INCLUDE, },
   { "module",             KW_MODULE, },
   { "define",             KW_DEFINE, },
+  { "requires",           KW_REQUIRES, },
   { CFG_KEYWORD_STOP },
 };
 

--- a/scl/cim/template.conf
+++ b/scl/cim/template.conf
@@ -20,4 +20,6 @@
 #
 #############################################################################
 
+@requires json-plugin
+
 template-function "format-cim" "$(format-json --pair @timestamp='${R_ISODATE}' --pair @message='${MSG}' --key .cim.* --shift 5 --key _* --key .* --replace-prefix .=_ --key *.*)\n";

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -20,6 +20,8 @@
 #
 #############################################################################
 
+@requires json-plugin
+
 block destination elasticsearch(
   index("")
   type("")

--- a/scl/ewmm/ewmm.conf
+++ b/scl/ewmm/ewmm.conf
@@ -35,6 +35,8 @@
 #   - regexp numeric matches ($0 .. $255) are not transmitted
 #
 
+@requires json-plugin
+
 block parser ewmm-parser() {
 	channel {
                 filter { program("@syslog-ng" type(string)); };

--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -21,6 +21,8 @@
 #
 #############################################################################
 
+@requires json-plugin
+
 template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
 block destination graylog2(host("127.0.0.1") port(12201) template("$(format-gelf)")) {

--- a/scl/loggly/loggly.conf
+++ b/scl/loggly/loggly.conf
@@ -62,6 +62,9 @@
 #        };
 #    }
 #
+
+@requires json-plugin
+
 block destination loggly(token(TOKEN)
                          tag("tag")
                          host('logs-01.loggly.com')

--- a/scl/logmatic/logmatic.conf
+++ b/scl/logmatic/logmatic.conf
@@ -59,6 +59,9 @@
 #             };
 #         }
 #
+
+@requires json-plugin
+
 block destination logmatic(token(TOKEN) host('api.logmatic.io') port(10514) template("$MSG")) {
     tcp("`host`" port(`port`)
         template("`token` <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} `template`\n")


### PR DESCRIPTION
A lot of `scl` has a hidden dependency for modules to be present. In case of that `scl` uses a plugin, that is not installed; the syslog-ng is not going to start up even if that specific block is not used in the configuration (but only included).

One of the most common example is the `json`, if the `json` module is not installed, with the default set of `scl`s syslog-ng is not going to start. There are two main workaround exists for this:
* install the module
* remove the scl file

This PR aim to give a solution by creating a new pragma keyword, which can specify module requirement. If the requirement is not specified the syslog-ng is going to skip the current file, thus not causing an issue in case of missing module.

Fixes #827.