### PR TITLE
Minor stats-query fixes and refactor

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -286,15 +286,15 @@ stats_counter_group_free(StatsCounterGroup *self)
 
 
 static void
-stats_cluster_free_counter_name(StatsCluster *self, gint type, StatsCounterItem *item, gpointer user_data)
+stats_cluster_free_counter(StatsCluster *self, gint type, StatsCounterItem *item, gpointer user_data)
 {
-  g_free(item->name);
+  stats_counter_free(item);
 }
 
 void
 stats_cluster_free(StatsCluster *self)
 {
-  stats_cluster_foreach_counter(self, stats_cluster_free_counter_name, NULL);
+  stats_cluster_foreach_counter(self, stats_cluster_free_counter, NULL);
   _stats_cluster_key_cloned_free(&self->key);
   g_free(self->query_key);
   stats_counter_group_free(&self->counter_group);

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -55,6 +55,5 @@ stats_reset_counters(void)
 void
 stats_counter_free(StatsCounterItem *counter)
 {
-  if (counter->name)
-    g_free(counter->name);
+  g_free(counter->name);
 }

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -85,7 +85,7 @@ stats_counter_get(StatsCounterItem *counter)
 static inline gchar *
 stats_counter_get_name(StatsCounterItem *counter)
 {
-  if (counter && counter->name)
+  if (counter)
     return counter->name;
   return NULL;
 }

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -69,7 +69,7 @@ _ctl_format_name_without_value(StatsCounterItem *ctr, gpointer user_data)
 }
 
 static gboolean
-_ctl_format_get_sum(StatsCounterItem *ctr, gpointer user_data)
+_ctl_format_get_sum(gpointer user_data)
 {
   gpointer *args = (gpointer *) user_data;
   GString *result = (GString *) args[0];

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -146,10 +146,7 @@ _is_pattern_matches_key(GPatternSpec *pattern, gpointer key)
 static gboolean
 _is_single_match(const gchar *key_str)
 {
-  gboolean is_wildcard = strchr(key_str, '*') ? TRUE : FALSE;
-  gboolean is_joker = strchr(key_str, '?') ? TRUE : FALSE;
-
-  return !is_wildcard && !is_joker;
+  return !strpbrk(key_str, "*?");
 }
 
 static GList *

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -265,11 +265,8 @@ _get_counters(const gchar *key_str)
 
   if (simple_counters != NULL && aggregated_counters != NULL)
     return g_list_concat(simple_counters, aggregated_counters);
-  if (simple_counters != NULL)
-    return simple_counters;
-  if (aggregated_counters != NULL)
-    return aggregated_counters;
-  return NULL;
+
+  return simple_counters ? simple_counters : aggregated_counters;
 }
 
 static void

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -61,17 +61,13 @@ stats_register_view(gchar *name, GList *queries, const AggregatedMetricsCb aggre
   g_hash_table_insert(stats_views, name, record);
 }
 
-static void
-_setup_filter_expression(const gchar *expr, gchar **key_str)
+static const gchar *
+_setup_filter_expression(const gchar *expr)
 {
   if (!expr || g_str_equal(expr, ""))
-    {
-      *key_str = g_strdup("*");
-    }
+    return "*";
   else
-    {
-      *key_str = g_strdup(expr);
-    }
+    return expr;
 }
 
 static gchar *
@@ -306,11 +302,10 @@ _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gb
   if (!expr)
     return FALSE;
 
-  gchar *key_str = NULL;
   GList *counters = NULL;
   gboolean found_match = FALSE;
 
-  _setup_filter_expression(expr, &key_str);
+  const gchar *key_str = _setup_filter_expression(expr);
   counters = _get_counters(key_str);
   _format_selected_counters(counters, format_cb, result);
 
@@ -320,7 +315,6 @@ _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gb
   if (g_list_length(counters) > 0)
     found_match = TRUE;
 
-  g_free(key_str);
   g_list_free(counters);
 
   return found_match;
@@ -365,13 +359,12 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
   if (!expr)
     return FALSE;
 
-  gchar *key_str = NULL;
   GList *counters = NULL;
   gboolean found_match = FALSE;
   gint64 sum = 0;
   gpointer args[] = {result, &sum};
 
-  _setup_filter_expression(expr, &key_str);
+  const gchar *key_str = _setup_filter_expression(expr);
   counters = _get_counters(key_str);
   _sum_selected_counters(counters, (gpointer)args);
   _format_selected_counters(counters, format_cb, (gpointer)args);
@@ -382,7 +375,6 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
   if (g_list_length(counters) > 0)
     found_match = TRUE;
 
-  g_free(key_str);
   g_list_free(counters);
 
   return found_match;
@@ -403,11 +395,10 @@ stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_c
 gboolean
 _stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
 {
-  gchar *key_str = NULL;
   GList *counters = NULL;
   gboolean found_match = FALSE;
 
-  _setup_filter_expression(expr, &key_str);
+  const gchar *key_str = _setup_filter_expression(expr);
   counters = _get_counters(key_str);
   _format_selected_counters(counters, format_cb, result);
 
@@ -417,7 +408,6 @@ _stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, g
   if (g_list_length(counters) > 0)
     found_match = TRUE;
 
-  g_free(key_str);
   g_list_free(counters);
 
   return found_match;

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -86,9 +86,8 @@ static void
 _add_counter_to_index(StatsCluster *sc, gint type)
 {
   StatsCounterItem *counter = &sc->counter_group.counters[type];
-  gchar *counter_full_name = NULL;
 
-  counter_full_name = stats_counter_get_name(counter);
+  gchar *counter_full_name = stats_counter_get_name(counter);
   if (counter_full_name == NULL)
     {
       counter_full_name = _construct_counter_item_name(sc, type);
@@ -296,11 +295,10 @@ _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gb
   if (!expr)
     return FALSE;
 
-  GList *counters = NULL;
   gboolean found_match = FALSE;
 
   const gchar *key_str = _setup_filter_expression(expr);
-  counters = _get_counters(key_str);
+  GList *counters = _get_counters(key_str);
   _format_selected_counters(counters, format_cb, result);
 
   if (must_reset)
@@ -353,13 +351,12 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
   if (!expr)
     return FALSE;
 
-  GList *counters = NULL;
   gboolean found_match = FALSE;
   gint64 sum = 0;
   gpointer args[] = {result, &sum};
 
   const gchar *key_str = _setup_filter_expression(expr);
-  counters = _get_counters(key_str);
+  GList *counters = _get_counters(key_str);
   _sum_selected_counters(counters, (gpointer)args);
   _format_selected_counters(counters, format_cb, (gpointer)args);
 
@@ -389,11 +386,10 @@ stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_c
 gboolean
 _stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
 {
-  GList *counters = NULL;
   gboolean found_match = FALSE;
 
   const gchar *key_str = _setup_filter_expression(expr);
-  counters = _get_counters(key_str);
+  GList *counters = _get_counters(key_str);
   _format_selected_counters(counters, format_cb, result);
 
   if (must_reset)

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -346,7 +346,7 @@ _sum_selected_counters(GList *counters, gpointer user_data)
 }
 
 gboolean
-_stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
+_stats_query_get_sum(const gchar *expr, StatsSumFormatCb format_cb, gpointer result, gboolean must_reset)
 {
   if (!expr)
     return FALSE;
@@ -358,7 +358,9 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
   const gchar *key_str = _setup_filter_expression(expr);
   GList *counters = _get_counters(key_str);
   _sum_selected_counters(counters, (gpointer)args);
-  _format_selected_counters(counters, format_cb, (gpointer)args);
+
+  if (counters)
+    format_cb(args);
 
   if (must_reset)
     _reset_selected_counters(counters);
@@ -372,13 +374,13 @@ _stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result
 }
 
 gboolean
-stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result)
+stats_query_get_sum(const gchar *expr, StatsSumFormatCb format_cb, gpointer result)
 {
   return _stats_query_get_sum(expr, format_cb, result, FALSE);
 }
 
 gboolean
-stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result)
+stats_query_get_sum_and_reset_counters(const gchar *expr, StatsSumFormatCb format_cb, gpointer result)
 {
   return _stats_query_get_sum(expr, format_cb, result, TRUE);
 }

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -103,7 +103,7 @@ _remove_counter_from_index(StatsCluster *sc, gint type)
 {
   gchar *key = stats_counter_get_name(&sc->counter_group.counters[type]);
   g_hash_table_remove(counter_index, key);
-  sc->indexed_mask |= (1 << type);
+  sc->indexed_mask &= ~(1 << type);
 }
 
 static void

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -28,14 +28,15 @@
 #include "syslog-ng.h"
 
 typedef gboolean (*StatsFormatCb)(StatsCounterItem *ctr, gpointer user_data);
+typedef gboolean (*StatsSumFormatCb)(gpointer user_data);
 typedef void (*AggregatedMetricsCb)(GList *counters, StatsCounterItem **result);
 
 gboolean stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
-gboolean stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result);
-gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
+gboolean stats_query_get_sum(const gchar *expr, StatsSumFormatCb format_cb, gpointer result);
+gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsSumFormatCb format_cb, gpointer result);
 
 void stats_query_init(void);
 void stats_query_deinit(void);

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -162,26 +162,25 @@ _test_format_str_get(StatsCounterItem *ctr, gpointer user_data)
 }
 
 static gboolean
-_test_format_log_msg_get_sum(StatsCounterItem *ctr, gpointer user_data)
+_test_format_log_msg_get_sum(gpointer user_data)
 {
   gchar *name, *value;
   gpointer *args = (gpointer *) user_data;
   LogMessage *msg = (LogMessage *) args[0];
   gint *sum = (gint *) args[1];
 
-  name = g_strdup_printf("%s", stats_counter_get_name(ctr));
+  name = "sum";
   value = g_strdup_printf("%d", *sum);
 
   log_msg_set_value_by_name(msg, name, value, -1);
 
-  g_free(name);
   g_free(value);
 
   return TRUE;
 }
 
 static gboolean
-_test_format_str_get_sum(StatsCounterItem *ctr, gpointer user_data)
+_test_format_str_get_sum(gpointer user_data)
 {
   gpointer *args = (gpointer *) user_data;
   GString *result = (GString *) args[0];
@@ -299,7 +298,7 @@ ParameterizedTest(QueryTestCase *test_cases, stats_query, test_stats_query_get_s
   LogMessage *msg = log_msg_new_empty();
 
   stats_query_get_sum(test_cases->pattern, _test_format_log_msg_get_sum, (gpointer)msg);
-  actual = log_msg_get_value_by_name(msg, test_cases->pattern, NULL);
+  actual = log_msg_get_value_by_name(msg, "sum", NULL);
   cr_assert_str_eq(actual, test_cases->expected,
                    "Pattern: '%s'; expected number: '%s';, got: '%s';", test_cases->pattern, test_cases->expected, actual);
 


### PR DESCRIPTION
During the investigation of #2084, I fixed/refactored a few stats-related things.

This PR contains:
- minor "simplifications" in the implementation of `stats-query`
- a fix for the usage of the format callback of aggregated queries
- a fix for `remove_counter_from_index()`
- a modification in the deallocation of `StatsCounterItem::name`

Questions:
- Why do we use a HashTable (`counter_index`) in `stats-query.c` when we do not call one single lookup function on it? (Only a full iteration is used [linear search])
- This "index" is updated before every query (which requires a full iteration of `stats_cluster_foreach_counter`) call. Does this increase the query performance?