### PR TITLE
Introduce syslog-ng() source

### DIFF
--- a/scl/ewmm/ewmm.conf
+++ b/scl/ewmm/ewmm.conf
@@ -65,3 +65,23 @@ block destination syslog-ng(server('127.0.0.1') transport(tcp) port(514) ...) {
 		`__VARARGS__`
         );
 };
+
+block source syslog-ng(
+        ip('0.0.0.0')
+        port(514)
+        transport(tcp)
+        flags("")
+        ...) {
+
+        channel {
+                source {
+                        network(ip("`ip`")
+                                transport(`transport`)
+                                port(`port`)
+                                flags(syslog-protocol, `flags`)
+                                `__VARARGS__`);
+                };
+
+                parser { ewmm-parser(); };
+        };
+};


### PR DESCRIPTION
scl/ewmm/ewmm.conf: added definition of syslog-ng() source

    * introduced the syslog-ng() source for ewmm formatted logs
    * originally only the syslog-ng() destination was defined here, but in
      most cases sources and destinations arrive in pairs, so I just
      implemented that

Signed-off-by: Janos SZIGETVARI <jszigetvari@gmail.com>