### PR TITLE
LogReader async wakeup

### DIFF
--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -539,7 +539,7 @@ error:
   return FALSE;
 }
 
-gboolean
+LogProtoPrepareAction
 log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED)
 {
   LogProtoBufferedServer *self = (LogProtoBufferedServer *) s;
@@ -550,7 +550,7 @@ log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *t
   if (*cond == 0)
     *cond = G_IO_IN;
 
-  return FALSE;
+  return LPPA_POLL_IO;
 }
 
 static gint

--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -101,7 +101,8 @@ log_proto_buffered_server_is_input_closed(LogProtoBufferedServer *self)
   return self->io_status != G_IO_STATUS_NORMAL;
 }
 
-gboolean log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED);
+LogProtoPrepareAction log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond,
+                                                        gint *timeout G_GNUC_UNUSED);
 LogProtoBufferedServerState *log_proto_buffered_server_get_state(LogProtoBufferedServer *self);
 void log_proto_buffered_server_put_state(LogProtoBufferedServer *self);
 

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -44,7 +44,7 @@ typedef struct _LogProtoFramedServer
   gboolean half_message_in_buffer;
 } LogProtoFramedServer;
 
-static gboolean
+static LogProtoPrepareAction
 log_proto_framed_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED)
 {
   LogProtoFramedServer *self = (LogProtoFramedServer *) s;
@@ -57,7 +57,7 @@ log_proto_framed_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *tim
       if (self->buffer_pos != self->buffer_end)
         {
           /* we have a full message in our buffer so parse it without reading new data from the transport layer */
-          return TRUE;
+          return LPPA_FORCE_SCHEDULE_FETCH;
         }
     }
 
@@ -65,7 +65,7 @@ log_proto_framed_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *tim
   if (*cond == 0)
     *cond = G_IO_IN;
 
-  return FALSE;
+  return LPPA_POLL_IO;
 }
 
 static LogProtoStatus

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -33,6 +33,13 @@
 typedef struct _LogProtoServer LogProtoServer;
 typedef struct _LogProtoServerOptions LogProtoServerOptions;
 
+typedef enum
+{
+  LPPA_POLL_IO,
+  LPPA_FORCE_SCHEDULE_FETCH,
+  LPPA_SUSPEND
+} LogProtoPrepareAction;
+
 #define LOG_PROTO_SERVER_OPTIONS_SIZE 128
 
 struct _LogProtoServerOptions
@@ -75,7 +82,7 @@ struct _LogProtoServer
   LogProtoServerWakeupCallback wakeup_callback;
   /* FIXME: rename to something else */
   gboolean (*is_position_tracked)(LogProtoServer *s);
-  gboolean (*prepare)(LogProtoServer *s, GIOCondition *cond, gint *timeout);
+  LogProtoPrepareAction (*prepare)(LogProtoServer *s, GIOCondition *cond, gint *timeout);
   gboolean (*restart_with_state)(LogProtoServer *s, PersistState *state, const gchar *persist_name);
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
                           LogTransportAuxData *aux, Bookmark *bookmark);

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -83,19 +83,18 @@ log_proto_get_char_size_for_fixed_encoding(const gchar *encoding)
 }
 
 
-static gboolean
+static LogProtoPrepareAction
 log_proto_text_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout)
 {
   LogProtoTextServer *self = (LogProtoTextServer *) s;
   gboolean avail;
 
-  if (log_proto_buffered_server_prepare(s, cond, timeout))
-    {
-      return TRUE;
-    }
+  LogProtoPrepareAction action = log_proto_buffered_server_prepare(s, cond, timeout);
+  if (action != LPPA_POLL_IO)
+    return action;
 
   avail = (self->cached_eol_pos != 0);
-  return avail;
+  return avail ? LPPA_FORCE_SCHEDULE_FETCH : LPPA_POLL_IO;
 }
 
 static void


### PR DESCRIPTION
This PR adds a thread-safe suspend and wakeup functionality to LogReader.

LogProtoServer is now able to instruct LogReader to suspend until an asynchronous event occurs.

----------------

Questions:
- I haven't changed the signature of LogProtoClient's prepare(). Since it does not have "suspend" functionality, I think it might be OK to leave it as is. What do you think?