### PR TITLE
LogTransportMock enhancement

### DIFF
--- a/libtest/CMakeLists.txt
+++ b/libtest/CMakeLists.txt
@@ -26,3 +26,5 @@ set(LIBTEST_SOURCES
 add_library(libtest STATIC ${LIBTEST_SOURCES})
 target_link_libraries(libtest syslog-ng ${CRITERION_LIBRARIES})
 target_include_directories(libtest INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR})
+
+add_test_subdirectory(tests)

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -38,3 +38,5 @@ pkgconfig_DATA			   +=	\
 	libtest/syslog-ng-test.pc
 
 LIBTEST_LIBS = $(top_builddir)/libtest/libsyslog-ng-test.a
+
+include libtest/tests/Makefile.am

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -43,8 +43,11 @@ struct iovec_const
 typedef struct data
 {
   data_type_t type;
-  struct iovec_const iov;
-  guint error_code;
+  union
+  {
+    struct iovec_const iov;
+    guint error_code;
+  };
 } data_t;
 
 struct _LogTransportMock

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -62,7 +62,20 @@ struct _LogTransportMock
   gboolean input_is_a_stream;
   gboolean inject_eagain;
   gboolean eof_is_eagain;
+  gpointer user_data;
 };
+
+gpointer
+log_transport_mock_get_user_data(LogTransportMock *self)
+{
+  return self->user_data;
+}
+
+void
+log_transport_mock_set_user_data(LogTransportMock *self, gpointer user_data)
+{
+  self->user_data = user_data;
+}
 
 gssize
 log_transport_mock_read_from_write_buffer(LogTransportMock *self, gchar *buffer, gsize len)

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -65,6 +65,17 @@ struct _LogTransportMock
   gpointer user_data;
 };
 
+LogTransportMock *
+log_transport_mock_clone(LogTransportMock *self)
+{
+  LogTransportMock *clone = g_new(LogTransportMock, 1);
+  *clone = *self;
+  clone->write_buffer = g_array_new(TRUE, TRUE, 1);
+  g_array_append_vals(clone->write_buffer, self->write_buffer->data, self->write_buffer->len);
+
+  return clone;
+}
+
 gpointer
 log_transport_mock_get_user_data(LogTransportMock *self)
 {

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -214,8 +214,7 @@ log_transport_mock_init(LogTransportMock *self, const gchar *read_buffer1, gssiz
   const gchar *buffer;
   gssize length;
 
-  self->super.fd = 0;
-  self->super.cond = 0;
+  log_transport_init_instance(&self->super, 0);
   self->super.read = log_transport_mock_read_method;
   self->super.write = log_transport_mock_write_method;
   self->super.free_fn = log_transport_mock_free_method;

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -27,6 +27,8 @@
 
 #include "transport/logtransport.h"
 
+typedef struct _LogTransportMock LogTransportMock;
+
 /* macro to be used when injecting an error in the I/O stream */
 #define LTM_INJECT_ERROR_LENGTH -2
 #define LTM_INJECT_ERROR(err)   (GUINT_TO_POINTER(err)), LTM_INJECT_ERROR_LENGTH
@@ -45,5 +47,8 @@ log_transport_mock_records_new(const gchar *read_buffer1, gssize read_buffer_len
 
 LogTransport *
 log_transport_mock_endless_records_new(const gchar *read_buffer1, gssize read_buffer_length1, ...);
+
+void
+log_transport_mock_inject_data(LogTransportMock *self, const gchar *buffer, gssize length);
 
 #endif

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -59,4 +59,6 @@ log_transport_mock_set_user_data(LogTransportMock *self, gpointer user_data);
 gssize
 log_transport_mock_read_from_write_buffer(LogTransportMock *self, gchar *buffer, gsize len);
 
+LogTransportMock *
+log_transport_mock_clone(LogTransportMock *self);
 #endif

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -59,6 +59,9 @@ log_transport_mock_set_user_data(LogTransportMock *self, gpointer user_data);
 gssize
 log_transport_mock_read_from_write_buffer(LogTransportMock *self, gchar *buffer, gsize len);
 
+gssize
+log_transport_mock_read_chunk_from_write_buffer(LogTransportMock *self, gchar *buffer);
+
 LogTransportMock *
 log_transport_mock_clone(LogTransportMock *self);
 #endif

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -51,4 +51,7 @@ log_transport_mock_endless_records_new(const gchar *read_buffer1, gssize read_bu
 void
 log_transport_mock_inject_data(LogTransportMock *self, const gchar *buffer, gssize length);
 
+gssize
+log_transport_mock_read_from_write_buffer(LogTransportMock *self, gchar *buffer, gsize len);
+
 #endif

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -51,6 +51,11 @@ log_transport_mock_endless_records_new(const gchar *read_buffer1, gssize read_bu
 void
 log_transport_mock_inject_data(LogTransportMock *self, const gchar *buffer, gssize length);
 
+gpointer
+log_transport_mock_get_user_data(LogTransportMock *self);
+void
+log_transport_mock_set_user_data(LogTransportMock *self, gpointer user_data);
+
 gssize
 log_transport_mock_read_from_write_buffer(LogTransportMock *self, gchar *buffer, gsize len);
 

--- a/libtest/tests/CMakeLists.txt
+++ b/libtest/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(CRITERION LIBTEST TARGET test_mock_transport)

--- a/libtest/tests/Makefile.am
+++ b/libtest/tests/Makefile.am
@@ -1,0 +1,8 @@
+libtest_tests_TESTS			= \
+	libtest/tests/test_mock_transport
+
+check_PROGRAMS					+= ${libtest_tests_TESTS}
+
+libtest_tests_test_mock_transport_CFLAGS	= $(TEST_CFLAGS) -I$(top_builddir)/libtest
+libtest_tests_test_mock_transport_LDADD	= \
+	$(TEST_LDADD)

--- a/libtest/tests/test_mock_transport.c
+++ b/libtest/tests/test_mock_transport.c
@@ -114,3 +114,24 @@ Test(mock_transport, test_mock_transport_read_chunk_from_write_buffer)
 
   log_transport_free((LogTransport *)transport);
 }
+
+Test(mock_transport, test_cloning)
+{
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  gchar buffer[100];
+
+  log_transport_write((LogTransport *)transport, "chunk1", sizeof("chunk1"));
+  log_transport_write((LogTransport *)transport, "chunk2", sizeof("chunk2"));
+
+  LogTransportMock *clone = log_transport_mock_clone(transport);
+
+  log_transport_mock_read_from_write_buffer(clone, buffer, sizeof("chunk1"));
+  cr_assert_str_eq(buffer, "chunk1");
+  log_transport_mock_read_from_write_buffer(clone, buffer, sizeof("chunk2"));
+  cr_assert_str_eq(buffer, "chunk2");
+
+  log_transport_free((LogTransport *)transport);
+  log_transport_free((LogTransport *)clone);
+}

--- a/libtest/tests/test_mock_transport.c
+++ b/libtest/tests/test_mock_transport.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <syslog-ng.h>
+
+#include <criterion/criterion.h>
+#include "mock-transport.h"
+
+#include <errno.h>
+
+Test(mock_transport, test_mock_transport_read)
+{
+
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  log_transport_mock_inject_data(transport, "chunk1", sizeof("chunk1"));
+  log_transport_mock_inject_data(transport, "chunk2", sizeof("chunk2"));
+
+  gchar buffer[100];
+  log_transport_read((LogTransport *)transport, buffer, sizeof(buffer), NULL);
+  cr_assert_str_eq(buffer, "chunk1");
+
+  /* Only odd reads result in data transfer. Every even read results in EAGAIN */
+  int rc;
+  rc = log_transport_read((LogTransport *)transport, buffer, sizeof(buffer), NULL);
+  cr_assert_eq(rc, -1);
+  cr_assert_eq(errno, EAGAIN);
+
+  log_transport_read((LogTransport *)transport, buffer, sizeof(buffer), NULL);
+  cr_assert_str_eq(buffer, "chunk2");
+
+  log_transport_free((LogTransport *)transport);
+}
+
+Test(mock_transport, test_mock_transport_simple_write)
+{
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  gchar buffer[100];
+
+  log_transport_write((LogTransport *)transport, "chunk", sizeof("chunk"));
+  log_transport_mock_read_from_write_buffer(transport, buffer, sizeof(buffer));
+  cr_assert_str_eq(buffer, "chunk");
+
+  log_transport_free((LogTransport *)transport);
+}
+
+Test(mock_transport, test_mock_transport_read_from_write_buffer)
+{
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  gchar buffer[100];
+
+  log_transport_write((LogTransport *)transport, "chunk1", sizeof("chunk1"));
+  log_transport_write((LogTransport *)transport, "chunk2", sizeof("chunk2"));
+
+  log_transport_mock_read_from_write_buffer(transport, buffer, sizeof("chunk1"));
+  cr_assert_str_eq(buffer, "chunk1");
+  log_transport_mock_read_from_write_buffer(transport, buffer, sizeof("chunk2"));
+  cr_assert_str_eq(buffer, "chunk2");
+
+  log_transport_free((LogTransport *)transport);
+}


### PR DESCRIPTION
This patchset adds a few enhancements to LogTransportMock:
- Exposing a new `log_transport_mock_inject_data` function, which can be used to add data to the transport. Originally, all data must have been added in the constructor. Now data can be injected after LogTransportMock is created
- General purpose user data is added to LogTransportMock, which can be used to carry test-specific data in the mock. For example one can give a name to the mock.
- Support for cloning LogTransportMock. Cloning can be used for testing drivers that can replace their transport on the fly. In that case, clone can carry the already injected and written data, that will be available after changing transport.
- Removing restriction of the number of injectable data chunks. Originally it was limited to 32.
- Support for two-way transports: a new write_buffer and write function is added. For drivers which not only read but also write the transport, tests can access the written data. Users can either read data from write buffer as stream, or they can fetch data by chunks.