### PR TITLE
RewriteExpr: Remove misleading print of result from log_rewrite_queue()

### DIFF
--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -26,12 +26,6 @@
 
 /* rewrite */
 
-static EVTTAG *
-rewrite_result_tag(gboolean res)
-{
-  return evt_tag_str("result", res ? "MATCH - Forwarding message" : "UNMATCHED - Forwarding message");
-}
-
 void
 log_rewrite_set_condition(LogRewrite *self, FilterExprNode *condition)
 {
@@ -42,23 +36,24 @@ static void
 log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogRewrite *self = (LogRewrite *) s;
-  gboolean res = FALSE;
 
   msg_debug(">>>>>> rewrite rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
-  if (self->condition && !(res=filter_expr_eval_root(self->condition, &msg, path_options)))
+  if (self->condition && !filter_expr_eval_root(self->condition, &msg, path_options))
     {
       msg_debug("Rewrite condition unmatched, skipping rewrite",
-                evt_tag_str("value", log_msg_get_value_name(self->value_handle, NULL)));
+                evt_tag_str("value", log_msg_get_value_name(self->value_handle, NULL)),
+                evt_tag_str("rule", self->name),
+                log_pipe_location_tag(s),
+                evt_tag_printf("msg", "%p", msg));
     }
   else
     {
       self->process(self, &msg, path_options);
     }
-  msg_debug("<<<<<< rewrite rule evaluation result",
-            rewrite_result_tag(res),
+  msg_debug("<<<<<< rewrite rule evaluation finished",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));


### PR DESCRIPTION
- this can be misleading when rewrite rule is used without condition,
for example with: set()

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>