### PR TITLE
Enable warning: warning manipulation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,9 +43,16 @@ AM_CPPFLAGS		= -I$(top_srcdir)/lib -I$(top_srcdir)/modules -I$(top_builddir)/lib
 # configure script gives us -g and/or -O2, but all warning related settings
 # should be here
 
+# Important warnings
 AM_CFLAGS = \
 	-Wshadow \
 	-fcommon
+
+# Acceptable warnings
+AM_CFLAGS += \
+	-Wno-stack-protector \
+	-Wno-unused-parameter \
+	-Wno-variadic-macros
 
 if ENABLE_EXTRA_WARNINGS
 AM_CFLAGS += \

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,13 +56,19 @@ AM_CFLAGS += \
 
 if ENABLE_EXTRA_WARNINGS
 AM_CFLAGS += \
-	-Wno-initializer-overrides \
-	-Wno-error=deprecated-declarations \
 	-Wimplicit-function-declaration \
 	-Wnested-externs \
 	-Wold-style-declaration \
 	-Wstrict-prototypes \
-	-Wswitch-default
+	-Wswitch-default \
+	-Wall \
+	-Wmissing-parameter-type \
+	-Wuninitialized \
+	-Wunused-but-set-parameter \
+	-Wcast-align \
+	-Wdeprecated \
+	-Wdeprecated-declarations \
+	-Woverflow
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest $(AM_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,9 +52,9 @@ AM_CFLAGS += \
 	-Wno-initializer-overrides \
 	-Wno-error=deprecated-declarations \
 	-Wimplicit-function-declaration \
-      	-Wnested-externs \
-      	-Wold-style-declaration \
-     	-Wstrict-prototypes \
+	-Wnested-externs \
+	-Wold-style-declaration \
+	-Wstrict-prototypes \
 	-Wswitch-default
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,10 +40,15 @@ pkgconfig_DATA		= syslog-ng.pc
 
 AM_CPPFLAGS		= -I$(top_srcdir)/lib -I$(top_srcdir)/modules -I$(top_builddir)/lib -I$(top_builddir)/modules
 
-AM_CFLAGS =
+# configure script gives us -g and/or -O2, but all warning related settings
+# should be here
+
+AM_CFLAGS = \
+	-Wshadow \
+	-fcommon
+
 if ENABLE_EXTRA_WARNINGS
 AM_CFLAGS += \
-	-Wshadow	\
 	-Wno-initializer-overrides \
 	-Wno-error=deprecated-declarations \
 	-Wimplicit-function-declaration \

--- a/configure.ac
+++ b/configure.ac
@@ -460,24 +460,51 @@ AC_SUBST([NO_PIE_LDFLAG])
 dnl ***************************************************************************
 dnl Set up CFLAGS
 
-if test "x$ac_compiler_gnu" = "xyes"; then
-        CFLAGS="${CFLAGS} -Wall"
-        if test "x$enable_debug" = "xyes"; then
-                CFLAGS="${ac_cv_env_CFLAGS_value} -Wall -g"
-        fi
 
+
+dnl The rest of CFLAGS. We produce
+dnl -g/-O2/-pg/-fprofile-arcs/-ftest-coverage combinations, the rest is
+dnl supplied by Makefile.am
+
+if test "x$ac_compiler_gnu" = "xyes"; then
+	# by ignoring the existing $CFLAGS setting we can override the
+	# default supplied by autoconf (which defaults to -O2), which
+	# we don't want to use with our debugging builds.
+
+	CFLAGS_ADD=""
+        if test "x$enable_debug" = "xyes"; then
+                CFLAGS_ADD="${CFLAGS_ADD} -g"
+        else
+                CFLAGS_ADD="${CFLAGS_ADD} -O2 -g"
+        fi
         if test "x$enable_gprof" = "xyes"; then
-                CFLAGS="${CFLAGS} -pg"
+                CFLAGS_ADD="${CFLAGS_ADD} -pg"
         fi
         if test "x$enable_gcov" = "xyes"; then
-                CFLAGS="${CFLAGS} -fprofile-arcs -ftest-coverage"
+                CFLAGS_ADD="${CFLAGS_ADD} -fprofile-arcs -ftest-coverage"
         fi
 else
         enable_extra_warnings="no"
 fi
-CFLAGS="${CFLAGS} -pthread"
+CFLAGS_ADD="${CFLAGS_ADD} -pthread"
+
+dnl We are checking for the postive warning flag, as gcc handles the
+dnl -Wno-XXX version oddly, so if no other warnings are present, it is not
+dnl reported at all, causing it to be unusable for detection purposes.
+
+AX_CFLAGS_GCC_OPTION(-Winitializer-overrides,
+		     CFLAGS_INITIALIZER_OVERRIDES,
+		     CFLAGS_ADD="${CFLAGS_ADD} -Wno-initializer-overrides")
+
+dnl This CFLAGS is used in db-parser, as it uses guint8 and gchar *
+dnl interchangeably, producing a lot of warnings, it is only added during the
+dnl compilation of db-parser().
+dnl
 
 AX_CFLAGS_GCC_OPTION(-Wno-pointer-sign, CFLAGS_NOWARN_POINTER_SIGN)
+
+dnl User supplied CFLAGS come last
+CFLAGS="${CFLAGS_ADD} ${ac_cv_env_CFLAGS_value}"
 
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
The final helper PR for #1302.

This is the last part I would like to extract from #1302. The idea is the following:
- This patchset adds those warnings to enable extra warnings that do not generate warnings for now. The other part of the list is left in #1302.
- Besides that part, I ported the CFLAGS specification cleanup patch of @bazsi.

The plan is #1302 will only contain those warning options, that we need to deal with code change. When we have a list, we will write issues about those and expect those be fixed/analyzed through the newly created issues and prs. As such, #1302 will be resolved.