### PR TITLE
system-source: added exclude_kmsg option instead of container detection

### DIFF
--- a/lib/cfg-args.c
+++ b/lib/cfg-args.c
@@ -103,6 +103,24 @@ cfg_args_contains(CfgArgs *self, const gchar *name)
   return contains;
 }
 
+void
+cfg_args_remove_normalized(CfgArgs *self, const gchar *normalized_name)
+{
+  gpointer orig_key;
+  if (g_hash_table_lookup_extended(self->args, normalized_name, &orig_key, NULL))
+    {
+      g_hash_table_remove(self->args, orig_key);
+    }
+}
+
+void
+cfg_args_remove(CfgArgs *self, const gchar *name)
+{
+  gchar *normalized_name = __normalize_key(name);
+  cfg_args_remove_normalized(self, normalized_name);
+  g_free(normalized_name);
+}
+
 CfgArgs *
 cfg_args_new(void)
 {

--- a/lib/cfg-args.h
+++ b/lib/cfg-args.h
@@ -34,6 +34,8 @@ gchar *cfg_args_format_varargs(CfgArgs *self, CfgArgs *defaults);
 void cfg_args_set(CfgArgs *self, const gchar *name, const gchar *value);
 const gchar *cfg_args_get(CfgArgs *self, const gchar *name);
 gboolean cfg_args_contains(CfgArgs *self, const gchar *name);
+void cfg_args_remove_normalized(CfgArgs *self, const gchar *normalized_name);
+void cfg_args_remove(CfgArgs *self, const gchar *name);
 void cfg_args_foreach(CfgArgs *self, GHFunc func, gpointer user_data);
 void cfg_args_accept_varargs(CfgArgs *self);
 gboolean cfg_args_is_accepting_varargs(CfgArgs *self);


### PR DESCRIPTION
system-source: removed container detection from system source,
because changes in kernel code made it unreliable. Since it was
only used for excluding kmsg logs, a new optional "exclude-kmsg()"
option was introduced to make the function user configurable.

Question: Where should we store the const string literal for the option?

Resolves #2156 