### PR TITLE
dbld/images/devshell: generate utf8 locale

### DIFF
--- a/dbld/images/devshell-apt/all.txt
+++ b/dbld/images/devshell-apt/all.txt
@@ -10,3 +10,4 @@ virtualenv
 valgrind
 linux-tools-generic
 libjemalloc-dev
+locales

--- a/dbld/images/devshell.dockerfile
+++ b/dbld/images/devshell.dockerfile
@@ -13,3 +13,5 @@ RUN cat /devshell-pip/* | grep -v '^$\|^#' | xargs pip install
 
 COPY devshell-apt/all.txt devshell-apt/${DISTRO}*.txt /devshell-apt/
 RUN cat /devshell-apt/* | grep -v '^$\|^#' | xargs apt-get install --no-install-recommends -y
+
+RUN echo en_US.UTF-8 UTF-8 > /etc/locale.gen && locale-gen


### PR DESCRIPTION
This patch adds locale and ensures en_US.utf8 is generated during
image build. This is required to use an utf8 locale at runtime, which
is the most common setup these days.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>