### PR TITLE
debuggercli: remove getframe() hacks from completerlang

### DIFF
--- a/modules/python/pylib/syslogng/debuggercli/completerlang.py
+++ b/modules/python/pylib/syslogng/debuggercli/completerlang.py
@@ -21,7 +21,6 @@
 #############################################################################
 
 from __future__ import print_function, absolute_import
-import sys
 from abc import abstractmethod, ABCMeta
 import ply.yacc as yacc
 from .tablexer import TabLexer
@@ -59,23 +58,7 @@ class CompleterLang(object):
             # EOF
             return
         elif p.type == 'TAB':
-            # We look up the current grammar state from the local variables of the caller,
-            # as it doesn't publish this information in self.
-            #
-            # This is somewhat fragile, however I don't really expect this variable to change
-            # too frequently.
-            #
-            # I don't want to hide this call within the _handle_injected_tab_token() call, as
-            # this is the very function that is close enough to the caller, moving this information
-            # deeper would probably improve readability at the cost of increasing fragility.
-
-            # pylint: disable=protected-access
-            if 'state' in sys._getframe(1).f_locals:
-                parser_state = sys._getframe(1).f_locals['state']
-            elif 'state' in sys._getframe(2).f_locals:
-                parser_state = sys._getframe(2).f_locals['state']
-            else:
-                return
+            parser_state = self._parser.state
 
             # now handle the error that the TAB token caused
             self._token_position = p.lexpos


### PR DESCRIPTION
The yacc implementation we are using (ply), didn't publish its state
variable, requiring us to look that up using sys._getframe() calls, which
was pretty fragile.

@dabeaz was nice enough to add this function to ply in 2016 (version 3.9),
which has now trickled into various distributions, so the hack can be removed.

	https://github.com/dabeaz/ply/issues/65

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>