### PR TITLE
[WIP]Log source max memory poc

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ set (LIB_HEADERS
     alarms.h
     apphook.h
     atomic.h
+    atomic-gssize.h
     block-ref-parser.h
     cache.h
     cfg.h

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -92,6 +92,7 @@ pkginclude_HEADERS			+= \
 	lib/alarms.h			\
 	lib/apphook.h			\
 	lib/atomic.h			\
+	lib/atomic-gssize.h \
 	lib/block-ref-parser.h		\
 	lib/cache.h			\
 	lib/cfg.h			\

--- a/lib/atomic-gssize.h
+++ b/lib/atomic-gssize.h
@@ -30,31 +30,28 @@ typedef struct
   gssize value;
 } atomic_gssize;
 
-static inline void
+static inline gssize
 atomic_gssize_add(atomic_gssize *a, gssize add)
 {
-  g_atomic_pointer_add(&a->value, add);
+  return g_atomic_pointer_add(&a->value, add);
 }
 
-static inline void
+static inline gssize
 atomic_gssize_sub(atomic_gssize *a, gssize sub)
 {
-  if (a)
-    g_atomic_pointer_add(&a->value, -1 * sub);
+  return g_atomic_pointer_add(&a->value, -1 * sub);
 }
 
-static inline void
+static inline gssize
 atomic_gssize_inc(atomic_gssize *a)
 {
-  if (a)
-    g_atomic_pointer_add(&a->value, 1);
+  return g_atomic_pointer_add(&a->value, 1);
 }
 
-static inline void
+static inline gssize
 atomic_gssize_dec(atomic_gssize *a)
 {
-  if (a)
-    g_atomic_pointer_add(&a->value, -1);
+  return g_atomic_pointer_add(&a->value, -1);
 }
 
 static inline gssize

--- a/lib/atomic-gssize.h
+++ b/lib/atomic-gssize.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ * Copyright (c) 2018 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef ATOMIC_GSSIZE_H_INCLUDED
+#define ATOMIC_GSSIZE_H_INCLUDED
+
+typedef struct
+{
+  gssize value;
+} atomic_gssize;
+
+static inline void
+atomic_gssize_add(atomic_gssize *a, gssize add)
+{
+  g_atomic_pointer_add(&a->value, add);
+}
+
+static inline void
+atomic_gssize_sub(atomic_gssize *a, gssize sub)
+{
+  if (a)
+    g_atomic_pointer_add(&a->value, -1 * sub);
+}
+
+static inline void
+atomic_gssize_inc(atomic_gssize *a)
+{
+  if (a)
+    g_atomic_pointer_add(&a->value, 1);
+}
+
+static inline void
+atomic_gssize_dec(atomic_gssize *a)
+{
+  if (a)
+    g_atomic_pointer_add(&a->value, -1);
+}
+
+static inline gssize
+atomic_gssize_get(atomic_gssize *a)
+{
+  return (gssize)g_atomic_pointer_get(&a->value);
+}
+
+static inline void
+atomic_gssize_set(atomic_gssize *a, gssize value)
+{
+  g_atomic_pointer_set(&a->value, value);
+}
+
+static inline gsize
+atomic_gssize_get_unsigned(atomic_gssize *a)
+{
+  return (gsize)g_atomic_pointer_get(&a->value);
+}
+
+static inline gssize
+atomic_gssize_racy_get(atomic_gssize *a)
+{
+  return a->value;
+}
+
+static inline gsize
+atomic_gssize_racy_get_unsigned(atomic_gssize *a)
+{
+  return (gsize)a->value;
+}
+
+static inline void
+atomic_gssize_racy_set(atomic_gssize *a, gssize value)
+{
+  a->value = value;
+}
+
+#endif

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -203,6 +203,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_KEEP_HOSTNAME               10092
 %token KW_CHECK_HOSTNAME              10093
 %token KW_BAD_HOSTNAME                10094
+%token KW_MAX_MEMORY                  10095
 
 %token KW_KEEP_TIMESTAMP              10100
 
@@ -1194,6 +1195,7 @@ source_option
 	| KW_LOG_PREFIX '(' string ')'	        { gchar *p = strrchr($3, ':'); if (p) *p = 0; last_source_options->program_override = g_strdup($3); free($3); }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ last_source_options->keep_timestamp = $3; }
 	| KW_READ_OLD_RECORDS '(' yesno ')'	{ last_source_options->read_old_records = $3; }
+	| KW_MAX_MEMORY '(' positive_integer64 ')' { last_source_options->max_memory = $3; }
         | KW_TAGS '(' string_list ')'		{ log_source_options_set_tags(last_source_options, $3); }
         | { last_host_resolve_options = &last_source_options->host_resolve_options; } host_resolve_option
         ;

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -125,6 +125,7 @@ static CfgLexerKeyword main_keywords[] =
   { "threaded",           KW_THREADED },
   { "use_rcptid",         KW_USE_RCPTID, KWS_OBSOLETE, "This has been deprecated, try use_uniqid() instead" },
   { "use_uniqid",         KW_USE_UNIQID },
+  { "max_memory",         KW_MAX_MEMORY},
 
   { "log_fifo_size",      KW_LOG_FIFO_SIZE },
   { "log_fetch_limit",    KW_LOG_FETCH_LIMIT },

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -62,11 +62,15 @@ early_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_typ
   EarlyAckTracker *self = (EarlyAckTracker *)s;
 
   if (ack_type == AT_SUSPENDED)
-    log_source_flow_control_suspend(self->super.source);
+    {
+      log_source_flow_control_suspend(self->super.source);
+    }
   else
-    log_source_flow_control_adjust(self->super.source, 1);
-
+    {
+      log_source_flow_control_adjust(self->super.source, 1);
+    }
   log_msg_unref(msg);
+  log_source_flow_control_adjust_memory_usage(self->super.source, msg->queued_bytes);
   log_pipe_unref((LogPipe *)self->super.source);
 }
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -173,6 +173,7 @@ struct _LogMessage
   LMAckFunc ack_func;
   LogMessage *original;
   gsize allocated_bytes;
+  gsize queued_bytes;
 
   /* message parts */
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -98,6 +98,7 @@ log_queue_is_empty_racy(LogQueue *self)
 static inline void
 log_queue_push_tail(LogQueue *self, LogMessage *msg, const LogPathOptions *path_options)
 {
+  msg->queued_bytes = log_msg_get_size(msg);
   self->push_tail(self, msg, path_options);
 }
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -27,6 +27,7 @@
 
 #include "logpipe.h"
 #include "stats/stats-registry.h"
+#include "atomic-gssize.h"
 
 typedef struct _LogSourceOptions
 {
@@ -46,6 +47,7 @@ typedef struct _LogSourceOptions
   GList *source_queue_callbacks;
   gint stats_level;
   gint stats_source;
+  guint64 max_memory;
 } LogSourceOptions;
 
 typedef struct _LogSource LogSource;
@@ -75,6 +77,8 @@ struct _LogSource
   glong window_full_sleep_nsec;
   struct timespec last_ack_rate_time;
   AckTracker *ack_tracker;
+  atomic_gssize memory_usage;
+  guint32 pending_window_size_increment;
 
   void (*wakeup)(LogSource *s);
   void (*window_empty_cb)(LogSource *s);
@@ -109,6 +113,7 @@ void log_source_free(LogPipe *s);
 void log_source_wakeup(LogSource *self);
 void log_source_window_empty(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
+void log_source_flow_control_adjust_memory_usage(LogSource *self, guint32 memory_decrement);
 void log_source_flow_control_suspend(LogSource *self);
 
 void log_source_global_init(void);

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -25,10 +25,11 @@
 #define STATS_COUNTER_H_INCLUDED 1
 
 #include "syslog-ng.h"
+#include "atomic-gssize.h"
 
 typedef struct _StatsCounterItem
 {
-  gssize value;
+  atomic_gssize value;
   gchar *name;
   gint type;
 } StatsCounterItem;
@@ -38,28 +39,28 @@ static inline void
 stats_counter_add(StatsCounterItem *counter, gssize add)
 {
   if (counter)
-    g_atomic_pointer_add(&counter->value, add);
+    atomic_gssize_add(&counter->value, add);
 }
 
 static inline void
 stats_counter_sub(StatsCounterItem *counter, gssize sub)
 {
   if (counter)
-    g_atomic_pointer_add(&counter->value, -1 * sub);
+    atomic_gssize_sub(&counter->value, sub);
 }
 
 static inline void
 stats_counter_inc(StatsCounterItem *counter)
 {
   if (counter)
-    g_atomic_pointer_add(&counter->value, 1);
+    atomic_gssize_inc(&counter->value);
 }
 
 static inline void
 stats_counter_dec(StatsCounterItem *counter)
 {
   if (counter)
-    g_atomic_pointer_add(&counter->value, -1);
+    atomic_gssize_dec(&counter->value);
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
@@ -67,7 +68,7 @@ static inline void
 stats_counter_set(StatsCounterItem *counter, gsize value)
 {
   if (counter)
-    counter->value = value;
+    atomic_gssize_racy_set(&counter->value, value);
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
@@ -77,7 +78,7 @@ stats_counter_get(StatsCounterItem *counter)
   gssize result = 0;
 
   if (counter)
-    result = counter->value;
+    result = atomic_gssize_racy_get_unsigned(&counter->value);
   return result;
 }
 

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -101,7 +101,7 @@ stats_cluster_is_expired(StatsOptions *options, StatsCluster *sc, time_t now)
   if ((sc->live_mask & (1 << SC_TYPE_STAMP)) == 0)
     return FALSE;
 
-  tstamp = sc->counter_group.counters[SC_TYPE_STAMP].value;
+  tstamp = atomic_gssize_racy_get(&(sc->counter_group.counters[SC_TYPE_STAMP].value));
   return (tstamp <= now - options->lifetime);
 }
 
@@ -122,7 +122,7 @@ stats_prune_counter(StatsCluster *sc, StatsTimerState *st)
   expired = stats_cluster_is_expired(st->options, sc, st->now.tv_sec);
   if (expired)
     {
-      time_t tstamp = sc->counter_group.counters[SC_TYPE_STAMP].value;
+      time_t tstamp = atomic_gssize_racy_get(&(sc->counter_group.counters[SC_TYPE_STAMP].value));
       if ((st->oldest_counter) == 0 || st->oldest_counter > tstamp)
         st->oldest_counter = tstamp;
       st->dropped_counters++;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_unit_test(CRITERION TARGET test_cache)
 add_unit_test(CRITERION TARGET test_scratch_buffers)
 add_unit_test(CRITERION TARGET test_timeutils)
 add_unit_test(CRITERION TARGET test_messages)
+add_unit_test(CRITERION TARGET test_atomic_gssize)
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES
   ADDITIONAL_MAKE_CLEAN_FILES

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -14,7 +14,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_pathutils	\
 	lib/tests/test_utf8utils	\
 	lib/tests/test_userdb		\
-	lib/tests/test_str-utils
+	lib/tests/test_str-utils \
+	lib/tests/test_atomic_gssize
 
 EXTRA_DIST += lib/tests/CMakeLists.txt
 
@@ -104,6 +105,12 @@ lib_tests_test_str_utils_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_str_utils_LDADD	=	\
 	$(TEST_LDADD)
+
+lib_tests_test_atomic_gssize_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_atomic_gssize_LDADD	=	\
+	$(TEST_LDADD)
+
 
 CLEANFILES				+= \
 	test_values.persist		   \

--- a/lib/tests/test_atomic_gssize.c
+++ b/lib/tests/test_atomic_gssize.c
@@ -43,7 +43,8 @@ Test(test_atomic_gssize, set_max_value)
   cr_assert_eq(atomic_gssize_get(&max), G_MAXSSIZE);
   atomic_gssize_dec(&max);
   cr_assert_eq(atomic_gssize_get(&max), G_MAXSSIZE - 1);
-  atomic_gssize_add(&max, 2);
+  gssize old = atomic_gssize_add(&max, 2);
+  cr_assert_eq(old, G_MAXSSIZE - 1);
   cr_assert_eq(atomic_gssize_get(&max), G_MINSSIZE);
 }
 

--- a/lib/tests/test_atomic_gssize.c
+++ b/lib/tests/test_atomic_gssize.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "atomic-gssize.h"
+#include <criterion/criterion.h>
+
+Test(test_atomic_gssize, set_min_value)
+{
+  atomic_gssize min;
+  atomic_gssize_set(&min, G_MINSSIZE);
+  cr_assert_eq(atomic_gssize_get(&min), G_MINSSIZE);
+  atomic_gssize_inc(&min);
+  cr_assert_eq(atomic_gssize_get(&min), G_MINSSIZE+1);
+  atomic_gssize_sub(&min, 2);
+  cr_assert_eq(atomic_gssize_get(&min), G_MAXSSIZE);
+}
+
+Test(test_atomic_gssize, set_max_value)
+{
+  atomic_gssize max;
+  atomic_gssize_set(&max, G_MAXSSIZE);
+  cr_assert_eq(atomic_gssize_get(&max), G_MAXSSIZE);
+  atomic_gssize_dec(&max);
+  cr_assert_eq(atomic_gssize_get(&max), G_MAXSSIZE - 1);
+  atomic_gssize_add(&max, 2);
+  cr_assert_eq(atomic_gssize_get(&max), G_MINSSIZE);
+}
+
+Test(test_atomic_gssize, use_as_unsigned)
+{
+  atomic_gssize a;
+  atomic_gssize_set(&a, G_MAXSIZE);
+  cr_assert_eq(atomic_gssize_get_unsigned(&a), G_MAXSIZE);
+  atomic_gssize_inc(&a);
+  cr_assert_eq(atomic_gssize_get_unsigned(&a), 0);
+  atomic_gssize_dec(&a);
+  cr_assert_eq(atomic_gssize_get_unsigned(&a), G_MAXSIZE);
+}

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -80,7 +80,8 @@ test_diskq_become_full(gboolean reliable)
   log_queue_disk_load_queue(q, DISKQ_FILENAME);
   feed_some_messages(q, 1000, &parse_options);
 
-  assert_gint(q->dropped_messages->value, 1000, "Bad dropped message number (reliable: %s)", reliable ? "TRUE" : "FALSE");
+  assert_gint(atomic_gssize_racy_get(&q->dropped_messages->value), 1000, "Bad dropped message number (reliable: %s)",
+              reliable ? "TRUE" : "FALSE");
 
   log_queue_unref(q);
   disk_queue_options_destroy(&options);

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -200,7 +200,7 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
 
   log_queue_set_use_backlog(q, TRUE);
 
-  cr_assert_eq(q->queued_messages->value, 0);
+  cr_assert_eq(atomic_gssize_racy_get(&q->queued_messages->value), 0);
 
   fed_messages = 0;
   acked_messages = 0;


### PR DESCRIPTION
First PR of the memory-limited flow control concept.
I'd discuss this topic IRL on tomorrow.

The concept:
 * `max-memory` could be defined for sources (also as a global option, which means that each source has the same memory limit, when defined per source , it can express a sort of priority between the sources)
 * when `max-memory` is used the fifo queues would become dynamic, also the window size calculation
Note: `max-memory` is calculated _after_ the message went through the processing pipeline, so the final size is known, this is not an exact number,  cloned messages are not counted... 

This PR just adds the memory-limitation for sources, without touching the destination side and iw-size calculations.