### PR TITLE
secret-storage: add safer mem_zero()

### DIFF
--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -182,6 +182,8 @@ process_credentials_add(GString *result, guint argc, gchar **arguments)
     g_string_assign(result,"Credentials stored successfully\n");
   else
     g_string_assign(result,"Error while saving credentials\n");
+
+  secret_storage_wipe(secret, strlen(secret));
   return result;
 }
 

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -24,6 +24,7 @@
 #include "control-server.h"
 #include "messages.h"
 #include "str-utils.h"
+#include "secret-storage/secret-storage.h"
 
 #include <string.h>
 #include <errno.h>
@@ -144,6 +145,7 @@ control_connection_io_input(void *s)
       command = g_string_sized_new(128);
       /* command doesn't contain NL */
       g_string_assign_len(command, self->input_buffer->str, nl - self->input_buffer->str);
+      secret_storage_wipe(self->input_buffer->str, nl - self->input_buffer->str);
       /* strip NL */
       /*g_string_erase(self->input_buffer, 0, command->len + 1);*/
       g_string_truncate(self->input_buffer, 0);
@@ -170,6 +172,7 @@ control_connection_io_input(void *s)
   control_connection_send_reply(self, reply);
 
   control_connection_update_watches(self);
+  secret_storage_wipe(command->str, command->len);
   g_string_free(command, TRUE);
   return;
 destroy_connection:

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -117,10 +117,19 @@ nondumpable_buffer_alloc(gsize len)
 }
 
 void
+nondumpable_mem_zero(gpointer s, gsize len)
+{
+  volatile guchar *p = s;
+
+  for (gsize i = 0; i < len; ++i)
+    p[i] = 0;
+}
+
+void
 nondumpable_buffer_free(gpointer buffer)
 {
   Allocation *allocation = BUFFER_TO_ALLOCATION(buffer);
-  memset(allocation->user_data, 0, allocation->data_len);
+  nondumpable_mem_zero(allocation->user_data, allocation->data_len);
   munmap(allocation, allocation->alloc_size);
 }
 

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -155,7 +155,7 @@ nondumpable_memcpy(gpointer dest, gpointer src, gsize len)
 {
   gchar *_dest = dest;
   gchar *_src = src;
-  for (int i = 0; i < len; i++)
+  for (gsize i = 0; i < len; i++)
     {
       _dest[i] = _src[i];
     }

--- a/lib/secret-storage/nondumpable-allocator.h
+++ b/lib/secret-storage/nondumpable-allocator.h
@@ -33,6 +33,7 @@ gpointer nondumpable_buffer_alloc(gsize len) PUBLIC;
 void nondumpable_buffer_free(gpointer buffer) PUBLIC;
 gpointer nondumpable_buffer_realloc(gpointer buffer, gsize len) PUBLIC;
 gpointer nondumpable_memcpy(gpointer dest, gpointer src, gsize len) PUBLIC;
+void nondumpable_mem_zero(gpointer s, gsize len) PUBLIC;
 void nondumpable_setlogger(void(*logger)(gchar *summary, gchar *reason)) PUBLIC;
 
 #endif

--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -93,7 +93,7 @@ write_secret(SecretStorage *storage, gchar *secret, gsize len)
 static SecretStorage *
 overwrite_secret(SecretStorage *storage, gchar *secret, gsize len)
 {
-  memset(storage->secret.data, 0, storage->secret.len);
+  nondumpable_mem_zero(storage->secret.data, storage->secret.len);
   write_secret(storage, secret, len);
   return storage;
 }
@@ -174,6 +174,12 @@ secret_storage_store_secret(const gchar *key, gchar *secret, gsize len)
   run_callbacks_initiate(key, secret_storage->subscriptions);
 
   return TRUE;
+}
+
+void
+secret_storage_wipe(gpointer s, gsize len)
+{
+  nondumpable_mem_zero(s, len);
 }
 
 gboolean

--- a/lib/secret-storage/secret-storage.h
+++ b/lib/secret-storage/secret-storage.h
@@ -42,6 +42,7 @@ void secret_storage_deinit(void) PUBLIC;
 
 gboolean secret_storage_store_string(const gchar *key, gchar *secret) PUBLIC;
 gboolean secret_storage_store_secret(const gchar *key, gchar *secret, gsize len) PUBLIC;
+void secret_storage_wipe(gpointer s, gsize len) PUBLIC;
 
 void secret_storage_with_secret(const gchar *key, SecretStorageCB func, gpointer user_data) PUBLIC;
 Secret *secret_storage_get_secret_by_name(const gchar *key) PUBLIC;

--- a/lib/secret-storage/tests/test_nondumpable_allocator.c
+++ b/lib/secret-storage/tests/test_nondumpable_allocator.c
@@ -22,6 +22,7 @@
  */
 
 #include <unistd.h>
+#include <string.h>
 #include <criterion/criterion.h>
 
 #include "secret-storage/nondumpable-allocator.h"
@@ -39,6 +40,25 @@ Test(nondumpableallocator, malloc_realloc_free)
   ((gchar *)buffer_realloc)[2*PAGESIZE] = 'a';
 
   nondumpable_buffer_free(buffer_realloc);
+}
+
+Test(nondumpableallocator, malloc_mem_zero)
+{
+  const gsize buffer_len = 256;
+  const guchar dummy_value = 0x44;
+
+  guchar *buffer = nondumpable_buffer_alloc(buffer_len);
+  memset(buffer, dummy_value, buffer_len);
+
+  for (gsize i = 0; i < buffer_len; ++i)
+    cr_assert_eq(buffer[i], dummy_value);
+
+  nondumpable_mem_zero(buffer, buffer_len);
+
+  for (gsize i = 0; i < buffer_len; ++i)
+    cr_assert_eq(buffer[i], 0);
+
+  nondumpable_buffer_free(buffer);
 }
 
 Test(nondumpableallocator, two_malloc)

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -307,3 +307,17 @@ Test(secretstorage, test_state_update)
   secret_storage_store_string("key", "wrong_password");
   secret_storage_status_foreach(assert_invalid_password_state, NULL);
 }
+
+Test(secretstorage, simple_store_get_and_wipe)
+{
+  secret_storage_store_secret("key1", "value1", -1);
+  Secret *secret = secret_storage_get_secret_by_name("key1");
+  cr_assert_str_eq(secret->data, "value1");
+
+  secret_storage_wipe(secret->data, secret->len);
+
+  for (gsize i = 0; i < secret->len; ++i)
+    cr_assert_eq(secret->data[i], 0);
+
+  secret_storage_put_secret(secret);
+}

--- a/syslog-ng-ctl/CMakeLists.txt
+++ b/syslog-ng-ctl/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SYSLOG_NG_CTL_SOURCES
 add_executable(syslog-ng-ctl ${SYSLOG_NG_CTL_SOURCES})
 target_link_libraries(syslog-ng-ctl PRIVATE
     syslog-ng
+    secret-storage
     ${GLIB_LIBRARIES}
     ${RESOLV_LIBS})
 target_include_directories(syslog-ng-ctl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -12,5 +12,7 @@ EXTRA_DIST					+=	\
 
 syslog_ng_ctl_syslog_ng_ctl_LDADD		= \
 	$(MODULE_DEPS_LIBS) \
-	$(TOOL_DEPS_LIBS)
-syslog_ng_ctl_syslog_ng_ctl_DEPENDENCIES	= lib/libsyslog-ng.la
+	$(TOOL_DEPS_LIBS) \
+	$(top_builddir)/lib/secret-storage/libsecret-storage.la
+
+syslog_ng_ctl_syslog_ng_ctl_DEPENDENCIES	= lib/libsyslog-ng.la lib/secret-storage/libsecret-storage.la

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -27,6 +27,7 @@
 #include "control-client.h"
 #include "cfg.h"
 #include "reloc.h"
+#include "secret-storage/secret-storage.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -111,7 +112,7 @@ _dispatch_command(const gchar *cmd)
 
   clear_and_free(rsp);
 
-  memset(dispatchable_command, 0, strlen(dispatchable_command));
+  secret_storage_wipe(dispatchable_command, strlen(dispatchable_command));
   g_free(dispatchable_command);
 
   return retval;
@@ -473,15 +474,15 @@ slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
   if (retval == -1)
     g_assert_not_reached();
 
-  memset(secret_to_store, 0, strlen(secret_to_store));
+  secret_storage_wipe(secret_to_store, strlen(secret_to_store));
   g_free(secret_to_store);
 
   if (credentials_secret)
-    memset(credentials_secret, 0, strlen(credentials_secret));
+    secret_storage_wipe(credentials_secret, strlen(credentials_secret));
 
   gint result = _dispatch_command(answer);
 
-  memset(answer, 0, strlen(answer));
+  secret_storage_wipe(answer, strlen(answer));
   g_free(answer);
 
   return result;


### PR DESCRIPTION
A simple `memset()` call can be optimized away. To prevent the optimization, `nondumpable_mem_zero()` has been added.

~It uses `explicit_bzero()` where available and falls back to a volatile memset function pointer (which is not guaranteed to be called, but it is better than calling `memset()` directly).~

Since secret-storage is not used on fast paths, I replaced the original implementation with a simple iteration on a pointer to a volatile char.