### PR TITLE
LogPipe: Improved debug logs 

### DIFF
--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -49,8 +49,7 @@ filter_call_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     stats_counter_inc(self->super.not_matched);
 
-  msg_debug("  filter() evaluation result",
-            filter_result_tag(res),
+  msg_debug("filter() evaluation started",
             evt_tag_str("called-rule", self->rule),
             evt_tag_printf("msg", "%p", msgs[num_msg - 1]));
 

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -85,8 +85,7 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       result = self->cmp_op & FCMP_GT || self->cmp_op == 0;
     }
 
-  msg_debug("  cmp() evaluation result",
-            filter_result_tag(result),
+  msg_debug("cmp() evaluation started",
             evt_tag_str("left", left_buf->str),
             evt_tag_str("operator", self->super.type),
             evt_tag_str("right", right_buf->str),

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -93,9 +93,3 @@ filter_expr_unref(FilterExprNode *self)
       g_free(self);
     }
 }
-
-EVTTAG *
-filter_result_tag(gboolean res)
-{
-  return evt_tag_str("result", res ? "MATCH" : "UNMATCHED");
-}

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -53,8 +53,6 @@ filter_expr_init(FilterExprNode *self, GlobalConfig *cfg)
     self->init(self, cfg);
 }
 
-EVTTAG *filter_result_tag(gboolean res);
-
 gboolean filter_expr_eval(FilterExprNode *self, LogMessage *msg);
 gboolean filter_expr_eval_with_context(FilterExprNode *self, LogMessage **msgs, gint num_msg);
 gboolean filter_expr_eval_root(FilterExprNode *self, LogMessage **msg, const LogPathOptions *path_options);

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -50,8 +50,7 @@ filter_in_list_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   APPEND_ZERO(value, value, len);
 
   gboolean result = (g_tree_lookup(self->tree, value) != NULL);
-  msg_debug("  in-list() evaluation result",
-            filter_result_tag(result),
+  msg_debug("in-list() evaluation started",
             evt_tag_str("value", value),
             evt_tag_printf("msg", "%p", msg));
 

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -63,8 +63,7 @@ filter_netmask_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     res = FALSE;
 
-  msg_debug("  netmask() evaluation result",
-            filter_result_tag(res),
+  msg_debug("netmask() evaluation started",
             evt_tag_inaddr("msg_address", addr),
             evt_tag_inaddr("address", &self->address),
             evt_tag_inaddr("netmask", &self->netmask),

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -128,8 +128,7 @@ _eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     result = FALSE;
 
-  msg_debug("  netmask6() evaluation result",
-            filter_result_tag(result),
+  msg_debug("netmask6() evaluation started",
             evt_tag_inaddr6("msg_address", address),
             evt_tag_inaddr6("address", &self->address),
             evt_tag_int("prefix", self->prefix),

--- a/lib/filter/filter-pri.c
+++ b/lib/filter/filter-pri.c
@@ -49,8 +49,7 @@ filter_facility_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
     {
       res = !!(self->valid & (1 << fac_num));
     }
-  msg_debug("  facility() evaluation result",
-            filter_result_tag(res),
+  msg_debug("facility() evaluation started",
             evt_tag_int("fac", fac_num),
             evt_tag_printf("valid_fac", "%08x", self->valid),
             evt_tag_printf("msg", "%p", msg));
@@ -80,8 +79,7 @@ filter_level_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 
   res = !!((1 << pri) & self->valid);
 
-  msg_debug("  level() evaluation result",
-            filter_result_tag(res),
+  msg_debug("level() evaluation started",
             evt_tag_int("pri", pri),
             evt_tag_printf("valid_pri", "%08x", self->valid),
             evt_tag_printf("msg", "%p", msg));

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -37,8 +37,7 @@ filter_re_eval_string(FilterExprNode *s, LogMessage *msg, gint value_handle, con
   if (str_len < 0)
     str_len = strlen(str);
   result = log_matcher_match(self->matcher, msg, value_handle, str, str_len);
-  msg_debug("  match() evaluation result",
-            filter_result_tag(result),
+  msg_debug("match() evaluation started",
             evt_tag_str("input", str),
             evt_tag_str("pattern", self->matcher->pattern),
             evt_tag_str("value", log_msg_get_value_name(value_handle, NULL)),

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -46,8 +46,7 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       if (log_msg_is_tag_by_id(msg, tag_id))
         {
           res = TRUE;
-          msg_debug("  tags() evaluation result",
-                    filter_result_tag(res),
+          msg_debug("tags() evaluation started",
                     evt_tag_str("tag", log_tags_get_by_id(tag_id)),
                     evt_tag_printf("msg", "%p", msg));
           return res ^ s->comp;
@@ -55,8 +54,7 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
     }
 
   res = FALSE;
-  msg_debug("  tags() evaluation result",
-            filter_result_tag(res),
+  msg_debug("tags() evaluation started",
             evt_tag_printf("msg", "%p", msg));
   return res ^ s->comp;
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1272,6 +1272,7 @@ log_msg_new(const gchar *msg, gint length,
 
   if (G_LIKELY(parse_options->format_handler))
     {
+      msg_debug("Initial message parsing follows");
       parse_options->format_handler->parse(parse_options, (guchar *) msg, length, self);
     }
   else

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -503,7 +503,7 @@ _log_name_value_updates(LogMessage *self)
    * log_msg_new_internal() calling log_msg_set_value(), which in turn
    * generates an internal message, again calling log_msg_set_value()
    */
-  return (!self->initial_parse && (self->flags & LF_INTERNAL) == 0);
+  return (self->flags & LF_INTERNAL) == 0;
 }
 
 void

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -524,9 +524,9 @@ log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *value, gssize 
   if (_log_name_value_updates(self))
     {
       msg_debug("Setting value",
-                evt_tag_printf("msg", "%p", self),
                 evt_tag_str("name", name),
-                evt_tag_printf("value", "%.*s", (gint) value_len, value));
+                evt_tag_printf("value", "%.*s", (gint) value_len, value),
+                evt_tag_printf("msg", "%p", self));
     }
 
   if (value_len < 0)

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1212,6 +1212,10 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
   memcpy(self, msg, sizeof(*msg));
   msg->allocated_bytes = allocated_bytes;
 
+  msg_debug("Message was cloned",
+            evt_tag_printf("original_msg", "%p", msg),
+            evt_tag_printf("new_msg", "%p", self));
+
   /* every field _must_ be initialized explicitly if its direct
    * copying would cause problems (like copying a pointer by value) */
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -332,6 +332,11 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   LogSource *self = (LogSource *) s;
   gint i;
 
+  msg_debug(">>>>>> Source side message processing begin",
+            evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
+            log_pipe_location_tag(s),
+            evt_tag_printf("msg", "%p", msg));
+
   msg_set_context(msg);
 
   if (!self->options->keep_timestamp)
@@ -392,6 +397,10 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       ts.tv_nsec = self->window_full_sleep_nsec;
       nanosleep(&ts, NULL);
     }
+  msg_debug("<<<<<< Source side message processing finish",
+            evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
+            log_pipe_location_tag(s),
+            evt_tag_printf("msg", "%p", msg));
 
 }
 

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -81,24 +81,32 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
 {
   LogParser *self = (LogParser *) s;
   gboolean success;
+  gchar *parser_result;
+
+  msg_debug(">>>>>> parser rule evaluation begin",
+            evt_tag_str("rule", self->name),
+            log_pipe_location_tag(s),
+            evt_tag_printf("msg", "%p", msg));
 
   success = log_parser_process_message(self, &msg, path_options);
+
   if (success)
     {
-      msg_debug("Message parsing successful",
-                evt_tag_str("rule", self->name),
-                log_pipe_location_tag(s));
+      parser_result = "Forwarding message to the next LogPipe";
       log_pipe_forward_msg(s, msg, path_options);
     }
   else
     {
-      msg_debug("Message parsing failed, dropping message",
-                evt_tag_str("rule", self->name),
-                log_pipe_location_tag(s));
+      parser_result = "Dropping message from LogPipe";
       if (path_options->matched)
         (*path_options->matched) = FALSE;
       log_msg_drop(msg, path_options, AT_PROCESSED);
     }
+  msg_debug("<<<<<< parser rule evaluation result",
+            evt_tag_str("result", parser_result),
+            evt_tag_str("rule", self->name),
+            log_pipe_location_tag(s),
+            evt_tag_printf("msg", "%p", msg));
 }
 
 gboolean

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -126,6 +126,9 @@ _process(LogParser *s, LogMessage **pmsg,
 {
   AddContextualData *self = (AddContextualData *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("add-contextual-data message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_printf("msg", "%p", *pmsg));
   gchar *resolved_selector = add_contextual_data_selector_resolve(self->selector, msg);
   const gchar *selector = resolved_selector;
 

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -125,6 +125,10 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
   CSVParser *self = (CSVParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
 
+  msg_debug("csv-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix),
+            evt_tag_printf("msg", "%p", *pmsg));
   CSVScanner scanner;
   csv_scanner_init(&scanner, &self->options, input);
 
@@ -145,13 +149,6 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
   gboolean result = csv_scanner_is_scan_finished(&scanner);
   csv_scanner_deinit(&scanner);
 
-  if (!result)
-    {
-      msg_debug("csv-parser() failed to parse all columns from the message, and drop-invalid flag is specified",
-                evt_tag_str("input", input),
-                log_pipe_location_tag(&s->super),
-                evt_tag_printf("msg", "%p", msg));
-    }
   return result;
 }
 

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -183,6 +183,10 @@ date_parser_process(LogParser *s,
 {
   DateParser *self = (DateParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("date-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("format", self->date_format),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   /* this macro ensures zero termination by copying input to a
    * g_alloca()-d buffer if necessary. In most cases it's not though.
@@ -194,13 +198,6 @@ date_parser_process(LogParser *s,
                                                 &msg->timestamps[self->time_stamp],
                                                 input);
 
-  if (!res)
-    {
-      msg_debug("date-parser() failed to parse its input",
-                evt_tag_str("input", input),
-                log_pipe_location_tag(&s->super),
-                evt_tag_printf("msg", "%p", msg));
-    }
   return res;
 }
 

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -209,7 +209,9 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   if (self->db)
     {
       log_msg_make_writable(pmsg, path_options);
-
+      msg_debug("db-parser message processing started",
+                evt_tag_str ("input", input),
+                evt_tag_printf("msg", "%p", *pmsg));
       if (G_UNLIKELY(self->super.super.template))
         matched = pattern_db_process_with_custom_message(self->db, *pmsg, input, input_len);
       else
@@ -218,10 +220,9 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
 
   if (self->drop_unmatched && !matched)
     {
-      msg_debug("db-parser() failed to parse its input and drop-unmatched flag was specified",
-                evt_tag_str("input", input),
-                log_pipe_location_tag(&s->super),
-                evt_tag_printf("msg", "%p", *pmsg));
+      msg_debug("db-parser failed",
+                evt_tag_str("error", "db-parser() failed to parse its input and drop-unmatched flag was specified"),
+                evt_tag_str("input", input));
     }
   if (!self->drop_unmatched)
     matched = TRUE;

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -126,6 +126,10 @@ geoip_parser_process(LogParser *s, LogMessage **pmsg,
 {
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("geoip-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   if (!self->dest.country_code &&
       !self->dest.latitude &&

--- a/modules/geoip2/geoip-parser.c
+++ b/modules/geoip2/geoip-parser.c
@@ -96,6 +96,10 @@ maxminddb_parser_process(LogParser *s, LogMessage **pmsg,
 {
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("geoip2-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   MMDB_entry_data_list_s *entry_data_list;
   if (!_mmdb_load_entry_data_list(self, input, &entry_data_list))

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -215,10 +215,21 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   struct json_object *jso;
   struct json_tokener *tok;
 
+  msg_debug("json-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix),
+            evt_tag_str ("marker", self->marker),
+            evt_tag_printf("msg", "%p", *pmsg));
   if (self->marker)
     {
       if (strncmp(input, self->marker, self->marker_len) != 0)
-        return FALSE;
+        {
+          msg_debug("json-parser failed",
+                    evt_tag_str ("error", "json marker not found at the beginning of the message"),
+                    evt_tag_str ("input", input),
+                    evt_tag_str ("marker", self->marker));
+          return FALSE;
+        }
       input += self->marker_len;
 
       while (isspace(*input))
@@ -229,9 +240,10 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   jso = json_tokener_parse_ex(tok, input, input_len);
   if (tok->err != json_tokener_success || !jso)
     {
-      msg_debug("Unparsable JSON stream encountered",
+      msg_debug("json-parser failed",
+                evt_tag_str ("error", "Unparsable JSON stream encountered"),
                 evt_tag_str ("input", input),
-                tok->err != json_tokener_success ? evt_tag_str ("error", json_tokener_error_desc(tok->err)) : NULL);
+                tok->err != json_tokener_success ? evt_tag_str ("json_error", json_tokener_error_desc(tok->err)) : NULL);
       json_tokener_free (tok);
       return FALSE;
     }
@@ -240,7 +252,8 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   log_msg_make_writable(pmsg, path_options);
   if (!json_parser_extract(self, jso, *pmsg))
     {
-      msg_error("Error extracting JSON members into LogMessage as the top-level JSON object is not an object",
+      msg_error("json-parser failed",
+                evt_tag_str ("error", "Error extracting JSON members into LogMessage as the top-level JSON object is not an object"),
                 evt_tag_str ("input", input));
       json_object_put(jso);
       return FALSE;

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -110,6 +110,10 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
   GString *formatted_key = scratch_buffers_alloc();
 
   log_msg_make_writable(pmsg, path_options);
+  msg_debug("kv-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix),
+            evt_tag_printf("msg", "%p", *pmsg));
   /* FIXME: input length */
   kv_scanner_input(&kv_scanner, input);
   while (kv_scanner_scan_next(&kv_scanner))

--- a/modules/map-value-pairs/map-value-pairs.c
+++ b/modules/map-value-pairs/map-value-pairs.c
@@ -40,6 +40,9 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
 {
   MapValuePairs *self = (MapValuePairs *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("value-pairs message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   value_pairs_foreach(self->value_pairs, _map_name_values,
                       msg,

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -182,10 +182,10 @@ python_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   {
     LogMessage *msg = log_msg_make_writable(pmsg, path_options);
 
-    msg_debug("Invoking the Python parse() method",
+    msg_debug("python-parser message processing started",
+              evt_tag_str ("input", input),
               evt_tag_str("parser", self->super.name),
               evt_tag_str("class", self->class),
-              log_pipe_location_tag(&self->super.super),
               evt_tag_printf("msg", "%p", msg));
 
     PyObject *msg_object = py_log_message_new(msg);

--- a/modules/snmptrapd-parser/snmptrapd-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser.c
@@ -176,6 +176,10 @@ snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *
   ScratchBuffersMarker marker;
 
   log_msg_make_writable(pmsg, path_options);
+  msg_debug("snmptrapd-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix->str),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   APPEND_ZERO(input, input, input_len);
 
@@ -195,10 +199,20 @@ snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *
   log_msg_set_value(nv_context.msg, LM_V_PROGRAM, "snmptrapd", -1);
 
   if (!snmptrapd_header_parser_parse(&nv_context, &input, &input_len))
-    return FALSE;
+    {
+      msg_debug("snmptrapd-parser failed",
+                evt_tag_str ("error", "cannot parse snmptrapd header"),
+                evt_tag_str ("input", input));
+      return FALSE;
+    };
 
   if (!_parse_varbindlist(&nv_context, &input, &input_len))
-    return FALSE;
+    {
+      msg_debug("snmptrapd-parser failed",
+                evt_tag_str ("error", "can not parse name-value pairs in the input"),
+                evt_tag_str ("input", input));
+      return FALSE;
+    };
 
 
   if (self->set_message_macro)

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -32,6 +32,9 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   LogMessage *msg;
 
   msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("syslog-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   syslog_format_handler(&self->parse_options, (guchar *) input, strlen(input), msg);
   return TRUE;

--- a/modules/tagsparser/tags-parser.c
+++ b/modules/tagsparser/tags-parser.c
@@ -38,6 +38,9 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
          gsize input_len)
 {
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("tags-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   ListScanner scanner;
   list_scanner_init(&scanner);

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -210,6 +210,10 @@ xml_parser_process(LogParser *s, LogMessage **pmsg,
 {
   XMLParser *self = (XMLParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
+  msg_debug("xml-parser message processing started",
+            evt_tag_str ("input", input),
+            evt_tag_str ("prefix", self->prefix),
+            evt_tag_printf("msg", "%p", *pmsg));
 
   GString *key = scratch_buffers_alloc();
   key = g_string_append(key, self->prefix);
@@ -230,8 +234,9 @@ xml_parser_process(LogParser *s, LogMessage **pmsg,
   return TRUE;
 
 err:
-  msg_error("xml: error",
-            evt_tag_str("str", error->message));
+  msg_error("xml-parser failed",
+            evt_tag_str("error", error->message),
+            evt_tag_int("forward_invalid", self->forward_invalid));
   g_error_free(error);
   g_markup_parse_context_free(xml_ctx);
   return self->forward_invalid;


### PR DESCRIPTION
Adding improved debug log for parsers, rewrite rules and logsources.

**Motivation came from**: 
 * after adding new config elements like: default-network-drivers, ewmm, app-parser..., syslog-ng's debug log became hard readable
 * improved debug logs of filters 9e3415b4e49b1addc8fac6eccd9f9c814e395e3d

**Conception**:
 1. Log debug message at the beginning and at the end of queuing methods, like: 
    * log_source_queue(), 
    * log_parser_queue(), 
    * log_rewrite_queue()
 * Debug message should contains:
    * name of the relevant logpipe element
    * rule name
    * location
    * msg pointer
    * result of filter_expr_eval_root() or log_parser_process_message() -> only at the end of queuing methods
 * Example:
```
>>>>>> parser rule evaluation begin; rule='#anon-parser0', location='parser generator app-parser:5:15', msg='0x7fc2f4013e00'
...
<<<<<< parser rule evaluation result; result='UNMATCHED', rule='#anon-parser0', location='parser generator app-parser:5:15', msg='0x7fc2f4013e00'
```


 2. Log a debug message from parsers at the beginning and on failures
 * Example
```
json-parser started message processing; input='AAAAAA', prefix='.cim.', marker='@cim:', msg='0x7fc2f4013e00'
json-parser failed; error='marker not found', input='AAAAAA', marker='@cim:'
```

 3. Log a debug message when a message macro will get a value during:
     * log_msg_parse_legacy()
     * log_msg_parse_syslog_proto()
     * syslog_format_handler()

 * Example:
```
Initial message parsing;
Setting macros on BSD syslog message;
Setting value; macro='.unix.pid', value='3763', msg='0x7ff6c0013e00'
Setting value; macro='.unix.uid', value='1000', msg='0x7ff6c0013e00'
Setting value; macro='.unix.gid', value='1000', msg='0x7ff6c0013e00'
```
