### PR TITLE
DefaultNetworkDrivers: added missing 'else {};' statement to legacy p…

### DIFF
--- a/scl/default-network-drivers/plugin.conf
+++ b/scl/default-network-drivers/plugin.conf
@@ -49,9 +49,11 @@ block source default-network-drivers(
 			parser { syslog-parser(flags(syslog-protocol)); };
 			if {
 				parser { ewmm-parser(); };
-			} else {
+			}
+			elif {
 				parser { app-parser(topic(syslog) `__VARARGS__`); };
-			};
+			}
+			else {};
 		};
 	};
 


### PR DESCRIPTION
…art in SCL

 * without this change legacy messages which are not matching on ewmm-parser()
 or on app-parser(topic(syslog)) will _not_ forwarded to destinations,
 they will dropped.

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>