### PR TITLE
Add debug message to program source/destination about successful start

### DIFF
--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -162,6 +162,9 @@ afprogram_popen(AFProgramProcessInfo *process_info, GIOCondition cond, gint *fd)
       *fd = msg_pipe[1];
       close(msg_pipe[0]);
     }
+  msg_verbose(cond == G_IO_IN ? "Program source started" : "Program destination started",
+              evt_tag_str("cmdline", process_info->cmdline->str),
+              evt_tag_int("fd", *fd));
   return TRUE;
 }
 


### PR DESCRIPTION
We don't have a debug message about a successful program source/destination start with the **fd** in it.  
That could be used later for identifying the driver when we see errors in the internal logs which only refer to fd-s.

This would be similar to what we currently have in the network based sources/destinations, e.g.
`Syslog connection accepted;` messages.