### PR TITLE
Fixed selinux module version inconsistency

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -60,6 +60,7 @@ EXTRA_DIST += \
 	contrib/selinux/labels.txt \
 	contrib/selinux/syslog_ng.sh \
 	contrib/selinux/src/syslog_ng.el67.te.in \
+	contrib/selinux/src/syslog_ng.module.version \
 	contrib/selinux/src/root_unsafe/syslog_ng.el7.fc.in \
 	contrib/selinux/src/root_unsafe/syslog_ng.el6.fc.in \
 	contrib/selinux/src/root_unsafe/syslog_ng.el5.fc.in \

--- a/contrib/selinux/src/syslog_ng.el5.te.in
+++ b/contrib/selinux/src/syslog_ng.el5.te.in
@@ -1,5 +1,3 @@
-policy_module(syslog_ng, 1.0.5)
-
 require {
         type syslogd_t, syslogd_var_run_t, shell_exec_t, bin_t;
         class file { ioctl read getattr lock execute execute_no_trans };

--- a/contrib/selinux/src/syslog_ng.el6.0to4.te.in
+++ b/contrib/selinux/src/syslog_ng.el6.0to4.te.in
@@ -1,5 +1,3 @@
-policy_module(syslog_ng, 1.0.5)
-
 require {
         type syslogd_t, shell_exec_t, bin_t;
         class file { ioctl read getattr lock execute execute_no_trans open };

--- a/contrib/selinux/src/syslog_ng.el67.te.in
+++ b/contrib/selinux/src/syslog_ng.el67.te.in
@@ -1,2 +1,1 @@
-policy_module(syslog_ng, 1.0.6)
 

--- a/contrib/selinux/src/syslog_ng.module.version
+++ b/contrib/selinux/src/syslog_ng.module.version
@@ -1,0 +1,2 @@
+policy_module(syslog_ng, 1.0.6)
+

--- a/contrib/selinux/syslog_ng.sh
+++ b/contrib/selinux/syslog_ng.sh
@@ -144,7 +144,7 @@ prepare_files() {
 	else
 		omit_install_path > "syslog_ng.fc"
 	fi
-	cp "src/${EL_TE}" "syslog_ng.te"
+	cat "src/syslog_ng.module.version" "src/${EL_TE}" > "syslog_ng.te"
 }
 
 


### PR DESCRIPTION
contrib/selinux/src/syslog_ng.el5.te.in: removed version information
contrib/selinux/src/syslog_ng.el6.0to4.te.in: removed version information
contrib/selinux/src/syslog_ng.el67.te.in: removed version information
contrib/selinux/syslog_ng.sh: updated to combine the version string and the .te.in files
contrib/selinux/src/syslog_ng.module.version: added new file to hold module version

Signed-off-by: Janos SZIGETVARI <jszigetvari@gmail.com>