### PR TITLE
file-perms: Default to -1 for file and directory owners

### DIFF
--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -139,11 +139,9 @@ file_perm_options_defaults(FilePermOptions *self)
 void
 file_perm_options_global_defaults(FilePermOptions *self)
 {
-  self->file_uid = 0;
-  self->file_gid = 0;
+  self->file_uid = self->file_gid = -1;
   self->file_perm = 0600;
-  self->dir_uid = 0;
-  self->dir_gid = 0;
+  self->dir_uid = self->dir_gid = -1;
   self->dir_perm = 0700;
 }
 


### PR DESCRIPTION
Default to -1 for file and directory ownership, meaning no ownership changes will be applied, unless explicitly specified. This becomes important when running syslog-ng as a user (with appropriate capabilities granted), because one would expect that - unless configured otherwise - it will use the running user for the owner of files it creates.

Fixes #2002.