### PR TITLE
transport-factory-registry: overwriting of a factory instance is not …

### DIFF
--- a/lib/transport/tests/test_transport_factory_registry.c
+++ b/lib/transport/tests/test_transport_factory_registry.c
@@ -57,3 +57,16 @@ Test(transport_factory_registry, basic_functionality)
 
   transport_factory_registry_free(registry);
 }
+
+Test(transport_factory_registry, abort_when_add_different_factory_with_same_id, .signal=SIGABRT)
+{
+  TransportFactoryRegistry *registry = transport_factory_registry_new();
+
+  TestTransportFactory *factory = _test_transport_factory_new();
+  TestTransportFactory *factory2 = _test_transport_factory_new();
+
+  transport_factory_registry_add(registry, &factory->super);
+  transport_factory_registry_add(registry, &factory2->super);
+
+  transport_factory_registry_free(registry);
+}

--- a/lib/transport/transport-factory-registry.c
+++ b/lib/transport/transport-factory-registry.c
@@ -61,6 +61,13 @@ void
 transport_factory_registry_add(TransportFactoryRegistry *self, TransportFactory *factory)
 {
   const TransportFactoryId *id = transport_factory_get_id(factory);
+
+  const TransportFactory *old = transport_factory_registry_lookup(self, id);
+  if (old)
+    {
+      g_assert(old == factory);
+    }
+
   g_hash_table_insert(self->registry, (TransportFactoryId *)id, factory);
 }
 


### PR DESCRIPTION
…allowed

Assert when someone wants to register a difference TransportFactory
instance with the same TransportFactoryId.

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>