### PR TITLE
Fix CMake unit test compilation (no-pie)

### DIFF
--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -40,7 +40,7 @@ function (add_unit_test)
   target_compile_definitions(${ADD_UNIT_TEST_TARGET} PRIVATE TOP_SRCDIR="${PROJECT_SOURCE_DIR}")
   target_link_libraries(${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_DEPENDS} syslog-ng)
   target_include_directories(${ADD_UNIT_TEST_TARGET} PUBLIC ${ADD_UNIT_TEST_INCLUDES})
-  if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  if (NOT APPLE)
     set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--no-as-needed")
   endif()
 
@@ -49,7 +49,7 @@ function (add_unit_test)
     target_include_directories(${ADD_UNIT_TEST_TARGET} PUBLIC ${CRITERION_INCLUDE_DIRS})
     set_property(TARGET ${ADD_UNIT_TEST_TARGET} PROPERTY POSITION_INDEPENDENT_CODE FALSE)
 
-    if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    if (APPLE)
       # https://gitlab.kitware.com/cmake/cmake/issues/16561
       set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-no_pie")
     endif()

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -49,10 +49,15 @@ function (add_unit_test)
     target_include_directories(${ADD_UNIT_TEST_TARGET} PUBLIC ${CRITERION_INCLUDE_DIRS})
     set_property(TARGET ${ADD_UNIT_TEST_TARGET} PROPERTY POSITION_INDEPENDENT_CODE FALSE)
 
-    if (APPLE)
-      # https://gitlab.kitware.com/cmake/cmake/issues/16561
+    # https://gitlab.kitware.com/cmake/cmake/issues/16561
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag(-no-pie NO_PIE_AVAILABLE)
+    if (NO_PIE_AVAILABLE)
+      set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -no-pie")
+    elseif (APPLE)
       set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-no_pie")
     endif()
+
   endif()
 
   if (${ADD_UNIT_TEST_LIBTEST})

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -41,7 +41,7 @@ function (add_unit_test)
   target_link_libraries(${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_DEPENDS} syslog-ng)
   target_include_directories(${ADD_UNIT_TEST_TARGET} PUBLIC ${ADD_UNIT_TEST_INCLUDES})
   if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND PROPERTY LINK_FLAGS "-Wl,--no-as-needed")
+    set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--no-as-needed")
   endif()
 
   if (${ADD_UNIT_TEST_CRITERION})
@@ -51,7 +51,7 @@ function (add_unit_test)
 
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
       # https://gitlab.kitware.com/cmake/cmake/issues/16561
-      set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND PROPERTY LINK_FLAGS "-Wl,-no_pie")
+      set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-no_pie")
     endif()
   endif()
 


### PR DESCRIPTION
This PR contains a workaround for a bug in the implementation of the `POSITION_INDEPENDENT_CODE` property (CMake).

https://gitlab.kitware.com/cmake/cmake/issues/16561

