### PR TITLE
tlscontext: set the ssl session id context to a static value

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -756,7 +756,10 @@ tls_context_new(TLSMode mode, const gchar *location)
   if (self->mode == TM_CLIENT)
     self->ssl_ctx = SSL_CTX_new(SSLv23_client_method());
   else
-    self->ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+    {
+      self->ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+      SSL_CTX_set_session_id_context(self->ssl_ctx, (const unsigned char *) "syslog", 6);
+    }
 
   return self;
 }


### PR DESCRIPTION
When using OpenSSL 1.1, and clients supporting SSL session resumption, we
need to set the SSL session ID context, otherwise Windows clients with client
certificate will fail to connect for the 2nd time.

Very helpful PostgreSQL thread:
https://www.postgresql.org/message-id/CADT4RqBU8N-csyZuzaook-c795dt22Zcwg1aHWB6tfVdAkodZA%40mail.gmail.com

Original bugreport:
https://github.com/balabit/syslog-ng/issues/1936

Should fix #1936

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>