### PR TITLE
logreader+logwriter: timeout support

### DIFF
--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -540,7 +540,7 @@ error:
 }
 
 gboolean
-log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond)
+log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED)
 {
   LogProtoBufferedServer *self = (LogProtoBufferedServer *) s;
 

--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -101,7 +101,7 @@ log_proto_buffered_server_is_input_closed(LogProtoBufferedServer *self)
   return self->io_status != G_IO_STATUS_NORMAL;
 }
 
-gboolean log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond);
+gboolean log_proto_buffered_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED);
 LogProtoBufferedServerState *log_proto_buffered_server_get_state(LogProtoBufferedServer *self);
 void log_proto_buffered_server_put_state(LogProtoBufferedServer *self);
 

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -62,7 +62,7 @@ struct _LogProtoClient
   const LogProtoClientOptions *options;
   LogTransport *transport;
   /* FIXME: rename to something else */
-  gboolean (*prepare)(LogProtoClient *s, gint *fd, GIOCondition *cond);
+  gboolean (*prepare)(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout);
   LogProtoStatus (*post)(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed);
   LogProtoStatus (*flush)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
@@ -120,9 +120,9 @@ log_proto_client_handshake(LogProtoClient *s)
 }
 
 static inline gboolean
-log_proto_client_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond)
+log_proto_client_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout)
 {
-  return s->prepare(s, fd, cond);
+  return s->prepare(s, fd, cond, timeout);
 }
 
 static inline LogProtoStatus

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -45,7 +45,7 @@ typedef struct _LogProtoFramedServer
 } LogProtoFramedServer;
 
 static gboolean
-log_proto_framed_server_prepare(LogProtoServer *s, GIOCondition *cond)
+log_proto_framed_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED)
 {
   LogProtoFramedServer *self = (LogProtoFramedServer *) s;
 

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -66,7 +66,7 @@ struct _LogProtoServer
   LogTransport *transport;
   /* FIXME: rename to something else */
   gboolean (*is_position_tracked)(LogProtoServer *s);
-  gboolean (*prepare)(LogProtoServer *s, GIOCondition *cond);
+  gboolean (*prepare)(LogProtoServer *s, GIOCondition *cond, gint *timeout);
   gboolean (*restart_with_state)(LogProtoServer *s, PersistState *state, const gchar *persist_name);
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
                           LogTransportAuxData *aux, Bookmark *bookmark);
@@ -109,9 +109,9 @@ log_proto_server_set_options(LogProtoServer *self, const LogProtoServerOptions *
 }
 
 static inline gboolean
-log_proto_server_prepare(LogProtoServer *s, GIOCondition *cond)
+log_proto_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout)
 {
-  return s->prepare(s, cond);
+  return s->prepare(s, cond, timeout);
 }
 
 static inline gboolean

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -27,7 +27,7 @@
 #include <errno.h>
 
 static gboolean
-log_proto_text_client_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond)
+log_proto_text_client_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
 

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -84,12 +84,12 @@ log_proto_get_char_size_for_fixed_encoding(const gchar *encoding)
 
 
 static gboolean
-log_proto_text_server_prepare(LogProtoServer *s, GIOCondition *cond)
+log_proto_text_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout)
 {
   LogProtoTextServer *self = (LogProtoTextServer *) s;
   gboolean avail;
 
-  if (log_proto_buffered_server_prepare(s, cond))
+  if (log_proto_buffered_server_prepare(s, cond, timeout))
     {
       return TRUE;
     }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1300,13 +1300,13 @@ log_writer_init_watches(LogWriter *self)
 
   ml_batched_timer_init(&self->mark_timer);
   self->mark_timer.cookie = self;
-  self->mark_timer.handler = (void (*)(void *)) log_writer_mark_timeout;
+  self->mark_timer.handler = log_writer_mark_timeout;
   self->mark_timer.ref_cookie = (gpointer (*)(gpointer)) log_pipe_ref;
   self->mark_timer.unref_cookie = (void (*)(gpointer)) log_pipe_unref;
 
   IV_TIMER_INIT(&self->reopen_timer);
   self->reopen_timer.cookie = self;
-  self->reopen_timer.handler = (void (*)(void *)) log_writer_reopen_timeout;
+  self->reopen_timer.handler = log_writer_reopen_timeout;
 
   IV_TIMER_INIT(&self->idle_timer);
   self->idle_timer.cookie = self;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -87,6 +87,7 @@ struct _LogWriter
   MlBatchedTimer suppress_timer;
   MlBatchedTimer mark_timer;
   struct iv_timer reopen_timer;
+  struct iv_timer idle_timer;
   gboolean work_result;
   gint pollable_state;
   LogProtoClient *proto, *pending_proto;
@@ -123,6 +124,7 @@ static gboolean log_writer_flush(LogWriter *self, LogWriterFlushMode flush_mode)
 static void log_writer_broken(LogWriter *self, gint notify_code);
 static void log_writer_start_watches(LogWriter *self);
 static void log_writer_stop_watches(LogWriter *self);
+static void log_writer_stop_idle_timer(LogWriter *self);
 static void log_writer_update_watches(LogWriter *self);
 static void log_writer_suspend(LogWriter *self);
 static void log_writer_free_proto(LogWriter *self);
@@ -423,12 +425,15 @@ log_writer_update_watches(LogWriter *self)
   gint fd;
   GIOCondition cond = 0;
   gint timeout_msec = 0;
+  gint idle_timeout = -1;
 
   main_loop_assert_main_thread();
 
+  log_writer_stop_idle_timer(self);
+
   /* NOTE: we either start the suspend_timer or enable the fd_watch. The two MUST not happen at the same time. */
 
-  if (log_proto_client_prepare(self->proto, &fd, &cond) ||
+  if (log_proto_client_prepare(self->proto, &fd, &cond, &idle_timeout) ||
       self->waiting_for_throttle ||
       log_queue_check_items(self->queue, &timeout_msec,
                             (LogQueuePushNotifyFunc) log_writer_schedule_update_watches, self, NULL))
@@ -451,6 +456,16 @@ log_writer_update_watches(LogWriter *self)
        * log_queue_check_items and its parallel_push argument above
        */
       log_writer_update_fd_callbacks(self, 0);
+    }
+
+  if (idle_timeout > 0)
+    {
+      iv_validate_now();
+
+      self->idle_timer.expires = iv_now;
+      self->idle_timer.expires.tv_sec += idle_timeout;
+
+      iv_timer_register(&self->idle_timer);
     }
 }
 
@@ -475,11 +490,12 @@ log_writer_start_watches(LogWriter *self)
 {
   gint fd;
   GIOCondition cond;
+  gint idle_timeout = -1;
 
   if (self->watches_running)
     return;
 
-  log_proto_client_prepare(self->proto, &fd, &cond);
+  log_proto_client_prepare(self->proto, &fd, &cond, &idle_timeout);
 
   self->fd_watch.fd = fd;
 
@@ -515,6 +531,13 @@ log_writer_stop_watches(LogWriter *self)
 
       self->watches_running = FALSE;
     }
+}
+
+static void
+log_writer_stop_idle_timer(LogWriter *self)
+{
+  if (iv_timer_registered(&self->idle_timer))
+    iv_timer_unregister(&self->idle_timer);
 }
 
 static void
@@ -1050,6 +1073,7 @@ static void
 log_writer_broken(LogWriter *self, gint notify_code)
 {
   log_writer_stop_watches(self);
+  log_writer_stop_idle_timer(self);
   log_pipe_notify(self->control, notify_code, self);
 }
 
@@ -1245,6 +1269,17 @@ log_writer_reopen_timeout(void *cookie)
 }
 
 static void
+log_writer_idle_timeout(void *cookie)
+{
+  LogWriter *self = (LogWriter *) cookie;
+
+  msg_notice("Destination timeout has elapsed, closing connection",
+             evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
+
+  log_pipe_notify(self->control, NC_CLOSE, self);
+}
+
+static void
 log_writer_init_watches(LogWriter *self)
 {
   IV_FD_INIT(&self->fd_watch);
@@ -1272,6 +1307,10 @@ log_writer_init_watches(LogWriter *self)
   IV_TIMER_INIT(&self->reopen_timer);
   self->reopen_timer.cookie = self;
   self->reopen_timer.handler = (void (*)(void *)) log_writer_reopen_timeout;
+
+  IV_TIMER_INIT(&self->idle_timer);
+  self->idle_timer.cookie = self;
+  self->idle_timer.handler = log_writer_idle_timeout;
 
   IV_EVENT_INIT(&self->queue_filled);
   self->queue_filled.cookie = self;
@@ -1391,6 +1430,8 @@ log_writer_deinit(LogPipe *s)
    * some kind of locking. */
 
   log_writer_stop_watches(self);
+  log_writer_stop_idle_timer(self);
+
   iv_event_unregister(&self->queue_filled);
 
   if (iv_timer_registered(&self->reopen_timer))
@@ -1509,6 +1550,7 @@ log_writer_reopen_deferred(gpointer s)
     }
 
   log_writer_stop_watches(self);
+  log_writer_stop_idle_timer(self);
 
   log_writer_free_proto(self);
   log_writer_set_proto(self, proto);

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -192,7 +192,7 @@ log_proto_file_writer_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, g
 }
 
 static gboolean
-log_proto_file_writer_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond)
+log_proto_file_writer_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout)
 {
   LogProtoFileWriter *self = (LogProtoFileWriter *) s;
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -575,7 +575,7 @@ afsocket_dd_notify(LogPipe *s, gint notify_code, gpointer user_data)
     case NC_WRITE_ERROR:
       log_writer_reopen(self->writer, NULL);
 
-      msg_notice("Syslog connection broken",
+      msg_notice((notify_code == NC_CLOSE) ? "Syslog connection closed" : "Syslog connection broken",
                  evt_tag_int("fd", self->fd),
                  evt_tag_str("server", g_sockaddr_format(self->dest_addr, buf, sizeof(buf), GSA_FULL)),
                  evt_tag_int("time_reopen", self->time_reopen));


### PR DESCRIPTION
LogProto can now express an idle timeout during prepare. When the timeout elapsed, logwriter/logreader will close the controlling pipe.

Credits for @MrAnno for the logwriter part. 