### PR TITLE
cfg-parser: Report memory exhaustion errors during config parsing

### DIFF
--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -350,7 +350,7 @@ extern int cfg_parser_debug;
 gboolean
 cfg_parser_parse(CfgParser *self, CfgLexer *lexer, gpointer *instance, gpointer arg)
 {
-  int parse_result;
+  enum { OK, ERROR, MEMORY_EXHAUSTED } parse_result;
   gboolean success;
 
   if (cfg_parser_debug)
@@ -361,13 +361,13 @@ cfg_parser_parse(CfgParser *self, CfgLexer *lexer, gpointer *instance, gpointer 
     (*self->debug_flag) = cfg_parser_debug;
   cfg_lexer_push_context(lexer, self->context, self->keywords, self->name);
   parse_result = self->parse(lexer, instance, arg);
-  success = (parse_result == 0);
+  success = (parse_result == OK);
   cfg_lexer_pop_context(lexer);
   if (cfg_parser_debug)
     {
       fprintf(stderr, "\nStopping parser %s, result: %d\n", self->name, parse_result);
     }
-  if (parse_result == 2)
+  if (parse_result == MEMORY_EXHAUSTED)
     {
       fprintf(stderr,
               "\nToo many tokens found during parsing, consider increasing YYMAXDEPTH in lib/cfg-grammar.y and recompiling.\n");

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -350,6 +350,7 @@ extern int cfg_parser_debug;
 gboolean
 cfg_parser_parse(CfgParser *self, CfgLexer *lexer, gpointer *instance, gpointer arg)
 {
+  int parse_result;
   gboolean success;
 
   if (cfg_parser_debug)
@@ -359,11 +360,17 @@ cfg_parser_parse(CfgParser *self, CfgLexer *lexer, gpointer *instance, gpointer 
   if (self->debug_flag)
     (*self->debug_flag) = cfg_parser_debug;
   cfg_lexer_push_context(lexer, self->context, self->keywords, self->name);
-  success = (self->parse(lexer, instance, arg) == 0);
+  parse_result = self->parse(lexer, instance, arg);
+  success = (parse_result == 0);
   cfg_lexer_pop_context(lexer);
   if (cfg_parser_debug)
     {
-      fprintf(stderr, "\nStopping parser %s, result: %d\n", self->name, success);
+      fprintf(stderr, "\nStopping parser %s, result: %d\n", self->name, parse_result);
+    }
+  if (parse_result == 2)
+    {
+      fprintf(stderr,
+              "\nToo many tokens found during parsing, consider increasing YYMAXDEPTH in lib/cfg-grammar.y and recompiling.\n");
     }
   return success;
 }


### PR DESCRIPTION
Instead of simply failing the configuration parse process when the parser encounters a memory exhaustion, report the fact more properly. To do this, we store the result of `self->parse`, so that we can check for the OOM state too. If we are in that state, report the error with a suggestion. We still narrow the return value of `cfg_parser_parse` to a boolean, with the OOM case obviously being a failure case.

Fixes #2030.
