### PR TITLE
pragma: lower the require message level to debug

### DIFF
--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -135,9 +135,9 @@ requires_stmt
                   }
                 else
                   {
-                    msg_warning("Included file was skipped because of a missing module",
-                                evt_tag_str("module", $2),
-                                cfg_lexer_format_location_tag(lexer,&@1));
+                    msg_debug("Included file was skipped because of a missing module",
+                              evt_tag_str("module", $2),
+                              cfg_lexer_format_location_tag(lexer,&@1));
                     cfg_lexer_start_next_include(lexer);
                   }
               }


### PR DESCRIPTION
The `@requires' keyword wrote a warning, when the component was missing. 
It is probably too verbose, this PR moves that warning message into the debug level.

Fixes #2138