### PR TITLE
dbld: fix pip package versions on older Distro releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
       criterion-dev
       libmaxminddb-dev
       libxml2-utils
-  - sudo pip install -r requirements.txt
+  - sudo pip install -r dbld/images/required-pip/devshell.txt
 before_script:
   - echo 'Europe/Budapest' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
@@ -169,7 +169,7 @@ matrix:
         - export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH
         - brew update > /dev/null
         - brew install python@2 &> /dev/null || brew link --overwrite python@2
-        - pip2 install --user -r dbld/images/required-pip/all.txt
+        - pip2 install --user -r dbld/images/required-pip/devshell.txt
         - brew bundle --file=contrib/Brewfile
       before_script:
         - ./autogen.sh

--- a/dbld/images/required-apt/all.txt
+++ b/dbld/images/required-apt/all.txt
@@ -52,3 +52,4 @@ dh-systemd
 docbook
 docbook-xsl
 dh-exec
+gnupg

--- a/dbld/images/required-apt/stretch.txt
+++ b/dbld/images/required-apt/stretch.txt
@@ -1,0 +1,13 @@
+# required for autogen
+
+# required for configure
+libsystemd-dev
+openjdk-8-jdk
+
+# required for make
+
+# required for make check
+
+# other tools
+
+# debian packaging tools

--- a/dbld/images/required-obs/stretch.txt
+++ b/dbld/images/required-obs/stretch.txt
@@ -1,0 +1,5 @@
+libbson-dev
+libmongoc-dev
+librabbitmq-dev
+libriemann-client-dev
+python-pep8

--- a/dbld/images/required-pip/all.txt
+++ b/dbld/images/required-pip/all.txt
@@ -1,6 +1,0 @@
-nose
-ply
-pep8
-pylint
-astroid
-logilab-common

--- a/dbld/images/required-pip/artful.txt
+++ b/dbld/images/required-pip/artful.txt
@@ -1,0 +1,6 @@
+nose
+ply
+pep8
+pylint
+astroid
+logilab-common

--- a/dbld/images/required-pip/centos6.txt
+++ b/dbld/images/required-pip/centos6.txt
@@ -1,0 +1,6 @@
+nose==1.3.7
+ply==3.10
+pep8==1.7.1
+pylint==1.8.2
+astroid==1.6.1
+logilab-common<=0.63.0

--- a/dbld/images/required-pip/centos7.txt
+++ b/dbld/images/required-pip/centos7.txt
@@ -1,0 +1,6 @@
+nose==1.3.7
+ply==3.10
+pep8==1.7.1
+pylint==1.8.2
+astroid==1.6.1
+logilab-common<=0.63.0

--- a/dbld/images/required-pip/devshell.txt
+++ b/dbld/images/required-pip/devshell.txt
@@ -1,0 +1,6 @@
+nose
+ply
+pep8
+pylint
+astroid
+logilab-common

--- a/dbld/images/required-pip/jessie.txt
+++ b/dbld/images/required-pip/jessie.txt
@@ -1,0 +1,6 @@
+nose==1.3.7
+ply==3.10
+pep8==1.7.1
+pylint==1.8.2
+astroid==1.6.1
+logilab-common<=0.63.0

--- a/dbld/images/required-pip/stretch.txt
+++ b/dbld/images/required-pip/stretch.txt
@@ -1,0 +1,6 @@
+nose
+ply
+pep8
+pylint
+astroid
+logilab-common

--- a/dbld/images/required-pip/trusty.txt
+++ b/dbld/images/required-pip/trusty.txt
@@ -1,0 +1,6 @@
+nose==1.3.7
+ply==3.10
+pep8==1.7.1
+pylint==1.8.2
+astroid==1.6.1
+logilab-common<=0.63.0

--- a/dbld/images/required-pip/xenial.txt
+++ b/dbld/images/required-pip/xenial.txt
@@ -1,0 +1,6 @@
+nose==1.3.7
+ply==3.10
+pep8==1.7.1
+pylint==1.8.2
+astroid==1.6.1
+logilab-common<=0.63.0

--- a/dbld/images/stretch.dockerfile
+++ b/dbld/images/stretch.dockerfile
@@ -1,0 +1,40 @@
+FROM debian:stretch
+ARG DISTRO=stretch
+ARG OBS_REPO=Debian_9.0
+
+LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>"
+
+COPY helpers/* /helpers/
+
+# Install packages
+RUN apt-get update -qq && apt-get install --no-install-recommends -y \
+  python-pip \
+  python-setuptools \
+  wget
+
+COPY required-pip/all.txt required-pip/${DISTRO}*.txt /required-pip/
+RUN cat /required-pip/* | grep -v '^$\|^#' | xargs pip install
+
+COPY required-apt/all.txt required-apt/${DISTRO}*.txt /required-apt/
+RUN cat /required-apt/* | grep -v '^$\|^#' | xargs apt-get install --no-install-recommends -y
+
+RUN /helpers/functions.sh add_obs_repo ${OBS_REPO}
+COPY required-obs/all.txt required-obs/${DISTRO}*.txt /required-obs/
+RUN cat /required-obs/* | grep -v '^$\|^#' | xargs apt-get install --no-install-recommends -y
+
+
+# grab gosu for easy step-down from root
+RUN /helpers/functions.sh step_down_from_root_with_gosu $(dpkg --print-architecture)
+
+
+# add a fake sudo command
+RUN mv /helpers/fake-sudo.sh /usr/bin/sudo
+
+
+# mount points for source code
+RUN mkdir /source
+VOLUME /source
+VOLUME /build
+
+
+ENTRYPOINT ["/helpers/entrypoint.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dbld/images/required-pip/all.txt
+dbld/images/required-pip/trusty.txt


### PR DESCRIPTION
Some packages (e.g.  pylint 2.0.0) declare package tags that are not
supported by ancient setuptools packages, that are available in centos 6 and
7, therefore use fixed versions on ancient distributions.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>