### PR TITLE
DiskQDestPlugin was not freed

### DIFF
--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -77,7 +77,7 @@ dest_diskq
         : KW_DISK_BUFFER
           {
             last_plugin = diskq_dest_plugin_new();
-            *instance = &last_plugin->super;
+            *instance = (LogDriverPlugin*)last_plugin;
             last_options = diskq_get_options(last_plugin);
           }
           '(' dest_diskq_options ')' { disk_queue_options_check_plugin_settings(last_options); }

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -78,7 +78,7 @@ dest_diskq
           {
             last_plugin = diskq_dest_plugin_new();
             *instance = &last_plugin->super;
-            last_options = &last_plugin->options;
+            last_options = diskq_get_options(last_plugin);
           }
           '(' dest_diskq_options ')' { disk_queue_options_check_plugin_settings(last_options); }
         ;

--- a/modules/diskq/diskq-parser.c
+++ b/modules/diskq/diskq-parser.c
@@ -48,7 +48,7 @@ CfgParser diskq_parser =
   .name = "disk_buffer",
   .keywords = diskq_keywords,
   .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer arg)) diskq_parse,
-  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+  .cleanup = (void (*)(gpointer)) log_driver_plugin_free,
 
 };
 

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -163,6 +163,10 @@ _free(LogDriverPlugin *s)
   disk_queue_options_destroy(&self->options);
 }
 
+DiskQueueOptions *diskq_get_options(DiskQDestPlugin *self)
+{
+  return &self->options;
+}
 
 DiskQDestPlugin *
 diskq_dest_plugin_new(void)

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -32,6 +32,12 @@
 
 #define DISKQ_PLUGIN_NAME "diskq"
 
+struct _DiskQDestPlugin
+{
+  LogDriverPlugin super;
+  DiskQueueOptions options;
+};
+
 static gboolean
 log_queue_disk_is_file_in_directory(const gchar *file, const gchar *directory)
 {

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -167,6 +167,7 @@ _free(LogDriverPlugin *s)
 {
   DiskQDestPlugin *self = (DiskQDestPlugin *)s;
   disk_queue_options_destroy(&self->options);
+  log_driver_plugin_free_method(s);
 }
 
 DiskQueueOptions *diskq_get_options(DiskQDestPlugin *self)

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -21,10 +21,10 @@
  *
  */
 
+#include "diskq.h"
+
 #include "driver.h"
 #include "messages.h"
-
-#include "diskq.h"
 #include "logqueue-disk.h"
 #include "logqueue-disk-reliable.h"
 #include "logqueue-disk-non-reliable.h"

--- a/modules/diskq/diskq.h
+++ b/modules/diskq/diskq.h
@@ -36,5 +36,6 @@ typedef struct _DiskQDestPlugin
 } DiskQDestPlugin;
 
 DiskQDestPlugin *diskq_dest_plugin_new(void);
+DiskQueueOptions *diskq_get_options(DiskQDestPlugin *self);
 
 #endif

--- a/modules/diskq/diskq.h
+++ b/modules/diskq/diskq.h
@@ -29,11 +29,7 @@
 #include "logmsg/logmsg-serialize.h"
 #include "diskq-options.h"
 
-typedef struct _DiskQDestPlugin
-{
-  LogDriverPlugin super;
-  DiskQueueOptions options;
-} DiskQDestPlugin;
+typedef struct _DiskQDestPlugin DiskQDestPlugin;
 
 DiskQDestPlugin *diskq_dest_plugin_new(void);
 DiskQueueOptions *diskq_get_options(DiskQDestPlugin *self);

--- a/modules/hook-commands/hook-commands-parser.c
+++ b/modules/hook-commands/hook-commands-parser.c
@@ -46,8 +46,7 @@ CfgParser hook_commands_parser =
   .name = "hook_commands",
   .keywords = hook_commands_keywords,
   .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer arg)) hook_commands_parse,
-  .cleanup = (void (*)(gpointer)) log_pipe_unref,
-
+  .cleanup = (void (*)(gpointer)) log_driver_plugin_free,
 };
 
 CFG_PARSER_IMPLEMENT_LEXER_BINDING(hook_commands_, LogDriverPlugin **)

--- a/modules/hook-commands/hook-commands.c
+++ b/modules/hook-commands/hook-commands.c
@@ -27,6 +27,17 @@
 
 #define HOOK_COMMANDS_PLUGIN "hook-commands"
 
+struct _HookCommandsPlugin
+{
+  LogDriverPlugin super;
+  gchar *startup;
+  gchar *setup;
+  gchar *teardown;
+  gchar *shutdown;
+  gboolean (*saved_init)(LogPipe *s);
+  gboolean (*saved_deinit)(LogPipe *s);
+};
+
 void
 hook_commands_plugin_set_startup(HookCommandsPlugin *self, const gchar *startup)
 {

--- a/modules/hook-commands/hook-commands.h
+++ b/modules/hook-commands/hook-commands.h
@@ -25,16 +25,7 @@
 
 #include "driver.h"
 
-typedef struct _HookCommandsPlugin
-{
-  LogDriverPlugin super;
-  gchar *startup;
-  gchar *setup;
-  gchar *teardown;
-  gchar *shutdown;
-  gboolean (*saved_init)(LogPipe *s);
-  gboolean (*saved_deinit)(LogPipe *s);
-} HookCommandsPlugin;
+typedef struct _HookCommandsPlugin HookCommandsPlugin;
 
 void hook_commands_plugin_set_startup(HookCommandsPlugin *s, const gchar *command);
 void hook_commands_plugin_set_setup(HookCommandsPlugin *s, const gchar *command);


### PR DESCRIPTION
This fixes two leaks connected to the `DiskQDestPlugin`.

The first could be triggered during configuration parsing, if the parsing was not successful the `cleanup` function were `log_pipe_unref`, but the `DiskQDestPlugin` has no relationship with the `LogPipe`. It was at least a leak, or arbitrary code execution from random memory.

The second one was easier, the `_free` function of `DiskQDestPlugin` did not called `g_free` on itself.

[edit]
Also the same have been done for hook commands.