### PR TITLE
cmake: glib detection more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ set(WITH_GETTEXT "" CACHE STRING "Set the prefix where gettext is installed (e.g
 set(CMAKE_C_STANDARD 99)
 
 find_package(BISON 2.4 REQUIRED)
-find_package(GLIB 2.10.1 REQUIRED)
+find_package(GLIB COMPONENTS gmodule gthread 2.10.1 REQUIRED)
 
 set (SYSLOG_NG_USE_CONST_IVYKIS_MOCK 1)
 external_or_find_package(IVYKIS REQUIRED)

--- a/cmake/Modules/FindGLIB.cmake
+++ b/cmake/Modules/FindGLIB.cmake
@@ -1,72 +1,124 @@
-#############################################################################
-# Copyright (c) 2016 Balabit
+# - Try to find Glib and its components (gio, gobject etc)
+# Once done, this will define
 #
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
+#  GLIB_FOUND - system has Glib
+#  GLIB_INCLUDE_DIRS - the Glib include directories
+#  GLIB_LIBRARIES - link these to use Glib
 #
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
+# Optionally, the COMPONENTS keyword can be passed to find_package()
+# and Glib components can be looked for.  Currently, the following
+# components can be used, and they define the following variables if
+# found:
 #
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#  gio:             GLIB_GIO_LIBRARIES
+#  gobject:         GLIB_GOBJECT_LIBRARIES
+#  gmodule:         GLIB_GMODULE_LIBRARIES
+#  gthread:         GLIB_GTHREAD_LIBRARIES
 #
-# As an additional exemption you are allowed to compile & link against the
-# OpenSSL libraries as published by the OpenSSL project. See the file
-# COPYING for details.
+# Note that the respective _INCLUDE_DIR variables are not set, since
+# all headers are in the same directory as GLIB_INCLUDE_DIRS.
 #
-#############################################################################
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# some parts have been copied from https://raw.githubusercontent.com/WebKit/webkit/master/Source/cmake/FindGLIB.cmake
-include(LibFindMacros)
+# Source https://raw.githubusercontent.com/WebKit/webkit/master/Source/cmake/FindGLIB.cmake
 
-libfind_pkg_check_modules(GLIB_GTHREAD_PKGCONF gthread-2.0)
-libfind_pkg_check_modules(GLIB_GMODULE_PKGCONF gmodule-2.0)
-libfind_pkg_check_modules(GLIB_PKGCONF glib-2.0)
+find_package(PkgConfig)
+pkg_check_modules(PC_GLIB QUIET glib-2.0)
+
+find_library(GLIB_LIBRARIES
+    NAMES glib-2.0
+    HINTS ${PC_GLIB_LIBDIR}
+          ${PC_GLIB_LIBRARY_DIRS}
+)
+
+# Files in glib's main include path may include glibconfig.h, which,
+# for some odd reason, is normally in $LIBDIR/glib-2.0/include.
+get_filename_component(_GLIB_LIBRARY_DIR ${GLIB_LIBRARIES} PATH)
+find_path(GLIBCONFIG_INCLUDE_DIR
+    NAMES glibconfig.h
+    HINTS ${PC_LIBDIR} ${PC_LIBRARY_DIRS} ${_GLIB_LIBRARY_DIR}
+          ${PC_GLIB_INCLUDEDIR} ${PC_GLIB_INCLUDE_DIRS}
+    PATH_SUFFIXES glib-2.0/include
+)
 
 find_path(GLIB_INCLUDE_DIR
-  NAMES glib.h
-  PATHS ${GLIB_PKGCONF_INCLUDE_DIRS}
-  PATH_SUFFIXES glib-2.0
+    NAMES glib.h
+    HINTS ${PC_GLIB_INCLUDEDIR}
+          ${PC_GLIB_INCLUDE_DIRS}
+    PATH_SUFFIXES glib-2.0
 )
 
-find_path(GLIBCONFIG_INCLUDE_DIR
-  NAMES glibconfig.h
-  HINTS ${GLIB_PKGCONF_INCLUDE_DIRS} ${GLIB_PKGCONF_INCLUDE_DIRS}/include
-  PATH_SUFFIXES glib-2.0/include
-)
-
-find_library(GLIB_LIBRARY
-  NAMES glib-2.0
-  PATHS ${GLIB_PKGCONF_LIBRARY_DIRS}
-)
-
-find_library(GLIB_GTHREAD_LIBRARIES
-  NAMES gthread-2.0
-  PATHS ${GLIB_PKGCONF_LIBRARY_DIRS}
-)
-
-find_library(GLIB_GMODULE_LIBRARIES
-  NAMES gmodule-2.0
-  PATHS ${GLIB_PKGCONF_LIBRARY_DIRS}
-)
+set(GLIB_INCLUDE_DIRS ${GLIB_INCLUDE_DIR} ${GLIBCONFIG_INCLUDE_DIR})
 
 # Version detection
-file(READ "${GLIBCONFIG_INCLUDE_DIR}/glibconfig.h" GLIBCONFIG_H_CONTENTS)
-string(REGEX MATCH "#define GLIB_MAJOR_VERSION ([0-9]+)" _dummy "${GLIBCONFIG_H_CONTENTS}")
-set(GLIB_VERSION_MAJOR "${CMAKE_MATCH_1}")
-string(REGEX MATCH "#define GLIB_MINOR_VERSION ([0-9]+)" _dummy "${GLIBCONFIG_H_CONTENTS}")
-set(GLIB_VERSION_MINOR "${CMAKE_MATCH_1}")
-string(REGEX MATCH "#define GLIB_MICRO_VERSION ([0-9]+)" _dummy "${GLIBCONFIG_H_CONTENTS}")
-set(GLIB_VERSION_MICRO "${CMAKE_MATCH_1}")
-set(GLIB_VERSION "${GLIB_VERSION_MAJOR}.${GLIB_VERSION_MINOR}.${GLIB_VERSION_MICRO}")
+if (EXISTS "${GLIBCONFIG_INCLUDE_DIR}/glibconfig.h")
+    file(READ "${GLIBCONFIG_INCLUDE_DIR}/glibconfig.h" GLIBCONFIG_H_CONTENTS)
+    string(REGEX MATCH "#define GLIB_MAJOR_VERSION ([0-9]+)" _dummy "${GLIBCONFIG_H_CONTENTS}")
+    set(GLIB_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "#define GLIB_MINOR_VERSION ([0-9]+)" _dummy "${GLIBCONFIG_H_CONTENTS}")
+    set(GLIB_VERSION_MINOR "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "#define GLIB_MICRO_VERSION ([0-9]+)" _dummy "${GLIBCONFIG_H_CONTENTS}")
+    set(GLIB_VERSION_MICRO "${CMAKE_MATCH_1}")
+    set(GLIB_VERSION "${GLIB_VERSION_MAJOR}.${GLIB_VERSION_MINOR}.${GLIB_VERSION_MICRO}")
+endif ()
 
-# Set the include dir variables and the libraries and let libfind_process do the rest.
-# NOTE: Singular variables for this library, plural for libraries this this lib depends on.
-set(GLIB_PROCESS_INCLUDES GLIB_INCLUDE_DIR GLIBCONFIG_INCLUDE_DIR)
-set(GLIB_PROCESS_LIBS GLIB_LIBRARY GLIB_GTHREAD_LIBRARY GLIB_GMODULE_LIBRARY)
-libfind_process(GLIB)
+# Additional Glib components.  We only look for libraries, as not all of them
+# have corresponding headers and all headers are installed alongside the main
+# glib ones.
+foreach (_component ${GLIB_FIND_COMPONENTS})
+    if (${_component} STREQUAL "gio")
+        find_library(GLIB_GIO_LIBRARIES NAMES gio-2.0 HINTS ${_GLIB_LIBRARY_DIR})
+        set(ADDITIONAL_REQUIRED_VARS ${ADDITIONAL_REQUIRED_VARS} GLIB_GIO_LIBRARIES)
+    elseif (${_component} STREQUAL "gobject")
+        find_library(GLIB_GOBJECT_LIBRARIES NAMES gobject-2.0 HINTS ${_GLIB_LIBRARY_DIR})
+        set(ADDITIONAL_REQUIRED_VARS ${ADDITIONAL_REQUIRED_VARS} GLIB_GOBJECT_LIBRARIES)
+    elseif (${_component} STREQUAL "gmodule")
+        find_library(GLIB_GMODULE_LIBRARIES NAMES gmodule-2.0 HINTS ${_GLIB_LIBRARY_DIR})
+        set(ADDITIONAL_REQUIRED_VARS ${ADDITIONAL_REQUIRED_VARS} GLIB_GMODULE_LIBRARIES)
+    elseif (${_component} STREQUAL "gthread")
+        find_library(GLIB_GTHREAD_LIBRARIES NAMES gthread-2.0 HINTS ${_GLIB_LIBRARY_DIR})
+        set(ADDITIONAL_REQUIRED_VARS ${ADDITIONAL_REQUIRED_VARS} GLIB_GTHREAD_LIBRARIES)
+    elseif (${_component} STREQUAL "gio-unix")
+        # gio-unix is compiled as part of the gio library, but the include paths
+        # are separate from the shared glib ones. Since this is currently only used
+        # by WebKitGTK+ we don't go to extraordinary measures beyond pkg-config.
+        pkg_check_modules(GIO_UNIX QUIET gio-unix-2.0)
+    endif ()
+endforeach ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLIB REQUIRED_VARS GLIB_INCLUDE_DIRS GLIB_LIBRARIES ${ADDITIONAL_REQUIRED_VARS}
+                                       VERSION_VAR   GLIB_VERSION)
+
+mark_as_advanced(
+    GLIBCONFIG_INCLUDE_DIR
+    GLIB_GIO_LIBRARIES
+    GLIB_GIO_UNIX_LIBRARIES
+    GLIB_GMODULE_LIBRARIES
+    GLIB_GOBJECT_LIBRARIES
+    GLIB_GTHREAD_LIBRARIES
+    GLIB_INCLUDE_DIR
+    GLIB_INCLUDE_DIRS
+    GLIB_LIBRARIES
+)

--- a/cmake/Modules/Findcriterion.cmake
+++ b/cmake/Modules/Findcriterion.cmake
@@ -21,6 +21,8 @@
 #
 #############################################################################
 
+include(LibFindMacros)
+
 libfind_pkg_check_modules(CRITERION_PKGCONF criterion)
 
 libfind_pkg_detect(CRITERION criterion FIND_PATH criterion/criterion.h FIND_LIBRARY criterion)

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -43,10 +43,9 @@ dbld/build/.*$
 dbld/release/.*$
 dbld/install/.*$
 dbld/images/.*$
-cmake/Modules/FindInotify.cmake
+cmake/.*$
  LGPLv2.1+_SSL
 autogen\.sh$
-cmake
 sub-configure\.sh$
 configure\.ac$
 Makefile\.am$


### PR DESCRIPTION
Changes:
* Copyright does not need to check the `cmake` directory, because there only should be compile related files
* Updated the `FindGLIB` for cmake
* Fix missing dependency for `FindCriterion`