### PR TITLE
cfg: free PersistState after deallocating all LogPipe objects

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -586,8 +586,6 @@ void
 cfg_free(GlobalConfig *self)
 {
   g_assert(self->persist == NULL);
-  if (self->state)
-    persist_state_free(self->state);
 
   g_free(self->file_template_name);
   g_free(self->proto_template_name);
@@ -607,6 +605,10 @@ cfg_free(GlobalConfig *self)
   cfg_tree_free_instance(&self->tree);
   g_hash_table_unref(self->module_config);
   cfg_args_unref(self->globals);
+
+  if (self->state)
+    persist_state_free(self->state);
+
   g_free(self);
 }
 


### PR DESCRIPTION
`cfg_tree_free_instance()` deallocates all `LogExprNode` instances (and their `LogPipe` instances as well).

**`LogPipe`s are deinitialized in this state, but they can still write to and read from `PersistState`, so it must not be freed.**

For example:
1. `cfg_free()` deallocates its persist-state
2. `cfg_tree_free_instance()` is called, which produces the following chain:
```
afsocket_dd_free() --> log_queue_fifo_free() --> log_reader_free() --> log_proto_server_free()
```
3. `LogProtoServer` does not have a deinit() method, so implementations might want to write/read persist-state in free() in order to persist their last state.

Since an active `AckTracker` prevents freeing the `LogReader` instance in deinit-time (to handle the remaining acks), `LogReader` will be freed only after the last message is acked (when the queue is deallocated).

`log_reader_free()` deallocates its LogProtoServer as well, where our persist-state is used, but it has been already freed.