### PR TITLE
Once java always java

### DIFF
--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -108,6 +108,12 @@ void
 java_machine_unref(JavaVMSingleton *self)
 {
   g_assert(self == global_jvm);
+  /* The last reference is always hold by a AH_SHUTDOWN app hook, when there is no java configured.
+   * The only way to get rid of it to shutdown syslog-ng.  */
+  if (g_atomic_counter_get(&self->ref_cnt) == 2)
+    {
+      msg_warning("The JVM is not used anymore, but it is not stopped, if you want to stop it, you have to restart syslog-ng");
+    }
   if (g_atomic_counter_dec_and_test(&self->ref_cnt))
     {
       _jvm_free(self);

--- a/modules/java/tools/syslog-ng.conf.example
+++ b/modules/java/tools/syslog-ng.conf.example
@@ -13,7 +13,7 @@ source s_tcp{
 
 destination d_java{
   java(
-    class_name("org.syslog_ng.TextDummyDestination")
+    class_name("org.syslog_ng.DummyTextDestination")
     option("name", "d_java")
   );
 };


### PR DESCRIPTION
Once a java is configured, and the JVM is loaded, and it is not possible to safely unload the JVM.
Because there cannot be two or more JVM in one process, the second time syslog-ng tries to create a JVM it wont succeeed.

The plan is to keep the JVM once created as long as syslog-ng is runnig.


Fixes #2163