### PR TITLE
errno safe evtlog

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -626,7 +626,7 @@ cfg_lexer_include_file(CfgLexer *self, const gchar *filename_)
       msg_error("Include file/directory not found",
                 evt_tag_str("filename", filename_),
                 evt_tag_str("include-path", _get_include_path(self)),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
   else

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -576,7 +576,7 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gboolean syntax_only, gc
     {
       msg_error("Error opening configuration file",
                 evt_tag_str(EVT_TAG_FILENAME, fname),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
     }
 
   return FALSE;

--- a/lib/control/control-server-unix.c
+++ b/lib/control/control-server-unix.c
@@ -130,7 +130,7 @@ control_socket_accept(void *cookie)
   if (status != G_IO_STATUS_NORMAL)
     {
       msg_error("Error accepting control socket connection",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       goto error;
     }
   /* NOTE: the connection will free itself if the peer terminates */
@@ -158,14 +158,14 @@ control_server_start(ControlServer *s)
     {
       msg_error("Error opening control socket, bind() failed",
                 evt_tag_str("socket", self->super.control_socket_name),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       goto error;
     }
   if (listen(self->control_socket, 255) < 0)
     {
       msg_error("Error opening control socket, listen() failed",
                 evt_tag_str("socket", self->super.control_socket_name),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       goto error;
     }
 

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -76,7 +76,7 @@ control_connection_io_output(gpointer s)
       if (errno != EAGAIN)
         {
           msg_error("Error writing control channel",
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           control_connection_stop_watches(self);
           control_connection_free(self);
           return;
@@ -119,7 +119,7 @@ control_connection_io_input(void *s)
       if (errno != EAGAIN)
         {
           msg_error("Error reading command on control channel, closing control channel",
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           goto destroy_connection;
         }
       /* EAGAIN, should try again when data comes */

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -280,7 +280,7 @@ dns_cache_check_hosts(DNSCache *self, glong t)
         {
           msg_error("Error loading dns cache hosts file",
                     evt_tag_str("filename", self->options->hosts),
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
         }
 
     }

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -78,7 +78,7 @@ filter_in_list_new(const gchar *list_file, const gchar *property)
     {
       msg_error("Error opening in-list filter list file",
                 evt_tag_str("file", list_file),
-                evt_tag_errno("errno", errno));
+                evt_tag_error("errno"));
       return NULL;
     }
 

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -234,7 +234,7 @@ g_process_cap_modify(int capability, int onoff)
   if (cap_set_flag(caps, CAP_EFFECTIVE, 1, &capability, onoff) == -1)
     {
       msg_error("Error managing capability set, cap_set_flag returned an error",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       cap_free(caps);
       return FALSE;
     }
@@ -246,7 +246,7 @@ g_process_cap_modify(int capability, int onoff)
       cap_text = cap_to_text(caps, NULL);
       msg_error("Error managing capability set, cap_set_proc returned an error",
                 evt_tag_str("caps", cap_text),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       cap_free(cap_text);
       cap_free(caps);
       return FALSE;
@@ -297,7 +297,7 @@ g_process_cap_restore(cap_t r)
       cap_text = cap_to_text(r, NULL);
       msg_error("Error managing capability set, cap_set_proc returned an error",
                 evt_tag_str("caps", cap_text),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       cap_free(cap_text);
       return;
     }

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -660,7 +660,7 @@ log_proto_buffered_server_fetch_into_buffer(LogProtoBufferedServer *self)
           /* an error occurred while reading */
           msg_error("I/O error occurred while reading",
                     evt_tag_int(EVT_TAG_FD, self->super.transport->fd),
-                    evt_tag_errno(EVT_TAG_OSERROR, errno));
+                    evt_tag_error(EVT_TAG_OSERROR));
           result = G_IO_STATUS_ERROR;
         }
     }

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -99,7 +99,7 @@ log_proto_framed_server_fetch_data(LogProtoFramedServer *self, gboolean *may_rea
         {
           msg_error("Error reading RFC5428 style framed data",
                     evt_tag_int("fd", self->super.transport->fd),
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           return LPS_ERROR;
         }
       else

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -58,7 +58,7 @@ log_proto_text_client_flush(LogProtoClient *s)
             {
               msg_error("I/O error occurred while writing",
                         evt_tag_int("fd", self->super.transport->fd),
-                        evt_tag_errno(EVT_TAG_OSERROR, errno));
+                        evt_tag_error(EVT_TAG_OSERROR));
               return LPS_ERROR;
             }
           return LPS_SUCCESS;

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -51,7 +51,7 @@ void msg_deinit(void);
 
 void msg_add_option_group(GOptionContext *ctx);
 
-#define evt_tag_capture_errno(tag) evt_tag_errno(tag, __local_copy_of_errno)
+#define evt_tag_error(tag) evt_tag_errno(tag, __local_copy_of_errno)
 
 #define CAPTURE_ERRNO(lambda) do {\
   int __local_copy_of_errno G_GNUC_UNUSED = errno; \

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -26,6 +26,7 @@
 #define MESSAGES_H_INCLUDED
 
 #include "syslog-ng.h"
+#include <errno.h>
 #include <evtlog.h>
 
 extern int startup_debug_flag;
@@ -50,13 +51,25 @@ void msg_deinit(void);
 
 void msg_add_option_group(GOptionContext *ctx);
 
+#define evt_tag_capture_errno(tag) evt_tag_errno(tag, __local_copy_of_errno)
+
+#define CAPTURE_ERRNO(lambda) do {\
+  int __local_copy_of_errno G_GNUC_UNUSED = errno; \
+  lambda; \
+} while(0)
+
 /* fatal->warning goes out to the console during startup, notice and below
  * comes goes to the log even during startup */
-#define msg_fatal(desc, tags...)    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_CRIT, desc, ##tags, NULL ))
-#define msg_error(desc, tags...)    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_ERR, desc, ##tags, NULL ))
-#define msg_warning(desc, tags...)  msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_WARNING, desc, ##tags, NULL ))
-#define msg_notice(desc, tags...)   msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_NOTICE, desc, ##tags, NULL ))
-#define msg_info(desc, tags...)     msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_INFO, desc, ##tags, NULL ))
+#define msg_fatal(desc, tags...)    CAPTURE_ERRNO(\
+    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_CRIT, desc, ##tags, NULL )))
+#define msg_error(desc, tags...)    CAPTURE_ERRNO(\
+    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_ERR, desc, ##tags, NULL )))
+#define msg_warning(desc, tags...)  CAPTURE_ERRNO(\
+    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_WARNING, desc, ##tags, NULL )))
+#define msg_notice(desc, tags...)   CAPTURE_ERRNO(\
+    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_NOTICE, desc, ##tags, NULL )))
+#define msg_info(desc, tags...)     CAPTURE_ERRNO(\
+    msg_event_suppress_recursions_and_send(msg_event_create(EVT_PRI_INFO, desc, ##tags, NULL )))
 
 /* just like msg_info, but prepends the message with a timestamp -- useful in interactive
  * tools with long running time to provide some feedback */

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -245,7 +245,7 @@ _create_store(PersistState *self)
     {
       msg_error("Error creating persistent state file",
                 evt_tag_str("filename", self->temp_filename),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
   g_fd_set_cloexec(self->fd, TRUE);
@@ -565,7 +565,7 @@ _load_v4(PersistState *self, gboolean load_all_entries)
     {
       msg_error("Error mapping persistent file into memory",
                 evt_tag_str("filename", self->committed_filename),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
   header = (PersistFileHeader *) map;

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -495,7 +495,7 @@ _parse_and_load_plugin_info_in_modules(int input_fd)
   if (!discovery)
     {
       msg_error("Error happened while opening plugin discovery output, fdopen() failed",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return NULL;
     }
 
@@ -548,14 +548,14 @@ plugin_discover_candidate_modules(const gchar *module_path)
   if (pipe(discover_pipe) < 0)
     {
       msg_error("Error creating pipe for discover process",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return NULL;
     }
 
   if ((discover_pid = fork()) < 0)
     {
       msg_error("Error creating discover process, fork() failed",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return NULL;
     }
 
@@ -577,7 +577,7 @@ plugin_discover_candidate_modules(const gchar *module_path)
       if (waitpid(discover_pid, &exit_code, 0) < 0)
         {
           msg_error("Error waiting for discover process, waitpid() failed",
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           _free_candidate_plugin_list(candidate_modules);
           return NULL;
         }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_unit_test(LIBTEST TARGET test_str-utils)
 add_unit_test(CRITERION TARGET test_cache)
 add_unit_test(CRITERION TARGET test_scratch_buffers)
 add_unit_test(CRITERION TARGET test_timeutils)
+add_unit_test(CRITERION TARGET test_messages)
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES
   ADDITIONAL_MAKE_CLEAN_FILES

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -107,7 +107,8 @@ lib_tests_test_userdb_LDADD	= \
 lib_tests_TESTS		+= \
 	lib/tests/test_cache		\
 	lib/tests/test_scratch_buffers 	\
-	lib/tests/test_timeutils
+	lib/tests/test_timeutils	\
+	lib/tests/test_messages
 
 lib_tests_test_cache_CFLAGS	=	\
 	$(TEST_CFLAGS)
@@ -122,4 +123,9 @@ lib_tests_test_timeutils_LDADD	=	\
 lib_tests_test_scratch_buffers_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_scratch_buffers_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_messages_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_messages_LDADD	=	\
 	$(TEST_LDADD)

--- a/lib/tests/test_messages.c
+++ b/lib/tests/test_messages.c
@@ -26,6 +26,7 @@
 #include "logmsg/logmsg.h"
 
 #include <criterion/criterion.h>
+#include <errno.h>
 
 TestSuite(test_messages, .init = app_startup, .fini = app_shutdown);
 
@@ -39,4 +40,36 @@ Test(test_messages, simple_test)
 {
   msg_set_post_func(simple_test_asserter);
   msg_error("simple test");
+}
+
+void test_errno_asserter(LogMessage *msg)
+{
+  gchar expected_message[100];
+  g_snprintf(expected_message, sizeof(expected_message), "test errno; error='%s (%d)'", strerror(5), 5);
+  cr_assert_str_eq(log_msg_get_value_by_name(msg, "MESSAGE", NULL), expected_message);
+  log_msg_unref(msg);
+}
+
+Test(test_messages, test_errno)
+{
+  errno = 5;
+  msg_set_post_func(test_errno_asserter);
+  msg_error("test errno",
+            evt_tag_errno("error", errno));
+}
+
+void test_errno_capture_asserter(LogMessage *msg)
+{
+  gchar pattern[100];
+  g_snprintf(pattern, sizeof(pattern), "error='%s (%d)'", strerror(9), 9);
+  const gchar *msg_content = log_msg_get_value_by_name(msg, "MESSAGE", NULL);
+  cr_assert(g_strstr_len(msg_content, -1, pattern), "searching: >>%s<< in >>%s<<", pattern, msg_content);
+  log_msg_unref(msg);
+}
+
+Test(test_messages, test_errno_capture)
+{
+  errno = 9;
+  msg_set_post_func(test_errno_capture_asserter);
+  msg_error("test errno capture", (errno=10,evt_tag_capture_errno("error")));
 }

--- a/lib/tests/test_messages.c
+++ b/lib/tests/test_messages.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "messages.h"
+#include "apphook.h"
+#include "logmsg/logmsg.h"
+
+#include <criterion/criterion.h>
+
+TestSuite(test_messages, .init = app_startup, .fini = app_shutdown);
+
+void simple_test_asserter(LogMessage *msg)
+{
+  cr_assert_str_eq(log_msg_get_value_by_name(msg, "MESSAGE", NULL), "simple test;");
+  log_msg_unref(msg);
+}
+
+Test(test_messages, simple_test)
+{
+  msg_set_post_func(simple_test_asserter);
+  msg_error("simple test");
+}

--- a/lib/tests/test_messages.c
+++ b/lib/tests/test_messages.c
@@ -71,5 +71,5 @@ Test(test_messages, test_errno_capture)
 {
   errno = 9;
   msg_set_post_func(test_errno_capture_asserter);
-  msg_error("test errno capture", (errno=10,evt_tag_capture_errno("error")));
+  msg_error("test errno capture", (errno=10,evt_tag_error("error")));
 }

--- a/lib/tests/test_messages.c
+++ b/lib/tests/test_messages.c
@@ -55,7 +55,7 @@ Test(test_messages, test_errno)
   errno = 5;
   msg_set_post_func(test_errno_asserter);
   msg_error("test errno",
-            evt_tag_errno("error", errno));
+            evt_tag_error("error"));
 }
 
 void test_errno_capture_asserter(LogMessage *msg)

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -354,7 +354,7 @@ _is_file_accessible(TLSContext *self, const gchar *fname)
     {
       msg_error("Error opening TLS related key or certificate file",
                 evt_tag_str("filename", fname),
-                evt_tag_errno("error", errno),
+                evt_tag_error("error"),
                 tls_context_format_location_tag(self));
 
       return FALSE;

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -187,7 +187,7 @@ affile_dw_reopen(AFFileDestWriter *self)
     {
       msg_error("Error opening file for writing",
                 evt_tag_str("filename", self->filename),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
     }
 
   log_writer_reopen(self->writer, proto);

--- a/modules/affile/directory-monitor-inotify.c
+++ b/modules/affile/directory-monitor-inotify.c
@@ -105,7 +105,7 @@ directory_monitor_inotify_new(const gchar *dir, guint recheck_time)
   IV_INOTIFY_INIT(&self->inotify);
   if (iv_inotify_register(&self->inotify))
     {
-      msg_error("directory-monitor-inotify: could not create inotify object", evt_tag_errno("errno", errno));
+      msg_error("directory-monitor-inotify: could not create inotify object", evt_tag_error("errno"));
       directory_monitor_free(&self->super);
       return NULL;
     }

--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -116,7 +116,7 @@ resolve_to_absolute_path(const gchar *path, const gchar *basedir)
         {
           msg_error("Can't resolve to absolute path",
                     evt_tag_str("path", path),
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           res = NULL;
         }
     }

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -229,7 +229,7 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
     {
       msg_error("Error opening file for reading",
                 evt_tag_str("filename", self->filename->str),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return self->owner->super.optional;
     }
   return TRUE;

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -134,7 +134,7 @@ write_error:
     {
       msg_error("I/O error occurred while writing",
                 evt_tag_int("fd", self->super.transport->fd),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return LPS_ERROR;
     }
 

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -65,7 +65,7 @@ poll_file_changes_check_file(gpointer s)
       if (pos == (off_t) -1)
         {
           msg_error("Error invoking seek on followed file",
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           goto reschedule;
         }
 
@@ -81,7 +81,7 @@ poll_file_changes_check_file(gpointer s)
           else
             {
               msg_error("Error invoking fstat() on followed file",
-                        evt_tag_errno("error", errno));
+                        evt_tag_error("error"));
               goto reschedule;
             }
         }

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -102,14 +102,14 @@ afprogram_popen(AFProgramProcessInfo *process_info, GIOCondition cond, gint *fd)
     {
       msg_error("Error creating program pipe",
                 evt_tag_str("cmdline", process_info->cmdline->str),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return FALSE;
     }
 
   if ((process_info->pid = fork()) < 0)
     {
       msg_error("Error in fork()",
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       close(msg_pipe[0]);
       close(msg_pipe[1]);
       return FALSE;

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -225,7 +225,7 @@ afsocket_dd_connected(AFSocketDestDriver *self)
           msg_error("getsockopt(SOL_SOCKET, SO_ERROR) failed for connecting socket",
                     evt_tag_int("fd", self->fd),
                     evt_tag_str("server", g_sockaddr_format(self->dest_addr, buf2, sizeof(buf2), GSA_FULL)),
-                    evt_tag_errno(EVT_TAG_OSERROR, errno),
+                    evt_tag_error(EVT_TAG_OSERROR),
                     evt_tag_int("time_reopen", self->time_reopen));
           goto error_reconnect;
         }
@@ -298,7 +298,7 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
                 evt_tag_int("fd", sock),
                 evt_tag_str("server", g_sockaddr_format(self->dest_addr, buf2, sizeof(buf2), GSA_FULL)),
                 evt_tag_str("local", g_sockaddr_format(self->bind_addr, buf1, sizeof(buf1), GSA_FULL)),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       close(sock);
       return FALSE;
     }

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -394,7 +394,7 @@ afsocket_sd_accept(gpointer s)
       else if (status != G_IO_STATUS_NORMAL)
         {
           msg_error("Error accepting new connection",
-                    evt_tag_errno(EVT_TAG_OSERROR, errno));
+                    evt_tag_error(EVT_TAG_OSERROR));
           return;
         }
 
@@ -554,7 +554,7 @@ _finalize_init(gpointer arg)
   if (listen(self->fd, self->listen_backlog) < 0)
     {
       msg_error("Error during listen()",
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       close(self->fd);
       self->fd = -1;
       return FALSE;

--- a/modules/afsocket/transport-mapper.c
+++ b/modules/afsocket/transport-mapper.c
@@ -61,7 +61,7 @@ transport_mapper_open_socket(TransportMapper *self,
   if (sock < 0)
     {
       msg_error("Error creating socket",
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       goto error;
     }
 
@@ -77,7 +77,7 @@ transport_mapper_open_socket(TransportMapper *self,
 
       msg_error("Error binding socket",
                 evt_tag_str("addr", g_sockaddr_format(bind_addr, buf, sizeof(buf), GSA_FULL)),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       goto error_close;
     }
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1301,7 +1301,7 @@ afsql_dd_init(LogPipe *s)
           /* NOTE: errno might be unreliable, but that's all we have */
           msg_error("Unable to initialize database access (DBI)",
                     evt_tag_int("rc", rc),
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           goto error;
         }
       else if (rc == 0)

--- a/modules/afstomp/stomp.c
+++ b/modules/afstomp/stomp.c
@@ -174,7 +174,7 @@ write_gstring_to_socket(int fd, GString *data)
   if (res < 0)
     {
       msg_error("Error happened during write",
-                evt_tag_errno("errno", errno));
+                evt_tag_error("errno"));
       return FALSE;
     }
 

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -129,7 +129,7 @@ afstreams_init_door(int hook_type G_GNUC_UNUSED, gpointer user_data)
         {
           msg_error("Error creating syslog door file",
                     evt_tag_str(EVT_TAG_FILENAME, self->door_filename->str),
-                    evt_tag_errno(EVT_TAG_OSERROR, errno));
+                    evt_tag_error(EVT_TAG_OSERROR));
           close(fd);
           return;
         }
@@ -140,7 +140,7 @@ afstreams_init_door(int hook_type G_GNUC_UNUSED, gpointer user_data)
     {
       msg_error("Error creating syslog door",
                 evt_tag_str(EVT_TAG_FILENAME, self->door_filename->str),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return;
     }
   g_fd_set_cloexec(self->door_fd, TRUE);
@@ -148,7 +148,7 @@ afstreams_init_door(int hook_type G_GNUC_UNUSED, gpointer user_data)
     {
       msg_error("Error attaching syslog door",
                 evt_tag_str(EVT_TAG_FILENAME, self->door_filename->str),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       close(self->door_fd);
       self->door_fd = -1;
       return;
@@ -179,7 +179,7 @@ afstreams_sd_init(LogPipe *s)
         {
           msg_error("Error in ioctl(I_STR, I_CONSLOG)",
                     evt_tag_str(EVT_TAG_FILENAME, self->dev_filename->str),
-                    evt_tag_errno(EVT_TAG_OSERROR, errno));
+                    evt_tag_error(EVT_TAG_OSERROR));
           close(fd);
           return FALSE;
         }
@@ -218,7 +218,7 @@ afstreams_sd_init(LogPipe *s)
     {
       msg_error("Error opening syslog device",
                 evt_tag_str(EVT_TAG_FILENAME, self->dev_filename->str),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return FALSE;
     }
   return TRUE;

--- a/modules/confgen/confgen-plugin.c
+++ b/modules/confgen/confgen-plugin.c
@@ -75,7 +75,7 @@ confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GS
                 evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(self->super.context)),
                 evt_tag_str("block", self->super.name),
                 evt_tag_str("exec", self->exec),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
   g_string_set_size(result, 1024);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -1143,7 +1143,7 @@ pdb_rule_set_load(PDBRuleSet *self, GlobalConfig *cfg, const gchar *config, GLis
     {
       msg_error("Error opening classifier configuration file",
                 evt_tag_str(EVT_TAG_FILENAME, config),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return FALSE;
     }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -205,7 +205,7 @@ _truncate_file(QDisk *self, gint64 new_size)
     {
       success = FALSE;
       msg_error("Error truncating disk-queue file",
-                evt_tag_errno("error", errno),
+                evt_tag_error("error"),
                 evt_tag_str("filename", self->filename),
                 evt_tag_int("newsize", self->hdr->write_head),
                 evt_tag_int("fd", self->fd));
@@ -240,7 +240,7 @@ qdisk_push_tail(QDisk *self, GString *record)
       !pwrite_strict(self->fd, record->str, record->len, self->hdr->write_head + sizeof(n)))
     {
       msg_error("Error writing disk-queue file",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
 
@@ -563,7 +563,7 @@ qdisk_write_serialized_string_to_file(QDisk *self, GString const *serialized, gi
     {
       msg_error("Error writing in-memory buffer of disk-queue to disk",
                 evt_tag_str("filename", self->filename),
-                evt_tag_errno("error", errno),
+                evt_tag_error("error"),
                 NULL);
       return FALSE;
     }
@@ -729,7 +729,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
     {
       msg_error("Error opening disk-queue file",
                 evt_tag_str("filename", self->filename),
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
 
@@ -739,7 +739,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
   if (p == MAP_FAILED)
     {
       msg_error("Error returned by mmap",
-                evt_tag_errno("errno", errno),
+                evt_tag_error("errno"),
                 evt_tag_str("filename", self->filename));
       return FALSE;
     }
@@ -769,7 +769,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
         {
           msg_error("Error occurred while initalizing the new queue file",
                     evt_tag_str("filename", self->filename),
-                    evt_tag_errno("error", errno));
+                    evt_tag_error("error"));
           munmap((void *)self->hdr, sizeof(QDiskFileHeader));
           self->hdr = NULL;
           close(self->fd);
@@ -802,7 +802,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
         {
           msg_error("Error loading disk-queue file",
                     evt_tag_str("filename", self->filename),
-                    evt_tag_errno("fstat error", errno),
+                    evt_tag_error("fstat error"),
                     evt_tag_int("size", st.st_size));
           munmap((void *)self->hdr, sizeof(QDiskFileHeader));
           self->hdr = NULL;

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -52,7 +52,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
     {
       msg_error("$(getent group) failed",
                 evt_tag_str("key", key),
-                evt_tag_errno("errno", errno),
+                evt_tag_error("errno"),
                 NULL);
       g_free(buf);
       return FALSE;

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -57,7 +57,7 @@ tf_getent_passwd(gchar *key, gchar *member_name, GString *result)
     {
       msg_error("$(getent passwd) failed",
                 evt_tag_str("key", key),
-                evt_tag_errno("errno", errno),
+                evt_tag_error("errno"),
                 NULL);
       g_free(buf);
       return FALSE;

--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -60,7 +60,7 @@ openbsd_create_newsyslog_socket(OpenBSDDriver *self)
   if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, self->pair) == -1)
     {
       msg_error("openBSD source: cannot bind socket fd",
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return 0;
     }
 
@@ -68,14 +68,14 @@ openbsd_create_newsyslog_socket(OpenBSDDriver *self)
     {
       msg_error("openBSD source: cannot open log device",
                 evt_tag_str(EVT_TAG_FILENAME, OPENBSD_LOG_DEV),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return 0;
     }
 
   if (ioctl(self->klog, LIOCSFD, &(self->pair[1])) == -1)
     {
       msg_error("openBSD source: cannot do ioctl LIOCSFD",
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
       return 0;
     }
 

--- a/modules/pseudofile/pseudofile.c
+++ b/modules/pseudofile/pseudofile.c
@@ -106,7 +106,7 @@ _write_message(PseudoFileDestDriver *self, const GString *msg)
       msg_error("Error opening pseudo file",
                 evt_tag_str("pseudofile", self->pseudofile_name),
                 evt_tag_str("driver", self->super.super.id),
-                evt_tag_errno("error", errno),
+                evt_tag_error("error"),
                 _evt_tag_message(msg));
       goto exit;
     }
@@ -117,7 +117,7 @@ _write_message(PseudoFileDestDriver *self, const GString *msg)
       msg_error("Error writing to pseudo file",
                 evt_tag_str("pseudofile", self->pseudofile_name),
                 evt_tag_str("driver", self->super.super.id),
-                evt_tag_errno("error", errno),
+                evt_tag_error("error"),
                 _evt_tag_message(msg));
       goto exit;
     }

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -311,7 +311,7 @@ riemann_dd_connect(RiemannDestDriver *self, gboolean reconnect)
   if (!self->client)
     {
       msg_error("Error connecting to Riemann",
-                evt_tag_errno("errno", errno));
+                evt_tag_error("errno"));
       return FALSE;
     }
 

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -209,7 +209,7 @@ system_sysblock_add_linux_kmsg(GString *sysblock)
       msg_warning("system(): The kernel message buffer is not readable, "
                   "please check permissions if this is unintentional.",
                   evt_tag_str("device", kmsg),
-                  evt_tag_errno("error", errno));
+                  evt_tag_error("error"));
     }
   else
     system_sysblock_add_file(sysblock, kmsg, -1,
@@ -262,7 +262,7 @@ system_generate_system_transports(GString *sysblock)
   if (uname(&u) < 0)
     {
       msg_error("system(): Cannot get information about the running kernel",
-                evt_tag_errno("error", errno));
+                evt_tag_error("error"));
       return FALSE;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/1990

Problem summary: the evaluation of `evt_tags` can happen in any order, any of which can modify `errno`, which makes hard to reason about code correctness when `evt_tag_errno` is used. More detailed explanation and example snippet is written in the description of #1990.

The resolution is:
- evtlog api is untouched, which is good because we will not break anything. Users can still use `evt_tag_errno(<string-literal>, int errno)` onwards.
- a new call is added: `evt_tag_error(<string_literal>)` to the `messages` module. The `messages` module is modified that `evt_tag_error` grabs `errno` safely.

Some technical info for developers
- By safely, I mean `msg_error` etc macros expand into a block which will capture `errno` in a block-local variable. Besides that `evt_tag_error` expands into an `evt_tag_errno`, but this time the block-local variable is passed, instead of the thread-local `errno`.
- Unit test added, which when was used with evt_tag_errno, showed the failing symthom.
- Originally I wanted the `int __local_copy_of_errno` to be a gensym, but I did not be able to make it. The problem is the gensym should have been generated by `CAPTURE_ERRNO` macro, but this same gensym should have been used by the expansion of `evt_tag_errno`. This means `CAPTURE_ERRNO` should have created the `evt_tag_error` macro, but macro creating macros are not supported by the c standard (and gcc was unwilling to compile it as well).
- Luckily there was no shadow variable warning, because the blocks built by `CAPTURE_ERRNO `are disjoint, considering you cannot call `msg_error` in any `evt_tag_*` kind of functions. Nested blocks are not possible, at least this time of writing.
- It is unfortunate, but not because not all expansions will use `__local_copy_of_errno`, in those expansions I got -Wunused-variable. So in the end I needed to add `G_GNUC_UNUSED` to the variable, even though it is a used variable in some expansions. The question naturally arises, am I allowed to use an `__attribute__(unused)` variable in an expansion? It seems the unit test does not have problem with that, so I believe it is fine.
