### PR TITLE
KW_FILE token in a global namespace

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -180,7 +180,6 @@ extern struct _StatsOptions *last_stats_options;
 
 /* source & destination items */
 %token KW_INTERNAL                    10020
-%token KW_FILE                        10021
 %token KW_SYSLOG                      10060
 
 /* option items */

--- a/lib/parser/parser-expr-parser.c
+++ b/lib/parser/parser-expr-parser.c
@@ -30,7 +30,6 @@ int parser_expr_parse(CfgLexer *lexer, LogExprNode **node, gpointer arg);
 
 static CfgLexerKeyword parser_expr_keywords[] =
 {
-  { "file",               KW_FILE },
   { NULL }
 };
 

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -60,6 +60,7 @@ LogProtoFileReaderOptions *last_log_proto_options;
 
 /* INCLUDE_DECLS */
 
+%token KW_FILE
 %token KW_PIPE
 
 %token KW_FSYNC

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -65,6 +65,7 @@ SyntheticMessage *last_message;
 %token KW_AGGREGATE
 %token KW_VALUE
 %token KW_DROP_UNMATCHED
+%token KW_FILE
 
 %type <num> stateful_parser_inject_mode
 %type <ptr> synthetic_message

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -33,6 +33,7 @@ static CfgLexerKeyword dbparser_keywords[] =
 {
   { "db_parser",          KW_DB_PARSER },
   { "grouping_by",        KW_GROUPING_BY },
+  { "file",               KW_FILE },
 
   /* correllate options */
   { "inject_mode",        KW_INJECT_MODE },


### PR DESCRIPTION
The following grammar does not parsed successfully, the syslog-ng reports that the `file` is an unexpected symbol (which is clearly not).

```
parser test_parser {
channel {
if (message('foo')) {
filter {message('foo2')};
parser { date-parser();};
destination { file("/tmp/out2" ); };
};
};
```
Thanks @mitzkia to come up with this configuration snippet.

The strange thing is that it works with every other destination (network, redis, ...) as far as I could see only the file was effected.

As it turned out the KW_FILE token was in a global namespace, every parser has a KW_FILE in it. In this situation the tokenazier must have found the KW_FILE (which is should not found, but because the lack of this token it should try to load the parser for the affile plugin.), but because it found this token, it went on parsing the grammar, and of course it cannot, so it roll back and it cannot do anything other than report unexpected `file`.