### PR TITLE
regression - internal mark mode: infinite loop with old ivykis

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -142,7 +142,6 @@ afinter_source_mark(gpointer s)
 
       /* the next_mark_target will be increased in afinter_postpone_mark */
     }
-  afinter_source_update_watches(self);
 }
 
 static void

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -632,7 +632,9 @@ log_writer_suppress_timeout(gpointer pt)
 static gboolean
 _is_message_a_mark(LogMessage *msg)
 {
-  return strcmp(log_msg_get_value(msg, LM_V_MESSAGE, NULL), "-- MARK --") == 0;
+  gssize msg_len;
+  const gchar *value = log_msg_get_value(msg, LM_V_MESSAGE, &msg_len);
+  return strncmp(value, "-- MARK --", msg_len) == 0;
 }
 
 static gboolean


### PR DESCRIPTION
 afinter: mark mode - no need to update watches

update_watches will be called in afinter_source_post later.

Regression was introduced in:  https://github.com/balabit/syslog-ng/pull/2146

The problem is update_watches reschedules
mark_timer, but in this code path, the timeout was not increased. It
is only increased when the mark message is actually added to the
queue (log_src_driver_queue_method). In older ivykis versions, this
caused infinite loop: the handler of the timer in the past is called
infinitely. With newer ivykis versions, the handler of the passed
timer is not called immediately, so syslog-ng could call the queue for
the message, which would increase the timeout, avoiding infinite loop.

https://github.com/buytenh/ivykis/commit/7190532aca902865ec8e578ac1c23d504f52a75a