### PR TITLE
python-destination: template support

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -35,6 +35,8 @@ set(PYTHON_SOURCES
     python-logmsg.c
     python-logtemplate.h
     python-logtemplate.c
+    python-logtemplate-options.h
+    python-logtemplate-options.c
     python-global-code-loader.h
     python-global-code-loader.c
     python-debugger.c

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -43,6 +43,8 @@ set(PYTHON_SOURCES
     python-debugger.h
     python-logparser.h
     python-logparser.c
+    python-integerpointer.h
+    python-integerpointer.c
     compat/compat-python.c
     ${CMAKE_CURRENT_BINARY_DIR}/python-grammar.c
     ${CMAKE_CURRENT_BINARY_DIR}/python-grammar.h

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -33,6 +33,8 @@ set(PYTHON_SOURCES
     python-parser.h
     python-logmsg.h
     python-logmsg.c
+    python-logtemplate.h
+    python-logtemplate.c
     python-global-code-loader.h
     python-global-code-loader.c
     python-debugger.c

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -46,6 +46,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-logtemplate.c       \
 	modules/python/python-logtemplate-options.h\
 	modules/python/python-logtemplate-options.c\
+	modules/python/python-integerpointer.c    \
+	modules/python/python-integerpointer.h    \
 	modules/python/python-global-code-loader.h\
 	modules/python/python-global-code-loader.c\
 	modules/python/python-debugger.h	  \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -42,6 +42,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-parser.h	          \
 	modules/python/python-logmsg.h		  \
 	modules/python/python-logmsg.c	          \
+	modules/python/python-logtemplate.h	  \
+	modules/python/python-logtemplate.c       \
 	modules/python/python-global-code-loader.h\
 	modules/python/python-global-code-loader.c\
 	modules/python/python-debugger.h	  \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -44,6 +44,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-logmsg.c	          \
 	modules/python/python-logtemplate.h	  \
 	modules/python/python-logtemplate.c       \
+	modules/python/python-logtemplate-options.h\
+	modules/python/python-logtemplate-options.c\
 	modules/python/python-global-code-loader.h\
 	modules/python/python-global-code-loader.c\
 	modules/python/python-debugger.h	  \

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -21,9 +21,17 @@
  *
  */
 
+#include "compat-python.h"
+
 void
 py_init_argv(void)
 {
   static char *argv[] = {"syslog-ng"};
   PySys_SetArgvEx(1, argv, 0);
 }
+
+PyObject *
+int_as_pyobject(gint num)
+{
+  return PyInt_FromLong(num);
+};

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -21,9 +21,17 @@
  *
  */
 
+#include "compat-python.h"
+
 void
 py_init_argv(void)
 {
   static wchar_t *argv[] = {L"syslog-ng"};
   PySys_SetArgvEx(1, argv, 0);
 }
+
+PyObject *
+int_as_pyobject(gint num)
+{
+  return PyLong_FromLong(num);
+};

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -36,5 +36,6 @@
 #endif
 
 void py_init_argv(void);
+PyObject *int_as_pyobject(gint num);
 
 #endif

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -27,6 +27,7 @@
 #include "python-value-pairs.h"
 #include "python-logmsg.h"
 #include "python-logtemplate-options.h"
+#include "python-integerpointer.h"
 #include "python-helpers.h"
 #include "logthrdestdrv.h"
 #include "stats/stats.h"
@@ -52,6 +53,7 @@ typedef struct
     PyObject *is_opened;
     PyObject *send;
     PyObject *log_template_options;
+    PyObject *seqnum;
   } py;
 } PythonDestDriver;
 
@@ -219,6 +221,8 @@ _py_init_bindings(PythonDestDriver *self)
 
   self->py.log_template_options = py_log_template_options_new(&self->template_options);
   PyObject_SetAttrString(self->py.class, "template_options", self->py.log_template_options);
+  self->py.seqnum = py_integer_pointer_new(&self->super.seq_num);
+  PyObject_SetAttrString(self->py.class, "seqnum", self->py.seqnum);
   Py_DECREF(self->py.log_template_options);
 
   self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.id);
@@ -254,6 +258,7 @@ _py_free_bindings(PythonDestDriver *self)
   Py_CLEAR(self->py.is_opened);
   Py_CLEAR(self->py.send);
   Py_CLEAR(self->py.log_template_options);
+  Py_CLEAR(self->py.seqnum);
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -26,6 +26,7 @@
 #include "python-module.h"
 #include "python-value-pairs.h"
 #include "python-logmsg.h"
+#include "python-logtemplate-options.h"
 #include "python-helpers.h"
 #include "logthrdestdrv.h"
 #include "stats/stats.h"
@@ -50,6 +51,7 @@ typedef struct
     PyObject *instance;
     PyObject *is_opened;
     PyObject *send;
+    PyObject *log_template_options;
   } py;
 } PythonDestDriver;
 
@@ -215,6 +217,10 @@ _py_init_bindings(PythonDestDriver *self)
       return FALSE;
     }
 
+  self->py.log_template_options = py_log_template_options_new(&self->template_options);
+  PyObject_SetAttrString(self->py.class, "template_options", self->py.log_template_options);
+  Py_DECREF(self->py.log_template_options);
+
   self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.id);
   if (!self->py.instance)
     {
@@ -247,6 +253,7 @@ _py_free_bindings(PythonDestDriver *self)
   Py_CLEAR(self->py.instance);
   Py_CLEAR(self->py.is_opened);
   Py_CLEAR(self->py.send);
+  Py_CLEAR(self->py.log_template_options);
 }
 
 static gboolean

--- a/modules/python/python-integerpointer.c
+++ b/modules/python/python-integerpointer.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-integerpointer.h"
+
+PyObject *
+py_integer_pointer_new(gpointer ptr)
+{
+  PyIntegerPointer *self = PyObject_New(PyIntegerPointer, &py_integer_pointer_type);
+  if (!self)
+    return NULL;
+
+  self->ptr = ptr;
+
+  return (PyObject *) self;
+}
+
+static PyObject *
+_as_int(PyObject *s)
+{
+  PyIntegerPointer *self = (PyIntegerPointer *)s;
+  return PyLong_FromLong(*self->ptr);
+}
+
+static PyObject *
+_as_str(PyObject *s)
+{
+  PyIntegerPointer *self = (PyIntegerPointer *)s;
+  return PyUnicode_FromFormat("%d", *self->ptr);
+}
+
+PyTypeObject py_integer_pointer_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "IntegerPointer",
+  .tp_basicsize = sizeof(PyIntegerPointer),
+  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_flags = Py_TPFLAGS_DEFAULT,
+  .tp_doc = "IntegerPointer class exposes an integer by a pointer",
+  .tp_as_number = &(PyNumberMethods){ .nb_int = _as_int },
+  .tp_str = _as_str,
+  0,
+};
+
+void
+py_integer_pointer_init(void)
+{
+  PyType_Ready(&py_integer_pointer_type);
+}

--- a/modules/python/python-integerpointer.h
+++ b/modules/python/python-integerpointer.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_INTEGERPOINTER_H
+#define _SNG_PYTHON_INTEGERPOINTER_H
+
+#include "python-module.h"
+
+typedef struct _PyIntegerPointer
+{
+  PyObject_HEAD
+  gint *ptr;
+} PyIntegerPointer;
+
+extern PyTypeObject py_integer_pointer_type;
+
+PyObject *py_integer_pointer_new(gpointer ptr);
+void py_integer_pointer_init(void);
+
+#endif

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -27,12 +27,6 @@
 #include "messages.h"
 #include "str-utils.h"
 
-typedef struct _PyLogMessage
-{
-  PyObject_HEAD
-  LogMessage *msg;
-} PyLogMessage;
-
 static PyTypeObject py_log_message_type;
 
 static int

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -27,6 +27,12 @@
 #include "messages.h"
 #include "str-utils.h"
 
+int
+py_is_log_message(PyObject *obj)
+{
+  return PyType_IsSubtype(Py_TYPE(obj), &py_log_message_type);
+}
+
 static int
 _str_cmp(const void *s1, const void *s2)
 {

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -27,8 +27,6 @@
 #include "messages.h"
 #include "str-utils.h"
 
-static PyTypeObject py_log_message_type;
-
 static int
 _str_cmp(const void *s1, const void *s2)
 {
@@ -231,7 +229,7 @@ static PyMethodDef py_log_message_methods[] =
   {NULL}
 };
 
-static PyTypeObject py_log_message_type =
+PyTypeObject py_log_message_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
   .tp_name = "LogMessage",

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -38,4 +38,6 @@ extern PyTypeObject py_log_message_type;
 PyObject *py_log_message_new(LogMessage *msg);
 void py_log_message_init(void);
 
+int py_is_log_message(PyObject *obj);
+
 #endif

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -33,6 +33,8 @@ typedef struct _PyLogMessage
   LogMessage *msg;
 } PyLogMessage;
 
+extern PyTypeObject py_log_message_type;
+
 PyObject *py_log_message_new(LogMessage *msg);
 void py_log_message_init(void);
 

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -27,6 +27,12 @@
 
 #include "python-module.h"
 
+typedef struct _PyLogMessage
+{
+  PyObject_HEAD
+  LogMessage *msg;
+} PyLogMessage;
+
 PyObject *py_log_message_new(LogMessage *msg);
 void py_log_message_init(void);
 

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -23,8 +23,6 @@
 
 #include "python-logtemplate-options.h"
 
-static PyTypeObject py_log_template_options_type;
-
 PyObject *
 py_log_template_options_new(LogTemplateOptions *template_options)
 {
@@ -38,7 +36,7 @@ py_log_template_options_new(LogTemplateOptions *template_options)
 }
 
 
-static PyTypeObject py_log_template_options_type =
+PyTypeObject py_log_template_options_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
   .tp_name = "LogTemplateOptions",

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -23,6 +23,12 @@
 
 #include "python-logtemplate-options.h"
 
+int
+py_is_log_template_options(PyObject *obj)
+{
+  return PyType_IsSubtype(Py_TYPE(obj), &py_log_template_options_type);
+}
+
 PyObject *
 py_log_template_options_new(LogTemplateOptions *template_options)
 {

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-logtemplate-options.h"
+
+static PyTypeObject py_log_template_options_type;
+
+PyObject *
+py_log_template_options_new(LogTemplateOptions *template_options)
+{
+  PyLogTemplateOptions *self = PyObject_New(PyLogTemplateOptions, &py_log_template_options_type);
+  if (!self)
+    return NULL;
+
+  self->template_options = template_options;
+
+  return (PyObject *) self;
+}
+
+
+static PyTypeObject py_log_template_options_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "LogTemplateOptions",
+  .tp_basicsize = sizeof(PyLogTemplateOptions),
+  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_flags = Py_TPFLAGS_DEFAULT,
+  .tp_doc = "LogTemplateOptions class encapsulating a syslog-ng LogTemplateOptions",
+  0,
+};
+
+void
+py_log_template_options_init(void)
+{
+  PyType_Ready(&py_log_template_options_type);
+}

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -38,4 +38,6 @@ extern PyTypeObject py_log_template_options_type;
 PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
 void py_log_template_options_init(void);
 
+int py_is_log_template_options(PyObject *obj);
+
 #endif

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_LOGTEMPLATEOPTIONS_H
+#define _SNG_PYTHON_LOGTEMPLATEOPTIONS_H
+
+#include "python-module.h"
+#include "template/templates.h"
+
+typedef struct _PyLogTemplateOptions
+{
+  PyObject_HEAD
+  LogTemplateOptions *template_options;
+} PyLogTemplateOptions;
+
+PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
+void py_log_template_options_init(void);
+
+#endif

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -33,6 +33,8 @@ typedef struct _PyLogTemplateOptions
   LogTemplateOptions *template_options;
 } PyLogTemplateOptions;
 
+extern PyTypeObject py_log_template_options_type;
+
 PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
 void py_log_template_options_init(void);
 

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -105,6 +105,8 @@ PyTypeObject py_log_template_type =
 void
 py_log_template_init(void)
 {
+  py_log_template_options_init();
+
   PyType_Ready(&py_log_template_type);
   PyModule_AddObject(PyImport_AddModule("syslogng"), "LogTemplate", (PyObject *) &py_log_template_type);
 }

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -53,10 +53,17 @@ py_log_template_format(PyObject *s, PyObject *args, PyObject *kwrds)
                                    &msg, &py_log_template_options, &tz, &seqnum))
     return NULL;
 
+  if (Py_TYPE(msg) != &py_log_message_type)
+    {
+      PyErr_Format(PyExc_TypeError,
+                   "LogMessage expected in the first parameter");
+      return NULL;
+    }
+
   if (py_log_template_options && (Py_TYPE(py_log_template_options) != &py_log_template_options_type))
     {
       PyErr_Format(PyExc_TypeError,
-                   "LogTemplateOptions expected");
+                   "LogTemplateOptions expected in the second parameter");
       return NULL;
     }
 

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -38,7 +38,7 @@ py_log_template_free(PyLogTemplate *self)
 }
 
 PyObject *
-py_log_template_format(PyObject *s, PyObject *args)
+py_log_template_format(PyObject *s, PyObject *args, PyObject *kwrds)
 {
   PyLogTemplate *self = (PyLogTemplate *)s;
 
@@ -47,7 +47,10 @@ py_log_template_format(PyObject *s, PyObject *args)
   gint tz = LTZ_SEND;
   gint seqnum = 0;
 
-  if (!PyArg_ParseTuple(args, "O|Oii", &msg, &py_log_template_options, &tz, &seqnum))
+  static const gchar *kwlist[] = {"msg", "options", "tz", "seqnum", NULL};
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "O|Oii", (gchar **)kwlist,
+                                   &msg, &py_log_template_options, &tz, &seqnum))
     return NULL;
 
   if (py_log_template_options && (Py_TYPE(py_log_template_options) != &py_log_template_options_type))
@@ -114,7 +117,7 @@ py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 static PyMethodDef py_log_template_methods[] =
 {
-  { "format", (PyCFunction)py_log_template_format, METH_VARARGS, "format template" },
+  { "format", (PyCFunction)py_log_template_format, METH_VARARGS | METH_KEYWORDS, "format template" },
   { NULL }
 };
 

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-logtemplate.h"
+#include "python-helpers.h"
+#include "messages.h"
+
+PyTypeObject py_log_template_type;
+
+static void
+py_log_template_free(PyLogTemplate *self)
+{
+  Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+PyTypeObject py_log_template_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "LogTemplate",
+  .tp_basicsize = sizeof(PyLogTemplate),
+  .tp_dealloc = (destructor) py_log_template_free,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "LogTemplate class encapsulating a syslog-ng template",
+  .tp_new = PyType_GenericNew,
+  0,
+};
+
+void
+py_log_template_init(void)
+{
+  PyType_Ready(&py_log_template_type);
+  PyModule_AddObject(PyImport_AddModule("syslogng"), "LogTemplate", (PyObject *) &py_log_template_type);
+}

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -44,7 +44,9 @@ py_log_template_format(PyObject *s, PyObject *args)
 
   PyLogMessage *msg;
   PyLogTemplateOptions *py_log_template_options = NULL;
-  if (!PyArg_ParseTuple(args, "O|O", &msg, &py_log_template_options))
+  gint tz = LTZ_SEND;
+
+  if (!PyArg_ParseTuple(args, "O|Oi", &msg, &py_log_template_options, &tz))
     return NULL;
 
   if (py_log_template_options && (Py_TYPE(py_log_template_options) != &py_log_template_options_type))
@@ -64,7 +66,7 @@ py_log_template_format(PyObject *s, PyObject *args)
     }
 
   GString *result = scratch_buffers_alloc();
-  log_template_format(self->template, msg->msg, log_template_options, LTZ_SEND, 0, NULL, result);
+  log_template_format(self->template, msg->msg, log_template_options, tz, 0, NULL, result);
 
   return _py_string_from_string(result->str, result->len);
 }
@@ -135,4 +137,12 @@ py_log_template_init(void)
 
   PyType_Ready(&py_log_template_type);
   PyModule_AddObject(PyImport_AddModule("syslogng"), "LogTemplate", (PyObject *) &py_log_template_type);
+  PyObject *PY_LTZ_LOCAL = int_as_pyobject(0);
+  PyObject *PY_LTZ_SEND = int_as_pyobject(1);
+
+  PyObject_SetAttrString(PyImport_AddModule("syslogng"), "LTZ_LOCAL", PY_LTZ_LOCAL);
+  PyObject_SetAttrString(PyImport_AddModule("syslogng"), "LTZ_SEND", PY_LTZ_SEND);
+
+  Py_DECREF(PY_LTZ_LOCAL);
+  Py_DECREF(PY_LTZ_SEND);
 }

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -61,7 +61,7 @@ py_log_template_format(PyObject *s, PyObject *args, PyObject *kwrds)
       return NULL;
     }
 
-  if (py_log_template_options && (Py_TYPE(py_log_template_options) != &py_log_template_options_type))
+  if (py_log_template_options && !py_is_log_template_options((PyObject *)py_log_template_options))
     {
       PyErr_Format(PyExc_TypeError,
                    "LogTemplateOptions expected in the second parameter");
@@ -91,7 +91,7 @@ py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
   if (!PyArg_ParseTuple(args, "s|O", &template_string, &py_log_template_options))
     return NULL;
 
-  if (py_log_template_options && (Py_TYPE(py_log_template_options) != &py_log_template_options_type))
+  if (py_log_template_options && !py_is_log_template_options((PyObject *)py_log_template_options))
     {
       PyErr_Format(PyExc_TypeError,
                    "LogTemplateOptions expected in the second parameter");

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -54,7 +54,7 @@ py_log_template_format(PyObject *s, PyObject *args, PyObject *kwrds)
                                    &msg, &py_log_template_options, &tz, &seqnum))
     return NULL;
 
-  if (Py_TYPE(msg) != &py_log_message_type)
+  if (!py_is_log_message((PyObject *)msg))
     {
       PyErr_Format(PyExc_TypeError,
                    "LogMessage expected in the first parameter");

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -45,8 +45,9 @@ py_log_template_format(PyObject *s, PyObject *args)
   PyLogMessage *msg;
   PyLogTemplateOptions *py_log_template_options = NULL;
   gint tz = LTZ_SEND;
+  gint seqnum = 0;
 
-  if (!PyArg_ParseTuple(args, "O|Oi", &msg, &py_log_template_options, &tz))
+  if (!PyArg_ParseTuple(args, "O|Oii", &msg, &py_log_template_options, &tz, &seqnum))
     return NULL;
 
   if (py_log_template_options && (Py_TYPE(py_log_template_options) != &py_log_template_options_type))
@@ -66,7 +67,7 @@ py_log_template_format(PyObject *s, PyObject *args)
     }
 
   GString *result = scratch_buffers_alloc();
-  log_template_format(self->template, msg->msg, log_template_options, tz, 0, NULL, result);
+  log_template_format(self->template, msg->msg, log_template_options, tz, seqnum, NULL, result);
 
   return _py_string_from_string(result->str, result->len);
 }

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -28,6 +28,7 @@
 #include "messages.h"
 
 PyTypeObject py_log_template_type;
+PyObject *PyExc_LogTemplate;
 
 void
 py_log_template_free(PyLogTemplate *self)
@@ -101,7 +102,7 @@ py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
   GError *error = NULL;
   if (!log_template_compile(template, template_string, &error))
     {
-      PyErr_Format(PyExc_RuntimeError,
+      PyErr_Format(PyExc_LogTemplate,
                    "Error compiling template: %s", error->message);
       g_clear_error(&error);
       log_template_unref(template);
@@ -156,4 +157,7 @@ py_log_template_init(void)
 
   Py_DECREF(PY_LTZ_LOCAL);
   Py_DECREF(PY_LTZ_SEND);
+
+  PyExc_LogTemplate = PyErr_NewException("syslogng.LogTemplateException", NULL, NULL);
+  PyModule_AddObject(PyImport_AddModule("syslogng"), "LogTemplateException", (PyObject *)PyExc_LogTemplate);
 }

--- a/modules/python/python-logtemplate.h
+++ b/modules/python/python-logtemplate.h
@@ -39,6 +39,6 @@ extern PyTypeObject py_log_template_type;
 void py_log_template_init(void);
 PyObject *py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 void py_log_template_free(PyLogTemplate *self);
-PyObject *py_log_template_format(PyObject *s, PyObject *args);
+PyObject *py_log_template_format(PyObject *s, PyObject *args, PyObject *kwds);
 
 #endif

--- a/modules/python/python-logtemplate.h
+++ b/modules/python/python-logtemplate.h
@@ -35,6 +35,8 @@ typedef struct _PyLogTemplate
 } PyLogTemplate;
 
 extern PyTypeObject py_log_template_type;
+extern PyObject *PyExc_LogTemplate;
+
 
 void py_log_template_init(void);
 PyObject *py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds);

--- a/modules/python/python-logtemplate.h
+++ b/modules/python/python-logtemplate.h
@@ -37,5 +37,8 @@ typedef struct _PyLogTemplate
 extern PyTypeObject py_log_template_type;
 
 void py_log_template_init(void);
+PyObject *py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
+void py_log_template_free(PyLogTemplate *self);
+PyObject *py_log_template_format(PyObject *s, PyObject *args);
 
 #endif

--- a/modules/python/python-logtemplate.h
+++ b/modules/python/python-logtemplate.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_TEMPLATE_H
+#define _SNG_PYTHON_TEMPLATE_H
+
+#include "python-module.h"
+#include "template/templates.h"
+
+typedef struct _PyLogTemplate
+{
+  PyObject_HEAD
+  LogTemplate *template;
+  LogTemplateOptions *template_options;
+} PyLogTemplate;
+
+extern PyTypeObject py_log_template_type;
+
+void py_log_template_init(void);
+
+#endif

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -69,6 +69,7 @@ _py_init_interpreter(void)
 
       PyEval_InitThreads();
       py_log_message_init();
+      py_log_template_init();
       py_global_code_loader_init();
       PyEval_SaveThread();
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -28,6 +28,7 @@
 #include "python-tf.h"
 #include "python-logmsg.h"
 #include "python-logtemplate.h"
+#include "python-integerpointer.h"
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
 
@@ -71,6 +72,7 @@ _py_init_interpreter(void)
       PyEval_InitThreads();
       py_log_message_init();
       py_log_template_init();
+      py_integer_pointer_init();
       py_global_code_loader_init();
       PyEval_SaveThread();
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -27,6 +27,7 @@
 #include "python-dest.h"
 #include "python-tf.h"
 #include "python-logmsg.h"
+#include "python-logtemplate.h"
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
 

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -2,3 +2,8 @@ add_unit_test(LIBTEST CRITERION
   TARGET test_python_logmsg
   INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
   DEPENDS mod-python "${PYTHON_LIBRARIES}")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_template
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS mod-python "${PYTHON_LIBRARIES}" syslogformat)

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -2,11 +2,19 @@ check_PROGRAMS += \
   ${modules_python_tests_TESTS}
 
 modules_python_tests_TESTS = \
-  modules/python/tests/test_python_logmsg
+  modules/python/tests/test_python_logmsg \
+  modules/python/tests/test_python_template
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS)
+
+modules_python_tests_test_python_template_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_template_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
+
 
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -144,3 +144,19 @@ Test(python_log_message, test_python_logmessage_set_value_indirect)
   }
   PyGILState_Release(gstate);
 }
+
+Test(python_log_message, test_py_is_log_message)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  LogMessage *msg = log_msg_new_empty();
+  PyObject *msg_object = py_log_message_new(msg);
+
+  cr_assert(py_is_log_message(msg_object));
+  cr_assert_not(py_is_log_message(_python_main));
+
+  log_msg_unref(msg);
+  Py_DECREF(msg_object);
+  PyGILState_Release(gstate);
+}

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "python-helpers.h"
+#include "python-logmsg.h"
+#include "python-logtemplate.h"
+#include "python-logtemplate-options.h"
+#include "apphook.h"
+#include "logmsg/logmsg.h"
+#include "syslog-format.h"
+
+#include <criterion/criterion.h>
+
+static MsgFormatOptions parse_options;
+
+static PyObject *_python_main;
+static PyObject *_python_main_dict;
+
+LogTemplateOptions log_template_options;
+PyObject *py_template_options;
+
+static void
+_py_init_interpreter(void)
+{
+  Py_Initialize();
+  py_init_argv();
+
+  PyEval_InitThreads();
+  py_log_message_init();
+  py_log_template_init();
+  PyEval_SaveThread();
+}
+
+static void
+_init_python_main(void)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    _python_main = PyImport_AddModule("__main__");
+    _python_main_dict = PyModule_GetDict(_python_main);
+  }
+  PyGILState_Release(gstate);
+}
+
+void setup(void)
+{
+  app_startup();
+  log_template_options_defaults(&log_template_options);
+  py_template_options = py_log_template_options_new(&log_template_options);
+  msg_format_options_defaults(&parse_options);
+  _py_init_interpreter();
+  _init_python_main();
+}
+
+void teardown(void)
+{
+  Py_DECREF(py_template_options);
+  app_shutdown();
+}
+
+TestSuite(python_log_logtemplate, .init = setup, .fini = teardown);
+
+static PyLogMessage *
+create_parsed_message(const gchar *raw_msg)
+{
+  LogMessage *msg = log_msg_new_empty();
+  MsgFormatOptions template_parse_options = {0};
+  msg_format_options_defaults(&template_parse_options);
+  syslog_format_handler(&template_parse_options, (const guchar *)raw_msg, strlen(raw_msg), msg);
+
+  PyLogMessage *py_log_msg = (PyLogMessage *)py_log_message_new(msg);
+  log_msg_unref(msg);
+
+  return py_log_msg;
+}
+
+static PyLogTemplate *
+create_py_log_template(const gchar *template)
+{
+  PyObject *template_str = _py_string_from_string(template, -1);
+  PyObject *args = PyTuple_Pack(1, template_str);
+  PyLogTemplate *py_template = (PyLogTemplate *)py_log_template_new(&py_log_template_type, args, NULL);
+  Py_DECREF(template_str);
+  Py_DECREF(args);
+  cr_assert(py_template);
+
+  return py_template;
+}
+
+void
+assert_format(gchar *expected, PyLogTemplate *template, PyLogMessage *msg)
+{
+
+  PyObject *args = PyTuple_Pack(2, msg,  py_template_options);
+  PyObject *result = py_log_template_format((PyObject *)template, args);
+  Py_DECREF(args);
+
+  cr_assert(result);
+  cr_assert_str_eq(_py_get_string_as_string(result), expected);
+  Py_DECREF(result);
+}
+
+Test(python_log_logtemplate, test_python_template)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyLogMessage *py_log_msg = create_parsed_message("<38>2018-07-20T00:00:00+00:00 localhost prg00000[1234]: test\n");
+  PyLogTemplate *py_template = create_py_log_template("${PROGRAM}");
+
+  assert_format("prg00000", py_template, py_log_msg);
+
+  Py_DECREF(py_log_msg);
+  Py_DECREF(py_template);
+  PyGILState_Release(gstate);
+}

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -113,7 +113,7 @@ assert_format(gchar *expected, PyLogTemplate *template, PyLogMessage *msg)
 {
 
   PyObject *args = PyTuple_Pack(2, msg,  py_template_options);
-  PyObject *result = py_log_template_format((PyObject *)template, args);
+  PyObject *result = py_log_template_format((PyObject *)template, args, NULL);
   Py_DECREF(args);
 
   cr_assert(result);
@@ -145,7 +145,7 @@ Test(python_log_logtemplate, format_all_parameters)
   PyLogTemplate *py_template = create_py_log_template("${S_STAMP} | ${SEQNUM}");
 
   PyObject *args = PyTuple_Pack(4, py_log_msg, py_template_options, int_as_pyobject(1), int_as_pyobject(10));
-  PyObject *result = py_log_template_format((PyObject *)py_template, args);
+  PyObject *result = py_log_template_format((PyObject *)py_template, args, NULL);
   Py_DECREF(args);
 
   cr_assert(result);

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -174,3 +174,27 @@ Test(python_log_logtemplate, test_logtemplate_exception)
   PyGILState_Release(gstate);
 
 }
+
+Test(python_log_logtemplate, test_py_is_log_template_options)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  cr_assert(py_is_log_template_options((PyObject *)py_template_options));
+
+  PyObject *template_str = _py_string_from_string("${PROGRAM}", -1);
+  cr_assert_not(py_is_log_template_options((PyObject *)template_str));
+
+  PyObject *args = PyTuple_Pack(2, template_str, Py_None); /* Second argument must be PyLogTemplateOptions */
+  PyLogTemplate *py_template = (PyLogTemplate *)py_log_template_new(&py_log_template_type, args, NULL);
+  Py_DECREF(template_str);
+  Py_DECREF(args);
+  cr_assert_null(py_template);
+
+  gchar buf[256];
+  _py_format_exception_text(buf, sizeof(buf));
+  cr_assert(g_strstr_len(buf, sizeof(buf), "TypeError"), "Wrong exception : %s", buf);
+
+  PyGILState_Release(gstate);
+
+}


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/2172

This patchset adds support for template formatting in python destination. All necessary parameters are exposed to the user code: LTZ_SEND, LTZ_LOCAL, sequence number, and LogTemplateOptions instance of the destination. This patchset does not support construction of LogTemplateOptions, nor their fields are exposed to the user, only that is generated by the grammar is available to the user. Though such functionality might be useful, and can be added later.

LTZ_SEND, LTZ_LOCAL is exposed in a newly created syslog-ng module. LogTemplateOptions and sequence number is exposed through self (the class, provided by the user).

Examples:
(Don't forget to add `import syslogng`)

* Creating a new LogTemplate object 
```
self.log_template = syslogng.LogTemplate("${S_STAMP}")
self.log_template = syslogng.LogTemplate("${S_STAMP}", self.template_options)
```

* LogTemplateException

In case a malformed template is provided, an exception will be raised. For that sake, a new exception class is added: syslogng.LogTemplateException:
```
try:
    syslogng.LogTemplate("$(incomplete");
except syslogng.LogTemplateException as e:
     print(e)
```


* Formatting template:
Templates can be formatted using the format method. 
Return value: with python3, the return value is unicode (the standard string representation) if the result is unicode or covertible to unicode, else PyBytes. With python2, the return value is PyBytes (the standart string representation).
```
self.log_template.format(msg)
self.log_template.format(msg, self.template_options)
self.log_template.format(msg, self.template_options, syslogng.LTZ_SEND)
self.log_template.format(msg, self.template_options, syslogng.LTZ_SEND, self.seqnum)
```
Only msg and is mandatory for the `format` method.

* Formatting template works with keyword arguments as well:
```
self.log_template.format(msg=msg, options=self.template_options, tz=syslogng.LTZ_SEND, seqnum=self.seqnum))
```

Template options must be either provided in the constructor or in the `format` method. Otherwise syslog-ng will raise RuntimeError during in the `format` method.

Notes to developers:
- In practice some macros could work without any LogTemplate options provided (NULL passed to log_template_format). Though in case of some macros: like STAMP, syslog-ng would crash, which I wanted to avoid in a language binding. That's why I am enforcing that LogTemplateOptions must be passed either in constructor or in the format method.

- I was trying hard to keep reference counts at bay. Though there is one place (somewhat hidden hidden :( )
that I know there is a reference leak: PY_LTZ_LOCAL, PY_LTZ_SEND. So that I could unref these, there should be a pair for python_module_init, like deinit, but syslog-ng currently does not support deinit for modules (so files). Or some kind of garbage collection mechanism. I created an internal jira ticket about it. As for this reference leak, this does **not** result in memory leak. Interestingly enough, it seems many (all?) PyObject numbers share the same object, so by the time I created these objects,  the reference count was already 433 for PY_LTZ_SEND (0), which means the zero-object was already reffed many times, and most probably will not disappear when syslog-ng exits. We cannot unload the zero object. So this is a cosmetic reference leak.