### PR TITLE
transport: extend TransportFactoryRegistry with remove() method

### DIFF
--- a/lib/transport/tests/test_transport_factory_registry.c
+++ b/lib/transport/tests/test_transport_factory_registry.c
@@ -55,6 +55,11 @@ Test(transport_factory_registry, basic_functionality)
                                               test_transport_factory_id());
   cr_expect_eq((gpointer)factory, (gpointer)looked_up_factory);
 
+  TestTransportFactory *removed_factory = (TestTransportFactory *)transport_factory_registry_remove(registry,
+                                          test_transport_factory_id());
+  cr_expect_eq((gpointer)factory, (gpointer)removed_factory);
+  cr_expect_null(transport_factory_registry_lookup(registry, test_transport_factory_id()));
+  transport_factory_free(&removed_factory->super);
   transport_factory_registry_free(registry);
 }
 

--- a/lib/transport/transport-factory-registry.c
+++ b/lib/transport/transport-factory-registry.c
@@ -76,3 +76,12 @@ transport_factory_registry_lookup(TransportFactoryRegistry *self, const Transpor
 {
   return g_hash_table_lookup(self->registry, id);
 }
+
+TransportFactory *
+transport_factory_registry_remove(TransportFactoryRegistry *self, const TransportFactoryId *id)
+{
+  TransportFactory *factory = g_hash_table_lookup(self->registry, id);
+  g_hash_table_steal(self->registry, id);
+
+  return factory;
+}

--- a/lib/transport/transport-factory-registry.h
+++ b/lib/transport/transport-factory-registry.h
@@ -36,6 +36,7 @@ void transport_factory_registry_free(TransportFactoryRegistry *self);
 
 void transport_factory_registry_add(TransportFactoryRegistry *self, TransportFactory *factory);
 const TransportFactory *transport_factory_registry_lookup(TransportFactoryRegistry *self, const TransportFactoryId *id);
+TransportFactory *transport_factory_registry_remove(TransportFactoryRegistry *self, const TransportFactoryId *id);
 
 #endif
 


### PR DESCRIPTION
Reason: to support writing "advanced" unit tests where it is required to
override an existing TransportFactory with a FakeFactory.
(override : remove old/steal TransportFactoryId/add fake factory with
the stolen id)

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>