### PR TITLE
telegram: fixing bug with bot id

### DIFF
--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -33,7 +33,7 @@ block destination telegram(
       ...)
 {
     http(
-        url("https://api.telegram.org/`bot-id`/sendMessage")
+        url("https://api.telegram.org/bot`bot-id`/sendMessage")
         method("POST")
         body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=`template`\n")
         throttle(`throttle`)


### PR DESCRIPTION
Due to scl error users needed to append "bot" before bot id:
The api url is
```https://api.telegram.org/bot{api-token}/sendMessage```
instead of
```https://api.telegram.org/{api-token}/sendMessage```

Fixes: https://github.com/balabit/syslog-ng/issues/2141

CC: @czanik thanks for the interest and test of the telegram destination!