### PR TITLE
Minor updates to SELinux policy installer script

### DIFF
--- a/contrib/selinux/src/root_safe/syslog_ng.el5.fc.in
+++ b/contrib/selinux/src/root_safe/syslog_ng.el5.fc.in
@@ -1,4 +1,5 @@
 $PATH$/etc/syslog-ng.conf(.*)?	--	gen_context(system_u:object_r:syslog_conf_t,s0)
+$PATH$/etc/conf.d/.*.conf	--	gen_context(system_u:object_r:syslog_conf_t,s0)
 $PATH$/var/syslog-ng.*		--	gen_context(system_u:object_r:syslogd_var_lib_t,s0)
 $PATH$/libexec/syslog-ng	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 /etc/rc\.d/init\.d/syslog-ng	--	gen_context(system_u:object_r:initrc_exec_t,s0)

--- a/contrib/selinux/src/root_safe/syslog_ng.el6.fc.in
+++ b/contrib/selinux/src/root_safe/syslog_ng.el6.fc.in
@@ -1,4 +1,5 @@
 $PATH$/etc/syslog-ng.conf(.*)?	--	gen_context(system_u:object_r:syslog_conf_t,s0)
+$PATH$/etc/conf.d/.*.conf	--	gen_context(system_u:object_r:syslog_conf_t,s0)
 $PATH$/var/syslog-ng.*		--	gen_context(system_u:object_r:syslogd_var_lib_t,s0)
 $PATH$/libexec/syslog-ng	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 /etc/rc\.d/init\.d/syslog-ng	--	gen_context(system_u:object_r:syslogd_initrc_exec_t,s0)

--- a/contrib/selinux/src/root_safe/syslog_ng.el7.fc.in
+++ b/contrib/selinux/src/root_safe/syslog_ng.el7.fc.in
@@ -1,6 +1,6 @@
 $PATH$/etc/syslog-ng.conf(.*)?	--	gen_context(system_u:object_r:syslog_conf_t,s0)
+$PATH$/etc/conf.d/.*.conf	--	gen_context(system_u:object_r:syslog_conf_t,s0)
 $PATH$/var/syslog-ng.*		--	gen_context(system_u:object_r:syslogd_var_lib_t,s0)
 $PATH$/libexec/syslog-ng	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
 $PATH$/libexec/syslog-ng-wrapper.sh	--	gen_context(system_u:object_r:syslogd_exec_t,s0)
-/etc/rc\.d/init\.d/syslog-ng	--	gen_context(system_u:object_r:syslogd_initrc_exec_t,s0)
 $PATH$/share/include/scl/system/generate-system-source.sh	--	gen_context(system_u:object_r:bin_t,s0)

--- a/contrib/selinux/src/syslog_ng.el67.te.in
+++ b/contrib/selinux/src/syslog_ng.el67.te.in
@@ -1,2 +1,2 @@
-policy_module(syslog_ng, 1.0.5)
+policy_module(syslog_ng, 1.0.6)
 

--- a/contrib/selinux/syslog_ng.sh
+++ b/contrib/selinux/syslog_ng.sh
@@ -54,7 +54,7 @@ extract_version_string() {
 detect_os_version() {
 	echo "Detecting RHEL/CentOS/Oracle Linux version..."
 	if [ -x "/usr/bin/lsb_release" ]; then
-		if lsb_release -d | grep -qE "Description:[[:space:]]+(CentOS|Red Hat Enterprise Linux Server|Oracle Linux Server|Enterprise Linux Enterprise Linux Server) release"; then
+		if lsb_release -d | grep -qE "Description:[[:space:]]+(CentOS|CentOS Linux|Red Hat Enterprise Linux Server|Oracle Linux Server|Enterprise Linux Enterprise Linux Server) release"; then
 			OS_VERSION=$( lsb_release -r | cut -f 2 )
 		else
 			echo "You don't seem to be running a supported Linux distribution!" >&2
@@ -182,8 +182,8 @@ install_module() {
 	
 	# Fixing the file context
 	/sbin/restorecon -F -Rv "${INSTALL_PATH}"
-	/sbin/restorecon -F -Rv /etc/init.d/syslog-ng
-	/sbin/restorecon -F -Rv /etc/rc.d/init.d/syslog-ng
+	[ -f /etc/init.d/syslog-ng ] && /sbin/restorecon -F -v /etc/init.d/syslog-ng
+	[ -f /etc/rc.d/init.d/syslog-ng ] && /sbin/restorecon -F -v /etc/rc.d/init.d/syslog-ng
 	/sbin/restorecon -F -Rv /dev/log
 	
 	echo -e "\nPlease restart syslog-ng. You can find more information about this in the README file."


### PR DESCRIPTION
src/root_safe/syslog_ng.el6.fc.in: added conf.d/*.conf to be marked as config files
src/root_safe/syslog_ng.el7.fc.in: added conf.d/*.conf to be marked as config files, removed labels for the init script
src/syslog_ng.el67.te.in: bumped module version to 1.0.6
syslog_ng.sh: updated OS detection code to properly detect CentOS 7, updated code for init-script labeling

    * added conf.d/*.conf to be marked with the label syslog_conf_t
    * removed labels for the init script for RHEL/CentOS 7
    * module version bump to 1.0.6
    * OS detection had problems with CentOS 7, when lsb_release was present, fixed it
    * updated init script relabeling code, to handle when the init scripts are not present

Signed-off-by: Szigetvari Janos <jszigetvari@gmail.com>