### PR TITLE
syslog-ng-ctl: fix shifting of the raw_query_params

### DIFF
--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -298,12 +298,11 @@ _is_query_params_empty(void)
   return raw_query_params == NULL;
 }
 
-static gchar *
+static void
 _shift_query_command_out_of_params(void)
 {
   if (raw_query_params[QUERY_COMMAND] != NULL)
-    return *(raw_query_params++);
-  return *raw_query_params;
+    ++raw_query_params;
 }
 
 static gboolean
@@ -348,7 +347,7 @@ _get_dispatchable_query_command(void)
   if (query_cmd < 0)
     return NULL;
 
-  *raw_query_params = _shift_query_command_out_of_params();
+  _shift_query_command_out_of_params();
   if(_validate_get_params(query_cmd))
     return NULL;
 


### PR DESCRIPTION
On ubuntu 18.04 the `syslog-ng-ctl query` command does not work because the command send the wrong data over the control file. The global `raw_query_params` "duplicates" the first parameter.

[Edit] As it turned out it was not related to the distribution, see my comment below. 