### PR TITLE
Fix missing normalize flags

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -40,6 +40,7 @@
 #include "rewrite/rewrite-expr-parser.h"
 #include "logmatcher.h"
 #include "logthrdestdrv.h"
+#include "str-utils.h"
 
 /* uses struct declarations instead of the typedefs to avoid having to
  * include logreader/logwriter/driver.h, which defines the typedefs.  This
@@ -444,6 +445,7 @@ DNSCacheOptions *last_dns_cache_options;
 
 %type	<cptr> string
 %type	<cptr> string_or_number
+%type	<cptr> normalized_flag
 %type   <ptr> string_list
 %type   <ptr> string_list_build
 %type   <num> facility_string
@@ -1060,6 +1062,10 @@ string_or_number
         : string                                { $$ = $1; }
         | LL_NUMBER                             { $$ = strdup(lexer->token_text->str); }
         | LL_FLOAT                              { $$ = strdup(lexer->token_text->str); }
+        ;
+
+normalized_flag
+        : string                                { $$ = normalize_flag($1); free($1); }
         ;
 
 string_list

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -799,7 +799,7 @@ log_flags
 	;
 
 log_flags_items
-	: string log_flags_items		{ $$ = log_expr_node_lookup_flag($1) | $2; free($1); }
+	: normalized_flag log_flags_items	{ $$ = log_expr_node_lookup_flag($1) | $2; free($1); }
 	|					{ $$ = 0; }
 	;
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1291,8 +1291,8 @@ dest_writer_option
 	;
 
 dest_writer_options_flags
-	: string dest_writer_options_flags      { $$ = log_writer_options_lookup_flag($1) | $2; free($1); }
-	|					{ $$ = 0; }
+	: normalized_flag dest_writer_options_flags   { $$ = log_writer_options_lookup_flag($1) | $2; free($1); }
+	|					      { $$ = 0; }
 	;
 
 file_perm_option

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -572,15 +572,15 @@ log_expr_node_new_conditional_with_block(LogExprNode *block, YYLTYPE *yylloc)
 gint
 log_expr_node_lookup_flag(const gchar *flag)
 {
-  if (strcmp(flag, "catch-all") == 0 || strcmp(flag, "catchall") == 0 || strcmp(flag, "catch_all") == 0)
+  if (strcmp(flag, "catch-all") == 0 || strcmp(flag, "catchall") == 0)
     return LC_CATCHALL;
   else if (strcmp(flag, "fallback") == 0)
     return LC_FALLBACK;
   else if (strcmp(flag, "final") == 0)
     return LC_FINAL;
-  else if (strcmp(flag, "flow_control") == 0 || strcmp(flag, "flow-control") == 0)
+  else if (strcmp(flag, "flow-control") == 0)
     return LC_FLOW_CONTROL;
-  else if (strcmp(flag, "drop_unmatched") == 0 || strcmp(flag, "drop-unmatched") == 0)
+  else if (strcmp(flag, "drop-unmatched") == 0)
     return LC_DROP_UNMATCHED;
   msg_error("Unknown log statement flag", evt_tag_str("flag", flag));
   return 0;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1758,13 +1758,13 @@ log_writer_options_destroy(LogWriterOptions *options)
 gint
 log_writer_options_lookup_flag(const gchar *flag)
 {
-  if (strcmp(flag, "syslog_protocol") == 0 || strcmp(flag, "syslog-protocol") == 0)
+  if (strcmp(flag, "syslog-protocol") == 0)
     return LWO_SYSLOG_PROTOCOL;
-  if (strcmp(flag, "no-multi-line") == 0 || strcmp(flag, "no_multi_line") == 0)
+  if (strcmp(flag, "no-multi-line") == 0)
     return LWO_NO_MULTI_LINE;
   if (strcmp(flag, "threaded") == 0)
     return LWO_THREADED;
-  if (strcmp(flag, "ignore-errors") == 0 || strcmp(flag, "ignore_errors") == 0)
+  if (strcmp(flag, "ignore-errors") == 0)
     return LWO_IGNORE_ERRORS;
   msg_error("Unknown dest writer flag", evt_tag_str("flag", flag));
   return 0;

--- a/lib/str-utils.c
+++ b/lib/str-utils.c
@@ -55,6 +55,13 @@ str_replace_char(const gchar *str, const gchar from, const gchar to)
   return ret;
 }
 
+/*
+  This function normalizes differently than the flags version. TODO:
+  investigate if the two can be aligned. Hint: as flag normalization has
+  strong position in the code, aligning block normalization to flag
+  normalization might prove easier. Some more info:
+  https://github.com/balabit/syslog-ng/pull/2162#discussion_r202247468
+*/
 gchar *
 __normalize_key(const gchar *buffer)
 {

--- a/lib/str-utils.c
+++ b/lib/str-utils.c
@@ -60,3 +60,9 @@ __normalize_key(const gchar *buffer)
 {
   return str_replace_char(buffer, '-', '_');
 }
+
+gchar *
+normalize_flag(const gchar *buffer)
+{
+  return str_replace_char(buffer, '_', '-');
+}

--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -81,6 +81,7 @@ g_string_append_unichar_optimized(GString *string, gunichar wc)
   } while (0)
 
 gchar *__normalize_key(const gchar *buffer);
+gchar *normalize_flag(const gchar *buffer);
 
 
 /* This version of strchr() is optimized for cases where the string we are

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -138,7 +138,7 @@ dest_afsql_values_build
         ;
 
 dest_afsql_flags
-        : string dest_afsql_flags               { $$ = afsql_dd_lookup_flag($1) | $2; free($1); }
+        : normalized_flag dest_afsql_flags      { $$ = afsql_dd_lookup_flag($1) | $2; free($1); }
         |                                       { $$ = 0; }
         ;
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -33,6 +33,7 @@
 #include "apphook.h"
 #include "timeutils.h"
 #include "mainloop-worker.h"
+#include "str-utils.h"
 
 #include <string.h>
 #include <errno.h>
@@ -1478,9 +1479,9 @@ afsql_dd_new(GlobalConfig *cfg)
 gint
 afsql_dd_lookup_flag(const gchar *flag)
 {
-  if (strcmp(flag, "explicit-commits") == 0 || strcmp(flag, "explicit_commits") == 0)
+  if (strcmp(flag, "explicit-commits") == 0)
     return AFSQL_DDF_EXPLICIT_COMMITS;
-  else if (strcmp(flag, "dont-create-tables") == 0 || strcmp(flag, "dont_create_tables") == 0)
+  else if (strcmp(flag, "dont-create-tables") == 0)
     return AFSQL_DDF_DONT_CREATE_TABLES;
   else
     msg_warning("Unknown SQL flag",

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -117,7 +117,7 @@ parser_csv_delimiters_opt
         ;
 
 parser_csv_flags
-        : string parser_csv_flags
+        : normalized_flag parser_csv_flags
           {
             guint32 flag = csv_parser_lookup_flag($1);
             CHECK_ERROR(flag != 0, @1, "unknown csv-parser() flag %s", $1);
@@ -128,7 +128,7 @@ parser_csv_flags
         ;
 
 parser_csv_dialect
-        : string                                {
+        : normalized_flag                       {
                                                   gint mode = csv_parser_lookup_dialect($1);
                                                   CHECK_ERROR(mode >= 0, @1, "unknown dialect() argument for csv-parser()");
                                                   free($1);

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -636,6 +636,7 @@ main(int argc, char *argv[])
   GString *cmdname_accumulator = g_string_new(argv[0]);
   CommandDescriptor *active_mode = find_active_mode(modes, &argc, argv, cmdname_accumulator);
   GOptionContext *ctx = setup_help_context(cmdname_accumulator->str, active_mode);
+  g_string_free(cmdname_accumulator, TRUE);
 
   if (!ctx)
     {


### PR DESCRIPTION
Release notes:
- syslog-ng-ctl: fixing a memleak
- afsql: normalizing key when checking flags
This can be useful on a rare occasion when user tries to use `dont_create-tables` or dont-create_tables`.
- Normalizing flags in log writer options. This can be useful on a rare occasion when user tries to use `no-multi_line` or `no_multi-line`.
- csvparser: normalizing flags was not supported earlier at all.

Developer notes:
- new token added: normalized_flag that can be used in grammar to replace underscores with hyphens.
- log_flags: just a refactor to use the new normalized_flag token