### PR TITLE
All drivers should support inner dst or src plugins

### DIFF
--- a/modules/pseudofile/pseudofile-grammar.ym
+++ b/modules/pseudofile/pseudofile-grammar.ym
@@ -77,6 +77,7 @@ pseudofile_opts
 pseudofile_opt
 	: KW_TEMPLATE '(' template_content ')'			{ pseudofile_dd_set_template(last_driver, $3); }
 	| { last_template_options = pseudofile_dd_get_template_options(last_driver); } template_option
+	| dest_driver_option
 	;
 
 /* INCLUDE_RULES */

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -90,7 +90,7 @@ redis_option
             redis_dd_set_command(last_driver, $3, $4, $5, $6);
             free($3);
           }
-        | dest_driver_option
+        | threaded_dest_driver_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -25,9 +25,10 @@
 
 template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
-block destination graylog2(host("127.0.0.1") port(12201) template("$(format-gelf)")) {
+block destination graylog2(host("127.0.0.1") port(12201) template("$(format-gelf)") ...) {
 	network("`host`"
                 port(`port`)
 		transport(tcp)
-		template("`template`"));
+		template("`template`")
+		`__VARARGS__`);
 };

--- a/scl/mbox/mbox.conf
+++ b/scl/mbox/mbox.conf
@@ -22,7 +22,7 @@
 #############################################################################
 
 
-block source mbox(filename()) {
+block source mbox(filename() ...) {
     file(
         "`filename`"
         log-msg-size(10000000)
@@ -30,5 +30,6 @@ block source mbox(filename()) {
         flags(no-parse)
         multi-line-mode(prefix-suffix)
         multi-line-prefix('^From ')
+	`__VARARGS__`
       );
 };

--- a/scl/osquery/plugin.conf
+++ b/scl/osquery/plugin.conf
@@ -21,9 +21,9 @@
 #############################################################################
 
 
-block source osquery(file("/var/log/osquery/osqueryd.results.log") prefix(".osquery.")) {
+block source osquery(file("/var/log/osquery/osqueryd.results.log") prefix(".osquery.") ...) {
   channel {
-    source { file("`file`" program-override("osquery") flags(no-parse)); };
+    source { file("`file`" program-override("osquery") flags(no-parse) `__VARARGS__`); };
     parser { json-parser (prefix("`prefix`")); };
   };
 };


### PR DESCRIPTION
This branch fixes a couple of cases where the source_driver_option or dest_driver_option rules were not
referenced.
 
It also fixes scl source/destination drivers to include __VARARGS__.

Both of these changes support the ability to use inner source/dest plugins such as hook-commands() in all drivers.
