### PR TITLE
WildcardFileReader: the callback registration mechanism is refactored

### DIFF
--- a/modules/affile/tests/test_wildcard_file_reader.c
+++ b/modules/affile/tests/test_wildcard_file_reader.c
@@ -33,7 +33,6 @@
 
 typedef struct _TestFileStateEvent
 {
-  FileStateEvent super;
   gboolean deleted_eof_called;
   gboolean finished_called;
 } TestFileStateEvent;
@@ -56,9 +55,6 @@ TestFileStateEvent *
 test_deleted_file_state_event_new(void)
 {
   TestFileStateEvent *self = g_new0(TestFileStateEvent, 1);
-  self->super.user_data = self;
-  self->super.deleted_file_eof = _eof;
-  self->super.deleted_file_finised = _finished;
   return self;
 }
 
@@ -116,7 +112,9 @@ _init(void)
 {
   app_startup();
   test_event = test_deleted_file_state_event_new();
-  reader = (WildcardFileReader *)wildcard_file_reader_new(TEST_FILE_NAME, NULL, NULL, NULL, NULL, &test_event->super);
+  reader = (WildcardFileReader *)wildcard_file_reader_new(TEST_FILE_NAME, NULL, NULL, NULL, NULL);
+  wildcard_file_reader_on_deleted_file_finished(reader, _finished, test_event);
+  wildcard_file_reader_on_deleted_file_eof(reader, _eof, test_event);
   cr_assert_eq(log_pipe_init(&reader->super.super), TRUE);
 }
 

--- a/modules/affile/wildcard-file-reader.h
+++ b/modules/affile/wildcard-file-reader.h
@@ -33,9 +33,10 @@ typedef void (*FileStateEventCallback)(FileReader *file_reader, gpointer user_da
 
 typedef struct _FileStateEvent
 {
-  FileStateEventCallback deleted_file_finised;
+  FileStateEventCallback deleted_file_finished;
+  gpointer deleted_file_finished_user_data;
   FileStateEventCallback deleted_file_eof;
-  gpointer user_data;
+  gpointer deleted_file_eof_user_data;
 } FileStateEvent;
 
 typedef struct _FileState
@@ -50,14 +51,19 @@ struct _WildcardFileReader
 {
   FileReader super;
   FileState file_state;
-  FileStateEvent *file_state_event;
+  FileStateEvent file_state_event;
   struct iv_task file_state_event_handler;
 };
 
-FileReader *
+WildcardFileReader *
 wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options,
                          FileOpener *opener, LogSrcDriver *owner,
-                         GlobalConfig *cfg, FileStateEvent *file_state_event);
+                         GlobalConfig *cfg);
+
+void wildcard_file_reader_on_deleted_file_finished(WildcardFileReader *self, FileStateEventCallback cb,
+                                                   gpointer user_data);
+void wildcard_file_reader_on_deleted_file_eof(WildcardFileReader *self, FileStateEventCallback cb, gpointer user_data);
+gboolean wildcard_file_reader_is_deleted(WildcardFileReader *self);
 
 
 #endif /* MODULES_AFFILE_WILDCARD_FILE_READER_H_ */

--- a/modules/affile/wildcard-source.h
+++ b/modules/affile/wildcard-source.h
@@ -50,7 +50,6 @@ typedef struct _WildcardSourceDriver
   GHashTable *file_readers;
   GHashTable *directory_monitors;
   FileOpener *file_opener;
-  FileStateEvent deleted_file_events;
 
   PendingFileList *waiting_list;
 } WildcardSourceDriver;


### PR DESCRIPTION
The callbacks have to be registered separated, not in the constructor.
New functions are introduced:
 - wildcard_file_reader_on_deleted_file_finished
 - wildcard_file_reader_on_deleted_file_eof

The wildcard_file_reader_is_deleted is also introduced in order to avoid
direct access of an object member

Signed-off-by: Viktor Juhasz <juhasz.viktor81@gmail.com>