### PR TITLE
RFC: m4/check_java_support: add -rpath to libmod-java so it finds libjvm.so

### DIFF
--- a/m4/check_java_support.m4
+++ b/m4/check_java_support.m4
@@ -91,7 +91,7 @@ AC_DEFUN([AX_CHECK_JAVA_VERSION],
       JNI_LIBDIR=`find $JNI_HOME \( -name "libjvm.so" -or -name "libjvm.dylib" \) \
         | sed "s-/libjvm\.so-/-" \
         | sed "s-/libjvm\.dylib-/-" | head -n 1`
-      JNI_LIBS="-L$JNI_LIBDIR -ljvm"
+      JNI_LIBS="-L$JNI_LIBDIR -ljvm -Wl,-rpath -Wl,$JNI_LIBDIR"
       JNI_INCLUDE_DIR=`find $JNI_HOME -name "jni.h" |  sed "s/\(.*\)jni.h/\1/" | head -n 1`
       JNI_CFLAGS="-I$JNI_INCLUDE_DIR"
 


### PR DESCRIPTION
This is primarily an RFC pull request, with this we would be encoding the path to libjvm.so into our libmod-java.so plugin, avoiding having to set LD_LIBRARY_PATH at runtime.

I think it is pretty common to run into java() being unavailable because of the missing LD_LIBRARY_PATH setting.

The risk is that not all platforms might support rpath the same. Also, Debian has a policy against rpath, but I think it does not apply (but I am not sure). @mochrul 

I haven't implemented the cmake variant.

What do you, especially package maintainers, think?
@czanik 