### PR TITLE
Partially revert some time-reap changes, to lessen the impact of a race

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -130,14 +130,8 @@ affile_dw_reap(gpointer s)
 
   main_loop_assert_main_thread();
 
-  if (log_writer_has_pending_writes(self->writer))
-    {
-      affile_dw_arm_reaper(self);
-      return;
-    }
-
   g_static_mutex_lock(&self->owner->lock);
-  if (!self->queue_pending)
+  if (!log_writer_has_pending_writes((LogWriter *) self->writer) && !self->queue_pending)
     {
       msg_verbose("Destination timed out, reaping",
                   evt_tag_str("template", self->owner->filename_template->template),


### PR DESCRIPTION
There is a pre-existing race condition related to `time-reap()`: when the timer times out, we check the queue without a lock (for a lot of reasons related to performance), to see if we should reap the destination. If a message arrives when the check finished, but the function didn't return yet, we'll put that in the queue, and still reap the destination. The new message in this case will likely get lost.

This condition has existed in `time-reap` for a long time, but recent changes and refactors made the situation worse. This pull request reverts the changes that do so.

We should fix the race properly, but until we can do so, bringing down the frequency at which it happens reduces the impact considerably.