### PR TITLE
Better python binary detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,16 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 set(SYSLOG_NG_HAVE_INOTIFY "${Inotify_FOUND}")
 
+set (PYTHON_VERSION "AUTO" CACHE STRING "Version of the installed development library" )
+
+if ("${PYTHON_VERSION}" STREQUAL "AUTO")
+  find_package(PythonInterp)
+  find_package(PythonLibs)
+else ()
+  find_package(PythonInterp EXACT "${PYTHON_VERSION}" REQUIRED)
+  find_package(PythonLibs EXACT "${PYTHON_VERSION}" REQUIRED)
+endif ()
+
 include(openssl_functions)
 openssl_set_defines()
 

--- a/Mk/lex-rules.am
+++ b/Mk/lex-rules.am
@@ -1,6 +1,6 @@
 %.y: %.ym $(syslog_ng_tools)/merge-grammar.py $(syslog_ng_tools)/cfg-grammar.y
 	$(AM_V_at) $(mkinstalldirs) $(dir $@)
-	$(AM_V_GEN) $(syslog_ng_tools)/merge-grammar.py $< > $@
+	$(AM_V_GEN) $(PYTHON) $(syslog_ng_tools)/merge-grammar.py $< > $@
 
 .l.c:
 	$(AM_V_LEX)$(am__skiplex) $(SHELL) $(YLWRAP) $< $(LEX_OUTPUT_ROOT).c $*.c $(LEX_OUTPUT_ROOT).h $*.h -- $(LEXCOMPILE) | ($(EGREP) -v "(^updating|unchanged)" || true)

--- a/cmake/Modules/GenerateYFromYm.cmake
+++ b/cmake/Modules/GenerateYFromYm.cmake
@@ -26,12 +26,12 @@
 function(generate_y_from_ym FileWoExt)
     if (${ARGC} EQUAL 1)
         add_custom_command (OUTPUT ${PROJECT_BINARY_DIR}/${FileWoExt}.y
-            COMMAND ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym > ${PROJECT_BINARY_DIR}/${FileWoExt}.y
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym > ${PROJECT_BINARY_DIR}/${FileWoExt}.y
             DEPENDS ${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y
                     ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym)
     elseif(${ARGC} EQUAL 2)
         add_custom_command (OUTPUT ${PROJECT_BINARY_DIR}/${ARGV1}.y
-            COMMAND ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym > ${PROJECT_BINARY_DIR}/${ARGV1}.y
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym > ${PROJECT_BINARY_DIR}/${ARGV1}.y
             DEPENDS ${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y
                     ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym)
     else()

--- a/configure.ac
+++ b/configure.ac
@@ -391,8 +391,12 @@ AM_PROG_LEX
 AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
 LT_INIT([dlopen disable-static])
-AC_PATH_PROG(PYTHON, python)
-if test -z "${PYTHON}"; then
+if test "x$with_python" = "xauto"; then
+  AM_PATH_PYTHON()
+else
+  AM_PATH_PYTHON([$with_python])
+fi
+if test "${PYTHON}" = ":"; then
 	AC_MSG_ERROR([Python interpreter is required])
 fi
 

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -1,18 +1,16 @@
-if ("${PYTHON_VERSION}" STREQUAL "AUTO")
-  if (PYTHONLIBS_FOUND)
-    option(ENABLE_PYTHON "Enable Python module" ON)
-  else()
-    option(ENABLE_PYTHON "Enable Python module" OFF)
-  endif()
+if (PYTHONLIBS_FOUND)
+  option(ENABLE_PYTHON "Enable Python module" ON)
+else()
+  option(ENABLE_PYTHON "Enable Python module" OFF)
+endif()
 
-  if (NOT ENABLE_PYTHON)
-    return()
-  endif ()
-
-  if (NOT PYTHONLIBS_FOUND)
-    message(FATAL_ERROR "Python module enabled, but python library not found.")
-  endif()
+if (NOT ENABLE_PYTHON)
+  return()
 endif ()
+
+if (NOT PYTHONLIBS_FOUND)
+  message(FATAL_ERROR "Python module enabled, but python library not found.")
+endif()
 
 MESSAGE(STATUS "Found python ${PYTHONLIBS_VERSION_STRING}")
 

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -1,9 +1,4 @@
-set (PYTHON_VERSION "AUTO" CACHE STRING "Version of the installed development library" )
-
 if ("${PYTHON_VERSION}" STREQUAL "AUTO")
-  find_package(PythonInterp)
-  find_package(PythonLibs)
-
   if (PYTHONLIBS_FOUND)
     option(ENABLE_PYTHON "Enable Python module" ON)
   else()
@@ -17,10 +12,6 @@ if ("${PYTHON_VERSION}" STREQUAL "AUTO")
   if (NOT PYTHONLIBS_FOUND)
     message(FATAL_ERROR "Python module enabled, but python library not found.")
   endif()
-
-else ()
-  find_package(PythonInterp EXACT "${PYTHON_VERSION}" REQUIRED)
-  find_package(PythonLibs EXACT "${PYTHON_VERSION}" REQUIRED)
 endif ()
 
 MESSAGE(STATUS "Found python ${PYTHONLIBS_VERSION_STRING}")

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_custom_target(func-test
-  ${CMAKE_COMMAND} -E env "top_srcdir=${PROJECT_SOURCE_DIR}" "top_builddir=${PROJECT_BINARY_DIR}"
+  ${CMAKE_COMMAND} -E env "top_srcdir=${PROJECT_SOURCE_DIR}" "top_builddir=${PROJECT_BINARY_DIR}" "PYTHON=${PYTHON_EXECUTABLE}"
   "${CMAKE_CURRENT_SOURCE_DIR}/runtests.sh")

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST	+= \
 		tests/functional/test_sql.py
 
 func-test:
-	@$(top_srcdir)/tests/functional/runtests.sh
+	@PYTHON=${PYTHON} $(top_srcdir)/tests/functional/runtests.sh
 
 .PHONY: func-test
 

--- a/tests/functional/runtests.sh
+++ b/tests/functional/runtests.sh
@@ -33,4 +33,4 @@ export srcdir
 
 install -d ${top_builddir}/tests/functional
 cd ${top_builddir}/tests/functional
-${top_srcdir}/tests/functional/func_test.py
+${PYTHON} ${top_srcdir}/tests/functional/func_test.py


### PR DESCRIPTION
Instead of using `AC_PATH_PROG` to find the python binary (which can only find binaries named `python`, not `python3` and similar), use `AM_PATH_PYTHON` instead, and take `--with-python` into account as well.

For this to work, we also need to call a few of our python scripts through the interpreter, to avoid having to generate the scripts.

Fixes #2090.