### PR TITLE
Reliable disk buffer non-empty backlog

### DIFF
--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -46,9 +46,9 @@ disk_queue_options_disk_buf_size_set(DiskQueueOptions *self, gint64 disk_buf_siz
   if (disk_buf_size < MIN_DISK_BUF_SIZE)
     {
       msg_warning("WARNING: The configured disk buffer size is smaller than the minimum allowed",
-                  evt_tag_int("configured_size", disk_buf_size),
-                  evt_tag_int("minimum_allowed_size", MIN_DISK_BUF_SIZE),
-                  evt_tag_int("new_size", MIN_DISK_BUF_SIZE));
+                  evt_tag_long("configured_size", disk_buf_size),
+                  evt_tag_long("minimum_allowed_size", MIN_DISK_BUF_SIZE),
+                  evt_tag_long("new_size", MIN_DISK_BUF_SIZE));
       disk_buf_size = MIN_DISK_BUF_SIZE;
     }
   self->disk_buf_size = disk_buf_size;

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -146,7 +146,7 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   if (self->options.disk_buf_size < MIN_DISK_BUF_SIZE && self->options.disk_buf_size != 0)
     {
       msg_warning("The value of 'disk_buf_size()' is too low, setting to the smallest acceptable value",
-                  evt_tag_int("min_space", MIN_DISK_BUF_SIZE));
+                  evt_tag_long("min_space", MIN_DISK_BUF_SIZE));
       self->options.disk_buf_size = MIN_DISK_BUF_SIZE;
     }
 

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -337,11 +337,11 @@ _push_tail (LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, con
           else
             {
               msg_debug ("Destination queue full, dropping message",
-                         evt_tag_str ("filename", qdisk_get_filename (self->super.qdisk)),
-                         evt_tag_int ("queue_len", _get_length(s)),
-                         evt_tag_int ("mem_buf_length", self->qoverflow_size),
-                         evt_tag_int ("size", qdisk_get_size (self->super.qdisk)),
-                         evt_tag_str ("persist_name", self->super.super.persist_name));
+                         evt_tag_str  ("filename", qdisk_get_filename (self->super.qdisk)),
+                         evt_tag_long ("queue_len", _get_length(s)),
+                         evt_tag_int  ("mem_buf_length", self->qoverflow_size),
+                         evt_tag_long ("size", qdisk_get_size (self->super.qdisk)),
+                         evt_tag_str  ("persist_name", self->super.super.persist_name));
               return FALSE;
             }
         }

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -260,9 +260,9 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
       /* we were not able to store the msg, warn */
       msg_error("Destination reliable queue full, dropping message",
                 evt_tag_str("filename", qdisk_get_filename (self->super.qdisk)),
-                evt_tag_int("queue_len", _get_length(s)),
+                evt_tag_long("queue_len", _get_length(s)),
                 evt_tag_int("mem_buf_size", qdisk_get_memory_size (self->super.qdisk)),
-                evt_tag_int("disk_buf_size", qdisk_get_size (self->super.qdisk)),
+                evt_tag_long("disk_buf_size", qdisk_get_size (self->super.qdisk)),
                 evt_tag_str("persist_name", self->super.super.persist_name));
 
       return FALSE;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -269,15 +269,7 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
     }
 
   /* check the remaining space: if it is less than the mem_buf_size, the message cannot be acked */
-  gint64 wpos = qdisk_get_writer_head (self->super.qdisk);
-  gint64 bpos = qdisk_get_backlog_head (self->super.qdisk);
-  gint64 diff;
-  if (wpos > bpos)
-    diff = qdisk_get_size (self->super.qdisk) - wpos + bpos - QDISK_RESERVED_SPACE;
-  else
-    diff = bpos - wpos;
-  gboolean overflow = diff < qdisk_get_memory_size (self->super.qdisk);
-
+  gboolean overflow = qdisk_get_empty_space(self->super.qdisk) < qdisk_get_memory_size (self->super.qdisk);
   if (overflow)
     {
       /* we have reached the reserved buffer size, keep the msg in memory

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -269,8 +269,7 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
     }
 
   /* check the remaining space: if it is less than the mem_buf_size, the message cannot be acked */
-  gboolean overflow = qdisk_get_empty_space(self->super.qdisk) < qdisk_get_memory_size (self->super.qdisk);
-  if (overflow)
+  if (qdisk_get_empty_space(self->super.qdisk) < qdisk_get_memory_size (self->super.qdisk))
     {
       /* we have reached the reserved buffer size, keep the msg in memory
        * the message is written but into the overflow area

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -214,6 +214,21 @@ _truncate_file(QDisk *self, gint64 new_size)
   return success;
 }
 
+gint64
+qdisk_get_empty_space(QDisk *self)
+{
+  gint64 wpos = qdisk_get_writer_head(self);
+  gint64 bpos = qdisk_get_backlog_head(self);
+
+  if (wpos > bpos)
+    {
+      return (qdisk_get_size(self) - wpos) +
+             (bpos - QDISK_RESERVED_SPACE);
+    }
+
+  return bpos - wpos;
+}
+
 gboolean
 qdisk_push_tail(QDisk *self, GString *record)
 {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -538,6 +538,20 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
         _truncate_file(self, end_ofs);
     }
 
+  if (!self->options->read_only && self->options->reliable)
+    {
+      if (self->hdr->backlog_len > 0 || self->hdr->backlog_head != self->hdr->read_head)
+        {
+          msg_warning("Reliable disk-buffer backlog is not empty, resetting",
+                      evt_tag_long("backlog_head", self->hdr->backlog_head),
+                      evt_tag_long("backlog_len", self->hdr->backlog_len));
+
+          self->hdr->length += self->hdr->backlog_len;
+          self->hdr->read_head = self->hdr->backlog_head;
+          self->hdr->backlog_len = 0;
+        }
+    }
+
   if (!self->options->reliable)
     {
       self->file_size = qout_ofs;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -558,6 +558,13 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
                evt_tag_str("filename", self->filename),
                evt_tag_long("queue_length", self->hdr->length),
                evt_tag_long("size", self->hdr->write_head - self->hdr->read_head));
+
+      msg_debug("Reliable disk-buffer internal state",
+                evt_tag_str("filename", self->filename),
+                evt_tag_long("backlog_head", self->hdr->backlog_head),
+                evt_tag_long("read_head", self->hdr->read_head),
+                evt_tag_long("write_head", self->hdr->write_head),
+                evt_tag_long("backlog_len", self->hdr->backlog_len));
     }
 
   return TRUE;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -207,7 +207,7 @@ _truncate_file(QDisk *self, gint64 new_size)
       msg_error("Error truncating disk-queue file",
                 evt_tag_error("error"),
                 evt_tag_str("filename", self->filename),
-                evt_tag_int("newsize", self->hdr->write_head),
+                evt_tag_long("newsize", self->hdr->write_head),
                 evt_tag_int("fd", self->fd));
     }
 
@@ -464,9 +464,9 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
     {
       msg_error("Inconsistent header data in disk-queue file, ignoring",
                 evt_tag_str("filename", self->filename),
-                evt_tag_int("read_head", self->hdr->read_head),
-                evt_tag_int("write_head", self->hdr->write_head),
-                evt_tag_int("qdisk_length",  self->hdr->length));
+                evt_tag_long("read_head", self->hdr->read_head),
+                evt_tag_long("write_head", self->hdr->write_head),
+                evt_tag_long("qdisk_length",  self->hdr->length));
       return FALSE;
     }
 
@@ -481,8 +481,8 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
         {
           msg_error("Inconsistent header data in disk-queue file, ignoring qout",
                     evt_tag_str("filename", self->filename),
-                    evt_tag_int("qout_ofs", qout_ofs),
-                    evt_tag_int("qdisk_length",  self->hdr->length));
+                    evt_tag_long("qout_ofs", qout_ofs),
+                    evt_tag_long("qdisk_length",  self->hdr->length));
         }
 
       if (!(qbacklog_ofs > 0 && qbacklog_ofs < self->hdr->write_head))
@@ -494,8 +494,8 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
         {
           msg_error("Inconsistent header data in disk-queue file, ignoring qbacklog",
                     evt_tag_str("filename", self->filename),
-                    evt_tag_int("qbacklog_ofs", qbacklog_ofs),
-                    evt_tag_int("qdisk_length",  self->hdr->length));
+                    evt_tag_long("qbacklog_ofs", qbacklog_ofs),
+                    evt_tag_long("qdisk_length",  self->hdr->length));
         }
 
       if (!(qoverflow_ofs > 0 && qoverflow_ofs < self->hdr->write_head))
@@ -507,8 +507,8 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
         {
           msg_error("Inconsistent header data in disk-queue file, ignoring qoverflow",
                     evt_tag_str("filename", self->filename),
-                    evt_tag_int("qoverflow_ofs", qoverflow_ofs),
-                    evt_tag_int("qdisk_length",  self->hdr->length));
+                    evt_tag_long("qoverflow_ofs", qoverflow_ofs),
+                    evt_tag_long("qdisk_length",  self->hdr->length));
         }
     }
 
@@ -532,7 +532,7 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
                evt_tag_int("qout_length", qout_count),
                evt_tag_int("qbacklog_length", qbacklog_count),
                evt_tag_int("qoverflow_length", qoverflow_count),
-               evt_tag_int("qdisk_length", self->hdr->length));
+               evt_tag_long("qdisk_length", self->hdr->length));
     }
   else
     {
@@ -541,8 +541,8 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
       self->file_size = st.st_size;
       msg_info("Reliable disk-buffer state loaded",
                evt_tag_str("filename", self->filename),
-               evt_tag_int("queue_length", self->hdr->length),
-               evt_tag_int("size", self->hdr->write_head - self->hdr->read_head));
+               evt_tag_long("queue_length", self->hdr->length),
+               evt_tag_long("size", self->hdr->write_head - self->hdr->read_head));
     }
 
   return TRUE;
@@ -676,11 +676,11 @@ qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
              evt_tag_int("qout_length", qout_count),
              evt_tag_int("qbacklog_length", qbacklog_count),
              evt_tag_int("qoverflow_length", qoverflow_count),
-             evt_tag_int("qdisk_length", self->hdr->length));
+             evt_tag_long("qdisk_length", self->hdr->length));
   else
     msg_info("Reliable disk-buffer state saved",
              evt_tag_str("filename", self->filename),
-             evt_tag_int("qdisk_length", self->hdr->length));
+             evt_tag_long("qdisk_length", self->hdr->length));
 
   return TRUE;
 }

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -42,6 +42,7 @@ typedef struct _QDisk QDisk;
 QDisk *qdisk_new(void);
 
 gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
+gint64 qdisk_get_empty_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -56,7 +56,7 @@ _dummy_ack(LogMessage *lm,  AckType ack_type)
 }
 
 static LogQueueDiskReliable *
-_init_diskq_for_test(gint64 size, gint64 membuf_size)
+_init_diskq_for_test(const gchar *filename, gint64 size, gint64 membuf_size)
 {
   LogQueueDiskReliable *dq;
 
@@ -64,7 +64,6 @@ _init_diskq_for_test(gint64 size, gint64 membuf_size)
   LogQueue *q = log_queue_disk_reliable_new(&options, NULL);
   struct stat st;
   num_of_ack = 0;
-  gchar *filename = FILENAME;
   unlink(filename);
   log_queue_disk_load_queue(q, filename);
   dq = (LogQueueDiskReliable *)q;
@@ -218,7 +217,7 @@ test_ack_over_eof(LogQueueDiskReliable *dq, LogMessage *msg1, LogMessage *msg2)
 static void
 test_over_EOF(void)
 {
-  LogQueueDiskReliable *dq = _init_diskq_for_test(TEST_DISKQ_SIZE, TEST_DISKQ_SIZE);
+  LogQueueDiskReliable *dq = _init_diskq_for_test(FILENAME, TEST_DISKQ_SIZE, TEST_DISKQ_SIZE);
   LogMessage *msg1;
   LogMessage *msg2;
 
@@ -362,7 +361,7 @@ test_rewind_backlog_use_whole_qbacklog(LogQueueDiskReliable *dq)
 void
 test_rewind_backlog(void)
 {
-  LogQueueDiskReliable *dq = _init_diskq_for_test(QDISK_RESERVED_SPACE + mark_message_serialized_size * 10,
+  LogQueueDiskReliable *dq = _init_diskq_for_test(FILENAME, QDISK_RESERVED_SPACE + mark_message_serialized_size * 10,
                                                   mark_message_serialized_size * 5);
   gint64 old_read_pos;
 

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -36,7 +36,7 @@
 
 MsgFormatOptions parse_options;
 
-#define FILENAME "test_reliable_backlog.qf"
+#define FILENAME "test_reliable_backlog.rqf"
 #define TEST_DISKQ_SIZE QDISK_RESERVED_SPACE + 1000 /* 4096 + 1000 */
 
 static gint num_of_ack;

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -237,6 +237,37 @@ test_over_EOF(void)
   _common_cleanup(dq);
 }
 
+/* TestCase:
+   * - create a diskq with one message that is in the backlog(push, and pop but do not ack)
+   * - close diskq
+   * - try to get back the message from diskq buffer
+   */
+static void
+test_not_empty_backlog(void)
+{
+  const gchar *filename = "non_empty_backlog.rqf";
+  LogPathOptions local_options = LOG_PATH_OPTIONS_INIT;
+
+  LogQueueDiskReliable *dq = _init_diskq_for_test(filename, TEST_DISKQ_SIZE, TEST_DISKQ_SIZE);
+
+  log_queue_push_tail(&dq->super.super, log_msg_new_mark(), &local_options);
+
+  LogMessage *msg = log_queue_pop_head(&dq->super.super, &local_options);
+  assert_not_null(msg, "Could not find message in the disk-buffer.");
+
+  log_queue_unref(&dq->super.super);
+
+  dq = (LogQueueDiskReliable *)log_queue_disk_reliable_new(&options, NULL);
+  log_queue_disk_load_queue(&dq->super.super, filename);
+
+  msg = log_queue_pop_head(&dq->super.super, &local_options);
+  assert_not_null(msg, "Could not find message in the disk-buffer.");
+
+  log_queue_unref(&dq->super.super);
+  unlink(filename);
+  disk_queue_options_destroy(&options);
+}
+
 /*
  * The method make the following situation
  * the backlog contains 6 messages
@@ -393,6 +424,8 @@ main(gint argc, gchar **argv)
   test_over_EOF();
 
   test_rewind_backlog();
+
+  test_not_empty_backlog();
 
   cfg_free(configuration);
   app_shutdown();


### PR DESCRIPTION
The reliable disk buffer can contain messages in the backlog, and during syslog-ng lifetime it is perfectly fine (by design).
But if there is a message in the backlog when syslog-ng is starting, it is not expected to have message in the backlog, because it should have been acknowledged or rewinded.
As of now it keeps that backlog slot as a sliding window, and message could be stuck there until other message does not replace it. (No message stuck there forever.)

This patch contains 2 things:
* When reliable disk buffer is started, it check if there is a message in the backlog, and moves them back the reliable queue, therefore they are going to be reprocessed again.
* dqtool is extended, so when the `dqtool info` is used with `-d` (debug) option, it also prints extra information: `backlog_head`, `read_head`, `write_head`, `backlog_len`.