### PR TITLE
sudo: filter out incorrectly parsed logs

### DIFF
--- a/scl/sudo/sudo.conf
+++ b/scl/sudo/sudo.conf
@@ -21,8 +21,15 @@
 #############################################################################
 
 block parser sudo-parser(prefix('.sudo.')) {
-	kv-parser(prefix(`prefix`) pair-separator(';') extract-stray-words-into('0'));
-        csv-parser(columns("`prefix`SUBJECT") template("$(list-head $0)") delimiters(' '));
+    channel {
+        parser {
+            kv-parser(prefix(`prefix`) pair-separator(';') extract-stray-words-into('0'));
+            csv-parser(columns("`prefix`SUBJECT") template("$(list-head $0)") delimiters(' '));
+        };
+	# drop everything which does not have a command (to exclude pam
+	# related logs)
+        filter { not match("" value("`prefix`COMMAND") type(string)); };
+    };
 };
 
 application sudo[syslog] {


### PR DESCRIPTION
sudo may generate some log messages through libpam, drop those messages.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>