### PR TITLE
afsql: added ignore_tns_config sql config option

### DIFF
--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -64,6 +64,7 @@
 %token KW_CREATE_STATEMENT_APPEND
 %token KW_COLUMNS
 %token KW_NULL
+%token KW_IGNORE_TNS_CONFIG
 
 %type   <ptr> dest_afsql
 %type   <ptr> dest_afsql_params
@@ -113,6 +114,7 @@ dest_afsql_option
         | KW_COLUMNS '(' string_list ')'	{ afsql_dd_set_columns(last_driver, $3); }
         | KW_INDEXES '(' string_list ')'        { afsql_dd_set_indexes(last_driver, $3); }
         | KW_VALUES '(' dest_afsql_values ')'		{ afsql_dd_set_values(last_driver, $3); }
+        | KW_IGNORE_TNS_CONFIG '(' yesno ')'    { afsql_dd_set_ignore_tns_config(last_driver,$3); }
         | KW_NULL '(' string ')'                { afsql_dd_set_null_value(last_driver, $3); free($3); }
         | KW_RETRIES '(' nonnegative_integer ')'          { afsql_dd_set_retries(last_driver, $3); }
         | KW_FLUSH_LINES '(' nonnegative_integer ')'      { afsql_dd_set_flush_lines(last_driver, $3); }

--- a/modules/afsql/afsql-parser.c
+++ b/modules/afsql/afsql-parser.c
@@ -54,6 +54,7 @@ static CfgLexerKeyword afsql_keywords[] =
   { "flush_timeout",      KW_FLUSH_TIMEOUT },
   { "flags",              KW_FLAGS },
   { "create_statement_append", KW_CREATE_STATEMENT_APPEND },
+  { "ignore_tns_config",  KW_IGNORE_TNS_CONFIG },
 
   { "dbd_option",         KW_DBD_OPTION },
   { NULL }

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -92,6 +92,7 @@ typedef struct _AFSqlDestDriver
   gint flush_timeout;
   gint flush_lines_queued;
   gint flags;
+  gboolean ignore_tns_config;
   GList *session_statements;
 
   LogTemplateOptions template_options;
@@ -143,5 +144,6 @@ gint afsql_dd_lookup_flag(const gchar *flag);
 void afsql_dd_set_retries(LogDriver *s, gint num_retries);
 void afsql_dd_add_dbd_option(LogDriver *s, const gchar *name, const gchar *value);
 void afsql_dd_add_dbd_option_numeric(LogDriver *s, const gchar *name, gint value);
+void afsql_dd_set_ignore_tns_config(LogDriver *s, const gboolean ignore_tns_config);
 
 #endif


### PR DESCRIPTION
 * If ignore_tns_config is "yes" then oracle sql destination does not use
   tnsnames.ora config file.
 * Default value of ignore_tns_config is "no".
   Destination driver uses tnsnames.ora

The motivation behind this patch is to be able to use Oracle destination without supplying tnsnames.ora config file.