### PR TITLE
Dbld: Add fixes to functions.sh

### DIFF
--- a/dbld/images/helpers/functions.sh
+++ b/dbld/images/helpers/functions.sh
@@ -47,12 +47,12 @@ function enable_dbgsyms {
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
     tee -a /etc/apt/sources.list.d/ddebs.list
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 428D7C01 C8CAB6595FDFF622
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 428D7C01 C8CAB6595FDFF622
     apt-get update
 }
 
 function install_perf {
-    apt-get install --no-install-recommends -y linux-tools-$(uname -r)
+    apt-cache search linux-tools | grep 'linux-tools-.*-generic' | cut -d" " -f1 | tail -n1 | cut -d"-" -f1-4 | xargs apt-get install --no-install-recommends -y
 }
 
 # DO NOT REMOVE!


### PR DESCRIPTION
 - enable_dbgsyms(): fix keyserver.ubuntu.com URI, without this change fetching can be stuck
 - install_perf(): install OS native version of linux-tools instead of hosts OS version

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>