### PR TITLE
testing: fixing symbol redefinition error

### DIFF
--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -31,22 +31,7 @@
 #include <criterion/criterion.h>
 #include <string.h>
 
-static void
-init_and_load_syslogformat_module(void)
-{
-  configuration = cfg_new_snippet();
-  cfg_load_module(configuration, "syslogformat");
-  msg_format_options_defaults(&parse_options);
-  msg_format_options_init(&parse_options, configuration);
-}
-
-static void
-deinit_syslogformat_module(void)
-{
-  if (configuration)
-    cfg_free(configuration);
-  configuration = NULL;
-}
+#include "msg_parse_lib.h"
 
 void
 init_template_tests(void)

--- a/libtest/cr_template.h
+++ b/libtest/cr_template.h
@@ -30,8 +30,6 @@
 #include "msg-format.h"
 #include <stdarg.h>
 
-MsgFormatOptions parse_options;
-
 void assert_template_format(const gchar *template, const gchar *expected);
 void assert_template_format_msg(const gchar *template,
                                 const gchar *expected, LogMessage *msg);


### PR DESCRIPTION
Only testing is affected!

Now both cr_template and msg_parse_lib contain the same symbol: `MsgFormatOptions parse_options`. Also the syslogformat module initializer/deinitializer functions are copy-pasted between the two modules.

This patch resolves the problem: cr_template should use these symbols from msg_parse_lib.