### PR TITLE
Always add test datafiles to the dist tarball

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -302,6 +302,4 @@ endif
 
 .PHONY: lib/ libsyslog-ng ivykis lib/ivykis/ lib/jsonc/ jsonc
 
-if ENABLE_TESTING
 include lib/tests/Makefile.am
-endif

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -17,8 +17,15 @@ lib_tests_TESTS		= \
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
+if ENABLE_TESTING
 noinst_PROGRAMS 	= \
 	lib/tests/test_host_resolve
+
+lib_tests_test_host_resolve_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_host_resolve_LDADD	=	\
+	$(TEST_LDADD)
+endif
 
 lib_tests_test_cfg_lexer_subst_CFLAGS	=	\
 	$(TEST_CFLAGS)
@@ -48,11 +55,6 @@ lib_tests_test_reloc_LDADD	=	\
 lib_tests_test_hostname_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_hostname_LDADD	=	\
-	$(TEST_LDADD)
-
-lib_tests_test_host_resolve_CFLAGS	=	\
-	$(TEST_CFLAGS)
-lib_tests_test_host_resolve_LDADD	=	\
 	$(TEST_LDADD)
 
 lib_tests_test_rcptid_CFLAGS = $(TEST_CFLAGS)


### PR DESCRIPTION
`lib/tests` contains `EXTRA_DIST` inputs for tests, for example: `lib/tests/testdata-lexer/`. They should not be excluded from the dist tarball, even if testing is disabled.

Note that only `EXTRA_DIST` is affected by automake's `if` conditional, source files can't be excluded from the tarball by `if`. automake handles them automatically (see `SOURCES_DIST`).