### PR TITLE
Afsql threaded dest driver

### DIFF
--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -118,7 +118,7 @@ dest_afsql_option
         | KW_NULL '(' string ')'                { afsql_dd_set_null_value(last_driver, $3); free($3); }
         | KW_RETRIES '(' nonnegative_integer ')'          { afsql_dd_set_retries(last_driver, $3); }
         | KW_FLUSH_LINES '(' nonnegative_integer ')'      { afsql_dd_set_flush_lines(last_driver, $3); }
-        | KW_FLUSH_TIMEOUT '(' positive_integer ')'    { /* this is deprecated parameter as of 3.5, doing nothing */ }
+        | KW_FLUSH_TIMEOUT '(' positive_integer ')'    { log_threaded_dest_driver_set_flush_timeout(last_driver, $3); }
         | KW_SESSION_STATEMENTS '(' string_list ')' { afsql_dd_set_session_statements(last_driver, $3); }
         | KW_FLAGS '(' dest_afsql_flags ')'     { afsql_dd_set_flags(last_driver, $3); }
 	| KW_CREATE_STATEMENT_APPEND '(' string ')' { afsql_dd_set_create_statement_append(last_driver, $3); free($3); }

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -118,7 +118,7 @@ dest_afsql_option
         | KW_NULL '(' string ')'                { afsql_dd_set_null_value(last_driver, $3); free($3); }
         | KW_RETRIES '(' nonnegative_integer ')'          { afsql_dd_set_retries(last_driver, $3); }
         | KW_FLUSH_LINES '(' nonnegative_integer ')'      { afsql_dd_set_flush_lines(last_driver, $3); }
-        | KW_FLUSH_TIMEOUT '(' positive_integer ')'    { afsql_dd_set_flush_timeout(last_driver, $3); }
+        | KW_FLUSH_TIMEOUT '(' positive_integer ')'    { /* this is deprecated parameter as of 3.5, doing nothing */ }
         | KW_SESSION_STATEMENTS '(' string_list ')' { afsql_dd_set_session_statements(last_driver, $3); }
         | KW_FLAGS '(' dest_afsql_flags ')'     { afsql_dd_set_flags(last_driver, $3); }
 	| KW_CREATE_STATEMENT_APPEND '(' string ')' { afsql_dd_set_create_statement_append(last_driver, $3); free($3); }

--- a/modules/afsql/afsql-parser.c
+++ b/modules/afsql/afsql-parser.c
@@ -51,7 +51,7 @@ static CfgLexerKeyword afsql_keywords[] =
   { "null",               KW_NULL },
   { "retry_sql_inserts",  KW_RETRIES },
   { "flush_lines",        KW_FLUSH_LINES },
-  { "flush_timeout",      KW_FLUSH_TIMEOUT },
+  { "flush_timeout",      KW_FLUSH_TIMEOUT, KWS_OBSOLETE, "The flush-timeout() option for sql() destinations has been broken without deprecation since " VERSION_3_5 },
   { "flags",              KW_FLAGS },
   { "create_statement_append", KW_CREATE_STATEMENT_APPEND },
   { "ignore_tns_config",  KW_IGNORE_TNS_CONFIG },

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -917,7 +917,7 @@ afsql_dd_insert(LogThreadedDestDriver *s, LogMessage *msg)
 
   if (afsql_dd_should_begin_new_transaction(self) && !afsql_dd_begin_transaction(self))
     goto error;
-  
+
   if (!afsql_dd_run_insert_query(self, table, msg))
     {
       retval = afsql_dd_handle_insert_row_error_depending_on_connection_availability(self);
@@ -931,8 +931,8 @@ afsql_dd_insert(LogThreadedDestDriver *s, LogMessage *msg)
   else
     {
       retval = afsql_dd_is_transaction_handling_enabled(self)
-                   ? WORKER_INSERT_RESULT_QUEUED
-                   : WORKER_INSERT_RESULT_SUCCESS;
+               ? WORKER_INSERT_RESULT_QUEUED
+               : WORKER_INSERT_RESULT_SUCCESS;
     }
 
 error:

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1072,6 +1072,8 @@ afsql_dd_init(LogPipe *s)
 
   if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
+  if (!_initialize_dbi())
+    return FALSE;
 
   if (!self->columns || !self->values)
     {
@@ -1086,19 +1088,14 @@ afsql_dd_init(LogPipe *s)
                   evt_tag_str("type", self->type));
     }
 
+  if (self->flush_lines == -1)
+    self->flush_lines = cfg->flush_lines;
+
   if (!_init_fields_from_columns_and_values(self))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);
-
-  if (self->flush_lines == -1)
-    self->flush_lines = cfg->flush_lines;
-
-  if (!_initialize_dbi())
-    return FALSE;
-
-
-  return TRUE;
+  return log_threaded_dest_driver_start_workers(&self->super);
 }
 
 static void

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -198,14 +198,6 @@ afsql_dd_set_flush_lines(LogDriver *s, gint flush_lines)
 }
 
 void
-afsql_dd_set_flush_timeout(LogDriver *s, gint flush_timeout)
-{
-  AFSqlDestDriver *self = (AFSqlDestDriver *) s;
-
-  self->flush_timeout = flush_timeout;
-}
-
-void
 afsql_dd_set_session_statements(LogDriver *s, GList *session_statements)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
@@ -1064,8 +1056,6 @@ afsql_dd_init(LogPipe *s)
 
   if (self->flush_lines == -1)
     self->flush_lines = cfg->flush_lines;
-  if (self->flush_timeout == -1)
-    self->flush_timeout = cfg->flush_timeout;
 
   if (!dbi_initialized)
     {
@@ -1176,7 +1166,6 @@ afsql_dd_new(GlobalConfig *cfg)
   self->failed_message_counter = 0;
 
   self->flush_lines = -1;
-  self->flush_timeout = -1;
   self->session_statements = NULL;
   self->num_retries = MAX_FAILED_ATTEMPTS;
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -744,7 +744,7 @@ afsql_dd_ensure_accessible_database_table(AFSqlDestDriver *self, LogMessage *msg
     {
       /* If validate table is FALSE then close the connection and wait time_reopen time (next call) */
       msg_error("Error checking table, disconnecting from database, trying again shortly",
-                evt_tag_int("time_reopen", self->time_reopen));
+                evt_tag_int("time_reopen", self->super.time_reopen));
       g_string_free(table, TRUE);
       return NULL;
     }
@@ -1049,8 +1049,6 @@ afsql_dd_init(LogPipe *s)
             }
         }
     }
-
-  self->time_reopen = cfg->time_reopen;
 
   log_template_options_init(&self->template_options, cfg);
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1036,6 +1036,35 @@ _init_fields_from_columns_and_values(AFSqlDestDriver *self)
 }
 
 static gboolean
+_initialize_dbi(void)
+{
+  if (!dbi_initialized)
+    {
+      errno = 0;
+      gint rc = dbi_initialize_r(NULL, &dbi_instance);
+
+      if (rc < 0)
+        {
+          /* NOTE: errno might be unreliable, but that's all we have */
+          msg_error("Unable to initialize database access (DBI)",
+                    evt_tag_int("rc", rc),
+                    evt_tag_error("error"));
+          return FALSE;
+        }
+      else if (rc == 0)
+        {
+          msg_error("The database access library (DBI) reports no usable SQL drivers, perhaps DBI drivers are not installed properly");
+          return FALSE;
+        }
+      else
+        {
+          dbi_initialized = TRUE;
+        }
+    }
+  return TRUE;
+}
+
+static gboolean
 afsql_dd_init(LogPipe *s)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
@@ -1065,29 +1094,9 @@ afsql_dd_init(LogPipe *s)
   if (self->flush_lines == -1)
     self->flush_lines = cfg->flush_lines;
 
-  if (!dbi_initialized)
-    {
-      errno = 0;
-      gint rc = dbi_initialize_r(NULL, &dbi_instance);
+  if (!_initialize_dbi())
+    return FALSE;
 
-      if (rc < 0)
-        {
-          /* NOTE: errno might be unreliable, but that's all we have */
-          msg_error("Unable to initialize database access (DBI)",
-                    evt_tag_int("rc", rc),
-                    evt_tag_error("error"));
-          return FALSE;
-        }
-      else if (rc == 0)
-        {
-          msg_error("The database access library (DBI) reports no usable SQL drivers, perhaps DBI drivers are not installed properly");
-          return FALSE;
-        }
-      else
-        {
-          dbi_initialized = TRUE;
-        }
-    }
 
   return TRUE;
 }

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -784,7 +784,9 @@ afsql_dd_build_insert_command(AFSqlDestDriver *self, LogMessage *msg, GString *t
 
       if ((self->fields[i].flags & AFSQL_FF_DEFAULT) == 0 && self->fields[i].value != NULL)
         {
-          log_template_format(self->fields[i].value, msg, &self->template_options, LTZ_SEND, self->super.worker.instance.seq_num, NULL, value);
+          log_template_format(self->fields[i].value, msg,
+                              &self->template_options, LTZ_SEND, self->super.worker.instance.seq_num,
+                              NULL, value);
           if (self->null_value && strcmp(self->null_value, value->str) == 0)
             {
               g_string_append(insert_command, "NULL");

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1056,7 +1056,7 @@ afsql_dd_database_thread(gpointer arg)
   AFSqlDestDriver *self = (AFSqlDestDriver *) arg;
 
   msg_verbose("Database thread started",
-              evt_tag_str("driver", self->super.super.id));
+              evt_tag_str("driver", self->super.super.super.id));
   while (!self->db_thread_terminate)
     {
       main_loop_worker_run_gc();
@@ -1124,7 +1124,7 @@ exit:
   afsql_dd_disconnect(self);
 
   msg_verbose("Database thread finished",
-              evt_tag_str("driver", self->super.super.id));
+              evt_tag_str("driver", self->super.super.super.id));
 }
 
 static void
@@ -1189,7 +1189,7 @@ _register_stats(AFSqlDestDriver *self)
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.super.id,
                                   afsql_dd_format_stats_instance(self) );
     stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
     log_queue_register_stats_counters(self->queue, 0, &sc_key);
@@ -1203,7 +1203,7 @@ _unregister_stats(AFSqlDestDriver *self)
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.super.id,
                                   afsql_dd_format_stats_instance(self) );
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
     log_queue_unregister_stats_counters(self->queue, &sc_key);
@@ -1238,7 +1238,7 @@ afsql_dd_init(LogPipe *s)
   if (!self->seq_num)
     init_sequence_number(&self->seq_num);
 
-  self->queue = log_dest_driver_acquire_queue(&self->super,
+  self->queue = log_dest_driver_acquire_queue(&self->super.super,
                                               afsql_dd_format_persist_name((const LogPipe *)self));
   if (self->queue == NULL)
     {
@@ -1249,6 +1249,7 @@ afsql_dd_init(LogPipe *s)
 
   if (self->flags & AFSQL_DDF_EXPLICIT_COMMITS)
     log_queue_set_use_backlog(self->queue, TRUE);
+
   if (!self->fields)
     {
       GList *col, *value;
@@ -1436,11 +1437,11 @@ afsql_dd_new(GlobalConfig *cfg)
 
   log_dest_driver_init_instance(&self->super, cfg);
 
-  self->super.super.super.init = afsql_dd_init;
-  self->super.super.super.deinit = afsql_dd_deinit;
-  self->super.super.super.queue = afsql_dd_queue;
-  self->super.super.super.free_fn = afsql_dd_free;
-  self->super.super.super.generate_persist_name = afsql_dd_format_persist_name;
+  self->super.super.super.super.init = afsql_dd_init;
+  self->super.super.super.super.deinit = afsql_dd_deinit;
+  self->super.super.super.super.queue = afsql_dd_queue;
+  self->super.super.super.super.free_fn = afsql_dd_free;
+  self->super.super.super.super.generate_persist_name = afsql_dd_format_persist_name;
 
   self->type = g_strdup("mysql");
   self->host = g_strdup("");
@@ -1472,7 +1473,7 @@ afsql_dd_new(GlobalConfig *cfg)
   self->db_thread_mutex = g_mutex_new();
 
   self->worker_options.is_output_thread = TRUE;
-  return &self->super.super;
+  return &self->super.super.super;
 }
 
 gint

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -89,7 +89,6 @@ typedef struct _AFSqlDestDriver
   gint time_reopen;
   gint num_retries;
   gint flush_lines;
-  gint flush_timeout;
   gint flags;
   gboolean ignore_tns_config;
   GList *session_statements;
@@ -121,7 +120,6 @@ void afsql_dd_set_null_value(LogDriver *s, const gchar *null);
 void afsql_dd_set_indexes(LogDriver *s, GList *indexes);
 void afsql_dd_set_retries(LogDriver *s, gint num_retries);
 void afsql_dd_set_flush_lines(LogDriver *s, gint flush_lines);
-void afsql_dd_set_flush_timeout(LogDriver *s, gint flush_timeout);
 void afsql_dd_set_session_statements(LogDriver *s, GList *session_statements);
 void afsql_dd_set_flags(LogDriver *s, gint flags);
 void afsql_dd_set_create_statement_append(LogDriver *s, const gchar *create_statement_append);

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -90,31 +90,19 @@ typedef struct _AFSqlDestDriver
   gint num_retries;
   gint flush_lines;
   gint flush_timeout;
-  gint flush_lines_queued;
   gint flags;
   gboolean ignore_tns_config;
   GList *session_statements;
 
   LogTemplateOptions template_options;
 
-  StatsCounterItem *dropped_messages;
-
   GHashTable *dbd_options;
   GHashTable *dbd_options_numeric;
 
-  /* shared by the main/db thread */
-  GMutex *db_thread_mutex;
-  GCond *db_thread_wakeup_cond;
-  gboolean db_thread_terminate;
-  gboolean db_thread_suspended;
-  GTimeVal db_thread_suspend_target;
-  LogQueue *queue;
   /* used exclusively by the db thread */
-  gint32 seq_num;
   dbi_conn dbi_ctx;
   GHashTable *syslogng_conform_tables;
   guint32 failed_message_counter;
-  WorkerOptions worker_options;
   gboolean transaction_active;
 } AFSqlDestDriver;
 

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -24,7 +24,7 @@
 #ifndef AFSQL_H_INCLUDED
 #define AFSQL_H_INCLUDED
 
-#include "driver.h"
+#include "logthrdestdrv.h"
 #include "mainloop-worker.h"
 #include "string-list.h"
 
@@ -69,7 +69,7 @@ typedef struct _AFSqlField
  **/
 typedef struct _AFSqlDestDriver
 {
-  LogDestDriver super;
+  LogThreadedDestDriver super;
   /* read by the db thread */
   gchar *type;
   gchar *host;

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -86,7 +86,6 @@ typedef struct _AFSqlDestDriver
   gint fields_len;
   AFSqlField *fields;
   gchar *null_value;
-  gint time_reopen;
   gint num_retries;
   gint flush_lines;
   gint flags;


### PR DESCRIPTION
This branch converts our afsql driver to use the LogThreadedDestDriver framework, instead of its home-grewn implementation (that has originally been the basis of LogThreadedDestDriver).

This should go in after #2315 because without that some of our stats counters would be missing.
