### PR TITLE
FileReader: Set missing expr_node in file_reader_init_instance()

### DIFF
--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -340,6 +340,7 @@ file_reader_init_instance (FileReader *self, const gchar *filename,
   self->options = options;
   self->opener = opener;
   self->owner = owner;
+  self->super.expr_node = owner->super.super.expr_node;
 }
 
 FileReader *


### PR DESCRIPTION
 * without this log_pipe_location_tag() will return with '#unknown' in log_source_queue()

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>
Signed-off-by: László Várady <laszlo.varady@balabit.com>