### PR TITLE
New linux-audit() source as SCL

### DIFF
--- a/scl/linux-audit/linux-audit.conf
+++ b/scl/linux-audit/linux-audit.conf
@@ -1,0 +1,31 @@
+#############################################################################
+# Copyright (c) 2018 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block source linux-audit(filename("/var/log/audit/audit.log") prefix(".auditd.") ...) {
+  channel {
+    source { file("`filename`" flags(no-parse) `__VARARGS__`); };
+    parser { linux-audit-parser (prefix("`prefix`")); };
+    parser { kv-parser (template("${`prefix`msg}") prefix("`prefix`msg.")); };
+    rewrite { unset(value("`prefix`msg")); };
+  };
+};
+


### PR DESCRIPTION
Add a new SCL: linux-audit() source. It reads and automatically
parses the Linux audit logs. You can override the file name using
the filename() parameter and the prefix for the created
name-value pairs using the prefix() parameter. Any additional
parameters are passed to the file source.

Example:

```
source s_auditd {
  linux-audit(
    prefix("test.")
    hook-commands(
      startup("auditctl -w /etc/ -p wa")
      shutdown("auditctl -W /etc/ -p wa")
    )
  );
};
```

Signed-off-by: Peter Czanik <peter@czanik.hu>