### PR TITLE
Rewrite some unit tests to criterion based

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
       };
       find . -name test-suite.log | xargs cat;
     else
-      make --keep-going -j 3;
+      make --keep-going -j $(nproc);
       S=$?;
       if [ "$S" = "0" ]; then
         make install
@@ -142,7 +142,7 @@ matrix:
             -DPYTHON_VERSION=2
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
-        - make --keep-going -j $(nproc) all test install
+        - make --keep-going -j $(nproc) ARGS="-j $(nproc)" all test install
         - make VERBOSE=1 func-test
     - env: B=trusty-cmake
       compiler: clang
@@ -157,7 +157,7 @@ matrix:
             -DPYTHON_VERSION=2
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
-        - make --keep-going -j $(nproc) all test install
+        - make --keep-going -j $(nproc) ARGS="-j $(nproc)" all test install
     - env: B=check
       os: osx
       osx_image: xcode9.3
@@ -180,14 +180,14 @@ matrix:
             --disable-smtp
             --disable-geoip
             --enable-all-modules
-        - make --keep-going -j 4 ||
+        - make --keep-going -j $(nproc) ||
           {
             S=$?;
             make V=1;
             return $S;
           }
       script:
-        - make --keep-going check -j 4 ||
+        - make --keep-going check -j $(nproc) ||
           {
             S=$?;
             make V=1 check;

--- a/lib/control/CMakeLists.txt
+++ b/lib/control/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CONTROL_HEADERS
     PARENT_SCOPE)
 
 set(CONTROL_SOURCES
+    control/control.c
     control/control-commands.c
     control/control-main.c
     control/control-server.c

--- a/lib/control/Makefile.am
+++ b/lib/control/Makefile.am
@@ -7,6 +7,7 @@ controlinclude_HEADERS = \
 	lib/control/control-server.h
 
 control_sources = \
+	lib/control/control.c			\
 	lib/control/control-commands.c		\
 	lib/control/control-main.c		\
 	lib/control/control-server.c		\

--- a/lib/control/control.c
+++ b/lib/control/control.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002-2010 Balabit
- * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,20 +22,14 @@
  *
  */
 
-#ifndef CONTROL_H_INCLUDED
-#define CONTROL_H_INCLUDED
+#include "control/control.h"
 
-#include "syslog-ng.h"
+#include "compat/glib.h"
 
-typedef GString *(*CommandFunction)(GString *, gpointer user_data);
-typedef struct _ControlCommand
+#include <string.h>
+
+gboolean control_command_start_with_command(const ControlCommand *cmd, const gchar *line)
 {
-  const gchar *command_name;
-  const gchar *description;
-  CommandFunction func;
-  gpointer user_data;
-} ControlCommand;
+  return strncmp(cmd->command_name, line, strlen(cmd->command_name));
+}
 
-gboolean control_command_start_with_command(const ControlCommand *cmd, const gchar *name);
-
-#endif

--- a/lib/control/tests/CMakeLists.txt
+++ b/lib/control/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_unit_test(LIBTEST TARGET test_control_cmds)
-add_unit_test(LIBTEST TARGET test_control_connection DEPENDS Threads::Threads)
+add_unit_test(CRITERION TARGET test_control_cmds)
+add_unit_test(CRITERION TARGET test_control_connection DEPENDS Threads::Threads)

--- a/lib/control/tests/test_control_connection.c
+++ b/lib/control/tests/test_control_connection.c
@@ -22,7 +22,8 @@
  *
  */
 
-#include "testutils.h"
+#include <criterion/criterion.h>
+
 #include "control/control.h"
 #include "control/control-server.h"
 #include "apphook.h"
@@ -142,7 +143,7 @@ control_connection_moc_new(ControlServer *server)
 GString *
 test_command(GString *command, gpointer user_data)
 {
-  assert_string(command->str,"test command", "Bad command handling");
+  cr_assert_str_eq(command->str,"test command", "Bad command handling");
   return g_string_new("OK");
 }
 
@@ -196,11 +197,10 @@ test_control_connection(gsize transaction_size)
   g_string_assign(moc_connection->source_buffer->buffer,"test command\n");
   moc_connection->transaction_size = transaction_size;
   control_connection_start_watches((ControlConnection *)moc_connection);
-  assert_string(result_string->str, "OK\n.\n", "BAD Behaviour transaction_size: %d",transaction_size);
+  cr_assert_str_eq(result_string->str, "OK\n.\n", "BAD Behaviour transaction_size: %lu",transaction_size);
 }
 
-int
-main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
+Test(control_connection, test_control_connection)
 {
   GList *commands = g_list_append(NULL, &command);
   moc_server.control_commands = commands;
@@ -213,5 +213,5 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
     }
   app_shutdown();
   g_list_free(commands);
-  return 0;
 }
+

--- a/lib/debugger/tests/CMakeLists.txt
+++ b/lib/debugger/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(TARGET test-debugger)
+add_unit_test(CRITERION TARGET test-debugger)

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -22,22 +22,30 @@
  *
  */
 
+#include <criterion/criterion.h>
+
 #include "debugger/debugger.h"
 #include "apphook.h"
 
 void
-test_debugger(void)
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+void
+teardown(void)
+{
+  cfg_free(configuration);
+}
+
+TestSuite(debugger, .init = setup, .fini = teardown);
+
+Test(debugger, test_debugger)
 {
   MainLoop *main_loop = main_loop_get_instance();
   Debugger *debugger = debugger_new(main_loop, configuration);
   debugger_free(debugger);
 }
 
-int
-main(void)
-{
-  app_startup();
-  configuration = cfg_new_snippet();
-  test_debugger();
-  cfg_free(configuration);
-}

--- a/lib/rewrite/tests/CMakeLists.txt
+++ b/lib/rewrite/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST TARGET test_rewrite)
+add_unit_test(LIBTEST CRITERION TARGET test_rewrite)

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -24,7 +24,7 @@
 
 #include "apphook.h"
 #include "plugin.h"
-#include "testutils.h"
+#include <criterion/criterion.h>
 #include "config_parse_lib.h"
 #include "cfg-grammar.h"
 #include "rewrite/rewrite-expr.h"
@@ -36,8 +36,7 @@ expect_config_parse_failure(const char *raw_rewrite_rule)
 
   configuration = cfg_new_snippet();
   snprintf(raw_config, sizeof(raw_config), "rewrite s_test{ %s };", raw_rewrite_rule);
-  assert_false(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL),
-               ASSERTION_ERROR("Parsing the given configuration failed"));
+  cr_assert_not(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL), "Parsing the given configuration failed");
   cfg_free(configuration);
 };
 
@@ -48,9 +47,8 @@ create_rewrite_rule(const char *raw_rewrite_rule)
 
   configuration = cfg_new_snippet();
   snprintf(raw_config, sizeof(raw_config), "rewrite s_test{ %s }; log{ rewrite(s_test); };", raw_rewrite_rule);
-  assert_true(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL),
-              ASSERTION_ERROR("Parsing the given configuration failed"));
-  assert_true(cfg_init(configuration), ASSERTION_ERROR("Config initialization failed"));
+  cr_assert(parse_config(raw_config, LL_CONTEXT_ROOT, NULL, NULL), "Parsing the given configuration failed");
+  cr_assert(cfg_init(configuration), "Config initialization failed");
 
   LogExprNode *expr_node = cfg_tree_get_object(&configuration->tree, ENC_REWRITE, "s_test");
   return (LogRewrite *)expr_node->children->object;
@@ -98,276 +96,256 @@ rewrite_teardown(LogMessage *msg)
 }
 
 void
-test_condition_success(void)
+cr_assert_msg_field_equals(LogMessage *msg, const gchar *field_name, const gchar *expected_value,
+                           gssize expected_value_len)
+{
+  const gboolean result = assert_msg_field_equals_non_fatal(msg, field_name, expected_value, expected_value_len, "");
+  cr_assert(result, "Message field assert");
+}
+
+Test(rewrite, condition_success)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"00100\", value(\"device_id\") condition(program(\"ARCGIS\")));");
   LogMessage *msg = create_message_with_field("PROGRAM", "ARCGIS");
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "device_id", "00100", -1, ASSERTION_ERROR("Bad device_id"));
+  cr_assert_msg_field_equals(msg, "device_id", "00100", -1);
   rewrite_teardown(msg);
 }
 
-void
-test_reference_on_condition_cloned(void)
+Test(rewrite, reference_on_condition_cloned)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"00100\", value(\"device_id\") condition(program(\"ARCGIS\")));");
   LogPipe *cloned_rule = log_pipe_clone(&test_rewrite->super);
-  assert_guint32(test_rewrite->condition->ref_cnt, 2, ASSERTION_ERROR("Bad reference number of condition"));
+  cr_assert_eq(test_rewrite->condition->ref_cnt, 2, "Bad reference number of condition");
   log_pipe_unref(cloned_rule);
-  assert_guint32(test_rewrite->condition->ref_cnt, 1, ASSERTION_ERROR("Bad reference number of condition"));
+  cr_assert_eq(test_rewrite->condition->ref_cnt, 1, "Bad reference number of condition");
   cfg_free(configuration);
 }
 
-void test_set_field_exist_and_set_literal_string(void)
+Test(rewrite, set_field_exist_and_set_literal_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"value\" value(\"field1\") );");
   LogMessage *msg = create_message_with_field("field1", "oldvalue");
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_not_exist_and_set_literal_string(void)
+Test(rewrite, set_field_not_exist_and_set_literal_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"value\" value(\"field1\") );");
   LogMessage *msg = log_msg_new_empty();
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1,
-                          ASSERTION_ERROR("Couldn't set message field when it doesn't exists"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_set_template_string(void)
+Test(rewrite, set_field_exist_and_set_template_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set(\"$field2\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "field2","newvalue", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "newvalue", -1,
-                          ASSERTION_ERROR("Couldn't set message field with template value"));
+  cr_assert_msg_field_equals(msg, "field1", "newvalue", -1);
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted(void)
+Test(rewrite, subst_field_exist_and_substring_substituted)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"substitute\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "asubstringb", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "asubstituteb", -1,
-                          ASSERTION_ERROR("Couldn't subst message field with literal"));
+  cr_assert_msg_field_equals(msg, "field1", "asubstituteb", -1);
   rewrite_teardown(msg);
 }
 
-void test_subst_pcre_unused_subpattern(void)
+Test(rewrite, subst_pcre_unused_subpattern)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("subst('(a|(z))(bc)', '.', value('field1') type(pcre) flags('store-matches'));");
   LogMessage *msg = create_message_with_fields("field1", "abc", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", ".", -1, ASSERTION_ERROR("Couldn't subst message field with literal"));
-  assert_msg_field_equals(msg, "0", "abc", -1, ASSERTION_ERROR("Invalid subpattern match"));
-  assert_msg_field_equals(msg, "1", "a", -1, ASSERTION_ERROR("Invalid subpattern match"));
-  assert_msg_field_equals(msg, "2", "", -1, ASSERTION_ERROR("Invalid subpattern match"));
-  assert_msg_field_equals(msg, "3", "bc", -1, ASSERTION_ERROR("Invalid subpattern match"));
+  cr_assert_msg_field_equals(msg, "field1", ".", -1);
+  cr_assert_msg_field_equals(msg, "0", "abc", -1);
+  cr_assert_msg_field_equals(msg, "1", "a", -1);
+  cr_assert_msg_field_equals(msg, "2", "", -1);
+  cr_assert_msg_field_equals(msg, "3", "bc", -1);
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_with_template(void)
+Test(rewrite, subst_field_exist_and_substring_substituted_with_template)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"$field2\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "asubstringb", "field2","substitute", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "asubstituteb", -1,
-                          ASSERTION_ERROR("Couldn't subst message field with template"));
+  cr_assert_msg_field_equals(msg, "field1", "asubstituteb", -1);
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_only_once_without_global(void)
+Test(rewrite, subst_field_exist_and_substring_substituted_only_once_without_global)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"substitute\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "substring substring", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "substitute substring", -1,
-                          ASSERTION_ERROR("Field substituted more than once without global flag"));
+  cr_assert_msg_field_equals(msg, "field1", "substitute substring", -1);
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_every_occurrence_with_global(void)
+Test(rewrite, subst_field_exist_and_substring_substituted_every_occurrence_with_global)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"substring\" \"substitute\" value(\"field1\") flags(global) );");
   LogMessage *msg = create_message_with_fields("field1", "substring substring", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "substitute substitute", -1,
-                          ASSERTION_ERROR("Field substituted less than every occurrence with global flag"));
+  cr_assert_msg_field_equals(msg, "field1", "substitute substitute", -1);
   rewrite_teardown(msg);
 }
 
-void test_subst_field_exist_and_substring_substituted_when_regexp_matched(void)
+Test(rewrite, subst_field_exist_and_substring_substituted_when_regexp_matched)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("subst(\"[0-9]+\" \"substitute\" value(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "a123b", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "asubstituteb", -1,
-                          ASSERTION_ERROR("Couldn't subst message field with literal"));
+  cr_assert_msg_field_equals(msg, "field1", "asubstituteb", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_literal_string(void)
+Test(rewrite, set_field_exist_and_group_set_literal_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field1\") );");
   LogMessage *msg = create_message_with_field("field1", "oldvalue");
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_honors_time_zone(void)
+Test(rewrite, set_field_honors_time_zone)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("set('${ISODATE}' value('UTCDATE') time-zone('Asia/Tokyo'));");
   LogMessage *msg = create_message_with_fields("field1", "a123b", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "UTCDATE", "1971-01-01T09:00:00+09:00", -1,
-                          ASSERTION_ERROR("Couldn't use time-zone option in rewrite-set"));
+  cr_assert_msg_field_equals(msg, "UTCDATE", "1971-01-01T09:00:00+09:00", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_multiple_fields_with_glob_pattern_literal_string(void)
+Test(rewrite, set_field_exist_and_group_set_multiple_fields_with_glob_pattern_literal_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field.*\") );");
   LogMessage *msg = create_message_with_fields("field.name1", "oldvalue","field.name2", "oldvalue", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field.name1", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
-  assert_msg_field_equals(msg, "field.name2", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field.name1", "value", -1);
+  cr_assert_msg_field_equals(msg, "field.name2", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_multiple_fields_with_glob_question_mark_pattern_literal_string(void)
+Test(rewrite, set_field_exist_and_group_set_multiple_fields_with_glob_question_mark_pattern_literal_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field?\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue","field2", "oldvalue", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
-  assert_msg_field_equals(msg, "field2", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
+  cr_assert_msg_field_equals(msg, "field2", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_multiple_fields_with_multiple_glob_pattern_literal_string(void)
+Test(rewrite, set_field_exist_and_group_set_multiple_fields_with_multiple_glob_pattern_literal_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"value\" values(\"field1\" \"field2\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue","field2", "oldvalue", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
-  assert_msg_field_equals(msg, "field2", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
+  cr_assert_msg_field_equals(msg, "field2", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_template_string(void)
+Test(rewrite, set_field_exist_and_group_set_template_string)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"$field2\" values(\"field1\") );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "field2", "value", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_template_string_with_old_value(void)
+Test(rewrite, set_field_exist_and_group_set_template_string_with_old_value)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupset(\"$_ alma\" values(\"field1\") );");
   LogMessage *msg = create_message_with_field("field1", "value");
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value alma", -1, ASSERTION_ERROR("Couldn't set message field"));
+  cr_assert_msg_field_equals(msg, "field1", "value alma", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_when_condition_doesnt_match(void)
+Test(rewrite, set_field_exist_and_group_set_when_condition_doesnt_match)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("groupset(\"value\" values(\"field1\") condition( program(\"program1\") ) );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "PROGRAM", "program2", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "oldvalue", -1,
-                          ASSERTION_ERROR("Shouldn't rewrite when condition doesn't match"));
+  cr_assert_msg_field_equals(msg, "field1", "oldvalue", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_exist_and_group_set_when_condition_matches(void)
+Test(rewrite, set_field_exist_and_group_set_when_condition_matches)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("groupset(\"value\" values(\"field1\") condition( program(\"program\") ) );");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "PROGRAM", "program", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_equals(msg, "field1", "value", -1, ASSERTION_ERROR("Shouldn't rewrite when condition doesn't match"));
+  cr_assert_msg_field_equals(msg, "field1", "value", -1);
   rewrite_teardown(msg);
 }
 
-void test_set_field_cloned(void)
+Test(rewrite, set_field_cloned)
 {
   LogRewrite *test_rewrite =
     create_rewrite_rule("groupset(\"value\" values(\"field1\") condition( program(\"program\") ) );");
   LogPipe *cloned_rule = log_pipe_clone(&test_rewrite->super);
-  assert_true(cloned_rule != NULL, ASSERTION_ERROR("Can't cloned the rewrite"));
+  cr_assert(cloned_rule != NULL, "Can't cloned the rewrite");
   log_pipe_unref(cloned_rule);
   cfg_free(configuration);
 }
 
-void test_set_field_invalid_template(void)
+Test(rewrite, set_field_invalid_template)
 {
   expect_config_parse_failure("groupset(\"${alma\" values(\"field1\") );");
 }
 
-static void
-test_unset_field_disappears(void)
+Test(rewrite, unset_field_disappears)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("unset(value('field1'));");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "PROGRAM", "foobar", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_unset(msg, "field1", ASSERTION_ERROR("field1 should be unset"));
-  assert_msg_field_equals(msg, "PROGRAM", "foobar", -1, ASSERTION_ERROR("field1 should be unset"));
+  cr_assert_msg_field_equals(msg, "field1", "", -1);
+  cr_assert_msg_field_equals(msg, "PROGRAM", "foobar", -1);
   rewrite_teardown(msg);
 }
 
-static void
-test_groupunset_field_disappears(void)
+Test(rewrite, groupunset_field_disappears)
 {
   LogRewrite *test_rewrite = create_rewrite_rule("groupunset(values('field?'));");
   LogMessage *msg = create_message_with_fields("field1", "oldvalue", "field2", "oldvalue2", "PROGRAM", "foobar", NULL);
   invoke_rewrite_rule(test_rewrite, msg);
-  assert_msg_field_unset(msg, "field1", ASSERTION_ERROR("field1 should be unset"));
-  assert_msg_field_unset(msg, "field2", ASSERTION_ERROR("field2 should be unset"));
-  assert_msg_field_equals(msg, "PROGRAM", "foobar", -1, ASSERTION_ERROR("field1 should be unset"));
+  cr_assert_msg_field_equals(msg, "field1", "", -1);
+  cr_assert_msg_field_equals(msg, "field2", "", -1);
+  cr_assert_msg_field_equals(msg, "PROGRAM", "foobar", -1);
   rewrite_teardown(msg);
 }
 
-int
-main(int argc, char **argv)
+void
+setup(void)
 {
   app_startup();
   setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
   start_grabbing_messages();
-  test_condition_success();
-  test_reference_on_condition_cloned();
-  test_set_field_exist_and_set_literal_string();
-  test_set_field_not_exist_and_set_literal_string();
-  test_set_field_exist_and_set_template_string();
-  test_subst_field_exist_and_substring_substituted();
-  test_subst_pcre_unused_subpattern();
-  test_subst_field_exist_and_substring_substituted_with_template();
-  test_subst_field_exist_and_substring_substituted_only_once_without_global();
-  test_subst_field_exist_and_substring_substituted_every_occurrence_with_global();
-  test_subst_field_exist_and_substring_substituted_when_regexp_matched();
-  test_set_field_honors_time_zone();
-  test_set_field_exist_and_group_set_literal_string();
-  test_set_field_exist_and_group_set_multiple_fields_with_glob_pattern_literal_string();
-  test_set_field_exist_and_group_set_multiple_fields_with_glob_question_mark_pattern_literal_string();
-  test_set_field_exist_and_group_set_multiple_fields_with_multiple_glob_pattern_literal_string();
-  test_set_field_exist_and_group_set_template_string();
-  test_set_field_exist_and_group_set_template_string_with_old_value();
-  test_set_field_invalid_template();
-  test_set_field_exist_and_group_set_when_condition_doesnt_match();
-  test_set_field_exist_and_group_set_when_condition_matches();
-  test_set_field_cloned();
-  test_unset_field_disappears();
-  test_groupunset_field_disappears();
-  stop_grabbing_messages();
 }
+
+void
+teardown(void)
+{
+  stop_grabbing_messages();
+  app_shutdown();
+}
+
+TestSuite(rewrite, .init = setup, .fini = teardown);
+


### PR DESCRIPTION
This PR has a few changes that is not a criterion conversion. 
* Tweaks the Travis.
* "Performance" tests take too long, while does not catch perf issues at all, so the iteration is decreased 
* The control command tests should use only the interface and shall not include `. c` files either. 

