### PR TITLE
Http framing support for batches

### DIFF
--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -66,6 +66,8 @@
 %token KW_TIMEOUT
 %token KW_TLS
 %token KW_FLUSH_BYTES
+%token KW_BODY_PREFIX
+%token KW_BODY_SUFFIX
 
 %type   <ptr> driver
 %type   <ptr> http_destination
@@ -108,6 +110,8 @@ http_option
     | KW_USER_AGENT '(' string ')'            { http_dd_set_user_agent(last_driver, $3); free($3); }
     | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free_full($3, free); }
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
+    | KW_BODY_PREFIX '(' string ')'        { http_dd_set_body_prefix(last_driver, $3); free($3); }
+    | KW_BODY_SUFFIX '(' string ')'        { http_dd_set_body_suffix(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_FLUSH_LINES '(' nonnegative_integer ')' { http_dd_set_flush_lines(last_driver, $3); }

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -68,6 +68,7 @@
 %token KW_FLUSH_BYTES
 %token KW_BODY_PREFIX
 %token KW_BODY_SUFFIX
+%token KW_DELIMITER
 
 %type   <ptr> driver
 %type   <ptr> http_destination
@@ -112,6 +113,7 @@ http_option
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
     | KW_BODY_PREFIX '(' string ')'        { http_dd_set_body_prefix(last_driver, $3); free($3); }
     | KW_BODY_SUFFIX '(' string ')'        { http_dd_set_body_suffix(last_driver, $3); free($3); }
+    | KW_DELIMITER  '(' string ')'        { http_dd_set_delimiter(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_FLUSH_LINES '(' nonnegative_integer ')' { http_dd_set_flush_lines(last_driver, $3); }

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -48,6 +48,8 @@ static CfgLexerKeyword http_keywords[] =
   { "timeout",      KW_TIMEOUT },
   { "tls",          KW_TLS },
   { "flush_bytes",  KW_FLUSH_BYTES },
+  { "body_prefix", KW_BODY_PREFIX },
+  { "body_suffix", KW_BODY_SUFFIX },
   { NULL }
 };
 

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -48,8 +48,9 @@ static CfgLexerKeyword http_keywords[] =
   { "timeout",      KW_TIMEOUT },
   { "tls",          KW_TLS },
   { "flush_bytes",  KW_FLUSH_BYTES },
-  { "body_prefix", KW_BODY_PREFIX },
-  { "body_suffix", KW_BODY_SUFFIX },
+  { "body_prefix",  KW_BODY_PREFIX },
+  { "body_suffix",  KW_BODY_SUFFIX },
+  { "delimiter",    KW_DELIMITER },
   { NULL }
 };
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -506,6 +506,13 @@ exit:
   return retval;
 }
 
+static gboolean
+_should_initiate_flush(HTTPDestinationDriver *self)
+{
+  return (self->flush_bytes && self->request_body->len >= self->flush_bytes) ||
+         (self->flush_lines && self->super.batch_size >= self->flush_lines);
+}
+
 static worker_insert_result_t
 _insert_batched(HTTPDestinationDriver *self, LogMessage *msg)
 {
@@ -514,8 +521,7 @@ _insert_batched(HTTPDestinationDriver *self, LogMessage *msg)
 
   _add_message_to_batch(self, msg);
 
-  if ((self->flush_bytes && self->request_body->len >= self->flush_bytes) ||
-      (self->flush_lines && self->super.batch_size >= self->flush_lines))
+  if (_should_initiate_flush(self))
     {
       return _flush(&self->super);
     }

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -47,6 +47,8 @@ typedef struct
   gchar *cert_file;
   gchar *key_file;
   gchar *ciphers;
+  GString *body_prefix;
+  GString *body_suffix;
   int ssl_version;
   gboolean peer_verify;
   short int method_type;
@@ -79,6 +81,8 @@ void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
 void http_dd_set_timeout(LogDriver *d, glong timeout);
 void http_dd_set_flush_lines(LogDriver *d, glong flush_lines);
 void http_dd_set_flush_bytes(LogDriver *d, glong flush_bytes);
+void http_dd_set_body_prefix(LogDriver *d, const gchar *body_prefix);
+void http_dd_set_body_suffix(LogDriver *d, const gchar *body_suffix);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 
 #endif

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -57,6 +57,7 @@ typedef struct
   glong flush_bytes;
   struct curl_slist *request_headers;
   GString *request_body;
+  GString *delimiter;
   LogTemplate *body_template;
   LogTemplateOptions template_options;
 } HTTPDestinationDriver;
@@ -83,6 +84,7 @@ void http_dd_set_flush_lines(LogDriver *d, glong flush_lines);
 void http_dd_set_flush_bytes(LogDriver *d, glong flush_bytes);
 void http_dd_set_body_prefix(LogDriver *d, const gchar *body_prefix);
 void http_dd_set_body_suffix(LogDriver *d, const gchar *body_suffix);
+void http_dd_set_delimiter(LogDriver *d, const gchar *delimiter);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 
 #endif


### PR DESCRIPTION
This series of patches add body-prefix(), body-suffix() and delimiter() option to the http driver, so that
one case create proper framing around items (formatted by the template specified with body()).

This allows us to post proper JSON encoded arrays as POST payloads, which is required by a number of REST APIs.

I am working on splitting the HTTPDestinationDriver class into a separate Worker and Driver class, which would make it easier to do actual testing in the http destination. Right now, I only did manual tests and it does work and the patches are simple enough. My refactorings are subsequent to this, and it is far from trivial to do bring testing in front of this patch, so please merge this without tests at this point.

Thanks.

