### PR TITLE
Loggen: improve file reader parse function

### DIFF
--- a/doc/man/loggen.1.xml
+++ b/doc/man/loggen.1.xml
@@ -191,7 +191,7 @@
             <command>--skip-tokens &lt;number&gt;</command>
           </term>
           <listitem>
-            <para>Skip the specified number of space-separated tokens (words) at the beginning of every line. For example, if the messages in the file look like <parameter>foo bar message</parameter>, <parameter>--skip-tokens 2</parameter> skips the <parameter>foo bar</parameter> part of the line, and sends only the <parameter>message</parameter> part. Works only when used together with the <parameter>--read-file</parameter> parameter. Default value: 3</para>
+            <para>Skips the specified number of space-separated tokens (words) at the beginning of every line. For example, if the messages in the file look like <parameter>foo bar message</parameter>, <parameter>--skip-tokens 2</parameter> skips the <parameter>foo bar</parameter> part of the line, and sends only the <parameter>message</parameter> part. Works only when used together with the <parameter>--read-file</parameter> parameter. Default value: 0</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -234,7 +234,7 @@
     <refsection>
       <title>Examples</title>
       <para>The following command generates 100 messages per second for ten minutes, and sends them to port 2010 of the localhost via TCP. Each message is 300 bytes long.</para>
-      <synopsis>loggen --size 300 --rate 100 --interval 600 127.0.0.1 2010</synopsis>
+      <synopsis>loggen --stream --size 300 --rate 100 --interval 600 127.0.0.1 2010</synopsis>
       <para>The following command is similar to the one above, but uses the UDP protocol.</para>
       <synopsis>loggen --inet --dgram --size 300 --rate 100 --interval 600 127.0.0.1 2010</synopsis>
       <para>Send a single message on TCP6 to the <parameter>::1</parameter> IPv6 address, port <parameter>1061</parameter>:</para>

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -81,4 +81,4 @@ install(TARGETS loggen RUNTIME DESTINATION bin)
 set(LOGGEN_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(socket_plugin)
 add_subdirectory(ssl_plugin)
-
+add_subdirectory(tests)

--- a/tests/loggen/Makefile.am
+++ b/tests/loggen/Makefile.am
@@ -68,3 +68,4 @@ tests_loggen_loggen_LDADD	= \
 
 include tests/loggen/socket_plugin/Makefile.am
 include tests/loggen/ssl_plugin/Makefile.am
+include tests/loggen/tests/Makefile.am

--- a/tests/loggen/file_reader.c
+++ b/tests/loggen/file_reader.c
@@ -292,18 +292,27 @@ parse_line_rfc3164(const char *line, SyslogMsgElements *elements)
   return 1;
 }
 
-static int
-parse_line(const char *line, SyslogMsgElements *elements, int skip)
+static const char *
+str_skip_tokens(const char *line, int number_of_skips)
 {
-  while (skip--)
+  while (number_of_skips--)
     {
       line = strchr(line, ' ');
 
       if (!line)
-        return -1;
+        return NULL;
 
-      line += 1;
+      ++line;
     }
+
+  return line;
+}
+
+static int
+parse_line(const char *line, SyslogMsgElements *elements)
+{
+  if (!line)
+    return -1;
 
   int ret_val;
   switch (get_line_format(line))
@@ -364,7 +373,7 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
       if (dont_parse)
         break;
 
-      if (parse_line(buf, &parsed_elements, skip_tokens) > 0)
+      if (parse_line(str_skip_tokens(buf, skip_tokens), &parsed_elements) > 0)
         break;
 
       fprintf(stderr, "Invalid line %d\n", ++lineno);

--- a/tests/loggen/file_reader.c
+++ b/tests/loggen/file_reader.c
@@ -29,16 +29,17 @@
 #include <unistd.h>
 #include <string.h>
 
+
 static int loop_reading = 0;
 static int dont_parse = 0;
-static int skip_tokens = 3;
+static int skip_tokens = 0;
 static char *read_file_name = NULL;
 
 static GOptionEntry loggen_file_reader_options[] =
 {
   { "read-file", 'R', 0, G_OPTION_ARG_STRING, &read_file_name, "Read log messages from file", "<filename>" },
   { "loop-reading", 'l', 0, G_OPTION_ARG_NONE, &loop_reading, "Read the file specified in read-file option in loop (it will restart the reading if reached the end of the file)", NULL },
-  { "skip-tokens", 0, 0, G_OPTION_ARG_INT, &skip_tokens, "Skip the given number of tokens (delimined by a space) at the beginning of each line (default value: 3)", "<number>" },
+  { "skip-tokens", 0, 0, G_OPTION_ARG_INT, &skip_tokens, "Skip the given number of tokens (delimined by a space) at the beginning of each line (default value: 0)", "<number>" },
   { "dont-parse", 'd', 0, G_OPTION_ARG_NONE, &dont_parse, "Don't parse the lines coming from the readed files. Loggen will send the whole lines as it is in the readed file", NULL },
   { NULL }
 };
@@ -103,69 +104,224 @@ void close_file_reader(int nr_threads)
   g_free((gpointer)source);
 }
 
-static int
-parse_line(const char *line, char *host, char *program, char *pid, char **msg)
+static LogFormatType
+get_line_format(const char *line)
 {
-  const char *pos0;
-  const char *pos = line;
-  const char *end;
-  int space = skip_tokens;
-  int pid_len;
+  if (line == NULL)
+    return LOG_FORMAT_UNKNOWN;
 
-  /* Find token */
-  while (space)
+  char *pri_end = g_strstr_len(line, 5, ">");
+  if (!pri_end)
+    return LOG_FORMAT_UNKNOWN;
+
+  /* Guess what is the actual logformat. In BSD format
+   * priority field <> is followed by timestamp. This starts
+   * with upercase letter (Jan Feb Mar ...)
+   *
+   * In Syslog format the priority field is followed by
+   * the version number decimal.
+   */
+  if (*(pri_end + 1) >= 'A' && *(pri_end + 1) <= 'Z')
+    return LOG_FORMAT_RFC3164;
+  else if (*(pri_end + 1) >= '0' && *(pri_end + 1) <= '9')
+    return LOG_FORMAT_RFC5424;
+  else
+    return LOG_FORMAT_UNKNOWN;
+}
+
+static gsize
+safe_copy_n_string(gchar *dest, const gchar *src, int count, int buffsize, const gchar *element_name)
+{
+  if (!dest || !src)
     {
-      pos = strchr(pos, ' ');
-
-      if (!pos)
-        return -1;
-      pos++;
-
-      space --;
+      ERROR("Invalid src or dest buffer (src=%p, dest=%p)\n", src, dest);
+      return 0;
     }
 
-  pos = strchr(pos, ':');
-  if (!pos)
-    return -1;
-
-  /* pid */
-  pos0 = pos;
-  if (*(--pos) == ']')
+  if (count >= buffsize)
     {
-      end = pos - 1;
-      while (*(--pos) != '[')
-        ;
+      count = buffsize - 1;
+      ERROR("\"%s\" string is too long to fit into buffer. Truncate it to %d chars\n", element_name, count);
+    }
 
-      pid_len = end -
-                pos; /* 'end' points to the last character of the pid string (not off by one), *pos = '[' -> pid length = end - pos*/
-      memcpy(pid, pos + 1, pid_len);
-      pid[pid_len] = '\0';
+  g_strlcpy(dest, src, count + 1);
+
+  return count;
+}
+
+static gsize
+safe_copy_string(gchar *dest, const gchar *src, int buffsize, const gchar *element_name)
+{
+  return safe_copy_n_string(dest, src, strlen(src), buffsize, element_name);
+}
+
+static void
+parse_sdata_and_message(const char *sdata_message, SyslogMsgElements *elements)
+{
+  /* sdata_message contains both SDATA and message parts. Need to find the
+   * SDATA between first "[" and BOM. The rest of the sdata_message contains the
+   * message */
+  gchar *sdata_start = g_strstr_len(sdata_message, PARS_BUF_SDATA_SIZE, "[");
+  gchar *sdata_end   = g_strstr_len(sdata_message, PARS_BUF_SDATA_SIZE, RFC5424_BOM);
+
+  if (!sdata_start || !sdata_end || (sdata_end - sdata_start) == 1)
+    {
+      DEBUG("no valid sdata found. use \"-\" as sdata\n");
+      safe_copy_string(elements->sdata, RFC5424_NIL_VALUE, PARS_BUF_SDATA_SIZE, "sdata");
+
+      gchar *sdata_nil_marker = g_strstr_len(sdata_message, PARS_BUF_SDATA_SIZE, RFC5424_NIL_VALUE);
+      if (!sdata_nil_marker)
+        safe_copy_string(elements->message, "", PARS_BUF_MSG_SIZE, "msg");
+      else
+        safe_copy_string(elements->message, sdata_nil_marker + 1, PARS_BUF_MSG_SIZE, "msg");
+
+      g_strchug(elements->message);
     }
   else
     {
-      pid[0] = '\0';
-      ++pos; /* the 'pos' has been decreased in the condition (']'), reset it to the original position */
+      *sdata_end = '\0';
+      safe_copy_string(elements->sdata, sdata_start, PARS_BUF_SDATA_SIZE, "sdata");
+      g_strchomp(elements->sdata);
+
+      safe_copy_string(elements->message, sdata_end + strlen(RFC5424_BOM), PARS_BUF_MSG_SIZE, "msg");
+    }
+}
+
+static int
+parse_line_rfc5424(const char *line, SyslogMsgElements *elements)
+{
+  if (!line)
+    return -1;
+
+  /* skip the leading '<' char */
+  if (g_str_has_prefix(line, "<"))
+    line = line + 1;
+
+  gchar **line_split = g_strsplit_set(line, RFC5424_DELIMITERS, RFC5424_HEADER_TOKEN_NUM);
+
+  if (g_strv_length(line_split) < RFC5424_HEADER_TOKEN_NUM)
+    {
+      ERROR("Invalid rfc5424 log format. Header is too short.\n");
+      g_strfreev(line_split);
+      return -1;
     }
 
-  /* Program */
-  end = pos;
-  while (*(--pos) != ' ')
-    ;
+  safe_copy_string(elements->pri, line_split[RFC5424_PRI_INDEX], PARS_BUF_PRI_SIZE, "priority");
+  safe_copy_string(elements->ver, line_split[RFC5424_VER_INDEX], PARS_BUF_VER_SIZE, "version");
+  safe_copy_string(elements->time_stamp, line_split[RFC5424_TIMESTAMP_INDEX], PARS_BUF_TIME_STAMP_SIZE, "time stamp");
+  safe_copy_string(elements->host, line_split[RFC5424_HOST_NAME_INDEX], PARS_BUF_HOST_SIZE, "host");
+  safe_copy_string(elements->app, line_split[RFC5424_APP_NAME_INDEX], PARS_BUF_APP_SIZE, "app");
+  safe_copy_string(elements->pid, line_split[RFC5424_PID_INDEX], PARS_BUF_PID_SIZE, "pid");
+  safe_copy_string(elements->msgid, line_split[RFC5424_MSGID_INDEX], PARS_BUF_MSG_ID_SIZE, "msgid");
 
-  memcpy(program, pos + 1, end - pos - 1);
-  program[end-pos-1] = '\0';
+  parse_sdata_and_message(line_split[RFC5424_SDATA_INDEX], elements);
 
-  /* Host */
-  end = pos;
-  while (*(--pos) != ' ')
-    ;
+  g_strfreev(line_split);
+  return 1;
+}
 
-  memcpy(host, pos + 1, end - pos - 1);
-  host[end-pos-1] = '\0';
+static int
+parse_line_rfc3164(const char *line, SyslogMsgElements *elements)
+{
+  if (!line)
+    return -1;
 
-  *msg = ((char *)pos0) + 2;
+  safe_copy_string(elements->ver, "", PARS_BUF_VER_SIZE, "version"); /* no version info in RFC3164 */
+  safe_copy_string(elements->msgid, "", PARS_BUF_MSG_ID_SIZE, "msg_id"); /* no msg_id in RFC3164 */
+  safe_copy_string(elements->sdata, "", PARS_BUF_SDATA_SIZE, "sdata"); /* no sdata in RFC3164 */
+
+  /* skip the leading '<' char */
+  if (g_str_has_prefix(line, "<"))
+    line = line + 1;
+
+  gchar *pri_end = g_strstr_len(line, PARS_BUF_MSG_SIZE, ">");
+  if (!pri_end)
+    {
+      ERROR("Invalid rfc3164 log format. No '>' found.\n");
+      return -1;
+    }
+
+  /* pri + time stamp */
+  safe_copy_n_string(elements->pri, line, pri_end - line, PARS_BUF_PRI_SIZE, "pri");
+  safe_copy_n_string(elements->time_stamp, pri_end+1, RFC3164_TIMESTAMP_SIZE, PARS_BUF_TIME_STAMP_SIZE, "timestamp");
+  gchar *timestamp_end = pri_end + 1 + RFC3164_TIMESTAMP_SIZE;
+
+  /* host name */
+  gchar *host_begin = timestamp_end + 1;
+  gchar *host_end = g_strstr_len(host_begin, PARS_BUF_MSG_SIZE, " ");
+  if (host_end)
+    safe_copy_n_string(elements->host, host_begin, host_end - host_begin, PARS_BUF_HOST_SIZE, "host");
+  else
+    {
+      safe_copy_string(elements->host, host_begin, PARS_BUF_HOST_SIZE, "host");
+      safe_copy_string(elements->pid, "", PARS_BUF_PID_SIZE, "pid");
+      safe_copy_string(elements->app, "", PARS_BUF_APP_SIZE, "app");
+      safe_copy_string(elements->message, "", PARS_BUF_MSG_SIZE, "msg");
+
+      return 1;
+    }
+
+  /* application[pid]: */
+  gchar *app_begin = host_end + 1;
+  gchar *app_end = g_strstr_len(app_begin, PARS_BUF_MSG_SIZE, " ");
+
+  /* netither PID nor application found */
+  if ( !g_strstr_len(app_begin, PARS_BUF_APP_SIZE, ":" ) )
+    {
+      safe_copy_string(elements->pid, "", PARS_BUF_PID_SIZE, "pid");
+      safe_copy_string(elements->app, "", PARS_BUF_APP_SIZE, "app");
+      safe_copy_string(elements->message, app_begin, PARS_BUF_MSG_SIZE, "msg");
+      return 1;
+    }
+
+  gchar *pid_begin = g_strstr_len(app_begin, PARS_BUF_APP_SIZE, "[");
+  gchar *pid_end   = g_strstr_len(app_begin, PARS_BUF_APP_SIZE, "]");
+  if ( !pid_begin || !pid_end )
+    {
+      safe_copy_string(elements->pid, "", PARS_BUF_PID_SIZE, "pid");
+      safe_copy_n_string(elements->app, app_begin, app_end - app_begin - 1, PARS_BUF_APP_SIZE, "app");
+    }
+  else
+    {
+      safe_copy_n_string(elements->pid, pid_begin + 1, pid_end - pid_begin - 1, PARS_BUF_PID_SIZE, "pid");
+      safe_copy_n_string(elements->app, app_begin, pid_begin - app_begin, PARS_BUF_APP_SIZE, "app");
+    }
+
+  safe_copy_string(elements->message, app_end + 1, PARS_BUF_MSG_SIZE, "msg");
 
   return 1;
+}
+
+static int
+parse_line(const char *line, SyslogMsgElements *elements, int skip)
+{
+  while (skip--)
+    {
+      line = strchr(line, ' ');
+
+      if (!line)
+        return -1;
+
+      line += 1;
+    }
+
+  int ret_val;
+  switch (get_line_format(line))
+    {
+    case LOG_FORMAT_RFC5424:
+      ret_val = parse_line_rfc5424(line, elements);
+      break;
+
+    case LOG_FORMAT_RFC3164:
+      ret_val =  parse_line_rfc3164(line, elements);
+      break;
+
+    default:
+      DEBUG("unknown logformat detected:%s\n", line);
+      ret_val = -1;
+    }
+
+  return ret_val;
 }
 
 int
@@ -174,8 +330,8 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
   static int lineno = 0;
   int linelen;
 
-  char host[128], program[128], pid[16];
-  char *msg = NULL;
+  SyslogMsgElements parsed_elements;
+  memset(&parsed_elements, 0, sizeof(SyslogMsgElements));
 
   if (!source[thread_index])
     return 0;
@@ -208,10 +364,10 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
       if (dont_parse)
         break;
 
-      if (parse_line(buf, host, program, pid, &msg) > 0)
+      if (parse_line(buf, &parsed_elements, skip_tokens) > 0)
         break;
 
-      fprintf(stderr, "\rInvalid line %d                  \n", ++lineno);
+      fprintf(stderr, "Invalid line %d\n", ++lineno);
     }
 
   if (dont_parse)
@@ -221,23 +377,37 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
     }
 
   char stamp[32];
-  int tslen = get_now_timestamp(stamp, sizeof(stamp));
+  int tslen;
 
   if (syslog_proto)
     {
       char tmp[11];
-      linelen = snprintf(buf + 10, buflen - 10, "<38>1 %.*s %s %s %s - - \xEF\xBB\xBF%s", tslen, stamp, host, program,
-                         (pid[0] ? pid : "-"), msg);
+      tslen = get_now_timestamp(stamp, sizeof(stamp));
+
+      linelen = snprintf(buf + 10, buflen - 10, "<%s>%s %.*s %s %s %s %s %s \xEF\xBB\xBF%s",
+                         parsed_elements.pri,
+                         parsed_elements.ver,
+                         tslen, stamp,
+                         parsed_elements.host,
+                         parsed_elements.app,
+                         parsed_elements.pid[0] ? parsed_elements.pid : "-",
+                         parsed_elements.msgid[0] ? parsed_elements.msgid : "-",
+                         parsed_elements.sdata[0] ? parsed_elements.sdata : "-",
+                         parsed_elements.message);
       snprintf(tmp, sizeof(tmp), "%09d ", linelen);
       memcpy(buf, tmp, 10);
       linelen += 10;
     }
   else
     {
-      if (*pid)
-        linelen = snprintf(buf, buflen, "<38>%.*s %s %s[%s]: %s", tslen, stamp, host, program, pid, msg);
+      tslen = get_now_timestamp_bsd(stamp, sizeof(stamp));
+
+      if (strlen(parsed_elements.pid))
+        linelen = snprintf(buf, buflen, "<38>%.*s %s %s[%s]: %s", tslen, stamp, parsed_elements.host, parsed_elements.app,
+                           parsed_elements.pid, parsed_elements.message);
       else
-        linelen = snprintf(buf, buflen, "<38>%.*s %s %s: %s", tslen, stamp, host, program, msg);
+        linelen = snprintf(buf, buflen, "<38>%.*s %s %s: %s", tslen, stamp, parsed_elements.host, parsed_elements.app,
+                           parsed_elements.message);
     }
 
   return linelen;

--- a/tests/loggen/file_reader.h
+++ b/tests/loggen/file_reader.h
@@ -25,7 +25,56 @@
 #define LOGGEN_FILE_READER_H_INCLUDED
 
 #include "compat/glib.h"
-#include <glib.h>
+#include "compat/compat.h"
+
+/* RFC5424 specific constants */
+#define RFC5424_NIL_VALUE "-"
+#define RFC5424_DELIMITERS " >"
+#define RFC5424_BOM "﻿"
+
+#define RFC5424_HEADER_TOKEN_NUM 8
+#define RFC5424_PRI_INDEX 0
+#define RFC5424_VER_INDEX 1
+#define RFC5424_TIMESTAMP_INDEX 2
+#define RFC5424_HOST_NAME_INDEX 3
+#define RFC5424_APP_NAME_INDEX 4
+#define RFC5424_PID_INDEX 5
+#define RFC5424_MSGID_INDEX 6
+#define RFC5424_SDATA_INDEX 7
+
+/* RFC3164 specific constants */
+#define RFC3164_TIMESTAMP_SIZE 15
+
+/* buffer & constants for parsed messages */
+#define PARS_BUF_PRI_SIZE 3+1
+#define PARS_BUF_VER_SIZE 2+1
+#define PARS_BUF_TIME_STAMP_SIZE 128+1
+#define PARS_BUF_HOST_SIZE 255+1
+#define PARS_BUF_APP_SIZE 48+1
+#define PARS_BUF_MSG_ID_SIZE 32+1
+#define PARS_BUF_PID_SIZE 128+1
+#define PARS_BUF_SDATA_SIZE 1024+1
+#define PARS_BUF_MSG_SIZE 4096+1
+
+typedef enum _LogFormatType
+{
+  LOG_FORMAT_UNKNOWN,
+  LOG_FORMAT_RFC5424,
+  LOG_FORMAT_RFC3164
+} LogFormatType;
+
+typedef struct _SyslogMsgElements
+{
+  gchar pri[PARS_BUF_PRI_SIZE];
+  gchar ver[PARS_BUF_VER_SIZE];
+  gchar time_stamp[PARS_BUF_TIME_STAMP_SIZE];
+  gchar host[PARS_BUF_HOST_SIZE];
+  gchar app[PARS_BUF_APP_SIZE];
+  gchar pid[PARS_BUF_PID_SIZE];
+  gchar msgid[PARS_BUF_MSG_ID_SIZE];
+  gchar sdata[PARS_BUF_SDATA_SIZE];
+  gchar message[PARS_BUF_MSG_SIZE];
+} SyslogMsgElements;
 
 GOptionEntry *get_file_reader_options(void);
 int read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_index);

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -299,7 +299,7 @@ start_plugins(GPtrArray *plugin_array)
 
   if (number_of_active_plugins != 1)
     {
-      ERROR("%d plugins activated. You should activate exactly one plugin at a time. See \"loggen --help-all\" for available plugin options\n",
+      ERROR("%d plugins activated. You should activate exactly one plugin at a time.\nDid you forget to add -S ?\nSee \"loggen --help-all\" for available plugin options\n",
             number_of_active_plugins);
       return 0;
     }
@@ -432,7 +432,7 @@ main(int argc, char *argv[])
   DEBUG("%d plugin successfuly loaded\n",plugin_num);
 
   /* create sub group for file reader functions */
-  GOptionGroup *group = g_option_group_new("File reader", "File reader", "Show options", NULL, NULL);
+  GOptionGroup *group = g_option_group_new("file-reader", "file-reader", "Show options", NULL, NULL);
   g_option_group_add_entries(group, get_file_reader_options());
   g_option_context_add_group(ctx, group);
 

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -201,6 +201,17 @@ get_now_timestamp(char *stamp, gsize stamp_size)
   return strftime(stamp, stamp_size, "%Y-%m-%dT%H:%M:%S", &tm);
 }
 
+size_t
+get_now_timestamp_bsd(char *stamp, gsize stamp_size)
+{
+  struct timeval now;
+  struct tm tm;
+
+  gettimeofday(&now, NULL);
+  localtime_r(&now.tv_sec, &tm);
+  return strftime(stamp, stamp_size, "%b %d %T", &tm);
+}
+
 void
 format_timezone_offset_with_colon(char *timestamp, int timestamp_size, struct tm *tm)
 {

--- a/tests/loggen/loggen_helper.h
+++ b/tests/loggen/loggen_helper.h
@@ -46,6 +46,7 @@ unsigned long time_val_diff_in_usec(struct timeval *t1, struct timeval *t2);
 double time_val_diff_in_sec(struct timeval *t1, struct timeval *t2);
 void time_val_diff_in_timeval(struct timeval *res, const struct timeval *t1, const struct timeval *t2);
 size_t get_now_timestamp(char *stamp, gsize stamp_size);
+size_t get_now_timestamp_bsd(char *stamp, gsize stamp_size);
 void format_timezone_offset_with_colon(char *timestamp, int timestamp_size, struct tm *tm);
 int connect_ip_socket(int sock_type, const char *target, const char *port, int use_ipv6);
 int connect_unix_domain_socket(int sock_type, const char *path);

--- a/tests/loggen/tests/CMakeLists.txt
+++ b/tests/loggen/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_unit_test(CRITERION TARGET test_loggen_filereader DEPENDS loggen_helper)
+include_directories(test_loggen_filereader PUBLIC
+  ${PROJECT_SOURCE_DIR}
+  )

--- a/tests/loggen/tests/Makefile.am
+++ b/tests/loggen/tests/Makefile.am
@@ -1,0 +1,15 @@
+tests_loggen_tests_test_loggen_filereader_TESTS			=	\
+	tests/loggen/tests/test_loggen_filereader
+
+check_PROGRAMS					+=	\
+	${tests_loggen_tests_test_loggen_filereader_TESTS}
+
+tests_loggen_tests_test_loggen_filereader_CFLAGS	=	\
+	$(TEST_CFLAGS) -I$(top_srcdir)/tests/loggen
+
+tests_loggen_tests_test_loggen_filereader_LDADD	=	\
+	$(TEST_LDADD) \
+	tests/loggen/libloggen_helper.la
+
+tests_loggen_tests_test_loggen_filereader_LDFLAGS	=	\
+	$(PREOPEN_SYSLOGFORMAT)

--- a/tests/loggen/tests/test_loggen_filereader.c
+++ b/tests/loggen/tests/test_loggen_filereader.c
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2007-2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "tests/loggen/file_reader.c"
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+typedef struct _filereader_test_param
+{
+  int   skip_tokens;
+  const gchar *line;
+  const gchar *expected_pri;
+  const gchar *expected_ver;
+  const gchar *expected_time_stamp;
+  const gchar *expected_host;
+  const gchar *expected_app;
+  const gchar *expected_pid;
+  const gchar *expected_msgid;
+  const gchar *expected_sdata;
+  const gchar *expected_message;
+} FileReaderTestParam;
+
+ParameterizedTestParameters(loggen, test_filereader)
+{
+  static FileReaderTestParam parser_params[] =
+  {
+    /* RFC5424 log format */
+    {
+      .skip_tokens = 0,
+      .line = "<134>1 2011-02-01T15:25:25+01:00 zts-win001 syslog-ng_Agent 3268 - [meta sequenceId=\"5\" sysUpTime=\"6\"][origin ip=\"zts-win001\" software=\"syslog-ng Agent\"][win@18372.4 EVENT_ID=\"17\" EVENT_NAME=\"Application\" EVENT_REC_NUM=\"2515\" EVENT_SID=\"S-1-5-21-1044605109-3424919905-550079122-1000\" EVENT_SID_TYPE=\"User\" EVENT_SOURCE=\"syslog-ng Agent\" EVENT_TYPE=\"Information\" EVENT_USERNAME=\"ZTS-WIN001\\balabit\"] ﻿ZTS-WIN001\balabit: Application syslog-ng Agent: [Information] Service Removed (EventID 17)",
+      .expected_pri = "134",
+      .expected_ver = "1",
+      .expected_time_stamp = "2011-02-01T15:25:25+01:00",
+      .expected_host = "zts-win001",
+      .expected_app = "syslog-ng_Agent",
+      .expected_pid = "3268",
+      .expected_msgid = "-",
+      .expected_sdata = "[meta sequenceId=\"5\" sysUpTime=\"6\"][origin ip=\"zts-win001\" software=\"syslog-ng Agent\"][win@18372.4 EVENT_ID=\"17\" EVENT_NAME=\"Application\" EVENT_REC_NUM=\"2515\" EVENT_SID=\"S-1-5-21-1044605109-3424919905-550079122-1000\" EVENT_SID_TYPE=\"User\" EVENT_SOURCE=\"syslog-ng Agent\" EVENT_TYPE=\"Information\" EVENT_USERNAME=\"ZTS-WIN001\\balabit\"]",
+      .expected_message = "ZTS-WIN001\balabit: Application syslog-ng Agent: [Information] Service Removed (EventID 17)"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<134>1 2016-04-15T11:00:06+02:00 zts-win101 Microsoft-Windows-Service_Control_Manager 3748 1234 [win@18372.4 EVENT_FACILITY=\"16\" EVENT_ID=\"7036\" EVENT_LEVEL=\"4\" EVENT_NAME=\"System\" EVENT_REC_NUM=\"471252\" EVENT_SID=\"N/A\" EVENT_SOURCE=\"Microsoft-Windows-Service Control Manager\" EVENT_TYPE=\"Information\" EVENT_CATEGORY=\"None\"][meta sequenceId=\"397\" sysUpTime=\"85\"] ﻿N/A: System Microsoft-Windows-Service Control Manager: [Information] The syslog-ng Agent service entered the running state. (EventID 7036)",
+      .expected_pri = "134",
+      .expected_ver = "1",
+      .expected_time_stamp = "2016-04-15T11:00:06+02:00",
+      .expected_host = "zts-win101",
+      .expected_app = "Microsoft-Windows-Service_Control_Manager",
+      .expected_pid = "3748",
+      .expected_msgid = "1234",
+      .expected_sdata = "[win@18372.4 EVENT_FACILITY=\"16\" EVENT_ID=\"7036\" EVENT_LEVEL=\"4\" EVENT_NAME=\"System\" EVENT_REC_NUM=\"471252\" EVENT_SID=\"N/A\" EVENT_SOURCE=\"Microsoft-Windows-Service Control Manager\" EVENT_TYPE=\"Information\" EVENT_CATEGORY=\"None\"][meta sequenceId=\"397\" sysUpTime=\"85\"]",
+      .expected_message = "N/A: System Microsoft-Windows-Service Control Manager: [Information] The syslog-ng Agent service entered the running state. (EventID 7036)"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<01>32 2016-04-15T11:00:06+03:00 zts-win101 loggen 12 34 - test message for loggen",
+      .expected_pri = "01",
+      .expected_ver = "32",
+      .expected_time_stamp = "2016-04-15T11:00:06+03:00",
+      .expected_host = "zts-win101",
+      .expected_app = "loggen",
+      .expected_pid = "12",
+      .expected_msgid = "34",
+      .expected_sdata = "-",
+      .expected_message = "test message for loggen"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<01>32 2016-04-15T11:00:06+04:00 - - - - - test message for loggen",
+      .expected_pri = "01",
+      .expected_ver = "32",
+      .expected_time_stamp = "2016-04-15T11:00:06+04:00",
+      .expected_host = "-",
+      .expected_app = "-",
+      .expected_pid = "-",
+      .expected_msgid = "-",
+      .expected_sdata = "-",
+      .expected_message = "test message for loggen"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<01>32 2016-04-15T11:00:06+05:00 - - - - [sdata_test=\"1\"] ﻿test message for loggen",
+      .expected_pri = "01",
+      .expected_ver = "32",
+      .expected_time_stamp = "2016-04-15T11:00:06+05:00",
+      .expected_host = "-",
+      .expected_app = "-",
+      .expected_pid = "-",
+      .expected_msgid = "-",
+      .expected_sdata = "[sdata_test=\"1\"]",
+      .expected_message = "test message for loggen"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<01>32 2016-04-15T11:00:07+02:00 - - - - [sdata_test=\"1\"] ﻿",
+      .expected_pri = "01",
+      .expected_ver = "32",
+      .expected_time_stamp = "2016-04-15T11:00:07+02:00",
+      .expected_host = "-",
+      .expected_app = "-",
+      .expected_pid = "-",
+      .expected_msgid = "-",
+      .expected_sdata = "[sdata_test=\"1\"]",
+      .expected_message = ""
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<01>32 2016-04-15T11:00:08+02:00 - - - - -",
+      .expected_pri = "01",
+      .expected_ver = "32",
+      .expected_time_stamp = "2016-04-15T11:00:08+02:00",
+      .expected_host = "-",
+      .expected_app = "-",
+      .expected_pid = "-",
+      .expected_msgid = "-",
+      .expected_sdata = "-",
+      .expected_message = ""
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<123>3210 2016-04-15T11:00:09+02:00 - - - - -",
+      .expected_pri = "123",
+      .expected_ver = "32", /* ver shall be truncated to 2 char long */
+      .expected_time_stamp = "2016-04-15T11:00:09+02:00",
+      .expected_host = "-",
+      .expected_app = "-",
+      .expected_pid = "-",
+      .expected_msgid = "-",
+      .expected_sdata = "-",
+      .expected_message = ""
+    },
+    {
+      /* invalid sdata */
+      .skip_tokens = 0,
+      .line = "<134>1 2016-04-15T14:00:06+02:00 zts-win101 Microsoft-Windows-Service_Control_Manager 3748 - [win@18372.4 EVENT_FACILITY=16 EVENT_ID=7036 EVENT_LEVEL=4 EVENT_NAME=System EVENT_REC_NUM=471252 EVENT_SID=N/Agent service entered the running state. (EventID 7036)\n",
+      .expected_pri = "134",
+      .expected_ver = "1", /* ver shall be truncated to 2 char long */
+      .expected_time_stamp = "2016-04-15T14:00:06+02:00",
+      .expected_host = "zts-win101",
+      .expected_app = "Microsoft-Windows-Service_Control_Manager",
+      .expected_pid = "3748",
+      .expected_msgid = "-",
+      .expected_sdata = "-",
+      .expected_message = ""
+    },
+    /* RFC3164 log format */
+    {
+      .skip_tokens = 1,
+      .line = "499 <134>Feb 04 16:22:31 zts-win001 Microsoft-Windows-Winlogon[3720]: : Application Microsoft-Windows-Winlogon: [Information] Windows license validated. (EventID 4101)",
+      .expected_pri = "134",
+      .expected_ver = "",
+      .expected_time_stamp = "Feb 04 16:22:31",
+      .expected_host = "zts-win001",
+      .expected_app = "Microsoft-Windows-Winlogon",
+      .expected_pid = "3720",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ": Application Microsoft-Windows-Winlogon: [Information] Windows license validated. (EventID 4101)"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<134>Jul 27 14:55:12 syslogng-win7 Microsoft-Windows-Service_Control_Manager[3720]: : System Microsoft-Windows-Service Control Manager: [Information] The Multimedia Class Scheduler service entered the running state. (EventID 7036)",
+      .expected_pri = "134",
+      .expected_ver = "",
+      .expected_time_stamp = "Jul 27 14:55:12",
+      .expected_host = "syslogng-win7",
+      .expected_app = "Microsoft-Windows-Service_Control_Manager",
+      .expected_pid = "3720",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ": System Microsoft-Windows-Service Control Manager: [Information] The Multimedia Class Scheduler service entered the running state. (EventID 7036)"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<34>Oct 11 22:14:15 mymachine su[123]: : 'su root' failed for lonvick on /dev/pts/8",
+      .expected_pri = "34",
+      .expected_ver = "",
+      .expected_time_stamp = "Oct 11 22:14:15",
+      .expected_host = "mymachine",
+      .expected_app = "su",
+      .expected_pid = "123",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ": 'su root' failed for lonvick on /dev/pts/8"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<13>Feb  5 17:32:18 10.0.0.99 myapp[222]: : Use the BFG!",
+      .expected_pri = "13",
+      .expected_ver = "",
+      .expected_time_stamp = "Feb  5 17:32:18",
+      .expected_host = "10.0.0.99",
+      .expected_app = "myapp",
+      .expected_pid = "222",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ": Use the BFG!"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<13>Feb  5 17:32:18 10.0.0.99 testapp: : Use the BFG!",
+      .expected_pri = "13",
+      .expected_ver = "",
+      .expected_time_stamp = "Feb  5 17:32:18",
+      .expected_host = "10.0.0.99",
+      .expected_app = "testapp",
+      .expected_pid = "",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ": Use the BFG!"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<165>Aug 24 05:34:00 mymachine myproc[10]: : %% It's time to make the do-nuts. []:#!@?<> %%  Ingredients: Mix=OK, Jelly=OK # Devices: Mixer=OK, Jelly_Injector=OK, Frier=OK # Transport: Conveyer1=OK, Conveyer2=OK # %%",
+      .expected_pri = "165",
+      .expected_ver = "",
+      .expected_time_stamp = "Aug 24 05:34:00",
+      .expected_host = "mymachine",
+      .expected_app = "myproc",
+      .expected_pid = "10",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ": %% It's time to make the do-nuts. []:#!@?<> %%  Ingredients: Mix=OK, Jelly=OK # Devices: Mixer=OK, Jelly_Injector=OK, Frier=OK # Transport: Conveyer1=OK, Conveyer2=OK # %%"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<13>Feb  5 17:32:18 10.0.0.99 Use the BFG 1!",
+      .expected_pri = "13",
+      .expected_ver = "",
+      .expected_time_stamp = "Feb  5 17:32:18",
+      .expected_host = "10.0.0.99",
+      .expected_app = "",
+      .expected_pid = "",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = "Use the BFG 1!"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<13>Feb  5 17:32:18 10.0.0.99 testapp: Use the BFG 2!",
+      .expected_pri = "13",
+      .expected_ver = "",
+      .expected_time_stamp = "Feb  5 17:32:18",
+      .expected_host = "10.0.0.99",
+      .expected_app = "testapp",
+      .expected_pid = "",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = "Use the BFG 2!"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<34>Oct 11 22:14:15 mymachine su[123]: 'su root' failed for lonvick on /dev/pts/8",
+      .expected_pri = "34",
+      .expected_ver = "",
+      .expected_time_stamp = "Oct 11 22:14:15",
+      .expected_host = "mymachine",
+      .expected_app = "su",
+      .expected_pid = "123",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = "'su root' failed for lonvick on /dev/pts/8"
+    },
+    {
+      .skip_tokens = 0,
+      .line = "<34>Oct 11 22:14:15 mymachine",
+      .expected_pri = "34",
+      .expected_ver = "",
+      .expected_time_stamp = "Oct 11 22:14:15",
+      .expected_host = "mymachine",
+      .expected_app = "",
+      .expected_pid = "",
+      .expected_msgid = "",
+      .expected_sdata = "",
+      .expected_message = ""
+    }
+  };
+
+  return cr_make_param_array(FileReaderTestParam, parser_params, G_N_ELEMENTS(parser_params));
+}
+
+ParameterizedTest(FileReaderTestParam *param, loggen, test_filereader)
+{
+  SyslogMsgElements elements;
+
+  parse_line(str_skip_tokens(param->line, param->skip_tokens), &elements);
+
+  cr_expect_str_eq(elements.pri, param->expected_pri, "Error: pri doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.pri, param->expected_pri);
+  cr_expect_str_eq(elements.ver, param->expected_ver, "Error: ver doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.ver, param->expected_ver);
+  cr_expect_str_eq(elements.time_stamp, param->expected_time_stamp,
+                   "Error: time_stamp doesn't match (val=\"%s\", expected=\"%s\")\n",elements.time_stamp, param->expected_time_stamp);
+  cr_expect_str_eq(elements.host, param->expected_host, "Error: host doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.host, param->expected_host);
+  cr_expect_str_eq(elements.app, param->expected_app, "Error: app doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.app, param->expected_app);
+  cr_expect_str_eq(elements.pid, param->expected_pid, "Error: pid doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.pid, param->expected_pid);
+  cr_expect_str_eq(elements.msgid, param->expected_msgid, "Error: msgid doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.msgid, param->expected_msgid);
+  cr_expect_str_eq(elements.sdata, param->expected_sdata, "Error: sdata doesn't match (val=\"%s\", expected=\"%s\")\n",
+                   elements.sdata, param->expected_sdata);
+  cr_expect_str_eq(elements.message, param->expected_message,
+                   "Error: message doesn't match (val=\"%s\", expected=\"%s\")\n",elements.message, param->expected_message);
+}
+


### PR DESCRIPTION
The space in the "File reader" makes hard to call
--help-File reader option. I removed the space.

A further clarification is about error message when
none of the plugins are activated. As a hint it print outs
the most frequently forget option -S

loggen was able to parse BSD (RFC3164) formated loglines
read from file. With this patch loggen is able to parse both RFC3164
and RFC5424 (syslog format).

It also fixes the possible buffer overrun in the old parse_line
function.

The deafult value of --skip-token has been changed to 0
as this is more intuitive as the old value 3. You have to use
the --skip-token option if and only if you want to skip the first N
token of the loglines. Otherwise you shouldn't care this option.

a new unittest has been added to test the file reader's
parser functions. It tests both RFC5424 and RFC3164 log formats.

Signed-off-by: norberttakacs <norbert.takacs@balabit.com>