### PR TITLE
autotools: fixing emitted warnings due to -no-pie detection for gcc 4.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -446,10 +446,17 @@ fi
 dnl ***************************************************************************
 dnl Set up NO_PIE_LDFLAG: -no-pie is compatible with $CC.
 
+AX_COMPILER_VENDOR
+AX_COMPILER_VERSION
+
 if test $ostype = "Darwin"; then
   no_pie_ldflags="-Wl,-no_pie"
 else
-  no_pie_ldflags="-no-pie"
+  if test x$ax_cv_c_compiler_vendor = "xgnu"; then
+    AX_COMPARE_VERSION($ax_cv_c_compiler_version, gt, [4.5], [no_pie_ldflags="-no-pie"], [no_pie_ldflags=""])
+  else
+    no_pie_ldflags="-no-pie"
+  fi;
 fi
 
 old_LDFLAGS="$LDFLAGS"

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -216,17 +216,6 @@ struct _LogPipe
   GAtomicCounter ref_cnt;
   gint32 flags;
 
-  /* moving queue to the front should improve performance somewhat, although
-   * I didn't measure it at all.  Rationale: the pointer pointing to this
-   * LogPipe instance is resolved right before calling queue and the
-   * colocation of flags and the queue pointer ensures that they are on the
-   * same cache line, and since the CPU returns memory reads sequentially,
-   * it is among the first values that are read ahead.  It might need to be
-   * measured sometime, but this method is probably the single most often
-   * called virual method, so I felt, that even though the optimization is
-   * probably premature without explicit tests, I can do this simply by
-   * believing it helps :) */
-
   void (*queue)(LogPipe *self, LogMessage *msg, const LogPathOptions *path_options);
 
   GlobalConfig *cfg;
@@ -252,6 +241,16 @@ struct _LogPipe
   void (*free_fn)(LogPipe *self);
   void (*notify)(LogPipe *self, gint notify_code, gpointer user_data);
 };
+
+/*
+   cpu-cache optimization: queue method should be as close as possible to flags.
+
+   Rationale: the pointer pointing to this LogPipe instance is
+   resolved right before calling queue and the colocation of flags and
+   the queue pointer ensures that they are on the same cache line. The
+   queue method is probably the single most often called virtual method
+ */
+G_STATIC_ASSERT(G_STRUCT_OFFSET(LogPipe, queue) - G_STRUCT_OFFSET(LogPipe, flags) <= 4);
 
 extern gboolean (*pipe_single_step_hook)(LogPipe *pipe, LogMessage *msg, const LogPathOptions *path_options);
 

--- a/modules/geoip2/maxminddb-helper.c
+++ b/modules/geoip2/maxminddb-helper.c
@@ -70,7 +70,7 @@ append_mmdb_entry_data_to_gstring(GString *target, MMDB_entry_data_s *entry_data
       g_string_append_printf(target, "%d", entry_data->int32);
       break;
     case MMDB_DATA_TYPE_UINT64:
-      g_string_append_printf(target, "%lu", entry_data->uint64);
+      g_string_append_printf(target, "%"G_GUINT64_FORMAT, entry_data->uint64);
       break;
     case MMDB_DATA_TYPE_BOOLEAN:
       g_string_append_printf(target, "%s", entry_data->boolean ? "true" : "false");


### PR DESCRIPTION
This patchset contains the following changes:
- fixing no-pie detection for gcc 4.4. With version 4.4, gcc cannot be configured to fail on unknown cli parameters. As a result, `-no-pie gcc: error: unrecognized command line option '-no_pie'` is emitted during the build. This did not cause any problem, just an unnecessary warning is emitted.
- Adding an assert for the exciting cpu-cache optimization introduced in  9fc86dfc6de3ad66862218522b2588d4553c70de.
- using glib macro in format string to write uint64 number.