### PR TITLE
[WIP] Python venv support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ include (CheckIncludeFiles)
 include (ExternalProject)
 include (external_or_find_package)
 include (add_tests)
+include (python_functions)
 
 set(MEMORYCHECK_SUPPRESSIONS_FILE "${CMAKE_SOURCE_DIR}/tests/valgrind/unit-test-leak.supp")
 set(MEMORYCHECK_COMMAND_OPTIONS "--num-callers=30 --sim-hints=no-nptl-pthread-stackcache --gen-suppressions=all --leak-check=full --freelist-vol=200000000 --freelist-big-blocks=10000000 --malloc-fill=55 --free-fill=AA")

--- a/Mk/Makefile.am
+++ b/Mk/Makefile.am
@@ -1,3 +1,17 @@
+PYTHON_VENV_DIR = $(abs_builddir)/.venv
+
+# can be used to reference to the Python interpreter, preferred from our
+# virtualenv should one be present.  The $(PYTHON) variable always
+# references the system Python.  Note that the libpython-dev detection uses
+# pkg-config from the configure script and they should match up with the
+# virtualenv.
+
+VPYTHON = $(or $(wildcard $(PYTHON_VENV_DIR)/bin/python),$(PYTHON))
+PYLINT = $(or $(wildcard $(PYTHON_VENV_DIR)/bin/pylint),$(shell which pylint))
+PEP8 = $(or $(wildcard $(PYTHON_VENV_DIR)/bin/pycodestyle),$(wildcard $(PYTHON_VENV_DIR)/bin/pep8),$(shell which pycodestyle),$(shell which pep8))
+NOSETESTS = $(or $(wildcard $(PYTHON_VENV_DIR)/bin/nosetests),$(shell which nosetests))
+
+
 EXTRA_DIST	+= Mk/lex-rules.am \
 		Mk/find-top-builddir.sh \
 		Mk/populate-makefiles.sh \
@@ -9,3 +23,8 @@ tools_DATA	= \
 
 tools_SCRIPTS	= \
 		lib/merge-grammar.py
+
+python-venv:
+	rm -rf $(PYTHON_VENV_DIR)
+	virtualenv --python=$(PYTHON) ${PYTHON_VENV_DIR}
+	$(PYTHON_VENV_DIR)/bin/pip install -r $(top_srcdir)/requirements.txt

--- a/cmake/python_functions.cmake
+++ b/cmake/python_functions.cmake
@@ -1,0 +1,30 @@
+#############################################################################
+# Copyright (c) 2018 Balabit
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+find_program(PEP8_EXECUTABLE NAMES pep8 pycodestyle HINTS ${CMAKE_BINARY_DIR}/.venv/bin)
+find_program(NOSETESTS_EXECUTABLE nosetests HINTS ${CMAKE_BINARY_DIR}/.venv/bin)
+find_program(PYLINT_EXECUTABLE pylint HINTS ${CMAKE_BINARY_DIR}/.venv/bin)
+
+
+add_custom_target(python-venv
+	COMMAND rm -rf .venv && virtualenv -p ${PYTHON_EXECUTABLE} .venv && .venv/bin/pip install -r ${CMAKE_HOME_DIRECTORY}/requirements.txt)

--- a/dbld/images/required-pip/all.txt
+++ b/dbld/images/required-pip/all.txt
@@ -1,6 +1,6 @@
-nose==1.3.7
-ply==3.10
-pep8==1.7.1
-pylint==1.8.2
-astroid==1.6.1
-logilab-common<=0.63.0
+nose
+ply
+pycodestyle
+pylint
+astroid
+logilab-common

--- a/modules/python/pylib/CMakeLists.txt
+++ b/modules/python/pylib/CMakeLists.txt
@@ -16,7 +16,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/install/ DESTINATION ${CMAKE_INSTA
 )
 
 if (BUILD_TESTING)
-add_test(test_pylib_unit ${CMAKE_COMMAND} -E env nosetests ${CMAKE_CURRENT_SOURCE_DIR}/syslogng)
-add_test(test_pylib_pep8 ${CMAKE_COMMAND} -E env pep8 --ignore=E501 ${CMAKE_CURRENT_SOURCE_DIR}/syslogng)
-add_test(test_pylib_pylint ${CMAKE_COMMAND} -E env pylint -r n --rcfile=${CMAKE_CURRENT_SOURCE_DIR}/pylintrc ${CMAKE_CURRENT_SOURCE_DIR}/syslogng)
+add_test(test_pylib_unit ${CMAKE_COMMAND} -E env ${NOSETESTS_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/syslogng)
+add_test(test_pylib_pep8 ${CMAKE_COMMAND} -E env ${PEP8_EXECUTABLE} --ignore=E501 ${CMAKE_CURRENT_SOURCE_DIR}/syslogng)
+add_test(test_pylib_pylint ${CMAKE_COMMAND} -E env ${PYLINT_EXECUTABLE} -r n --rcfile=${CMAKE_CURRENT_SOURCE_DIR}/pylintrc ${CMAKE_CURRENT_SOURCE_DIR}/syslogng)
 endif()

--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -52,7 +52,7 @@ CLEAN_HOOKS += clean-pylib
 PYSETUP_OPTIONS ?= --root="$(PYTHON_ROOT)" --prefix="$(prefix)"
 
 install-pylib:
-	(cd $(PYLIB_SRCDIR) && $(PYTHON) setup.py \
+	(cd $(PYLIB_SRCDIR) && $(VPYTHON) setup.py \
 		build --build-base="$(PYLIB_BUILDDIR)/build" \
 		install --record=$(SETUPPY_MANIFEST) ${PYSETUP_OPTIONS})
 
@@ -66,13 +66,13 @@ clean-pylib:
 python-checks: python-unit python-pep8 python-pylint
 
 python-unit:
-	nosetests $(PYLIB_SRCDIR)/syslogng
+	$(NOSETESTS) $(PYLIB_SRCDIR)/syslogng
 
 python-pep8:
-	pep8 --ignore=E501 $(PYLIB_SRCDIR)/syslogng
+	$(PEP8) --ignore=E501 $(PYLIB_SRCDIR)/syslogng
 
 python-pylint:
-	pylint -r n --rcfile=$(PYLIB_SRCDIR)/pylintrc $(PYLIB_SRCDIR)/syslogng
+	$(PYLINT) -r n --rcfile=$(PYLIB_SRCDIR)/pylintrc $(PYLIB_SRCDIR)/syslogng
 
 modules_python_pylib_tests_TESTS = modules/python/pylib/test_pylib.sh
 check_SCRIPTS += $(modules_python_pylib_tests_TESTS)


### PR DESCRIPTION
This series of patches add support for a Makefile managed Python virtualenv so that one does not need to use the system deployed packages. This can be used when working with the syslog-ng source tree outside of the developer's docker images.