### PR TITLE
nvtable: deserialized handle access crash

### DIFF
--- a/lib/logmsg/logmsg-serialize-fixup.c
+++ b/lib/logmsg/logmsg-serialize-fixup.c
@@ -234,11 +234,11 @@ _fixup_entry(NVHandle old_handle, NVEntry *entry, NVIndexEntry *index_entry, gpo
 
   new_handle = _allocate_handle_for_entry_name(old_handle, entry);
 
+  if (index_entry)
+    _fixup_handle_in_index_entry(state, index_entry, new_handle);
+
   if (new_handle != old_handle)
     {
-      if (index_entry)
-        _fixup_handle_in_index_entry(state, index_entry, new_handle);
-
       if (log_msg_is_handle_sdata(new_handle))
         _fixup_sdata_handle(state, old_handle, new_handle);
       state->handle_changed = TRUE;


### PR DESCRIPTION
This crash happens, when a message is deserialized. (An example for this is the disk queue file.)

The deserialization process has two steps. One that actually make the deserialization, and an additional *fixup* step.

The additional *fixup* step tries to validate and updated the index table with the new handles (if they are new).

The issue comes from this fixup, because first it creates a temporary index table, if a handle has a new handle it saves the updated entry to the temporary table.
After going through all of the entries, if there was even one updated entry it just swaps the two table (temporary, and active).

The issue here, that when there were some handle which has been updated, and there were some that have not, the temporary table has gaps with uninitialized entities.

This probably Fixes #1919.