### PR TITLE
requirements.txt: drop explicit version numbers

### DIFF
--- a/dbld/images/required-pip/all.txt
+++ b/dbld/images/required-pip/all.txt
@@ -1,6 +1,6 @@
-nose==1.3.7
-ply==3.10
-pep8==1.7.1
-pylint==1.8.2
-astroid==1.6.1
-logilab-common<=0.63.0
+nose
+ply
+pep8
+pylint
+astroid
+logilab-common


### PR DESCRIPTION
We are only using requirements.txt to bootstrap the development environment,
and that file is not really used in production. It is better to rely on
the latest and greatest so we actually follow pep8/pylint etc changes as
they happen.

If we get too many issues with that, we might pin some of the version
numbers in te future, but so far the experience has been that we simply
forget to bump versions and stick to very old versions instead.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>