### PR TITLE
eventlog: Extend evtlog.h to use evt_tag_inaddr/inaddr6 functions on …

### DIFF
--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -44,6 +44,11 @@
 # include <syslog.h>
 #endif
 #include <stdarg.h>
+#ifdef __FreeBSD__
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+#endif
 #include <arpa/inet.h>
 
 #include "evtmaps.h"

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -44,11 +44,9 @@
 # include <syslog.h>
 #endif
 #include <stdarg.h>
-#ifdef __FreeBSD__
- #include <sys/types.h>
- #include <sys/socket.h>
- #include <netinet/in.h>
-#endif
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 
 #include "evtmaps.h"


### PR DESCRIPTION
Corrects issue #2014 on FreeBSD

Fixes #2014