### PR TITLE
afsocket: Add ref-counted TLSVerifier struct

### DIFF
--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -69,13 +69,19 @@ typedef struct _TLSContext TLSContext;
 #define X509_MAX_O_LEN 64
 #define X509_MAX_OU_LEN 32
 
+typedef struct _TLSVerifier
+{
+  GAtomicCounter ref_cnt;
+  TLSSessionVerifyFunc verify_func;
+  gpointer verify_data;
+  GDestroyNotify verify_data_destroy;
+} TLSVerifier;
+
 typedef struct _TLSSession
 {
   SSL *ssl;
   TLSContext *ctx;
-  TLSSessionVerifyFunc verify_func;
-  gpointer verify_data;
-  GDestroyNotify verify_data_destroy;
+  TLSVerifier *verifier;
   struct
   {
     int found;
@@ -85,8 +91,7 @@ typedef struct _TLSSession
   } peer_info;
 } TLSSession;
 
-void tls_session_set_verify(TLSSession *self, TLSSessionVerifyFunc verify_func, gpointer verify_data,
-                            GDestroyNotify verify_destroy);
+void tls_session_set_verifier(TLSSession *self, TLSVerifier *verifier);
 void tls_session_free(TLSSession *self);
 
 TLSContextSetupResult tls_context_setup_context(TLSContext *self);
@@ -97,6 +102,10 @@ void tls_session_set_trusted_dn(TLSContext *self, GList *dns);
 TLSContext *tls_context_new(TLSMode mode, const gchar *config_location);
 TLSContext *tls_context_ref(TLSContext *self);
 void tls_context_unref(TLSContext *self);
+TLSVerifier *tls_verifier_new(TLSSessionVerifyFunc verify_func, gpointer verify_data,
+                              GDestroyNotify verify_data_destroy);
+TLSVerifier *tls_verifier_ref(TLSVerifier *self);
+void tls_verifier_unref(TLSVerifier *self);
 
 
 gboolean tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode_str);

--- a/lib/transport/transport-factory-tls.c
+++ b/lib/transport/transport-factory-tls.c
@@ -51,7 +51,7 @@ _construct_transport(const TransportFactory *s, gint fd)
 
   _tls_session_allow_compress(tls_session, self->allow_compress);
 
-  tls_session_set_verify(tls_session, self->tls_verify_cb, self->tls_verify_data, NULL);
+  tls_session_set_verifier(tls_session, self->tls_verifier);
 
   return log_transport_tls_new(tls_session, fd);
 }
@@ -75,18 +75,17 @@ _free(TransportFactory *s)
 {
   TransportFactoryTLS *self = (TransportFactoryTLS *)s;
   tls_context_unref(self->tls_context);
+  if (self->tls_verifier)
+    tls_verifier_unref(self->tls_verifier);
 }
 
 TransportFactory *
-transport_factory_tls_new(TLSContext *ctx,
-                          TLSSessionVerifyFunc tls_verify_cb,
-                          gpointer tls_verify_data)
+transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier)
 {
   TransportFactoryTLS *instance = g_new0(TransportFactoryTLS, 1);
 
   instance->tls_context = tls_context_ref(ctx);
-  instance->tls_verify_cb = tls_verify_cb;
-  instance->tls_verify_data  = tls_verify_data;
+  instance->tls_verifier = tls_verifier ? tls_verifier_ref(tls_verifier) : NULL;
 
   instance->super.id = transport_factory_tls_id();
   instance->super.construct_transport = _construct_transport;

--- a/lib/transport/transport-factory-tls.h
+++ b/lib/transport/transport-factory-tls.h
@@ -34,14 +34,11 @@ struct _TransportFactoryTLS
 {
   TransportFactory super;
   TLSContext *tls_context;
-  TLSSessionVerifyFunc tls_verify_cb;
-  gpointer tls_verify_data;
+  TLSVerifier *tls_verifier;
   gboolean allow_compress;
 };
 
-TransportFactory *transport_factory_tls_new(TLSContext *ctx,
-                                            TLSSessionVerifyFunc tls_verify_cb,
-                                            gpointer tls_verify_data);
+TransportFactory *transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier);
 
 void transport_factory_tls_enable_compression(TransportFactory *);
 void transport_factory_tls_disable_compression(TransportFactory *);

--- a/modules/afsocket/afinet-source.c
+++ b/modules/afsocket/afinet-source.c
@@ -59,7 +59,7 @@ afinet_sd_set_tls_context(LogDriver *s, TLSContext *tls_context)
 {
   AFInetSourceDriver *self = (AFInetSourceDriver *) s;
 
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context, NULL, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context, NULL);
 }
 
 static gboolean

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -189,7 +189,7 @@ test_udp_apply_transport_sets_defaults(void)
 static void
 test_udp_apply_fails_when_tls_context_is_set(void)
 {
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
 }
 
@@ -220,7 +220,7 @@ test_network_transport_udp_apply_transport_sets_defaults(void)
 static void
 test_network_transport_udp_apply_fails_when_tls_context_is_set(void)
 {
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
 }
 
@@ -245,7 +245,7 @@ test_network_transport_tls_apply_fails_without_tls_context(void)
 static void
 test_network_transport_tls_apply_transport_sets_defaults(void)
 {
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
   assert_transport_mapper_apply(transport_mapper, "tls");
   assert_transport_mapper_tcp_socket(transport_mapper);
 
@@ -282,7 +282,7 @@ test_syslog_transport_udp_apply_transport_sets_defaults(void)
 static void
 test_syslog_transport_udp_apply_fails_when_tls_context_is_set(void)
 {
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
 }
 
@@ -307,7 +307,7 @@ test_syslog_transport_tls_apply_fails_without_tls_context(void)
 static void
 test_syslog_transport_tls_apply_transport_sets_defaults(void)
 {
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
   assert_transport_mapper_apply(transport_mapper, "tls");
   assert_transport_mapper_tcp_socket(transport_mapper);
 

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -36,8 +36,7 @@ typedef struct _TransportMapperInet
   gboolean allow_tls;
   gboolean require_tls_when_has_tls_context;
   TLSContext *tls_context;
-  TLSSessionVerifyFunc tls_verify_callback;
-  gpointer tls_verify_data;
+  TLSVerifier *tls_verifier;
   gpointer secret_store_cb_data;
 } TransportMapperInet;
 
@@ -62,12 +61,10 @@ transport_mapper_inet_get_port_change_warning(TransportMapper *s)
 }
 
 static inline void
-transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context,
-                                      TLSSessionVerifyFunc tls_verify_callback, gpointer tls_verify_data)
+transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context, TLSVerifier *tls_verifier)
 {
   self->tls_context = tls_context;
-  self->tls_verify_callback = tls_verify_callback;
-  self->tls_verify_data = tls_verify_data;
+  self->tls_verifier = tls_verifier;
 }
 
 void transport_mapper_inet_init_instance(TransportMapperInet *self, const gchar *transport);


### PR DESCRIPTION
When a TLS session is initiated, the afsocket module passes a
reference to the AFInetDestDriver instance to the TLSSession
structure to use as verification data. Due to the timing of
configuration changes, the driver structure may be freed before
the TLSSession structure, meaning that TLSSession will contain a
dangling pointer to the AFInetDestDriver. The afsocket module may
try to verify the session using the invalid data, which result in
a crash.

This patch adds two extra function pointers to the
TransportMapperInet structure, one that is used to increment the
driver's reference counter when it is passed to the TLSSession,
and one that is called to decrement the driver's reference
counter when the session structure is destroyed. This ensures
that the driver is only freed once there are no sessions
referencing it.

Signed-off-by: Bernie Harris <bernie.harris@alliedtelesis.co.nz>