### PR TITLE
Logthreaded nonfunctional changes

### DIFF
--- a/dbld/images/devshell-apt/all.txt
+++ b/dbld/images/devshell-apt/all.txt
@@ -12,3 +12,4 @@ linux-tools-generic
 libjemalloc-dev
 locales
 lcov
+gdbserver

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -335,7 +335,7 @@ _update_memory_usage_counter_when_fifo_is_used(LogThrDestDriver *self)
 }
 
 gboolean
-log_threaded_dest_driver_start(LogPipe *s)
+log_threaded_dest_driver_init_method(LogPipe *s)
 {
   LogThrDestDriver *self = (LogThrDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
@@ -446,7 +446,7 @@ log_threaded_dest_driver_init_instance(LogThrDestDriver *self, GlobalConfig *cfg
 
   self->worker_options.is_output_thread = TRUE;
 
-  self->super.super.super.init = log_threaded_dest_driver_start;
+  self->super.super.super.init = log_threaded_dest_driver_init_method;
   self->super.super.super.deinit = log_threaded_dest_driver_deinit_method;
   self->super.super.super.queue = log_threaded_dest_driver_queue;
   self->super.super.super.free_fn = log_threaded_dest_driver_free;

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -325,11 +325,10 @@ _worker_thread(gpointer arg)
 
   _init_watches(self);
 
-  _start_watches(self);
-
   if (self->worker.thread_init)
     self->worker.thread_init(self);
 
+  _start_watches(self);
   iv_main();
 
   _disconnect(self);

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -428,9 +428,6 @@ log_threaded_dest_driver_queue(LogPipe *s, LogMessage *msg,
   if (!path_options->flow_control_requested)
     path_options = log_msg_break_ack(msg, path_options, &local_options);
 
-  if (self->queue_method)
-    self->queue_method(self);
-
   log_msg_add_ack(msg, path_options);
   log_queue_push_tail(self->queue, log_msg_ref(msg), path_options);
 

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -99,7 +99,7 @@ struct _LogThrDestDriver
 };
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);
-gboolean log_threaded_dest_driver_start(LogPipe *s);
+gboolean log_threaded_dest_driver_init_method(LogPipe *s);
 
 void log_threaded_dest_driver_init_instance(LogThrDestDriver *self, GlobalConfig *cfg);
 void log_threaded_dest_driver_free(LogPipe *s);

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -43,6 +43,17 @@ typedef enum
 } worker_insert_result_t;
 
 typedef struct _LogThreadedDestDriver LogThreadedDestDriver;
+typedef struct _LogThreadedDestWorker
+{
+  gboolean connected;
+  void (*thread_init)(LogThreadedDestDriver *s);
+  void (*thread_deinit)(LogThreadedDestDriver *s);
+  worker_insert_result_t (*insert)(LogThreadedDestDriver *s, LogMessage *msg);
+  gboolean (*connect)(LogThreadedDestDriver *s);
+  void (*worker_message_queue_empty)(LogThreadedDestDriver *s);
+  void (*disconnect)(LogThreadedDestDriver *s);
+} LogThreadedDestWorker;
+
 struct _LogThreadedDestDriver
 {
   LogDestDriver super;
@@ -59,17 +70,7 @@ struct _LogThreadedDestDriver
 
   LogQueue *queue;
 
-  /* Worker stuff */
-  struct
-  {
-    gboolean connected;
-    void (*thread_init) (LogThreadedDestDriver *s);
-    void (*thread_deinit) (LogThreadedDestDriver *s);
-    worker_insert_result_t (*insert) (LogThreadedDestDriver *s, LogMessage *msg);
-    gboolean (*connect) (LogThreadedDestDriver *s);
-    void (*worker_message_queue_empty)(LogThreadedDestDriver *s);
-    void (*disconnect) (LogThreadedDestDriver *s);
-  } worker;
+  LogThreadedDestWorker worker;
 
   struct
   {

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -89,7 +89,6 @@ struct _LogThrDestDriver
     gint max;
   } retries;
 
-  void (*queue_method) (LogThrDestDriver *s);
   WorkerOptions worker_options;
   struct iv_event wake_up_event;
   struct iv_event shutdown_event;

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -103,13 +103,6 @@ gboolean log_threaded_dest_driver_init_method(LogPipe *s);
 void log_threaded_dest_driver_init_instance(LogThrDestDriver *self, GlobalConfig *cfg);
 void log_threaded_dest_driver_free(LogPipe *s);
 
-void log_threaded_dest_driver_message_accept(LogThrDestDriver *self,
-                                             LogMessage *msg);
-void log_threaded_dest_driver_message_drop(LogThrDestDriver *self,
-                                           LogMessage *msg);
-void log_threaded_dest_driver_message_rewind(LogThrDestDriver *self,
-                                             LogMessage *msg);
-
 void log_threaded_dest_driver_set_max_retries(LogDriver *s, gint max_retries);
 
 #endif

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -42,8 +42,8 @@ typedef enum
   WORKER_INSERT_RESULT_NOT_CONNECTED
 } worker_insert_result_t;
 
-typedef struct _LogThrDestDriver LogThrDestDriver;
-struct _LogThrDestDriver
+typedef struct _LogThreadedDestDriver LogThreadedDestDriver;
+struct _LogThreadedDestDriver
 {
   LogDestDriver super;
 
@@ -63,22 +63,22 @@ struct _LogThrDestDriver
   struct
   {
     gboolean connected;
-    void (*thread_init) (LogThrDestDriver *s);
-    void (*thread_deinit) (LogThrDestDriver *s);
-    worker_insert_result_t (*insert) (LogThrDestDriver *s, LogMessage *msg);
-    gboolean (*connect) (LogThrDestDriver *s);
-    void (*worker_message_queue_empty)(LogThrDestDriver *s);
-    void (*disconnect) (LogThrDestDriver *s);
+    void (*thread_init) (LogThreadedDestDriver *s);
+    void (*thread_deinit) (LogThreadedDestDriver *s);
+    worker_insert_result_t (*insert) (LogThreadedDestDriver *s, LogMessage *msg);
+    gboolean (*connect) (LogThreadedDestDriver *s);
+    void (*worker_message_queue_empty)(LogThreadedDestDriver *s);
+    void (*disconnect) (LogThreadedDestDriver *s);
   } worker;
 
   struct
   {
-    void (*retry_over) (LogThrDestDriver *s, LogMessage *msg);
+    void (*retry_over) (LogThreadedDestDriver *s, LogMessage *msg);
   } messages;
 
   struct
   {
-    gchar *(*stats_instance) (LogThrDestDriver *s);
+    gchar *(*stats_instance) (LogThreadedDestDriver *s);
   } format;
   gint stats_source;
   gint32 seq_num;
@@ -100,7 +100,7 @@ struct _LogThrDestDriver
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);
 gboolean log_threaded_dest_driver_init_method(LogPipe *s);
 
-void log_threaded_dest_driver_init_instance(LogThrDestDriver *self, GlobalConfig *cfg);
+void log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig *cfg);
 void log_threaded_dest_driver_free(LogPipe *s);
 
 void log_threaded_dest_driver_set_max_retries(LogDriver *s, gint max_retries);

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -40,7 +40,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   /* Shared between main/writer; only read by the writer, never written */
   gchar *exchange;
@@ -234,7 +234,7 @@ afamqp_dd_set_peer_verify(LogDriver *d, gboolean verify)
  */
 
 static gchar *
-afamqp_dd_format_stats_instance(LogThrDestDriver *s)
+afamqp_dd_format_stats_instance(LogThreadedDestDriver *s)
 {
   AMQPDestDriver *self = (AMQPDestDriver *) s;
   static gchar persist_name[1024];
@@ -279,7 +279,7 @@ _amqp_connection_disconnect(AMQPDestDriver *self)
 }
 
 static void
-afamqp_dd_disconnect(LogThrDestDriver *s)
+afamqp_dd_disconnect(LogThreadedDestDriver *s)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)s;
 
@@ -581,7 +581,7 @@ afamqp_worker_publish(AMQPDestDriver *self, LogMessage *msg)
 }
 
 static worker_insert_result_t
-afamqp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+afamqp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)s;
 
@@ -595,7 +595,7 @@ afamqp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-afamqp_worker_thread_init(LogThrDestDriver *d)
+afamqp_worker_thread_init(LogThreadedDestDriver *d)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)d;
 
@@ -659,7 +659,7 @@ afamqp_dd_free(LogPipe *d)
 }
 
 static gboolean
-afamqp_dd_worker_connect(LogThrDestDriver *s)
+afamqp_dd_worker_connect(LogThreadedDestDriver *s)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)s;
   return afamqp_dd_connect(self, FALSE);

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -631,7 +631,7 @@ afamqp_dd_init(LogPipe *s)
               evt_tag_str("exchange", self->exchange),
               evt_tag_str("exchange_type", self->exchange_type));
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 static void

--- a/modules/afmongodb/afmongodb-private.h
+++ b/modules/afmongodb/afmongodb-private.h
@@ -54,8 +54,6 @@ typedef struct _MongoDBDestDriver
 
   LogTemplateOptions template_options;
 
-  time_t last_msg_stamp;
-
   ValuePairs *vp;
 
   /* Writer-only stuff */

--- a/modules/afmongodb/afmongodb-private.h
+++ b/modules/afmongodb/afmongodb-private.h
@@ -35,7 +35,7 @@
 
 typedef struct _MongoDBDestDriver
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   /* Shared between main/writer; only read by the writer, never
    written */

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -533,7 +533,7 @@ _init(LogPipe *s)
   if (!afmongodb_dd_private_uri_init(&self->super.super.super))
     return FALSE;
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 static void

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -89,7 +89,7 @@ afmongodb_dd_set_value_pairs(LogDriver *d, ValuePairs *vp)
  */
 
 static gchar *
-_format_instance_id(const LogThrDestDriver *d, const gchar *format)
+_format_instance_id(const LogThreadedDestDriver *d, const gchar *format)
 {
   const MongoDBDestDriver *self = (const MongoDBDestDriver *)d;
   static gchar args[1024];
@@ -126,7 +126,7 @@ _format_instance_id(const LogThrDestDriver *d, const gchar *format)
 }
 
 static gchar *
-_format_stats_instance(LogThrDestDriver *d)
+_format_stats_instance(LogThreadedDestDriver *d)
 {
   return _format_instance_id(d, "mongodb,%s");
 }
@@ -134,14 +134,14 @@ _format_stats_instance(LogThrDestDriver *d)
 static const gchar *
 _format_persist_name(const LogPipe *s)
 {
-  const LogThrDestDriver *self = (const LogThrDestDriver *)s;
+  const LogThreadedDestDriver *self = (const LogThreadedDestDriver *)s;
 
   return s->persist_name ? _format_instance_id(self, "afmongodb.%s")
          : _format_instance_id(self, "afmongodb(%s)");
 }
 
 static void
-_worker_disconnect(LogThrDestDriver *s)
+_worker_disconnect(LogThreadedDestDriver *s)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
@@ -361,7 +361,7 @@ _vp_process_value(const gchar *name, const gchar *prefix, TypeHint type,
 }
 
 static void
-_worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
+_worker_retry_over_message(LogThreadedDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
 
@@ -372,7 +372,7 @@ _worker_retry_over_message(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static worker_insert_result_t
-_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
   gboolean success;
@@ -476,7 +476,7 @@ afmongodb_dd_private_uri_init(LogDriver *d)
 }
 
 static void
-_worker_thread_init(LogThrDestDriver *d)
+_worker_thread_init(LogThreadedDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 
@@ -488,7 +488,7 @@ _worker_thread_init(LogThrDestDriver *d)
 }
 
 static void
-_worker_thread_deinit(LogThrDestDriver *d)
+_worker_thread_deinit(LogThreadedDestDriver *d)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)d;
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -563,14 +563,6 @@ _free(LogPipe *d)
   log_threaded_dest_driver_free(d);
 }
 
-static void
-_logthrdest_queue_method(LogThrDestDriver *d)
-{
-  MongoDBDestDriver *self = (MongoDBDestDriver *)d;
-
-  self->last_msg_stamp = cached_g_current_time_sec();
-}
-
 /*
  * Plugin glue.
  */
@@ -587,7 +579,6 @@ afmongodb_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.init = _init;
   self->super.super.super.super.free_fn = _free;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
-  self->super.queue_method = _logthrdest_queue_method;
 
   self->super.worker.thread_init = _worker_thread_init;
   self->super.worker.thread_deinit = _worker_thread_deinit;

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -130,7 +130,7 @@ _expect_uri_in_log(const gchar *testcase, const gchar *uri, const gchar *db, con
 static gboolean
 _execute_compare_persist_name(const gchar *expected_name)
 {
-  LogThrDestDriver *self = (LogThrDestDriver *)mongodb;
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *)mongodb;
   const gchar *name = log_pipe_get_persist_name((const LogPipe *)self);
   return assert_nstring_non_fatal(name, -1, expected_name, -1, "mismatch");
 }
@@ -147,7 +147,7 @@ _test_persist_name(void)
 static gboolean
 _execute_compare_stats_name(const gchar *expected_name)
 {
-  LogThrDestDriver *self = (LogThrDestDriver *)mongodb;
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *)mongodb;
   const gchar *name = self->format.stats_instance(self);
   return assert_nstring_non_fatal(name, -1, expected_name, -1, "mismatch");
 }

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -614,7 +614,7 @@ afsmtp_dd_init(LogPipe *s)
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 static void

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -48,7 +48,7 @@ typedef struct
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   /* Shared between main/writer; only read by the writer, never
      written */
@@ -199,7 +199,7 @@ ignore_sigpipe (void)
 }
 
 static gchar *
-afsmtp_dd_format_stats_instance(LogThrDestDriver *d)
+afsmtp_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   AFSMTPDriver *self = (AFSMTPDriver *)d;
   static gchar persist_name[1024];
@@ -483,7 +483,7 @@ __send_message(AFSMTPDriver *self, smtp_session_t session)
 }
 
 static worker_insert_result_t
-afsmtp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+afsmtp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AFSMTPDriver *self = (AFSMTPDriver *)s;
   gboolean success = TRUE;
@@ -518,7 +518,7 @@ afsmtp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-afsmtp_worker_thread_init(LogThrDestDriver *d)
+afsmtp_worker_thread_init(LogThreadedDestDriver *d)
 {
   AFSMTPDriver *self = (AFSMTPDriver *)d;
 
@@ -528,7 +528,7 @@ afsmtp_worker_thread_init(LogThrDestDriver *d)
 }
 
 static void
-afsmtp_worker_thread_deinit(LogThrDestDriver *d)
+afsmtp_worker_thread_deinit(LogThreadedDestDriver *d)
 {
   AFSMTPDriver *self = (AFSMTPDriver *)d;
 

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -358,7 +358,7 @@ afstomp_dd_init(LogPipe *s)
               evt_tag_int("port", self->port),
               evt_tag_str("destination", self->destination));
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 static void

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -39,7 +39,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   gchar *destination;
   LogTemplate *body_template;
@@ -158,7 +158,7 @@ afstomp_dd_get_template_options(LogDriver *s)
  */
 
 static gchar *
-afstomp_dd_format_stats_instance(LogThrDestDriver *s)
+afstomp_dd_format_stats_instance(LogThreadedDestDriver *s)
 {
   STOMPDestDriver *self = (STOMPDestDriver *) s;
   static gchar persist_name[1024];
@@ -241,7 +241,7 @@ afstomp_dd_connect(STOMPDestDriver *self, gboolean reconnect)
 }
 
 static void
-afstomp_dd_disconnect(LogThrDestDriver *s)
+afstomp_dd_disconnect(LogThreadedDestDriver *s)
 {
   STOMPDestDriver *self = (STOMPDestDriver *)s;
 
@@ -319,7 +319,7 @@ afstomp_worker_publish(STOMPDestDriver *self, LogMessage *msg)
 }
 
 static worker_insert_result_t
-afstomp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+afstomp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   STOMPDestDriver *self = (STOMPDestDriver *)s;
 
@@ -333,7 +333,7 @@ afstomp_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-afstomp_worker_thread_init(LogThrDestDriver *s)
+afstomp_worker_thread_init(LogThreadedDestDriver *s)
 {
   STOMPDestDriver *self = (STOMPDestDriver *) s;
 

--- a/modules/http/http-plugin.h
+++ b/modules/http/http-plugin.h
@@ -31,7 +31,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
   gchar *curl;
   gchar *url;
   gchar *user;

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -516,7 +516,7 @@ http_dd_init(LogPipe *s)
 
   _set_curl_opt(self);
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 gboolean

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -41,7 +41,7 @@ _format_persist_name(const LogPipe *s)
 }
 
 static gchar *
-_format_stats_instance(LogThrDestDriver *s)
+_format_stats_instance(LogThreadedDestDriver *s)
 {
   static gchar stats[1024];
 
@@ -60,7 +60,7 @@ _http_write_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 }
 
 static void
-_thread_init(LogThrDestDriver *s)
+_thread_init(LogThreadedDestDriver *s)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) s;
 
@@ -71,18 +71,18 @@ _thread_init(LogThrDestDriver *s)
 }
 
 static void
-_thread_deinit(LogThrDestDriver *s)
+_thread_deinit(LogThreadedDestDriver *s)
 {
 }
 
 static gboolean
-_connect(LogThrDestDriver *s)
+_connect(LogThreadedDestDriver *s)
 {
   return TRUE;
 }
 
 static void
-_disconnect(LogThrDestDriver *s)
+_disconnect(LogThreadedDestDriver *s)
 {
 }
 
@@ -261,7 +261,7 @@ _map_http_status_to_worker_status(glong http_code)
 }
 
 static worker_insert_result_t
-_insert(LogThrDestDriver *s, LogMessage *msg)
+_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   CURLcode ret;
   worker_insert_result_t retval;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -158,7 +158,7 @@ java_dd_send_to_object(JavaDestDriver *self, LogMessage *msg)
 }
 
 gboolean
-java_dd_open(LogThrDestDriver *s)
+java_dd_open(LogThreadedDestDriver *s)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;
   if (!java_destination_proxy_is_opened(self->proxy))
@@ -169,7 +169,7 @@ java_dd_open(LogThrDestDriver *s)
 }
 
 void
-java_dd_close(LogThrDestDriver *s)
+java_dd_close(LogThreadedDestDriver *s)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;
   if (java_destination_proxy_is_opened(self->proxy))
@@ -179,7 +179,7 @@ java_dd_close(LogThrDestDriver *s)
 }
 
 static worker_insert_result_t
-java_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+java_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;
 
@@ -193,14 +193,14 @@ java_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-java_worker_message_queue_empty(LogThrDestDriver *d)
+java_worker_message_queue_empty(LogThreadedDestDriver *d)
 {
   JavaDestDriver *self = (JavaDestDriver *)d;
   java_destination_proxy_on_message_queue_empty(self->proxy);
 }
 
 static void
-java_worker_thread_deinit(LogThrDestDriver *d)
+java_worker_thread_deinit(LogThreadedDestDriver *d)
 {
   java_dd_close(d);
   java_machine_detach_thread();
@@ -222,7 +222,7 @@ java_dd_format_persist_name(const LogPipe *s)
 }
 
 static gchar *
-java_dd_format_stats_instance(LogThrDestDriver *d)
+java_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   JavaDestDriver *self = (JavaDestDriver *)d;
   static gchar persist_name[1024];

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -140,7 +140,7 @@ java_dd_init(LogPipe *s)
   if (!java_destination_proxy_init(self->proxy))
     return FALSE;
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 gboolean

--- a/modules/java/native/java-destination.h
+++ b/modules/java/native/java-destination.h
@@ -40,7 +40,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
   JavaDestinationProxy *proxy;
   GString *class_path;
   gchar *class_name;

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -35,7 +35,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   gchar *class;
   GList *loaders;
@@ -108,7 +108,7 @@ python_dd_get_template_options(LogDriver *d)
 /** Helpers for stats & persist_name formatting **/
 
 static gchar *
-python_dd_format_stats_instance(LogThrDestDriver *d)
+python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
   static gchar persist_name[1024];
@@ -310,7 +310,7 @@ _py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_ob
 
 
 static worker_insert_result_t
-python_dd_insert(LogThrDestDriver *d, LogMessage *msg)
+python_dd_insert(LogThreadedDestDriver *d, LogMessage *msg)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
   worker_insert_result_t result = WORKER_INSERT_RESULT_ERROR;
@@ -390,7 +390,7 @@ python_dd_close(PythonDestDriver *self)
 }
 
 static void
-python_dd_worker_init(LogThrDestDriver *d)
+python_dd_worker_init(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
@@ -398,7 +398,7 @@ python_dd_worker_init(LogThrDestDriver *d)
 }
 
 static void
-python_dd_disconnect(LogThrDestDriver *d)
+python_dd_disconnect(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *) d;
 
@@ -406,7 +406,7 @@ python_dd_disconnect(LogThrDestDriver *d)
 }
 
 static void
-python_dd_over_message(LogThrDestDriver *s, LogMessage *msg)
+python_dd_over_message(LogThreadedDestDriver *s, LogMessage *msg)
 {
   PythonDestDriver *self = (PythonDestDriver *)s;
   python_dd_retry_error(self, msg);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -445,7 +445,7 @@ python_dd_init(LogPipe *d)
               evt_tag_str("driver", self->super.super.super.id),
               evt_tag_str("class", self->class));
 
-  return log_threaded_dest_driver_start(d);
+  return log_threaded_dest_driver_init_method(d);
 
 fail:
   PyGILState_Release(gstate);

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -360,7 +360,7 @@ redis_dd_init(LogPipe *s)
               evt_tag_str("host", self->host),
               evt_tag_int("port", self->port));
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 static void

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -36,7 +36,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   gchar *host;
   gint   port;
@@ -117,7 +117,7 @@ redis_dd_get_template_options(LogDriver *d)
  */
 
 static gchar *
-redis_dd_format_stats_instance(LogThrDestDriver *d)
+redis_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   RedisDriver *self = (RedisDriver *)d;
   static gchar persist_name[1024];
@@ -219,7 +219,7 @@ redis_dd_connect(RedisDriver *self, gboolean reconnect)
 }
 
 static void
-redis_dd_disconnect(LogThrDestDriver *s)
+redis_dd_disconnect(LogThreadedDestDriver *s)
 {
   RedisDriver *self = (RedisDriver *)s;
 
@@ -233,7 +233,7 @@ redis_dd_disconnect(LogThrDestDriver *s)
  */
 
 static worker_insert_result_t
-redis_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   RedisDriver *self = (RedisDriver *)s;
   redisReply *reply;
@@ -309,7 +309,7 @@ redis_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-redis_worker_thread_init(LogThrDestDriver *d)
+redis_worker_thread_init(LogThreadedDestDriver *d)
 {
   RedisDriver *self = (RedisDriver *)d;
 
@@ -324,7 +324,7 @@ redis_worker_thread_init(LogThrDestDriver *d)
 }
 
 static void
-redis_worker_thread_deinit(LogThrDestDriver *d)
+redis_worker_thread_deinit(LogThreadedDestDriver *d)
 {
   RedisDriver *self = (RedisDriver *)d;
 

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -386,7 +386,7 @@ riemann_worker_init(LogPipe *s)
               evt_tag_str("server", self->server),
               evt_tag_int("port", self->port));
 
-  return log_threaded_dest_driver_start(s);
+  return log_threaded_dest_driver_init_method(s);
 }
 
 static void

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -34,7 +34,7 @@
 
 typedef struct
 {
-  LogThrDestDriver super;
+  LogThreadedDestDriver super;
 
   gchar *server;
   gint port;
@@ -246,7 +246,7 @@ riemann_dd_get_template_options(LogDriver *d)
  */
 
 static gchar *
-riemann_dd_format_stats_instance(LogThrDestDriver *s)
+riemann_dd_format_stats_instance(LogThreadedDestDriver *s)
 {
   RiemannDestDriver *self = (RiemannDestDriver *)s;
   static gchar persist_name[1024];
@@ -274,7 +274,7 @@ riemann_dd_format_persist_name(const LogPipe *s)
 }
 
 static void
-riemann_dd_disconnect(LogThrDestDriver *s)
+riemann_dd_disconnect(LogThreadedDestDriver *s)
 {
   RiemannDestDriver *self = (RiemannDestDriver *)s;
 
@@ -634,7 +634,7 @@ riemann_worker_batch_flush(RiemannDestDriver *self)
 }
 
 static worker_insert_result_t
-riemann_worker_insert(LogThrDestDriver *s, LogMessage *msg)
+riemann_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   RiemannDestDriver *self = (RiemannDestDriver *)s;
   worker_insert_result_t result;
@@ -655,7 +655,7 @@ riemann_worker_insert(LogThrDestDriver *s, LogMessage *msg)
 }
 
 static void
-riemann_worker_thread_deinit(LogThrDestDriver *s)
+riemann_worker_thread_deinit(LogThreadedDestDriver *s)
 {
   RiemannDestDriver *self = (RiemannDestDriver *)s;
 
@@ -663,7 +663,7 @@ riemann_worker_thread_deinit(LogThrDestDriver *s)
 }
 
 static void
-riemann_flush_queue(LogThrDestDriver *s)
+riemann_flush_queue(LogThreadedDestDriver *s)
 {
   RiemannDestDriver *self = (RiemannDestDriver *)s;
   riemann_worker_batch_flush(self);


### PR DESCRIPTION
This is the initial set of _non-functional_ changes in log threaded dest driver that should be risk-free to merge. 

I've extracted these from PR #2063 

I am going to rebase the rest of my branches on top of this one.

The core of the patches are:
 * rename and reorder functions to make logthrdestdrv.c easier to navigate
 * extract some code into smaller functions (without other changes)
 * drop some unused functionality from afmongodb and the supporting code from logthrdestdrv

I also left in my devshell dbld patch, which adds gdbserver to the devshell docker image, so that I can run/debug unit tests within docker.

