### PR TITLE
Make g_atomic_counter_set() atomic and update minimum glib version to 2.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ set(WITH_GETTEXT "" CACHE STRING "Set the prefix where gettext is installed (e.g
 set(CMAKE_C_STANDARD 99)
 
 find_package(BISON 2.4 REQUIRED)
-find_package(GLIB COMPONENTS gmodule gthread 2.10.1 REQUIRED)
+find_package(GLIB COMPONENTS gmodule gthread 2.26.1 REQUIRED)
 
 set (SYSLOG_NG_USE_CONST_IVYKIS_MOCK 1)
 external_or_find_package(IVYKIS REQUIRED)

--- a/configure.ac
+++ b/configure.ac
@@ -910,7 +910,7 @@ LDFLAGS="$LDFLAGS $GLIB_LIBS"
 
 old_LIBS=$LIBS
 LIBS="$LIBS $GLIB_LIBS"
-AC_CHECK_FUNCS(g_mapped_file_unref g_list_copy_deep g_queue_free_full g_list_free_full)
+AC_CHECK_FUNCS(g_list_copy_deep g_queue_free_full g_list_free_full)
 LIBS=$old_LIBS
 
 AC_CACHE_CHECK(sanity checking Glib headers,

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 dnl ***************************************************************************
 dnl dependencies
 
-GLIB_MIN_VERSION="2.10.1"
+GLIB_MIN_VERSION="2.26.1"
 OPENSSL_MIN_VERSION="0.9.8"
 LIBDBI_MIN_VERSION="0.9.0"
 LIBRABBITMQ_MIN_VERSION="0.5.3"

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -25,6 +25,7 @@
 #ifndef ATOMIC_H_INCLUDED
 #define ATOMIC_H_INCLUDED
 
+#include "compat/glib.h"
 
 typedef struct
 {
@@ -68,13 +69,7 @@ g_atomic_counter_racy_get(GAtomicCounter *c)
 static inline void
 g_atomic_counter_set(GAtomicCounter *c, gint value)
 {
-  /* FIXME: we should use g_atomic_int_set, but that's available starting
-   * with GLib 2.10 only, and we only use this function for initialization,
-   * thus atomic write is not strictly needed as there's no concurrency
-   * while initializing a refcounter.
-   */
-
-  c->counter = value;
+  g_atomic_int_set(&c->counter, value);
 }
 
 #endif

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -30,10 +30,6 @@
 
 #include <glib.h>
 
-#if !SYSLOG_NG_HAVE_G_MAPPED_FILE_UNREF
-#define g_mapped_file_unref g_mapped_file_free
-#endif
-
 #if !SYSLOG_NG_HAVE_G_LIST_COPY_DEEP
 GList *g_list_copy_deep (GList *list, GCopyFunc func, gpointer user_data);
 #endif


### PR DESCRIPTION
Extracted from #2045.

This function was not used only for initialization, because its name deceived others.
The name does not imply being racy, so I've fixed the implementation.