### PR TITLE
telegram destination + urlencode template function

### DIFF
--- a/modules/basicfuncs/Makefile.am
+++ b/modules/basicfuncs/Makefile.am
@@ -14,9 +14,10 @@ modules_basicfuncs_libbasicfuncs_la_DEPENDENCIES=	\
 	$(MODULE_DEPS_LIBS)
 
 EXTRA_DIST					+=	\
-	modules/basicfuncs/cond-funcs.c 		\
-	modules/basicfuncs/context-funcs.c 		\
-	modules/basicfuncs/numeric-funcs.c 		\
+	modules/basicfuncs/urlencode.c			\
+	modules/basicfuncs/cond-funcs.c		\
+	modules/basicfuncs/context-funcs.c		\
+	modules/basicfuncs/numeric-funcs.c		\
 	modules/basicfuncs/str-funcs.c			\
 	modules/basicfuncs/fname-funcs.c		\
 	modules/basicfuncs/ip-funcs.c			\

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -38,6 +38,7 @@
  * include them all here. If it causes compilation times to increase
  * drastically, we should probably make them into separate compilation
  * units. (Bazsi) */
+#include "urlencode.c"
 #include "numeric-funcs.c"
 #include "str-funcs.c"
 #include "cond-funcs.c"
@@ -102,7 +103,8 @@ static Plugin basicfuncs_plugins[] =
 
   /* misc funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_env, "env"),
-  TEMPLATE_FUNCTION_PLUGIN(tf_template, "template")
+  TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "urlencode")
 };
 
 gboolean

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -392,3 +392,12 @@ Test(basicfuncs, test_context_funcs)
   assert_template_format_with_context("$(context-values ${comma_value})",
                                       "\"value,with,a,comma\",\"value,with,a,comma\"");
 }
+
+
+Test(basicfuncs, test_tfurlencode)
+{
+  assert_template_format("$(urlencode '')", "");
+  assert_template_format("$(urlencode test)", "test");
+  assert_template_format("$(urlencode <>)", "%3C%3E");
+  assert_template_format("$(urlencode &)", "%26");
+}

--- a/modules/basicfuncs/urlencode.c
+++ b/modules/basicfuncs/urlencode.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static void
+tf_urlencode(LogMessage *msg, gint argc, GString *argv[], GString *result)
+{
+  if (argc < 1)
+    return;
+
+  for (gint i = 0; i < argc; i++)
+    {
+      gchar *escaped = g_uri_escape_string(argv[i]->str, NULL, FALSE);
+      g_string_append(result, escaped);
+      g_free(escaped);
+    }
+}
+
+TEMPLATE_FUNCTION_SIMPLE(tf_urlencode);

--- a/packaging/debian/syslog-ng-mod-http.install
+++ b/packaging/debian/syslog-ng-mod-http.install
@@ -1,1 +1,2 @@
 usr/lib/syslog-ng/*/libhttp.so
+usr/share/syslog-ng/include/scl/telegram/*

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SCL_DIRS
     sudo
     syslogconf
     system
+    telegram
     windowseventlog
 )
 

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -23,6 +23,7 @@ SCL_SUBDIRS	= \
 	sudo		\
 	syslogconf	\
 	system		\
+	telegram	\
 	windowseventlog
 
 

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,29 +1,30 @@
 SCL_SUBDIRS	= \
-	system		\
-	pacct		\
-	syslogconf	\
-	rewrite		\
-	nodejs		\
-	graphite	\
+	apache		\
 	cim		\
-	solaris		\
-	mbox		\
+	cisco		\
+	default-network-drivers	\
 	elasticsearch	\
+	ewmm		\
+	graphite	\
 	graylog2	\
-	kafka		\
 	hdfs		\
 	iptables	\
-	apache		\
-	cisco		\
-	default-network-drivers		\
-	ewmm		\
-	sudo		\
+	kafka		\
+	loadbalancer	\
 	loggly		\
 	logmatic	\
-	snmptrap        \
-	osquery	        \
-        windowseventlog  \
-        loadbalancer
+	mbox		\
+	nodejs		\
+	osquery	\
+	pacct		\
+	rewrite	\
+	snmptrap	\
+	solaris	\
+	sudo		\
+	syslogconf	\
+	system		\
+	windowseventlog
+
 
 SCL_CONFIGS	= scl.conf syslog-ng.conf
 

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -23,12 +23,18 @@
 @requires http
 
 # Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
-block destination telegram(bot-id() chat-id() template("$(urlencode \"${MSG}\")") parse-mode("none") ...)
+block destination telegram(
+      bot-id()
+      chat-id()
+      template("$(urlencode \"${MSG}\")")
+      parse-mode("none")
+      disable-web-page-preview("true")
+      ...)
 {
     http(
         url("https://api.telegram.org/`bot-id`/sendMessage")
         method("POST")
-        body("parse_mode=`parse-mode`&chat_id=`chat-id`&text=`template`\n")
+        body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=`template`\n")
         throttle(1)
         `__VARARGS__`
     );

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -23,12 +23,12 @@
 @requires http
 
 # Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
-block destination telegram(bot-id() chat-id() ...)
+block destination telegram(bot-id() chat-id() template("$(urlencode \"${MSG}\")") ...)
 {
     http(
         url("https://api.telegram.org/`bot-id`/sendMessage")
         method("POST")
-        body("chat_id=`chat-id`&text=${MSG}\n")
+        body("chat_id=`chat-id`&text=`template`\n")
         throttle(1)
         `__VARARGS__`
     );

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -23,12 +23,12 @@
 @requires http
 
 # Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
-block destination telegram(bot-id() chat-id() template("$(urlencode \"${MSG}\")") ...)
+block destination telegram(bot-id() chat-id() template("$(urlencode \"${MSG}\")") parse-mode("none") ...)
 {
     http(
         url("https://api.telegram.org/`bot-id`/sendMessage")
         method("POST")
-        body("chat_id=`chat-id`&text=`template`\n")
+        body("parse_mode=`parse-mode`&chat_id=`chat-id`&text=`template`\n")
         throttle(1)
         `__VARARGS__`
     );

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -28,6 +28,7 @@ block destination telegram(
       chat-id()
       template("$(urlencode \"${MSG}\")")
       parse-mode("none")
+      throttle(1)
       disable-web-page-preview("true")
       ...)
 {
@@ -35,7 +36,7 @@ block destination telegram(
         url("https://api.telegram.org/`bot-id`/sendMessage")
         method("POST")
         body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=`template`\n")
-        throttle(1)
+        throttle(`throttle`)
         `__VARARGS__`
     );
 };

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -1,0 +1,35 @@
+#############################################################################
+# Copyright (c) 2018 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@requires http
+
+# Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
+block destination telegram(bot-id() chat-id() ...)
+{
+    http(
+        url("https://api.telegram.org/`bot-id`/sendMessage")
+        method("POST")
+        body("chat_id=`chat-id`&text=${MSG}\n")
+        throttle(1)
+        `__VARARGS__`
+    );
+};


### PR DESCRIPTION
This patchset contains two changes:
- Support to send messages to [telegram](https://telegram.org/).
- urlencode template function

CC: @fekete-robert for documentation
CC: @lbudai - packaging

**Telegram destination:**
A new destination is available:
```
destination d_telegram {
  telegram(
    template("$(urlencode \"${MSG}\")")
    throttle(1)
    parse-mode("markdown")
    disable-web-page-preview("true")
    bot-id("<bot id>")
    chat-id("<chat id>"));
};
```

Parameters:
- template: specifies the content of the message. Optional. Default value: `$(urlencode \"${MSG}\")`. According to telegram API, the message must be urlencoded.
- throttle: same as in other destinations: rate limit of sending message. One can read the limits from telegram in https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this.
- parse-mode: string, optional parameter. Format message as none, markdown or html. Default value is `none`. When parse-mode is set to markdown or html, user is responsible to send a valid markdown or html message, otherwise telegram server will fail with parse error.
- disable-web-page-preview: boolean, optional parameter. Disables link previews for links in this message. Default value is true. From security point of view, it is recommended to leave it true, otherwise malicious messages can trick telegram destination to generate traffic to any url.
- bot-id: id of the telegram bot. String, mandatory.
- chat-id: id of the chat of the telegram destination. String, mandatory.

Please refer to https://core.telegram.org/bots/api#sendmessage for more details and up-to-date values.

**UrlEncode**
A new template function is added: urlencode. This template function escapes strings: all input characters that are not a-z, A-Z, 0-9, '-', '.', '_' or '~' are converted to their "URL escaped" version.
Example:
```
$(urlencode ${MSG})\n")
```