### PR TITLE
packaging/debian: remove libsyslog-ng-test.a from syslog-ng-dev package

### DIFF
--- a/packaging/debian/syslog-ng-dev.install
+++ b/packaging/debian/syslog-ng-dev.install
@@ -1,8 +1,6 @@
 usr/include/syslog-ng/*
 usr/lib/syslog-ng/libsyslog-ng.so
-usr/lib/syslog-ng/syslog-ng/libtest/libsyslog-ng-test.a
 usr/lib/syslog-ng/libsyslog-ng-native-connector.a
 usr/lib/**/syslog-ng.pc
-usr/lib/**/syslog-ng-test.pc
 usr/lib/**/syslog-ng-native-connector.pc
 usr/share/syslog-ng/tools


### PR DESCRIPTION
The library is generated only when criterion is available.
As criterion (and criterion-dev) is not part of the Build-Depends
in control file, this should be removed from here.
Criterion is not supported by deb package builder environments
currently, this is why not adding criterion-dev to Build-Depends.

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>