### PR TITLE
Fix lloc tracking for multi line blockrefs

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -543,7 +543,7 @@ rewrite_stmt
 
 log_stmt
         : KW_LOG
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_LOG, NULL, "log"); }
+          { cfg_lexer_push_context(lexer, LL_CONTEXT_LOG, NULL, "log statement"); }
           '{' log_content '}'
           { cfg_lexer_pop_context(lexer); }
           {
@@ -574,7 +574,7 @@ plugin_stmt
 
 source_content
         :
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_SOURCE, NULL, "source"); }
+          { cfg_lexer_push_context(lexer, LL_CONTEXT_SOURCE, NULL, "source statement"); }
           source_items
           { cfg_lexer_pop_context(lexer); }
           {
@@ -665,7 +665,7 @@ rewrite_content
         ;
 
 dest_content
-         : { cfg_lexer_push_context(lexer, LL_CONTEXT_DESTINATION, NULL, "destination"); }
+         : { cfg_lexer_push_context(lexer, LL_CONTEXT_DESTINATION, NULL, "destination statement"); }
             dest_items
            { cfg_lexer_pop_context(lexer); }
            {

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -132,10 +132,16 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size)
 static void
 _cfg_lex_new_line(CfgLexer *lexer)
 {
-  lexer->include_stack[lexer->include_depth].lloc.first_line++;
-  lexer->include_stack[lexer->include_depth].lloc.last_line++;
-  lexer->include_stack[lexer->include_depth].lloc.first_column = 1;
-  lexer->include_stack[lexer->include_depth].lloc.last_column = 1;
+  CfgIncludeLevel *level = &lexer->include_stack[lexer->include_depth];
+
+  /* if the last token span multiple lines (e.g.  block references), it
+   * might happen that last_line != first_line, in that case, initialize the
+   * first_line of the token to the subsequent line after last_line */
+
+  level->lloc.first_line = level->lloc.last_line + 1;
+  level->lloc.last_line = level->lloc.first_line;
+  level->lloc.first_column = 1;
+  level->lloc.last_column = 1;
 }
 
 %}

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -961,6 +961,8 @@ relex:
         }
       else
         {
+          level->lloc.first_line = saved_line;
+          level->lloc.first_column = saved_column;
           free(yylval->cptr);
           self->preprocess_suppress_tokens--;
         }

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -310,7 +310,7 @@ exit:
 }
 
 void
-report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const char *msg)
+report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const char *msg, gboolean in_main_grammar)
 {
   CfgIncludeLevel *level = yylloc->level, *from;
 
@@ -338,8 +338,9 @@ report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const ch
       fprintf(stderr, "\n");
     }
 
-  fprintf(stderr, "\nsyslog-ng documentation: https://www.balabit.com/support/documentation?product=%s\n"
-          "contact: %s\n", PRODUCT_NAME, PRODUCT_CONTACT);
+  if (in_main_grammar)
+    fprintf(stderr, "\nsyslog-ng documentation: https://www.balabit.com/support/documentation?product=%s\n"
+            "contact: %s\n", PRODUCT_NAME, PRODUCT_CONTACT);
 
 }
 

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -91,11 +91,14 @@ extern CfgParser main_parser;
                                                                               \
     void                                                                      \
     parser_prefix ## error(YYLTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg) \
-    {                                                                                             \
-      report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg);          \
+    {                                                                 \
+      gboolean in_main_grammar = __builtin_strcmp( # parser_prefix, "main_") == 0;              \
+      report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg,   \
+                          in_main_grammar);                                                     \
     }
 
-void report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const char *msg);
+void report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const char *msg,
+                         gboolean in_main_grammar);
 
 CFG_PARSER_DECLARE_LEXER_BINDING(main_, gpointer *)
 


### PR DESCRIPTION
The issue I noticed while finishing up a previous PR was that line tracking got broken by 2e196c393e. While fixing the problem I've also improved error logging a bit more, which I've piggybacked to the same branch.

    cfg-lex.l: fix location tracking for multi-line block-refs
    
    For tokens that span multiple lines (in our case this only happens when
    a block-ref is parsed that spans multiple lines), we blew up the line
    number counter, so whenever reporting locations or errors we got an
    incorrect value.
    
    This patch fixes that by shifting to the new line number relative to
    last_line, instead of simply increasing the first_line.
    
    Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>
