### PR TITLE
[WIP] Fix window leak in log_source_flow_control_suspend()

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -32,6 +32,8 @@ typedef struct
   gint counter;
 } GAtomicCounter;
 
+typedef GAtomicCounter GAtomicBool;
+
 static inline void
 g_atomic_counter_inc(GAtomicCounter *c)
 {
@@ -70,6 +72,19 @@ static inline void
 g_atomic_counter_set(GAtomicCounter *c, gint value)
 {
   g_atomic_int_set(&c->counter, value);
+}
+
+
+static inline gboolean
+g_atomic_bool_get(GAtomicBool *b)
+{
+  return !!g_atomic_counter_get(b);
+}
+
+static inline void
+g_atomic_bool_set(GAtomicBool *b, gboolean value)
+{
+  g_atomic_counter_set(b, !!value);
 }
 
 #endif

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -25,6 +25,7 @@
 #ifndef ATOMIC_H_INCLUDED
 #define ATOMIC_H_INCLUDED
 
+#include "compat/glib.h"
 
 typedef struct
 {
@@ -68,13 +69,7 @@ g_atomic_counter_racy_get(GAtomicCounter *c)
 static inline void
 g_atomic_counter_set(GAtomicCounter *c, gint value)
 {
-  /* FIXME: we should use g_atomic_int_set, but that's available starting
-   * with GLib 2.10 only, and we only use this function for initialization,
-   * thus atomic write is not strictly needed as there's no concurrency
-   * while initializing a refcounter.
-   */
-
-  c->counter = value;
+  g_atomic_int_set(&c->counter, value);
 }
 
 #endif

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -62,7 +62,10 @@ early_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_typ
   EarlyAckTracker *self = (EarlyAckTracker *)s;
 
   if (ack_type == AT_SUSPENDED)
-    log_source_flow_control_suspend(self->super.source);
+    {
+      log_source_flow_control_adjust(self->super.source, 1);
+      log_source_flow_control_suspend(self->super.source);
+    }
   else
     log_source_flow_control_adjust(self->super.source, 1);
 

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -141,7 +141,10 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
         _drop_range(self, ack_range_length);
 
         if (ack_type == AT_SUSPENDED)
-          log_source_flow_control_suspend(self->super.source);
+          {
+            log_source_flow_control_adjust(self->super.source, 1);
+            log_source_flow_control_suspend(self->super.source);
+          }
         else
           log_source_flow_control_adjust(self->super.source, ack_range_length);
       }

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -67,7 +67,7 @@ struct _LogSource
   gchar *stats_id;
   gchar *stats_instance;
   GAtomicCounter window_size;
-  GAtomicCounter suspended_window_size;
+  GAtomicBool forced_suspend;
   StatsCounterItem *last_message_seen;
   StatsCounterItem *recvd_messages;
   guint32 last_ack_count;
@@ -83,7 +83,8 @@ struct _LogSource
 static inline gboolean
 log_source_free_to_send(LogSource *self)
 {
-  return g_atomic_counter_get(&self->window_size) > 0;
+  return !g_atomic_bool_get(&self->forced_suspend)
+         && g_atomic_counter_get(&self->window_size) > 0;
 }
 
 static inline gint


### PR DESCRIPTION
This PR contains 3 fixes that prevents a source getting stuck/leaking the window.

- `g_atomic_counter_set()` was not atomic. I would have called it `g_atomic_counter_init_racy`.
- `AckTracker` did not increase the window size by 1 in case of an `AT_SUSPENDED` ack type.
- `log_source_flow_control_suspend()` was not "atomic enough":

```C
void
log_source_flow_control_suspend(LogSource *self)
{
  msg_debug("Source has been suspended", log_pipe_location_tag(&self->super));

  g_atomic_counter_set(&self->suspended_window_size, /* ! */ g_atomic_counter_get(&self->window_size));
  /* !!! A context switch here and an incrementation of window_size from a different thread
   * make it possible to lose acknowledged "values" from the window
   */
  g_atomic_counter_set(&self->window_size, 0);
  _flow_control_rate_adjust(self);
}
```

Between setting `suspended_window_size` and setting the original window size to 0, it is possible that `window_size` is incremented by another message consumer in a different thread.

This window leak is permanent, it can not be reversed without reloading syslog-ng. Since the problem can occur multiple times in a multithreaded environment, the source may also get stuck.

-------------

Questions:
- **In late-ack-tracker, should I adjust the window size by 1 or `ack_range_length`?**