### PR TITLE
rpm generation process update

### DIFF
--- a/dbld/images/helpers/functions.sh
+++ b/dbld/images/helpers/functions.sh
@@ -14,7 +14,7 @@ function add_epel_repo {
     if [ "$1" == "centos6" ]; then
         wget https://copr.fedorainfracloud.org/coprs/czanik/syslog-ng39epel6/repo/epel-6/czanik-syslog-ng39epel6-epel-6.repo
     elif [ "$1" == "centos7" ]; then
-        wget https://copr.fedorainfracloud.org/coprs/czanik/syslog-ng311/repo/epel-7/czanik-syslog-ng311-epel-7.repo
+        wget https://copr.fedorainfracloud.org/coprs/czanik/syslog-ng-githead/repo/epel-7/czanik-syslog-ng-githead-epel-7.repo
     else
         return 1
     fi

--- a/dbld/images/required-epel/all.txt
+++ b/dbld/images/required-epel/all.txt
@@ -2,3 +2,5 @@
 libdbi
 libdbi-drivers
 riemann-c-client-devel
+syslog-ng-java-deps
+gradle

--- a/dbld/rpm
+++ b/dbld/rpm
@@ -7,6 +7,10 @@ VERSION=`cat VERSION`
 RPMBUILD=${HOME}/rpmbuild
 RPMBUILD_SOURCES=$RPMBUILD/SOURCES
 
+# CzP's spec file expect it in the pwd
+# where the build was initiated
+cp packaging/rhel/syslog-ng.* /build
+
 cd /build
 mkdir -p $RPMBUILD_SOURCES
 cp  syslog-ng-${VERSION}.tar.gz $RPMBUILD_SOURCES


### PR DESCRIPTION
RPM generation process update from @Czanik.
This is the first step in a long process, the final goal is to harmonize Peter's work and `/dbld`
  - remove syslog-ng-add-contextual-data.pc from file list
  - update to 3.14.1
  - re-enable amqp & mongodb on RHEL only
  - keep tcp wrappers support only on RHEL

Fixes: #1857