### PR TITLE
Goodbye "goto relex" (refactor)

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -972,7 +972,7 @@ cfg_lexer_parse_include(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
 }
 
 static gboolean
-cfg_lexer_process_token(CfgLexer *self, gint tok, YYSTYPE *yylval, YYLTYPE *yylloc, gboolean *lex_again)
+cfg_lexer_preprocess(CfgLexer *self, gint tok, YYSTYPE *yylval, YYLTYPE *yylloc, gboolean *lex_again)
 {
   /*
    * NOTE:
@@ -1082,7 +1082,7 @@ cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
           cfg_lexer_append_preprocessed_output(self, self->token_pretext->str);
         }
 
-      if (!cfg_lexer_process_token(self, tok, yylval, yylloc, &lex_again))
+      if (!cfg_lexer_preprocess(self, tok, yylval, yylloc, &lex_again))
         return LL_ERROR;
     }
   while (lex_again);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -886,6 +886,60 @@ cfg_lexer_append_preprocessed_output(CfgLexer *self, const gchar *token_text)
     g_string_append_printf(self->preprocess_output, "%s", token_text);
 }
 
+static gboolean
+cfg_lexer_parse_and_run_block_generator(CfgLexer *self, CfgBlockGenerator *gen, YYSTYPE *yylval)
+{
+  CfgArgs *args;
+  CfgIncludeLevel *level = &self->include_stack[self->include_depth];
+
+  self->preprocess_suppress_tokens++;
+
+  gint saved_line = level->lloc.first_line;
+  gint saved_column = level->lloc.first_column;
+  if (cfg_parser_parse(&block_ref_parser, self, (gpointer *) &args, NULL))
+    {
+      gboolean success;
+      gchar buf[256];
+      GString *result = g_string_sized_new(256);
+
+      level->lloc.first_line = saved_line;
+      level->lloc.first_column = saved_column;
+      self->preprocess_suppress_tokens--;
+      success = cfg_block_generator_generate(gen, self->cfg, args, result,
+                                             cfg_lexer_format_location(self, &level->lloc, buf, sizeof(buf)));
+
+      free(yylval->cptr);
+      cfg_args_unref(args);
+
+      if (!success)
+        {
+          g_string_free(result, TRUE);
+          return FALSE;
+        }
+
+      cfg_block_generator_format_name(gen, buf, sizeof(buf));
+
+      if (gen->suppress_backticks)
+        success = cfg_lexer_include_buffer_without_backtick_substitution(self, buf, result->str, result->len);
+      else
+        success = cfg_lexer_include_buffer(self, buf, result->str, result->len);
+      g_string_free(result, TRUE);
+
+      if (!success)
+        return FALSE;
+
+      return TRUE;
+    }
+  else
+    {
+      level->lloc.first_line = saved_line;
+      level->lloc.first_column = saved_column;
+      free(yylval->cptr);
+      self->preprocess_suppress_tokens--;
+      return FALSE;
+    }
+}
+
 int
 cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
 {
@@ -935,55 +989,9 @@ relex:;
       self->cfg &&
       (gen = cfg_lexer_find_generator(self, self->cfg, cfg_lexer_get_context_type(self), yylval->cptr)))
     {
-      CfgArgs *args;
-      CfgIncludeLevel *level = &self->include_stack[self->include_depth];
-
-      self->preprocess_suppress_tokens++;
-
-      gint saved_line = level->lloc.first_line;
-      gint saved_column = level->lloc.first_column;
-      if (cfg_parser_parse(&block_ref_parser, self, (gpointer *) &args, NULL))
-        {
-          gboolean success;
-          gchar buf[256];
-          GString *result = g_string_sized_new(256);
-
-          level->lloc.first_line = saved_line;
-          level->lloc.first_column = saved_column;
-          self->preprocess_suppress_tokens--;
-          success = cfg_block_generator_generate(gen, self->cfg, args, result,
-                                                 cfg_lexer_format_location(self, &level->lloc, buf, sizeof(buf)));
-
-          free(yylval->cptr);
-          cfg_args_unref(args);
-
-          if (!success)
-            {
-              g_string_free(result, TRUE);
-              return LL_ERROR;
-            }
-
-          cfg_block_generator_format_name(gen, buf, sizeof(buf));
-
-          if (gen->suppress_backticks)
-            success = cfg_lexer_include_buffer_without_backtick_substitution(self, buf, result->str, result->len);
-          else
-            success = cfg_lexer_include_buffer(self, buf, result->str, result->len);
-          g_string_free(result, TRUE);
-
-          if (!success)
-            return LL_ERROR;
-
-          goto relex;
-        }
-      else
-        {
-          level->lloc.first_line = saved_line;
-          level->lloc.first_column = saved_column;
-          free(yylval->cptr);
-          self->preprocess_suppress_tokens--;
-          return LL_ERROR;
-        }
+      if (!cfg_lexer_parse_and_run_block_generator(self, gen, yylval))
+        return LL_ERROR;
+      goto relex;
     }
 
   if (self->ignore_pragma || self->cfg == NULL)
@@ -998,9 +1006,7 @@ relex:;
 
       cfg_lexer_append_preprocessed_output(self, "@");
       if (!cfg_parser_parse(&pragma_parser, self, &dummy, NULL))
-        {
-          return LL_ERROR;
-        }
+        return LL_ERROR;
       goto relex;
     }
   else if (tok == KW_INCLUDE && cfg_lexer_get_context_type(self) != LL_CONTEXT_PRAGMA)

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -864,6 +864,21 @@ cfg_lexer_consume_next_injected_token(CfgLexer *self, gint *tok, YYSTYPE *yylval
   return FALSE;
 }
 
+static gint
+cfg_lexer_lex_next_token(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
+{
+  yylval->type = 0;
+
+  g_string_truncate(self->token_text, 0);
+  g_string_truncate(self->token_pretext, 0);
+
+  gint tok = _invoke__cfg_lexer_lex(self, yylval, yylloc);
+  if (yylval->type == 0)
+    yylval->type = tok;
+
+  return tok;
+}
+
 int
 cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
 {
@@ -882,14 +897,7 @@ relex:
       else if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_ARG)
         cfg_lexer_start_block_state(self, "()");
 
-      yylval->type = 0;
-
-      g_string_truncate(self->token_text, 0);
-      g_string_truncate(self->token_pretext, 0);
-
-      tok = _invoke__cfg_lexer_lex(self, yylval, yylloc);
-      if (yylval->type == 0)
-        yylval->type = tok;
+      tok = cfg_lexer_lex_next_token(self, yylval, yylloc);
 
       if (self->preprocess_output)
         g_string_append_printf(self->preprocess_output, "%s", self->token_pretext->str);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -889,25 +889,6 @@ cfg_lexer_append_preprocessed_output(CfgLexer *self, const gchar *token_text)
 int
 cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
 {
-  CfgBlockGenerator *gen;
-  gint tok;
-  gboolean injected;
-
-relex:
-
-  injected = cfg_lexer_consume_next_injected_token(self, &tok, yylval, yylloc);
-
-  if (!injected)
-    {
-      if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_CONTENT)
-        cfg_lexer_start_block_state(self, "{}");
-      else if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_ARG)
-        cfg_lexer_start_block_state(self, "()");
-
-      tok = cfg_lexer_lex_next_token(self, yylval, yylloc);
-      cfg_lexer_append_preprocessed_output(self, self->token_pretext->str);
-    }
-
   /* NOTE: most of the code below is a monster, which should be factored out
    * to tiny little functions.  This is not very simple and I am in the
    * middle of something that I would rather close than doing the
@@ -933,6 +914,24 @@ relex:
    *
    */
 
+  CfgBlockGenerator *gen;
+  gint tok;
+  gboolean injected;
+
+relex:
+
+  injected = cfg_lexer_consume_next_injected_token(self, &tok, yylval, yylloc);
+
+  if (!injected)
+    {
+      if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_CONTENT)
+        cfg_lexer_start_block_state(self, "{}");
+      else if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_ARG)
+        cfg_lexer_start_block_state(self, "()");
+
+      tok = cfg_lexer_lex_next_token(self, yylval, yylloc);
+      cfg_lexer_append_preprocessed_output(self, self->token_pretext->str);
+    }
 
   if (tok == LL_IDENTIFIER &&
       self->cfg &&

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -913,16 +913,14 @@ cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc)
    * grammar. (on Windows glib, malloc/g_malloc are NOT equivalent)
    *
    */
-
   CfgBlockGenerator *gen;
   gint tok;
-  gboolean injected;
 
-relex:
+relex:;
 
-  injected = cfg_lexer_consume_next_injected_token(self, &tok, yylval, yylloc);
+  gboolean is_token_injected = cfg_lexer_consume_next_injected_token(self, &tok, yylval, yylloc);
 
-  if (!injected)
+  if (!is_token_injected)
     {
       if (cfg_lexer_get_context_type(self) == LL_CONTEXT_BLOCK_CONTENT)
         cfg_lexer_start_block_state(self, "{}");
@@ -1061,7 +1059,7 @@ relex:
       self->non_pragma_seen = TRUE;
     }
 
-  if (!injected && self->preprocess_suppress_tokens == 0)
+  if (!is_token_injected && self->preprocess_suppress_tokens == 0)
     cfg_lexer_append_preprocessed_output(self, self->token_text->str);
 
   return tok;


### PR DESCRIPTION
This PR contains equivalent transformations only (I hope so).

Extracted methods:
- `cfg_lexer_lex_next_token()`
- `cfg_lexer_append_preprocessed_output()`
- `cfg_lexer_parse_and_run_block_generator()`
- `cfg_lexer_parse_include()`
- `cfg_lexer_preprocess()`
