### PR TITLE
autotools: linking mode static

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -805,6 +805,13 @@ EVTLOG_NO_LIBTOOL_LIBS="\$(top_builddir)/lib/eventlog/src/.libs/libevtlog.so"
 EVTLOG_CFLAGS="-I\$(top_srcdir)/lib/eventlog/src -I\$(top_builddir)/lib/eventlog/src"
 
 dnl ***************************************************************************
+dnl secret storage libraries
+dnl ***************************************************************************
+
+SECRETSTORAGE_LIBS="\$(top_builddir)/lib/secret-storage/libsecret-storage.la"
+SECRETSTORAGE_NO_LIBTOOL_LIBS="\$(top_builddir)/lib/secret-storage/.libs/libsecret-storage.so"
+
+dnl ***************************************************************************
 dnl libwrap headers/libraries
 dnl ***************************************************************************
 
@@ -1644,7 +1651,7 @@ fi
 MODULE_DEPS_LIBS="\$(top_builddir)/lib/libsyslog-ng.la"
 
 if test "x$linking_mode" = "xdynamic"; then
-	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $GLIB_LIBS $EVTLOG_LIBS $RESOLV_LIBS $LIBCAP_LIBS $PCRE_LIBS $REGEX_LIBS $DL_LIBS"
+	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $GLIB_LIBS $EVTLOG_LIBS $SECRETSTORAGE_LIBS $RESOLV_LIBS $LIBCAP_LIBS $PCRE_LIBS $REGEX_LIBS $DL_LIBS"
 
 	if test "x$with_ivykis" = "xinternal"; then
 		# when using the internal ivykis, we're linking it statically into libsyslog-ng.so
@@ -1663,8 +1670,8 @@ if test "x$linking_mode" = "xdynamic"; then
 	# syslog-ng binary is linked with the default link command (e.g. libtool)
 	SYSLOGNG_LINK='$(LINK)'
 else
-	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $RESOLV_LIBS $EVTLOG_NO_LIBTOOL_LIBS $LD_START_STATIC -Wl,${WHOLE_ARCHIVE_OPT} $GLIB_LIBS $PCRE_LIBS $REGEX_LIBS  -Wl,${NO_WHOLE_ARCHIVE_OPT} $IVYKIS_NO_LIBTOOL_LIBS $LD_END_STATIC $LIBCAP_LIBS $DL_LIBS"
-	TOOL_DEPS_LIBS="$LIBS $BASE_LIBS $GLIB_LIBS $EVTLOG_LIBS $RESOLV_LIBS $LIBCAP_LIBS $PCRE_LIBS $REGEX_LIBS $IVYKIS_LIBS $DL_LIBS"
+	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $RESOLV_LIBS $EVTLOG_NO_LIBTOOL_LIBS $SECRETSTORAGE_NO_LIBTOOL_LIBS $LD_START_STATIC -Wl,${WHOLE_ARCHIVE_OPT} $GLIB_LIBS $PCRE_LIBS $REGEX_LIBS  -Wl,${NO_WHOLE_ARCHIVE_OPT} $IVYKIS_NO_LIBTOOL_LIBS $LD_END_STATIC $LIBCAP_LIBS $DL_LIBS"
+	TOOL_DEPS_LIBS="$LIBS $BASE_LIBS $GLIB_LIBS $EVTLOG_LIBS $SECRETSTORAGE_LIBS $RESOLV_LIBS $LIBCAP_LIBS $PCRE_LIBS $REGEX_LIBS $IVYKIS_LIBS $DL_LIBS"
 	CORE_DEPS_LIBS=""
 
 	# bypass libtool in case we want to do mixed linking because it
@@ -1672,8 +1679,6 @@ else
 	SYSLOGNG_LINK='$(CCLD) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@'
 fi
 YFLAGS="-d"
-
-TOOL_DEPS_LIBS="${TOOL_DEPS_LIBS} \$(top_builddir)/lib/secret-storage/libsecret-storage.la"
 
 enable_value()
 {

--- a/syslog-ng/Makefile.am
+++ b/syslog-ng/Makefile.am
@@ -14,8 +14,7 @@ EXTRA_DIST += syslog-ng/CMakeLists.txt
 # phase.  See the comment in the configure script for details.
 
 syslog_ng_syslog_ng_LDADD		= -L${top_builddir}/lib/.libs \
-					  -lsyslog-ng @SYSLOGNG_DEPS_LIBS@ \
-					  $(top_builddir)/lib/secret-storage/libsecret-storage.la
+					  -lsyslog-ng @SYSLOGNG_DEPS_LIBS@
 syslog_ng_syslog_ng_LINK		=  @SYSLOGNG_LINK@
 syslog_ng_syslog_ng_DEPENDENCIES	= lib/libsyslog-ng.la
 


### PR DESCRIPTION
At some point we broke the disable-dynamic-linking option. This patch tries to fix this.
I created a jenkins job that can be used to test it:
With master (red):
https://ci.syslog-ng.com/jenkins/job/furiel-test-static-linking-mode/5/

With the patch (green):
https://ci.syslog-ng.com/jenkins/job/furiel-test-static-linking-mode/4/

This job can be started manually together with the other tests in https://ci.syslog-ng.com/jenkins/view/furiel/job/furiel-paranoid/.

@algernon I somewhat agressively modified your patch in #2100, can you please recheck with this pr if you can still compile syslog-ng? My strategy was that libsecret-storage is applied similarly to libeventlog,  so I expect this version would work for you too, but I would like to be sure of it.
