### PR TITLE
Fix suspend race cond

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -133,6 +133,7 @@ set (LIB_HEADERS
     ack_tracker.h
     host-id.h
     resolved-configurable-paths.h
+    window-size-counter.h
     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.h
     ${PROJECT_BINARY_DIR}/lib/block-ref-grammar.h
     ${PROJECT_BINARY_DIR}/lib/cfg-lex.h
@@ -215,6 +216,7 @@ set(LIB_SOURCES
     utf8utils.c
     host-id.c
     resolved-configurable-paths.c
+    window-size-counter.c
     ${COMPAT_SOURCES}
     ${CONTROL_SOURCES}
     ${DEBUGGER_SOURCES}

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -175,7 +175,8 @@ pkginclude_HEADERS			+= \
 	lib/late_ack_tracker.h \
 	lib/host-id.h			\
 	lib/resolved-configurable-paths.h \
-	lib/pe-versioning.h
+	lib/pe-versioning.h \
+	lib/window-size-counter.h
 
 # this is intentionally formatted so conflicts are less likely to arise. one name in every line.
 lib_libsyslog_ng_la_SOURCES		= \
@@ -255,6 +256,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(transport_crypto_sources)	\
 	lib/host-id.c			\
 	lib/resolved-configurable-paths.c \
+	lib/window-size-counter.c \
 					\
 	lib/cfg-lex.l			\
 	lib/cfg-grammar.y		\

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -63,8 +63,8 @@ early_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_typ
 
   if (ack_type == AT_SUSPENDED)
     log_source_flow_control_suspend(self->super.source);
-  else
-    log_source_flow_control_adjust(self->super.source, 1);
+
+  log_source_flow_control_adjust(self->super.source, 1);
 
   log_msg_unref(msg);
   log_pipe_unref((LogPipe *)self->super.source);

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -158,6 +158,9 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
 
   ack_rec->acked = TRUE;
 
+  if (ack_type == AT_SUSPENDED)
+    log_source_flow_control_suspend(self->super.source);
+
   late_ack_tracker_lock(s);
   {
     ack_range_length = _get_continuous_range_length(self);
@@ -172,7 +175,7 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
         _drop_range(self, ack_range_length);
 
         if (ack_type == AT_SUSPENDED)
-          log_source_flow_control_suspend(self->super.source);
+          log_source_flow_control_adjust_when_suspended(self->super.source, ack_range_length);
         else
           log_source_flow_control_adjust(self->super.source, ack_range_length);
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -27,6 +27,7 @@
 
 #include "logpipe.h"
 #include "stats/stats-registry.h"
+#include "window-size-counter.h"
 
 typedef struct _LogSourceOptions
 {
@@ -66,8 +67,7 @@ struct _LogSource
   gboolean pos_tracked;
   gchar *stats_id;
   gchar *stats_instance;
-  GAtomicCounter window_size;
-  GAtomicCounter suspended_window_size;
+  WindowSizeCounter window_size;
   StatsCounterItem *last_message_seen;
   StatsCounterItem *recvd_messages;
   guint32 last_ack_count;
@@ -83,7 +83,7 @@ struct _LogSource
 static inline gboolean
 log_source_free_to_send(LogSource *self)
 {
-  return g_atomic_counter_get(&self->window_size) > 0;
+  return !window_size_counter_suspended(&self->window_size);
 }
 
 static inline gint
@@ -109,6 +109,7 @@ void log_source_free(LogPipe *s);
 void log_source_wakeup(LogSource *self);
 void log_source_window_empty(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
+void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);
 
 void log_source_global_init(void);

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_unit_test(CRITERION TARGET test_scratch_buffers)
 add_unit_test(CRITERION TARGET test_timeutils)
 add_unit_test(CRITERION TARGET test_messages)
 add_unit_test(CRITERION TARGET test_atomic_gssize)
+add_unit_test(CRITERION TARGET test_window_size_counter)
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES
   ADDITIONAL_MAKE_CLEAN_FILES

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -15,7 +15,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_utf8utils	\
 	lib/tests/test_userdb		\
 	lib/tests/test_str-utils \
-	lib/tests/test_atomic_gssize
+	lib/tests/test_atomic_gssize \
+	lib/tests/test_window_size_counter
 
 EXTRA_DIST += lib/tests/CMakeLists.txt
 
@@ -109,6 +110,11 @@ lib_tests_test_str_utils_LDADD	=	\
 lib_tests_test_atomic_gssize_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_atomic_gssize_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_window_size_counter_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_window_size_counter_LDADD	=	\
 	$(TEST_LDADD)
 
 

--- a/lib/tests/test_window_size_counter.c
+++ b/lib/tests/test_window_size_counter.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "window-size-counter.h"
+#include <criterion/criterion.h>
+
+
+Test(test_window_size_counter, suspend_resume)
+{
+  WindowSizeCounter c;
+  gboolean suspended = FALSE;
+  window_size_counter_set(&c, 10);
+  cr_expect_not(window_size_counter_suspended(&c));
+
+  window_size_counter_sub(&c, 10, &suspended);
+  cr_expect_not(suspended);
+  cr_expect(window_size_counter_suspended(&c));
+
+  window_size_counter_add(&c, 10, &suspended);
+  cr_expect(suspended);
+  cr_expect_not(window_size_counter_suspended(&c));
+
+  window_size_counter_suspend(&c);
+  cr_expect(window_size_counter_suspended(&c));
+
+  gsize val = window_size_counter_get(&c, &suspended);
+  cr_expect(suspended);
+  cr_expect_eq(val, 10);
+
+  window_size_counter_add(&c, 1, &suspended);
+  cr_expect_eq(window_size_counter_get(&c, &suspended), 11);
+  window_size_counter_resume(&c);
+  cr_expect_not(window_size_counter_suspended(&c));
+}
+
+Test(test_window_size_counter, negative_value)
+{
+  WindowSizeCounter c;
+  gboolean suspended = FALSE;
+  window_size_counter_set(&c, -1);
+  gint v = (gint)window_size_counter_get(&c, &suspended);
+  cr_assert_eq(v, -1);
+}
+
+Test(test_window_size_counter, suspend_resume_multiple_times)
+{
+  WindowSizeCounter c;
+  window_size_counter_set(&c, window_size_counter_get_max());
+
+  window_size_counter_resume(&c);
+  cr_expect_not(window_size_counter_suspended(&c));
+  gboolean suspended;
+  cr_expect_eq(window_size_counter_get(&c, &suspended), window_size_counter_get_max());
+  cr_expect_not(suspended);
+  window_size_counter_resume(&c);
+  cr_expect_not(window_size_counter_suspended(&c));
+  cr_expect_eq(window_size_counter_get(&c, &suspended), window_size_counter_get_max());
+  cr_expect_not(suspended);
+
+  window_size_counter_suspend(&c);
+  cr_expect(window_size_counter_suspended(&c));
+  cr_expect_eq(window_size_counter_get(&c, &suspended), window_size_counter_get_max());
+  cr_expect(suspended);
+
+  window_size_counter_suspend(&c);
+  cr_expect(window_size_counter_suspended(&c));
+  cr_expect_eq(window_size_counter_get(&c, &suspended), window_size_counter_get_max());
+  cr_expect(suspended);
+  window_size_counter_resume(&c);
+  cr_expect_not(window_size_counter_suspended(&c));
+  cr_expect_eq(window_size_counter_get(&c, &suspended), window_size_counter_get_max());
+  cr_expect_not(suspended);
+}

--- a/lib/window-size-counter.c
+++ b/lib/window-size-counter.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ * Copyright (c) 2018 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "window-size-counter.h"
+
+#define COUNTER_MASK (((gsize)1<<(8*sizeof(gsize)-1)) - 1)
+static const gsize COUNTER_MAX = COUNTER_MASK;
+static const gsize SUSPEND_MASK = G_MAXSIZE ^ COUNTER_MASK;
+static const gsize RESUME_MASK = G_MAXSIZE >> 1;
+
+static gboolean
+_is_suspended(gsize v)
+{
+  return (v == 0) || ((v & SUSPEND_MASK) == SUSPEND_MASK);
+}
+
+gsize
+window_size_counter_get_max(void)
+{
+  return COUNTER_MAX;
+}
+
+void
+window_size_counter_set(WindowSizeCounter *c, gsize value)
+{
+  atomic_gssize_set(&c->counter, value & COUNTER_MASK);
+}
+
+gsize
+window_size_counter_get(WindowSizeCounter *c, gboolean *suspended)
+{
+  gsize v = atomic_gssize_get_unsigned(&c->counter);
+  if (suspended)
+    *suspended = _is_suspended(v);
+  return v & COUNTER_MASK;
+}
+
+gsize
+window_size_counter_add(WindowSizeCounter *c, gsize value, gboolean *suspended)
+{
+  gsize v = (gsize)atomic_gssize_add(&c->counter, value);
+  gsize old_value = v & COUNTER_MASK;
+  g_assert (old_value + value <= COUNTER_MAX);
+  if (suspended)
+    *suspended = _is_suspended(v);
+
+  return old_value;
+}
+
+gsize
+window_size_counter_sub(WindowSizeCounter *c, gsize value, gboolean *suspended)
+{
+  gsize v = (gsize)atomic_gssize_add(&c->counter, -1 * value);
+  gsize old_value = v & COUNTER_MASK;
+  g_assert (old_value >= value);
+  if (suspended)
+    *suspended = _is_suspended(v);
+
+  return old_value;
+}
+
+void
+window_size_counter_suspend(WindowSizeCounter *c)
+{
+  atomic_gssize_or(&c->counter, SUSPEND_MASK);
+}
+
+void
+window_size_counter_resume(WindowSizeCounter *c)
+{
+  atomic_gssize_and(&c->counter, RESUME_MASK);
+}
+
+gboolean
+window_size_counter_suspended(WindowSizeCounter *c)
+{
+  gsize v = atomic_gssize_get_unsigned(&c->counter);
+  return _is_suspended(v);
+}
+

--- a/lib/window-size-counter.h
+++ b/lib/window-size-counter.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ * Copyright (c) 2018 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef WINDOW_SIZE_COUNTER_H_INCLUDED
+#define WINDOW_SIZE_COUNTER_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "atomic-gssize.h"
+
+typedef struct _WindowSizeCounter WindowSizeCounter;
+
+struct _WindowSizeCounter
+{
+  atomic_gssize counter;
+};
+
+
+void window_size_counter_set(WindowSizeCounter *c, gsize value);
+gsize window_size_counter_get(WindowSizeCounter *c, gboolean *suspended);
+gsize window_size_counter_add(WindowSizeCounter *c, gsize value, gboolean *suspended);
+gsize window_size_counter_sub(WindowSizeCounter *c, gsize value, gboolean *suspended);
+void window_size_counter_suspend(WindowSizeCounter *c);
+void window_size_counter_resume(WindowSizeCounter *c);
+gboolean window_size_counter_suspended(WindowSizeCounter *c);
+
+gsize window_size_counter_get_max(void);
+
+#endif
+


### PR DESCRIPTION
@MrAnno : please check whether it supersedes #2045 or not. 

 * suspend is set by `log_source_flow_control_suspend`
 * suspend is unset by `log_source_wakeup`
 * `free_to_send` blocks reading until suspend bit is set or the window size is 0
 * when window size was 0 before `log_source_flow_control_adjust` is called, then we call `log_source_wakeup`
 * when ack_tracker receives an ACK, then it checks if source is suspended or not (and based on the acknowledge type it makes a decision whether we need to suspend/wakeup the source)
