### PR TITLE
client-lib-dir, loggen, eventlog: minor fixes

### DIFF
--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -146,7 +146,7 @@ void evt_rec_free(EVTREC *e);
  **/
 EVTTAG *evt_tag_str(const char *tag, const char *value);
 EVTTAG *evt_tag_int(const char *tag, int value);
-EVTTAG *evt_tag_long(const char *tag, long value);
+EVTTAG *evt_tag_long(const char *tag, long long value);
 EVTTAG *evt_tag_errno(const char *tag, int err);
 EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) EVT_GNUC_PRINTF_FUNC(2, 3);
 EVTTAG *evt_tag_inaddr(const char *tag, const struct in_addr *addr);

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -90,11 +90,11 @@ evt_tag_int(const char *tag, int value)
 }
 
 EVTTAG *
-evt_tag_long(const char *tag, long value)
+evt_tag_long(const char *tag, long long value)
 {
   char buf[32]; /* a 64 bit int fits into 20 characters */
 
-  snprintf(buf, sizeof(buf), "%ld", value);
+  snprintf(buf, sizeof(buf), "%lld", value);
   return evt_tag_str(tag, buf);
 }
 

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -33,7 +33,7 @@ block destination elasticsearch(
   cluster("")
   custom_id("")
   resource("")
-  client_lib_dir()
+  client_lib_dir("")
   concurrent_requests("1")
   ...
 )
@@ -67,7 +67,7 @@ block destination elasticsearch2(
   cluster("")
   custom_id("")
   resource("")
-  client_lib_dir()
+  client_lib_dir("")
   concurrent_requests("1")
   skip_cluster_health_check("")
   cluster_url("")

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -27,7 +27,7 @@ block destination hdfs(
   hdfs_archive_dir("")
   hdfs_resources("")
   hdfs_max_filename_length("")
-  client_lib_dir()
+  client_lib_dir("")
   kerberos_principal("")
   kerberos_keytab_file("")
   template("")

--- a/scl/kafka/plugin.conf
+++ b/scl/kafka/plugin.conf
@@ -27,7 +27,7 @@ block destination kafka(
   kafka_bootstrap_servers()
   properties_file("")
   sync_send("")
-  client_lib_dir()
+  client_lib_dir("")
   ...
 )
 {

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -148,7 +148,15 @@ int connect_unix_domain_socket(int sock_type, const char *path)
 
   DEBUG("unix domain socket: %s\n",path);
   saun.sun_family = AF_UNIX;
-  strncpy(saun.sun_path, path, sizeof(saun.sun_path));
+
+  gsize max_target_path_size = sizeof(saun.sun_path);
+  if (strlen(path) >= max_target_path_size)
+    {
+      ERROR("Target path is too long; max_target_length=%" G_GSIZE_FORMAT "\n", max_target_path_size - 1);
+      return -1;
+    }
+
+  strcpy(saun.sun_path, path);
 
   dest_addr = (struct sockaddr *) &saun;
   dest_addr_len = sizeof(saun);


### PR DESCRIPTION
- elastic, hdfs, kafka: make client-lib-dir() optional
- loggen: fix strncpy compiler warning
- eventlog: use long long parameter for evt_tag_long()