### PR TITLE
Fix test_rcptid

### DIFF
--- a/lib/tests/test_rcptid.c
+++ b/lib/tests/test_rcptid.c
@@ -72,6 +72,9 @@ Test(rcptid, test_rcptid_is_persistent_across_persist_backend_reinits)
 
   state = restart_persist_state(state);
 
+  rcptid_deinit();
+  rcptid_init(state, TRUE);
+
   rcptid = rcptid_generate_id();
   cr_assert_eq(rcptid, 0xFFFFFFFFFFFFFFFF, "Rcptid did not persisted across persist backend reinit!");
   teardown_persist_id_test(state);


### PR DESCRIPTION
After calling `restart_persist_state`, rcptid must be reinitialized with the new `PersistState` instance.

The macOS CI job caught this. \o/