### PR TITLE
FreeBSD 11.2 builderror SOCK_STREAM

### DIFF
--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -30,6 +30,8 @@
 #include <stdio.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <unistd.h>
 #include <string.h>
 #include <netdb.h>


### PR DESCRIPTION
FreeBSD 11.2 builderror SOCK_STREAM on tests/loggen/ssl_plugin/ssl_plugin.c with syslog-3.16.1 
 fix issues #2124 and #2150