### PR TITLE
mock-transport: make it inheritable

### DIFF
--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -242,7 +242,7 @@ exit:
   return count;
 }
 
-static gssize
+gssize
 log_transport_mock_write_method(LogTransport *s, const gpointer buf, gsize count)
 {
   LogTransportMock *self = (LogTransportMock *)s;
@@ -257,7 +257,7 @@ log_transport_mock_write_method(LogTransport *s, const gpointer buf, gsize count
   return count;
 }
 
-static void
+void
 log_transport_mock_free_method(LogTransport *s)
 {
   LogTransportMock *self = (LogTransportMock *)s;
@@ -300,7 +300,7 @@ log_transport_mock_inject_data(LogTransportMock *self, const gchar *buffer, gssi
     inject_chunk(self, buffer, length);
 }
 
-static void
+void
 log_transport_mock_init(LogTransportMock *self, const gchar *read_buffer1, gssize read_buffer_length1, va_list va)
 {
   const gchar *buffer;

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -64,4 +64,14 @@ log_transport_mock_read_chunk_from_write_buffer(LogTransportMock *self, gchar *b
 
 LogTransportMock *
 log_transport_mock_clone(LogTransportMock *self);
+
+void
+log_transport_mock_init(LogTransportMock *self, const gchar *read_buffer1, gssize read_buffer_length1, va_list va);
+gssize
+log_transport_mock_write_method(LogTransport *s, const gpointer buf, gsize count);
+gssize
+log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTransportAuxData *aux);
+void
+log_transport_mock_free_method(LogTransport *s);
+
 #endif


### PR DESCRIPTION
Tests might need to inherit from mock-transport, for example calling some test specific business logic before read, or after write method. This patch exposes the necessary functions so that specialized test transport classes can be built from mock-transport.