### PR TITLE
[WIP] transport/transport-tls.c: Work around a race condition

### DIFF
--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -144,8 +144,7 @@ log_transport_tls_write_method(LogTransport *s, const gpointer buf, gsize buflen
 tls_error:
 
   msg_error("SSL error while writing stream",
-            tls_context_format_tls_error_tag(self->tls_session->ctx),
-            tls_context_format_location_tag(self->tls_session->ctx));
+            tls_context_format_tls_error_tag(self->tls_session->ctx));
   ERR_clear_error();
 
   errno = EPIPE;


### PR DESCRIPTION
It appears that there's a race somewhere during reload, that sometimes corrupts the TLSContext's location (likely the rest too, but location is reused earlier). As this race likely existed before without ill side effects, as a workaround, remove the location reporting for now.

It should be re-introduced later, once the correct fix is in place.

This partly addresses #2080, but does not fix it.