### PR TITLE
Fix connection close in network sources

### DIFF
--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -107,9 +107,19 @@ log_proto_server_validate_options_method(LogProtoServer *s)
 }
 
 void
+log_proto_server_close_transport(LogProtoServer *s)
+{
+  if (s->transport)
+    {
+      log_transport_free(s->transport);
+      s->transport = NULL;
+    }
+}
+
+void
 log_proto_server_free_method(LogProtoServer *s)
 {
-  log_transport_free(s->transport);
+  log_proto_server_close_transport(s);
 }
 
 void

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -157,6 +157,7 @@ log_proto_server_is_position_tracked(LogProtoServer *s)
 
 gboolean log_proto_server_validate_options_method(LogProtoServer *s);
 void log_proto_server_init(LogProtoServer *s, LogTransport *transport, const LogProtoServerOptions *options);
+void log_proto_server_close_transport(LogProtoServer *s);
 void log_proto_server_free_method(LogProtoServer *s);
 void log_proto_server_free(LogProtoServer *s);
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -569,6 +569,13 @@ log_reader_reopen(LogReader *self, LogProtoServer *proto, PollEvents *poll_event
 }
 
 void
+log_reader_close_transport(LogReader *self)
+{
+  if (self->proto)
+    log_proto_server_close_transport(self->proto);
+}
+
+void
 log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr)
 {
   LogReader *self = (LogReader *) s;

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -57,6 +57,7 @@ void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filenam
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_immediate_check(LogReader *s);
 void log_reader_reopen(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
+void log_reader_close_transport(LogReader *s);
 LogReader *log_reader_new(GlobalConfig *cfg);
 
 void log_reader_options_defaults(LogReaderOptions *options);

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -212,6 +212,8 @@ afsocket_sd_kill_connection(AFSocketSourceConnection *connection)
 {
   log_pipe_deinit(&connection->super);
 
+  log_reader_close_transport(connection->reader);
+
   /* Remove the circular reference between the connection and its
    * reader (through the connection->reader and reader->control
    * pointers these have a circular references).


### PR DESCRIPTION
Previously, the connection was closed after calling the destructor of LogReader.

The destruction of LogReader might be delayed, for example, by AckTracker, so an explicit close method is required.