### PR TITLE
packaging/debian: Add libhook-commands.so to syslog-ng-core.install

### DIFF
--- a/packaging/debian/syslog-ng-core.install
+++ b/packaging/debian/syslog-ng-core.install
@@ -16,6 +16,7 @@ usr/lib/syslog-ng/*/libconfgen.so
 usr/lib/syslog-ng/*/libcryptofuncs.so
 usr/lib/syslog-ng/*/libcsvparser.so
 usr/lib/syslog-ng/*/libdbparser.so
+usr/lib/syslog-ng/*/libhook-commands.so
 usr/lib/syslog-ng/*/libkvformat.so
 usr/lib/syslog-ng/*/libtags-parser.so
 usr/lib/syslog-ng/*/liblinux-kmsg-format.so


### PR DESCRIPTION
Fixes #2040.