### PR TITLE
LogProto partial write

### DIFF
--- a/lib/logproto/logproto-framed-client.c
+++ b/lib/logproto/logproto-framed-client.c
@@ -39,7 +39,7 @@ log_proto_framed_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg,
 {
   LogProtoFramedClient *self = (LogProtoFramedClient *) s;
   gint frame_hdr_len;
-  gint rc;
+  LogProtoStatus status;
 
   if (msg_len > 9999999)
     {
@@ -54,25 +54,25 @@ log_proto_framed_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg,
       msg_len = 9999999;
     }
 
-  rc = LPS_SUCCESS;
-  while (rc == LPS_SUCCESS && !(*consumed) && self->super.partial == NULL)
+  status = LPS_SUCCESS;
+  while (status == LPS_SUCCESS && !(*consumed) && self->super.partial == NULL)
     {
       switch (self->super.state)
         {
         case LPFCS_FRAME_SEND:
           frame_hdr_len = g_snprintf((gchar *) self->frame_hdr_buf, sizeof(self->frame_hdr_buf), "%" G_GSIZE_FORMAT" ", msg_len);
-          rc = log_proto_text_client_submit_write(s, self->frame_hdr_buf, frame_hdr_len, NULL, LPFCS_MESSAGE_SEND);
+          status = log_proto_text_client_submit_write(s, self->frame_hdr_buf, frame_hdr_len, NULL, LPFCS_MESSAGE_SEND);
           break;
         case LPFCS_MESSAGE_SEND:
           *consumed = TRUE;
-          rc = log_proto_text_client_submit_write(s, msg, msg_len, (GDestroyNotify) g_free, LPFCS_FRAME_SEND);
+          status = log_proto_text_client_submit_write(s, msg, msg_len, (GDestroyNotify) g_free, LPFCS_FRAME_SEND);
           break;
         default:
           g_assert_not_reached();
         }
     }
 
-  return rc;
+  return status;
 }
 
 LogProtoClient *

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -70,7 +70,7 @@ log_proto_text_client_flush(LogProtoClient *s)
   if (rc != len)
     {
       self->partial_pos += rc;
-      return LPS_SUCCESS;
+      return LPS_PARTIAL;
     }
 
   if (self->partial_free)
@@ -129,7 +129,7 @@ log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, g
       return status;
     }
 
-  if (self->partial)
+  if (self->partial || LPS_PARTIAL == status)
     {
       /* NOTE: the partial buffer has not been emptied yet even with the
        * flush above, we shouldn't attempt to write again.
@@ -142,7 +142,7 @@ log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, g
        * This obviously would cause the framing to break. Also libssl
        * returns an error in this case, which is how this was discovered.
        */
-      return status;
+      return LPS_PARTIAL;
     }
 
   *consumed = TRUE;

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -46,45 +46,45 @@ log_proto_text_client_flush(LogProtoClient *s)
   LogProtoTextClient *self = (LogProtoTextClient *) s;
   gint rc;
 
-  /* attempt to flush previously buffered data */
-  if (self->partial)
+  if (!self->partial)
     {
-      gint len = self->partial_len - self->partial_pos;
-
-      rc = log_transport_write(self->super.transport, &self->partial[self->partial_pos], len);
-      if (rc < 0)
-        {
-          if (errno != EAGAIN && errno != EINTR)
-            {
-              msg_error("I/O error occurred while writing",
-                        evt_tag_int("fd", self->super.transport->fd),
-                        evt_tag_error(EVT_TAG_OSERROR));
-              return LPS_ERROR;
-            }
-          return LPS_SUCCESS;
-        }
-      else if (rc != len)
-        {
-          self->partial_pos += rc;
-          return LPS_SUCCESS;
-        }
-      else
-        {
-          if (self->partial_free)
-            self->partial_free(self->partial);
-          self->partial = NULL;
-          if (self->next_state >= 0)
-            {
-              self->state = self->next_state;
-              self->next_state = -1;
-            }
-
-          log_proto_client_msg_ack(&self->super, 1);
-
-          /* NOTE: we return here to give a chance to the framed protocol to send the frame header. */
-          return LPS_SUCCESS;
-        }
+      return LPS_SUCCESS;
     }
+
+  /* attempt to flush previously buffered data */
+  gint len = self->partial_len - self->partial_pos;
+
+  rc = log_transport_write(self->super.transport, &self->partial[self->partial_pos], len);
+  if (rc < 0)
+    {
+      if (errno != EAGAIN && errno != EINTR)
+        {
+          msg_error("I/O error occurred while writing",
+                    evt_tag_int("fd", self->super.transport->fd),
+                    evt_tag_error(EVT_TAG_OSERROR));
+          return LPS_ERROR;
+        }
+      return LPS_SUCCESS;
+    }
+
+  if (rc != len)
+    {
+      self->partial_pos += rc;
+      return LPS_SUCCESS;
+    }
+
+  if (self->partial_free)
+    self->partial_free(self->partial);
+  self->partial = NULL;
+  if (self->next_state >= 0)
+    {
+      self->state = self->next_state;
+      self->next_state = -1;
+    }
+
+  log_proto_client_msg_ack(&self->super, 1);
+
+  /* NOTE: we return here to give a chance to the framed protocol to send the frame header. */
   return LPS_SUCCESS;
 }
 

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -119,15 +119,14 @@ static LogProtoStatus
 log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
-  gint rc;
 
   /* try to flush already buffered data */
   *consumed = FALSE;
-  rc = log_proto_text_client_flush(s);
-  if (rc == LPS_ERROR)
+  const LogProtoStatus status = log_proto_text_client_flush(s);
+  if (status == LPS_ERROR)
     {
       /* log_proto_flush() already logs in the case of an error */
-      return rc;
+      return status;
     }
 
   if (self->partial)
@@ -143,7 +142,7 @@ log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, g
        * This obviously would cause the framing to break. Also libssl
        * returns an error in this case, which is how this was discovered.
        */
-      return rc;
+      return status;
     }
 
   *consumed = TRUE;

--- a/lib/logproto/logproto.h
+++ b/lib/logproto/logproto.h
@@ -32,6 +32,7 @@ typedef enum
   LPS_SUCCESS,
   LPS_ERROR,
   LPS_EOF,
+  LPS_PARTIAL,
 } LogProtoStatus;
 
 

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -67,7 +67,7 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
               errno = EAGAIN;
               break;
             case SSL_ERROR_WANT_WRITE:
-              /* although we are writing this fd, libssl wants to write. This
+              /* although we are reading this fd, libssl wants to write. This
                * happens during renegotiation for example */
               self->super.cond = G_IO_OUT;
               errno = EAGAIN;


### PR DESCRIPTION
The `LogQueue` and the `LogProto` has shared knowledge about the messages states.
The `LogQueue` holds the messages(both need processing, and ones in processing), in case of partial message(the whole message was not sent), the `LogProto` knows, which part of the message is sent and not, from the `LogQueue` point of view that partial message is still in progress. Which is fine, as long as we have both the `LogQueue` and the `LogProto`.

Actually we keep the `LogProto` around as long as the connection is alive, when the connection is closed the `LogProto` and the partial state of the message is thrown away.

Base on the above, if there is a partial message, when the connection is closed (by destination), the partial (and correct) state of the actually processed message is gone. That message is stuck in the `backlog`, from which it cannot be poped out, at least one message have to be in that area.

A proposed solution would be to rewind all item from backlog, when the connection is closed, and there have been a partial write reported by `LogProtoClient`.

From now on the `LogProtoClient` is responsible to send `LPS_PARTIAL` if the last write was partial, and it cannot continue after connection reset.