### PR TITLE
undefined behavior fix

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1056,6 +1056,7 @@ cfg_tree_compile_junction(CfgTree *self,
           if (!fork_mpx)
             {
               fork_mpx = cfg_tree_new_mpx(self, node);
+              *outer_pipe_head = &fork_mpx->super;
             }
           log_multiplexer_add_next_hop(fork_mpx, sub_pipe_head);
         }
@@ -1082,7 +1083,6 @@ cfg_tree_compile_junction(CfgTree *self,
         }
     }
 
-  *outer_pipe_head = &fork_mpx->super;
   if (outer_pipe_tail)
     *outer_pipe_tail = join_pipe;
   return TRUE;

--- a/lib/serialize.c
+++ b/lib/serialize.c
@@ -79,6 +79,11 @@ serialize_file_archive_read_bytes(SerializeArchive *s, gchar *buf, gsize buflen,
 
   g_return_val_if_fail(error == NULL || (*error) == NULL, FALSE);
 
+  if (buflen == 0)
+    {
+      return TRUE;
+    }
+
   bytes_read = fread(buf, 1, buflen, self->f);
   if (bytes_read < 0 || bytes_read != buflen)
     {
@@ -133,6 +138,11 @@ serialize_string_archive_read_bytes(SerializeArchive *s, gchar *buf, gsize bufle
   SerializeStringArchive *self = (SerializeStringArchive *) s;
 
   g_return_val_if_fail(error == NULL || (*error) == NULL, FALSE);
+
+  if (buflen == 0)
+    {
+      return TRUE;
+    }
 
   if ((gssize) self->pos + buflen > (gssize) self->string->len)
     {


### PR DESCRIPTION
* In the `cfg_tree_compile_junction` function the `fork_mpx` unconditionally dereferenced, and it can be a null pointer.
* When the `LogMessage` is deserialized and the `sdata` does not have data (`sdata==NULL`), it tries to read zero byte into a zero length buffer (null pointer).  Reading zero was a valid operation before this PR, it just make sure, that the read function does not touch anything as they should not.

Question:
* Is it okay to move the `outer_pipe_head` initialization ?