### PR TITLE
logqueue-fifo: memory_usage - possible underflow (afsql)

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -467,8 +467,8 @@ log_queue_fifo_rewind_backlog_all(LogQueue *s)
 {
   LogQueueFifo *self = (LogQueueFifo *) s;
 
-  iv_list_splice_tail_init(&self->qbacklog, &self->qoverflow_output);
   iv_list_update_msg_size(self, &self->qbacklog);
+  iv_list_splice_tail_init(&self->qbacklog, &self->qoverflow_output);
 
   self->qoverflow_output_len += self->qbacklog_len;
   stats_counter_add(self->super.queued_messages, self->qbacklog_len);


### PR DESCRIPTION
In the original code, the content of backlog is dropped earlier, then
the empty list is iterated through to update memory_usage
counter. This means when messages put back to backlog later again,
the size was subtracted twice, hence the underflow.

This patch first updates statistics, then drops the content of backlog, fixing the problem.

The only place when this code path is walked in ose is in afsql, where I could reproduce the problem:
created an sql destination with type(sqlite3), setting flush-lines(1000). After starting to send logs, I deleted the sql database file. This triggered an underflow in memory_usage. After this patch, the memory_usage counter goes back to zero, when the load stops.