### PR TITLE
Fix possible LogMessage-related crash (NVTable)

### DIFF
--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -312,7 +312,7 @@ nv_table_get_ofs_table_top(NVTable *self)
 static inline gboolean
 nv_table_alloc_check(NVTable *self, gsize alloc_size)
 {
-  if (nv_table_get_bottom(self) - alloc_size < nv_table_get_ofs_table_top(self))
+  if (nv_table_get_bottom(self) - nv_table_get_ofs_table_top(self) < alloc_size)
     return FALSE;
   return TRUE;
 }


### PR DESCRIPTION
Subtracting an "out-of-boundary" number from a pointer is undefined.
The result may underflow making the condition false, causing a crash.

(`alloc_size` is the size of a new entry that we want to store in NVTable.)

Apart from this, my change is an equivalent transformation.

This bug has been identified on a Solaris 11 machine, where `NVTable` is often stored on low addresses.