### PR TITLE
CMake compile issue because of PR #2003 and #2007

### DIFF
--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -24,9 +24,9 @@
 
 #include <criterion/criterion.h>
 
-#include "lib/messages.h"
+#include "messages.h"
 #include "control/control.h"
-#include "lib/control/control-commands.h"
+#include "control/control-commands.h"
 #include "stats/stats-control.h"
 #include "control/control-server.h"
 #include "stats/stats-cluster.h"


### PR DESCRIPTION
The CMake modernization PR changed some include paths, and the UT refactor used the old one the lack of rebasing causes a compile error on the master. This PR fixes the include path in the test source file.