### PR TITLE
force syslog-ng SIGCHLD handlers on top

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -86,6 +86,7 @@ set (LIB_HEADERS
     logthrdestdrv.h
     logwriter.h
     mainloop.h
+    signal-handler.h
     mainloop-call.h
     mainloop-worker.h
     mainloop-io-worker.h
@@ -174,6 +175,7 @@ set(LIB_SOURCES
     logthrdestdrv.c
     logwriter.c
     mainloop.c
+    signal-handler.c
     mainloop-call.c
     mainloop-worker.c
     mainloop-io-worker.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -125,6 +125,7 @@ pkginclude_HEADERS			+= \
 	lib/logthrdestdrv.h		\
 	lib/logwriter.h			\
 	lib/mainloop.h			\
+	lib/signal-handler.h		\
 	lib/mainloop-call.h		\
 	lib/mainloop-worker.h		\
 	lib/mainloop-io-worker.h	\
@@ -211,6 +212,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/logthrdestdrv.c		\
 	lib/logwriter.c			\
 	lib/mainloop.c			\
+	lib/signal-handler.c		\
 	lib/mainloop-call.c		\
 	lib/mainloop-worker.c		\
 	lib/mainloop-io-worker.c	\

--- a/lib/children.c
+++ b/lib/children.c
@@ -69,7 +69,7 @@ child_manager_unregister(pid_t pid)
 void
 child_manager_register_external_sigchld_handler(void (*callback)(int))
 {
-   sigchld_callback = callback;
+  sigchld_callback = callback;
 }
 
 void

--- a/lib/children.c
+++ b/lib/children.c
@@ -33,6 +33,7 @@ typedef struct _ChildEntry
 } ChildEntry;
 
 GHashTable *child_hash;
+static void (*sigchld_callback)(int);
 
 static void
 child_manager_child_entry_free(ChildEntry *ce)
@@ -66,6 +67,12 @@ child_manager_unregister(pid_t pid)
 }
 
 void
+child_manager_register_external_sigchld_handler(void (*callback)(int))
+{
+   sigchld_callback = callback;
+}
+
+void
 child_manager_sigchild(pid_t pid, int status)
 {
   ChildEntry *ce;
@@ -76,6 +83,9 @@ child_manager_sigchild(pid_t pid, int status)
       ce->exit_callback(pid, status, ce->callback_data);
       g_hash_table_remove(child_hash, &pid);
     }
+
+  if (sigchld_callback)
+    sigchld_callback(SIGCHLD);
 }
 
 void

--- a/lib/children.h
+++ b/lib/children.h
@@ -30,6 +30,7 @@
 
 void child_manager_register(pid_t pid, void (*callback)(pid_t, int, gpointer), gpointer user_data,
                             GDestroyNotify user_data_destroy);
+void child_manager_register_external_sigchld_handler(void (*callback)(int));
 void child_manager_unregister(pid_t pid);
 void child_manager_sigchild(pid_t pid, int status);
 

--- a/lib/signal-handler.c
+++ b/lib/signal-handler.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "signal-handler.h"
+
+#include "syslog-ng.h"
+#include "children.h"
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
+static const struct sigaction *sgchld_handler;
+
+void
+trigger_sigchld_handler_chain(int signum)
+{
+  if (sgchld_handler && sgchld_handler->sa_handler)
+    {
+      sgchld_handler->sa_handler(signum);
+    }
+}
+
+#ifndef _WIN32
+static int
+call_original_sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
+{
+  static int (*real_sa)(int, const struct sigaction *, struct sigaction *);
+
+  if (real_sa == NULL)
+    {
+      real_sa = dlsym(RTLD_NEXT, "sigaction");
+    }
+  return real_sa(signum, act, oldact);
+}
+
+static gboolean
+_save_handler(const struct sigaction *act)
+{
+  static gboolean is_first_handler = TRUE;
+  if (is_first_handler)
+    {
+      is_first_handler = FALSE;
+      return FALSE;
+    }
+
+  sgchld_handler = act;
+
+  child_manager_register_external_sigchld_handler(&trigger_sigchld_handler_chain);
+
+  return TRUE;
+}
+
+/* This should be as defined in the <signal.h> */
+int
+sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
+{
+
+  if (signum == SIGCHLD)
+    {
+      if (act && act->sa_handler == SIG_DFL)
+        {
+          return 0;
+        }
+
+      if (_save_handler(act))
+        {
+          return 0;
+        }
+    }
+
+
+  return call_original_sigaction(signum, act, oldact);
+}
+#endif
+

--- a/lib/signal-handler.h
+++ b/lib/signal-handler.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef SIGNAL_HANDLER_H_INCLUDED
+#define SIGNAL_HANDLER_H_INCLUDED
+
+#include <signal.h>
+
+void trigger_sigchld_handler_chain(int);
+
+#endif

--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -86,8 +86,8 @@ modules_java_libmod_java_la_SOURCES = \
     modules/java/native/java_machine.c \
     modules/java/native/java_machine.h \
     modules/java/native/java-destination.h \
-		modules/java/native/java-config.c \
-		modules/java/native/java-config.h \
+    modules/java/native/java-config.c \
+    modules/java/native/java-config.h \
     modules/java/proxies/java-destination-proxy.c \
     modules/java/proxies/java-destination-proxy.h \
     modules/java/proxies/java-logmsg-proxy.c \


### PR DESCRIPTION
The initial issue:

In case of both java destination and program source/destination configured, syslog-ng cannot reap the program source/destination, which is started in a fork. Those fork remains in Zombie state until syslog-ng is restarted.

This is because the java virtual machine  sets  its own  signal handler. The syslog-ng reaping
happens when the SIGCHLD handler is  called, but the java replaced our SIGCHLD
handler. Therefore every forked process became a zombie, there is nobody calling wait on them.

A proposed solution:

The sigaction is registers the signal handlers, to overcome the java own
registration process in syslog-ng we implement our own sigaction implementation,
which is called instead of the one in libc. Every single case our sigaction
calls the original one, except in case of SIGCHLD. If it is called with SIGCHLD
out of setup phase, the new handler is saved and called, when we are not waiting
for SIGCHLD.

Questions:
* Right now it is called signal chaining, but only one handler is saved and triggered. Is it okay to save just the latest and do not trigger the other handlers ?
* Should it trigger the saved signal handler even if syslog-ng is sure that it was sent by the system because of forked process ?
