### PR TITLE
Fix padding template function

### DIFF
--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -411,7 +411,7 @@ _padding_prepare_parse_state(TFStringPaddingState *state, gint argc, gchar **arg
       return FALSE;
     }
 
-  if (!parse_number_with_suffix(argv[2], &state->width))
+  if (!parse_number(argv[2], &state->width))
     {
 
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -402,11 +402,8 @@ typedef struct _TFStringPaddingState
 } TFStringPaddingState;
 
 static gboolean
-tf_string_padding_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
-                          gint argc, gchar *argv[], GError **error)
+_padding_prepare_parse_state(TFStringPaddingState *state, gint argc, gchar **argv, GError **error)
 {
-  TFStringPaddingState *state = (TFStringPaddingState *) s;
-
   if (argc < 3)
     {
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
@@ -421,7 +418,12 @@ tf_string_padding_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *pa
                   "Padding template function requires a number as second argument!");
       return FALSE;
     }
+  return TRUE;
+}
 
+static void
+_padding_prepare_fill_padding_pattern(TFStringPaddingState *state, gint argc, gchar **argv)
+{
   state->padding_pattern = g_string_sized_new(state->width);
   if (argc < 4)
     {
@@ -444,6 +446,18 @@ tf_string_padding_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *pa
           g_string_append_len(state->padding_pattern, argv[3], state->width - (repeat * len));
         }
     }
+}
+
+static gboolean
+tf_string_padding_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
+                          gint argc, gchar *argv[], GError **error)
+{
+  TFStringPaddingState *state = (TFStringPaddingState *) s;
+
+  if (!_padding_prepare_parse_state(state, argc, argv, error))
+    return FALSE;
+
+  _padding_prepare_fill_padding_pattern(state, argc, argv);
 
   if (!tf_simple_func_prepare(self, state, parent, 2, argv, error))
     {

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -394,47 +394,95 @@ tf_replace_delimiter(LogMessage *msg, gint argc, GString *argv[], GString *resul
 
 TEMPLATE_FUNCTION_SIMPLE(tf_replace_delimiter);
 
-static void
-tf_string_padding(LogMessage *msg, gint argc, GString *argv[], GString *result)
+typedef struct _TFStringPaddingState
 {
-  GString *text = argv[0];
-  GString *padding;
-  gint64 width, i;
+  TFSimpleFuncState super;
+  GString *padding_pattern;
+  gint64  width;
+} TFStringPaddingState;
 
-  if (argc <= 1)
+static gboolean
+tf_string_padding_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
+                          gint argc, gchar *argv[], GError **error)
+{
+  TFStringPaddingState *state = (TFStringPaddingState *) s;
+
+  if (argc < 3)
     {
-      msg_debug("Not enough arguments for padding template function!");
-      return;
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(padding) Not enough arguments, usage $(padding <input> <width> [padding string])");
+      return FALSE;
     }
 
-  if (!parse_number_with_suffix(argv[1]->str, &width))
+  if (!parse_number_with_suffix(argv[2], &state->width))
     {
-      msg_debug("Padding template function requires a number as second argument!");
-      return;
+
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "Padding template function requires a number as second argument!");
+      return FALSE;
     }
 
-  if (argc <= 2)
-    padding = g_string_new(" ");
+  state->padding_pattern = g_string_sized_new(state->width);
+  if (argc < 4)
+    {
+      g_string_printf(state->padding_pattern, "%*s", (int)(state->width), "");
+    }
   else
-    padding = argv[2];
-
-  if (text->len < width)
     {
-      for (i = 0; i < width - text->len; i++)
+      gint len = strlen(argv[3]);
+      if (len < 1)
         {
-          g_string_append_c(result, *(padding->str + (i % padding->len)));
+          g_string_printf(state->padding_pattern, "%*s", (int)(state->width), "");
+        }
+      else
+        {
+          gint repeat = state->width / len; // integer division!
+          for (gint i = 0; i < repeat; i++)
+            {
+              g_string_append_len(state->padding_pattern, argv[3], len);
+            }
+          g_string_append_len(state->padding_pattern, argv[3], state->width - (repeat * len));
         }
     }
 
-  g_string_append_len(result, text->str, text->len);
-
-  if (argc <= 2)
+  if (!tf_simple_func_prepare(self, state, parent, 2, argv, error))
     {
-      g_string_free(padding, TRUE);
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "padding: prepare failed");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+tf_string_padding_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
+{
+  TFStringPaddingState *state = (TFStringPaddingState *) s;
+  GString **argv = (GString **) args->bufs->pdata;
+
+  if (argv[0]->len > state->width)
+    {
+      g_string_append_len(result, argv[0]->str, argv[0]->len);
+    }
+  else
+    {
+      g_string_append_len(result, state->padding_pattern->str, state->width - argv[0]->len);
+      g_string_append_len(result, argv[0]->str, argv[0]->len);
     }
 }
 
-TEMPLATE_FUNCTION_SIMPLE(tf_string_padding);
+static void
+tf_string_padding_free_state(gpointer s)
+{
+  TFStringPaddingState *state = (TFStringPaddingState *) s;
+  if (state->padding_pattern)
+    g_string_free(state->padding_pattern, TRUE);
+  tf_simple_func_free_state(&state->super);
+}
+
+TEMPLATE_FUNCTION(TFStringPaddingState, tf_string_padding, tf_string_padding_prepare,
+                  tf_simple_func_eval, tf_string_padding_call, tf_string_padding_free_state, NULL);
 
 typedef struct _TFBinaryState
 {

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -172,6 +172,10 @@ Test(basicfuncs, test_str_funcs)
   assert_template_format("$(padding foo 10)", "       foo");
   assert_template_format("$(padding foo 10 x)", "xxxxxxxfoo");
   assert_template_format("$(padding foo 10 abc)", "abcabcafoo");
+  assert_template_format("$(padding foo 2)", "foo");        // longer macro than padding
+  assert_template_format("$(padding foo 3)", "foo");        // len(macro) == padding length
+  assert_template_format("$(padding foo 6 abc)", "abcfoo"); // len(padding string) == padding length
+  assert_template_format("$(padding foo 4 '')", " foo");    // padding string == ''
 
   assert_template_failure("$(binary)", "Incorrect parameters");
   assert_template_failure("$(binary abc)", "unable to parse abc");


### PR DESCRIPTION
Triggered by the mailing list. To calculate the proper prefix length, we divide by the length of the optional padding string (default: <space>) , which leads to crash in case of zero length input.

Rewritten from "TEMPLATE_FUNCTION_SIMPLE" to a state full template. In prepare time, we:
- make the padding length number conversion
- create a helper string with the length of the maximum possible padding.
Thus, the work/message is reduced.

Questions:
- Why do we use `parse_number_with_suffix` to parse the padding width?
- Can we trust in the number of arguments in the "_call" method? (Not existing macros are expanded to empty strings)