### PR TITLE
[WIP] $(context-length) should not count synthetic messages (PatternDB, grouping-by())

### DIFF
--- a/modules/dbparser/synthetic-context.h
+++ b/modules/dbparser/synthetic-context.h
@@ -41,6 +41,4 @@ void synthetic_context_set_context_scope(SyntheticContext *self, const gchar *sc
 void synthetic_context_init(SyntheticContext *self);
 void synthetic_context_deinit(SyntheticContext *self);
 
-gint synthetic_context_lookup_context_scope(const gchar *context_scope);
-
 #endif

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -215,9 +215,7 @@ synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationCont
       g_assert_not_reached();
       break;
     }
-  g_ptr_array_add(context->messages, genmsg);
   synthetic_message_apply(self, context, genmsg, buffer);
-  g_ptr_array_remove_index_fast(context->messages, context->messages->len - 1);
   return genmsg;
 }
 
@@ -236,7 +234,7 @@ synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *m
    * messages, but without allocating a full-blown
    * structure.
    */
-  LogMessage *dummy_msgs[] = { msg, genmsg, NULL };
+  LogMessage *dummy_msgs[] = { msg, NULL };
   GPtrArray dummy_ptr_array = { .pdata = (void **) dummy_msgs, .len = 2 };
   CorrellationContext dummy_context = { .messages = &dummy_ptr_array, 0 };
 

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -1072,8 +1072,8 @@ test_patterndb_context_length(void)
 {
   _load_pattern_db_from_string(pdb_msg_count_skeleton);
 
-  assert_msg_matches_and_output_message_nvpair_equals("pattern13", 1, "CONTEXT_LENGTH", "2");
-  assert_msg_matches_and_output_message_nvpair_equals("pattern14", 1, "CONTEXT_LENGTH", "2");
+  assert_msg_matches_and_output_message_nvpair_equals("pattern13", 1, "CONTEXT_LENGTH", "1");
+  assert_msg_matches_and_output_message_nvpair_equals("pattern14", 1, "CONTEXT_LENGTH", "1");
 
   assert_msg_with_program_matches_and_nvpair_equals("prog2", "pattern15-a", "p15", "-a");
 


### PR DESCRIPTION
Counting synthetic messages with $(context-length) seems intuitive, but its side effects are not intuitive at all.

For example:
Triggering a context close event with `"$(context-length)" == "N"`, where the user wants to include `$(context-length)` in the message looks really weird (the output is N+1).

```
@version: 3.16

parser contextlength_test {
    grouping-by(
        key("${PROGRAM}")
        trigger("$(context-length)" == "5")
        aggregate(
            value("MESSAGE" "We have $(context-length) messages out of 5 considering a 30 secs timeout.")
        )
        timeout(30)
    );
};

log {
    source { stdin(); };
    parser(contextlength_test);
    destination { file("/dev/stdout"); };
};
```

Input:
```
program1 m1
program1 m2
program1 m3
program1 m4
program1 m5
```

Output prior to this PR:
```
We have 6 messages out of 5 considering a 30 secs timeout.
```

--------

The same applies to PatternDB:
```
<action condition='"$(context-length)" == "5"'>
        <message inherit-properties='true'>
        <tags>
        <tag>pdb_action</tag>
        </tags>

        <values> <value name="ACTION_MSG">$(context-length) is equal to 5 for '${.CEF.dhost}'</value> </values>
        </message>
</action>
```

--------

Questions:
- @bazsi What do you think about this? AFAIK this can not break old configs, but it may change the output of the last synthetic message. I know it can be argued whether this is a bug or not..

This problem was reported internally by a customer.