### PR TITLE
configure.ac: Fix mixed linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -794,7 +794,7 @@ dnl libevtlog headers/libraries (remove after relicensing libevtlog)
 dnl ***************************************************************************
 
 EVTLOG_LIBS="\$(top_builddir)/lib/eventlog/src/libevtlog.la"
-EVTLOG_NO_LIBTOOL_LIBS="\$(top_builddir)/lib/eventlog/src/.libs/libevtlog.la"
+EVTLOG_NO_LIBTOOL_LIBS="\$(top_builddir)/lib/eventlog/src/.libs/libevtlog.so"
 EVTLOG_CFLAGS="-I\$(top_srcdir)/lib/eventlog/src -I\$(top_builddir)/lib/eventlog/src"
 
 dnl ***************************************************************************
@@ -1688,7 +1688,7 @@ if test "x$linking_mode" = "xdynamic"; then
 	# syslog-ng binary is linked with the default link command (e.g. libtool)
 	SYSLOGNG_LINK='$(LINK)'
 else
-	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $RESOLV_LIBS $LD_START_STATIC -Wl,${WHOLE_ARCHIVE_OPT} $GLIB_LIBS $EVTLOG_NO_LIBTOOL_LIBS $PCRE_LIBS $REGEX_LIBS  -Wl,${NO_WHOLE_ARCHIVE_OPT} $IVYKIS_NO_LIBTOOL_LIBS $LD_END_STATIC $LIBCAP_LIBS $DL_LIBS "
+	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $RESOLV_LIBS $EVTLOG_NO_LIBTOOL_LIBS $LD_START_STATIC -Wl,${WHOLE_ARCHIVE_OPT} $GLIB_LIBS $PCRE_LIBS $REGEX_LIBS  -Wl,${NO_WHOLE_ARCHIVE_OPT} $IVYKIS_NO_LIBTOOL_LIBS $LD_END_STATIC $LIBCAP_LIBS $DL_LIBS"
 	TOOL_DEPS_LIBS="$LIBS $BASE_LIBS $GLIB_LIBS $EVTLOG_LIBS $RESOLV_LIBS $LIBCAP_LIBS $PCRE_LIBS $REGEX_LIBS $IVYKIS_LIBS $DL_LIBS"
 	CORE_DEPS_LIBS=""
 

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -46,8 +46,8 @@ modules_diskq_libdisk_buffer_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(LIBSYSLOG_N
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = \
-  $(TOOL_DEPS_LIBS) \
   $(MODULE_DEPS_LIBS) \
+  $(TOOL_DEPS_LIBS) \
   $(LIBSYSLOG_NG_DISK_BUFFER)
 
 modules/diskq modules/diskq/ mod-diskq: modules/diskq/libdisk-buffer.la \

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -10,5 +10,7 @@ syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 EXTRA_DIST					+=	\
 	syslog-ng-ctl/control-client-unix.c
 
-syslog_ng_ctl_syslog_ng_ctl_LDADD		= lib/libsyslog-ng.la @BASE_LIBS@ @GLIB_LIBS@ @RESOLV_LIBS@
-
+syslog_ng_ctl_syslog_ng_ctl_LDADD		= \
+	$(MODULE_DEPS_LIBS) \
+	$(TOOL_DEPS_LIBS)
+syslog_ng_ctl_syslog_ng_ctl_DEPENDENCIES	= lib/libsyslog-ng.la


### PR DESCRIPTION
When using mixed linking, we want to link libevtlog dynamically, and without using libtool. For this reason, we can't use the '.la' file, and we want to link it before we tell the linker to "link the rest statically".

Additionally, we need to specify the libraries in a certain order, otherwise the linker will not be able to resolve symbols. The diskq and syslog-ng-ctl Makefiles were adjusted accordingly.

Fixes #2020.