### PR TITLE
secret-storage: rename PAGESIZE variables to pagesize

### DIFF
--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -104,8 +104,8 @@ gpointer
 nondumpable_buffer_alloc(gsize len)
 {
   gsize minimum_size = len + ALLOCATION_HEADER_SIZE;
-  gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
-  gsize alloc_size = round_to_nearest(minimum_size, PAGESIZE);
+  gsize pagesize = sysconf(_SC_PAGE_SIZE);
+  gsize alloc_size = round_to_nearest(minimum_size, pagesize);
 
   Allocation *buffer = _mmap(alloc_size);
   if (!buffer)

--- a/lib/secret-storage/tests/test_nondumpable_allocator.c
+++ b/lib/secret-storage/tests/test_nondumpable_allocator.c
@@ -34,10 +34,10 @@ Test(nondumpableallocator, malloc_realloc_free)
   strcpy(buffer, test_string);
   cr_assert_str_eq(buffer, test_string);
 
-  const gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
-  gpointer buffer_realloc = nondumpable_buffer_realloc(buffer, 2*PAGESIZE);
+  const gsize pagesize = sysconf(_SC_PAGE_SIZE);
+  gpointer buffer_realloc = nondumpable_buffer_realloc(buffer, 2*pagesize);
   cr_assert_str_eq(buffer_realloc, test_string);
-  ((gchar *)buffer_realloc)[2*PAGESIZE] = 'a';
+  ((gchar *)buffer_realloc)[2*pagesize] = 'a';
 
   nondumpable_buffer_free(buffer_realloc);
 }

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -263,11 +263,11 @@ Test(secretstorage, test_rlimit)
   cr_assert(!getrlimit(RLIMIT_MEMLOCK, &locked_limit));
   locked_limit.rlim_cur = MIN(locked_limit.rlim_max, 64 * 1024);
   cr_assert(!setrlimit(RLIMIT_MEMLOCK, &locked_limit));
-  const gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
+  const gsize pagesize = sysconf(_SC_PAGE_SIZE);
 
   gchar *key_fmt = g_strdup("keyXXX");
   int i = 0;
-  int for_limit = locked_limit.rlim_cur/PAGESIZE;
+  int for_limit = locked_limit.rlim_cur/pagesize;
   for (; i < for_limit; i++)
     {
       sprintf(key_fmt, "key%03d", i);


### PR DESCRIPTION
PAGESIZE is a define in some libc libraries, which conflicts with these local variables.

This PR is fix for:
```
In file included from
/mnt/a/oe/build/tmp/work/core2-64-bec-linux-musl/syslog-ng/3.15.1-r0/recipe-sysroot/usr/include/limits.h:8,
                 from
/mnt/a/oe/build/tmp/work/core2-64-bec-linux-musl/syslog-ng/3.15.1-r0/recipe-sysroot/usr/lib/glib-2.0/include/glibconfig.h:11,
                 from
/mnt/a/oe/build/tmp/work/core2-64-bec-linux-musl/syslog-ng/3.15.1-r0/recipe-sysroot/usr/include/glib-2.0/glib/gtypes.h:32,
                 from
/mnt/a/oe/build/tmp/work/core2-64-bec-linux-musl/syslog-ng/3.15.1-r0/recipe-sysroot/usr/include/glib-2.0/glib/galloca.h:32,
                 from
/mnt/a/oe/build/tmp/work/core2-64-bec-linux-musl/syslog-ng/3.15.1-r0/recipe-sysroot/usr/include/glib-2.0/glib.h:30,
                 from ../syslog-ng-3.15.1/lib/compat/glib.h:31,
                 from
../syslog-ng-3.15.1/lib/secret-storage/nondumpable-allocator.h:27,
                 from
../syslog-ng-3.15.1/lib/secret-storage/nondumpable-allocator.c:31:
../syslog-ng-3.15.1/lib/secret-storage/nondumpable-allocator.c: In
function 'nondumpable_buffer_alloc':
../syslog-ng-3.15.1/lib/secret-storage/nondumpable-allocator.c:107:9:
error: expected identifier or '(' before numeric constant
   gsize PAGESIZE = sysconf(_SC_PAGE_SIZE);
         ^~~~~~~~
```