### PR TITLE
Fix a groupset/groupunset and map-value-pairs() crash

### DIFF
--- a/lib/rewrite/rewrite-groupset.c
+++ b/lib/rewrite/rewrite-groupset.c
@@ -70,12 +70,13 @@ static void
 log_rewrite_groupset_process(LogRewrite *s, LogMessage **msg, const LogPathOptions *path_options)
 {
   LogRewriteGroupSet *self = (LogRewriteGroupSet *) s;
+  GlobalConfig *cfg = log_pipe_get_config(&s->super);
   LogRewriteGroupSetCallbackData userdata;
 
   log_msg_make_writable(msg, path_options);
   userdata.msg = *msg;
   userdata.template = self->replacement;
-  value_pairs_foreach(self->query, self->vp_func, *msg, 0, LTZ_LOCAL, NULL, &userdata);
+  value_pairs_foreach(self->query, self->vp_func, *msg, 0, LTZ_LOCAL, &cfg->template_options, &userdata);
 }
 
 static void

--- a/modules/map-value-pairs/map-value-pairs.c
+++ b/modules/map-value-pairs/map-value-pairs.c
@@ -39,6 +39,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
          const gchar *input, gsize input_len)
 {
   MapValuePairs *self = (MapValuePairs *) s;
+  GlobalConfig *cfg = log_pipe_get_config(&s->super);
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
   msg_debug("value-pairs message processing started",
             evt_tag_str ("input", input),
@@ -46,7 +47,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
 
   value_pairs_foreach(self->value_pairs, _map_name_values,
                       msg,
-                      0, LTZ_LOCAL, NULL,
+                      0, LTZ_LOCAL, &cfg->template_options,
                       msg);
 
   return TRUE;


### PR DESCRIPTION
The `template_options` parameter of `value_pairs_foreach()` is mandatory, because it is used by `log_macro_expand()` (through `vp_merge_builtins()`).

There are additional (serious) problems with groupset/groupunset and value-pairs (see: https://github.com/balabit/syslog-ng/issues/1673#issuecomment-331413086 and https://github.com/balabit/syslog-ng/issues/1673#issuecomment-331438954), but fixing the crash itself might not be a bad idea.

Fixes #1673