### PR TITLE
dns: Inform about the right dns-cache() configuration

### DIFF
--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -398,7 +398,7 @@ _init_options(HostResolveOptions *options)
     {
       if (options->use_dns_cache != 0)
         {
-          msg_warning("WARNING: With use-dns(no), use-dns-cache() will be forced to 'no' too!");
+          msg_warning("WARNING: With use-dns(no), dns-cache() will be forced to 'no' too!");
         }
       options->use_dns_cache = 0;
     }


### PR DESCRIPTION
Since bad916a9e6c5 ("Enforce use-dns-cache(no) when use-dns(no) is
set"), the emitted warning does not refer to an existing setting