### PR TITLE
 Dbld coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ m4/ax*.m4
 dbld/build/
 dbld/release/
 dbld/install/
+dbld/rules.conf
 debian/build-tree/
 debian/*.log
 debian/autoreconf.*

--- a/dbld/bootstrap
+++ b/dbld/bootstrap
@@ -8,4 +8,3 @@ cd /source
 cd /build
 echo "Running configure with: ${CONFIGURE_OPTS}"
 /source/configure ${CONFIGURE_OPTS}
-make python-venv

--- a/dbld/images/devshell-apt/all.txt
+++ b/dbld/images/devshell-apt/all.txt
@@ -11,3 +11,4 @@ valgrind
 linux-tools-generic
 libjemalloc-dev
 locales
+lcov

--- a/dbld/rules
+++ b/dbld/rules
@@ -21,6 +21,8 @@ TARBALL=$(BUILD_DIR)/syslog-ng-$(VERSION).tar.gz
 MODE=snapshot
 CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl $(CONFIGURE_ADD)
 
+-include dbld/rules.conf
+
 help:
 	@echo "This script allows you to build release/snapshot artifacts, such "
 	@echo "as rpm, deb packages and tarballs in controlled environments (e.g. "

--- a/tests/collect-cov.sh
+++ b/tests/collect-cov.sh
@@ -23,7 +23,7 @@
 
 set -e
 
-lcov --capture --directory `pwd` --compat-libtool --output-file coverage.info --base-directory "${top_srcdir}"
+lcov --capture --directory `pwd` --compat-libtool --output-file coverage.info --rc geninfo_auto_base=1
 lcov --extract coverage.info "${top_srcdir}/*" --output-file coverage.info
 lcov --remove coverage.info "${top_srcdir}/modules/afmongodb/mongo-c-driver/*" --output-file coverage.info
 lcov --remove coverage.info "${top_srcdir}/modules/afamqp/rabbitmq-c/*" --output-file coverage.info


### PR DESCRIPTION
This patch set makes it possible to generate coverage reports in the devshell image. It contains a set of fixes that:

1) removes python-venv from dbld/bootstrap
2) adds lcov package to the devshell image
3) fixes an lcov compatibility issue that comes up with the lcov version in artful
4) makes it possible to customize dbld options locally from a dlbd/rules.conf file that is included into the main makefile.

With that, if --enable-gcov is added as a configure option, "make coverage" would work from within the devshell image, generating an HTML report into dbld/build/coverage.html

We roughly have 67% coverage with the unit tests alone. Could be better, but some parts look really nice, others less so.
