### PR TITLE
build: Link everything to libsecret-storage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1669,6 +1669,8 @@ else
 fi
 YFLAGS="-d"
 
+TOOL_DEPS_LIBS="${TOOL_DEPS_LIBS} \$(top_builddir)/lib/secret-storage/libsecret-storage.la"
+
 enable_value()
 {
         if test "x$1" = "xyes" ; then

--- a/lib/logproto/tests/Makefile.am
+++ b/lib/logproto/tests/Makefile.am
@@ -23,6 +23,7 @@ lib_logproto_tests_test_findeom_CFLAGS	= \
 	-I${top_srcdir}/libtest
 lib_logproto_tests_test_findeom_LDADD	= \
 	${top_builddir}/lib/libsyslog-ng.la \
-	${top_builddir}/libtest/libsyslog-ng-test.a
+	${top_builddir}/libtest/libsyslog-ng-test.a \
+	$(TEST_LDADD)
 lib_logproto_tests_test_findeom_SOURCES = \
 	lib/logproto/tests/test_findeom.c

--- a/syslog-ng/Makefile.am
+++ b/syslog-ng/Makefile.am
@@ -11,7 +11,9 @@ syslog_ng_syslog_ng_SOURCES	= syslog-ng/main.c
 # libtool, because in mixed mode libtool is not used for the final linking
 # phase.  See the comment in the configure script for details.
 
-syslog_ng_syslog_ng_LDADD		= -L${top_builddir}/lib/.libs -lsyslog-ng @SYSLOGNG_DEPS_LIBS@
+syslog_ng_syslog_ng_LDADD		= -L${top_builddir}/lib/.libs \
+					  -lsyslog-ng @SYSLOGNG_DEPS_LIBS@ \
+					  $(top_builddir)/lib/secret-storage/libsecret-storage.la
 syslog_ng_syslog_ng_LINK		=  @SYSLOGNG_LINK@
 syslog_ng_syslog_ng_DEPENDENCIES	= lib/libsyslog-ng.la
 


### PR DESCRIPTION
To help linkers find symbols in libsecret-storage, even when used only indirectly via libsyslog-ng, link everything to it. We do this by adding it to `TOOLS_DEPS_LIBS`, and fixing a few places where this wasn't used.

This fixes #2094.