### PR TITLE
logreader: add log_reader_close_proto()

### DIFF
--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -107,19 +107,9 @@ log_proto_server_validate_options_method(LogProtoServer *s)
 }
 
 void
-log_proto_server_close_transport(LogProtoServer *s)
-{
-  if (s->transport)
-    {
-      log_transport_free(s->transport);
-      s->transport = NULL;
-    }
-}
-
-void
 log_proto_server_free_method(LogProtoServer *s)
 {
-  log_proto_server_close_transport(s);
+  log_transport_free(s->transport);
 }
 
 void

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -187,7 +187,6 @@ log_proto_server_wakeup_cb_call(LogProtoServerWakeupCallback *wakeup_callback)
 
 gboolean log_proto_server_validate_options_method(LogProtoServer *s);
 void log_proto_server_init(LogProtoServer *s, LogTransport *transport, const LogProtoServerOptions *options);
-void log_proto_server_close_transport(LogProtoServer *s);
 void log_proto_server_free_method(LogProtoServer *s);
 void log_proto_server_free(LogProtoServer *s);
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -632,13 +632,6 @@ log_reader_idle_timeout(void *cookie)
 }
 
 void
-log_reader_close_transport(LogReader *self)
-{
-  if (self->proto)
-    log_proto_server_close_transport(self->proto);
-}
-
-void
 log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr)
 {
   LogReader *self = (LogReader *) s;

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -620,6 +620,12 @@ log_reader_reopen(LogReader *self, LogProtoServer *proto, PollEvents *poll_event
     }
 }
 
+void
+log_reader_close_proto(LogReader *self)
+{
+  log_reader_reopen(self, NULL, NULL);
+}
+
 static void
 log_reader_idle_timeout(void *cookie)
 {

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -57,7 +57,6 @@ void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filenam
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_immediate_check(LogReader *s);
 void log_reader_reopen(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
-void log_reader_close_transport(LogReader *s);
 LogReader *log_reader_new(GlobalConfig *cfg);
 
 void log_reader_options_defaults(LogReaderOptions *options);

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -57,6 +57,7 @@ void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filenam
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_immediate_check(LogReader *s);
 void log_reader_reopen(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
+void log_reader_close_proto(LogReader *s);
 LogReader *log_reader_new(GlobalConfig *cfg);
 
 void log_reader_options_defaults(LogReaderOptions *options);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -321,7 +321,7 @@ file_reader_remove_persist_state(FileReader *self)
 void
 file_reader_stop_follow_file(FileReader *self)
 {
-  log_reader_reopen(self->reader, NULL, NULL);
+  log_reader_close_proto(self->reader);
 }
 
 void

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -442,6 +442,8 @@ afsocket_sd_close_connection(AFSocketSourceDriver *self, AFSocketSourceConnectio
                 evt_tag_int("fd", sc->sock),
                 evt_tag_str("client", g_sockaddr_format(sc->peer_addr, buf1, sizeof(buf1), GSA_FULL)),
                 evt_tag_str("local", g_sockaddr_format(self->bind_addr, buf2, sizeof(buf2), GSA_FULL)));
+
+  log_reader_close_proto(sc->reader);
   log_pipe_deinit(&sc->super);
   self->connections = g_list_remove(self->connections, sc);
   afsocket_sd_kill_connection(sc);

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -212,8 +212,6 @@ afsocket_sd_kill_connection(AFSocketSourceConnection *connection)
 {
   log_pipe_deinit(&connection->super);
 
-  log_reader_close_transport(connection->reader);
-
   /* Remove the circular reference between the connection and its
    * reader (through the connection->reader and reader->control
    * pointers these have a circular references).


### PR DESCRIPTION
This PR reverts #1991 and fixes connection close in afsocket on the proto level.

`log_reader_reopen(self, NULL, NULL);` is already used in `file-reader`, I just gave it a more descriptive name (`log_reader_close_proto`) and used it in `afsocket_sd_close_connection`.