### PR TITLE
dbld: corrected path's in case of root user

### DIFF
--- a/dbld/rpm
+++ b/dbld/rpm
@@ -4,8 +4,7 @@ set -e
 
 cd /source
 VERSION=`cat VERSION`
-USER=`whoami`
-RPMBUILD=/home/${USER}/rpmbuild
+RPMBUILD=${HOME}/rpmbuild
 RPMBUILD_SOURCES=$RPMBUILD/SOURCES
 
 cd /build

--- a/dbld/rules
+++ b/dbld/rules
@@ -11,7 +11,7 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
 	-v $(ROOT_DIR):/source \
 	-v $(DBLD_DIR)/build:/build \
 	-v $(DBLD_DIR)/install:/install \
-	-v ~/.gitconfig:/home/$(shell whoami)/.gitconfig
+	-v ~/.gitconfig:${HOME}/.gitconfig
 ROOT_DIR=$(shell pwd)
 DBLD_DIR=$(ROOT_DIR)/dbld
 BUILD_DIR=$(DBLD_DIR)/build


### PR DESCRIPTION
root users home directory is not under /home, replaced `home/$(whoami)` in rpmbuild.