### PR TITLE
scl/ewmm: rename syslog-ng() source to ewmm()

### DIFF
--- a/scl/ewmm/ewmm.conf
+++ b/scl/ewmm/ewmm.conf
@@ -58,15 +58,38 @@ block parser ewmm-parser() {
 
 template-function "format-ewmm" "<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --leave-initial-dot --scope all-nv-pairs --exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* --exclude 6* --exclude 7* --exclude 8* --exclude 9* --exclude SOURCE --exclude .SDATA.* ._TAGS=${TAGS})\n";
 
-block destination syslog-ng(server('127.0.0.1') transport(tcp) port(514) ...) {
-        network("`server`" transport(`transport`) port(`port`)
+#
+# syslog-ng is just an alias for the ewmm destination there's no syslog-ng()
+# source and shouldn't be one, even if it sounds asymmetrical.
+#
+# Rationale:
+#   - on the source side we want ewmm to be processed on the same channel as
+#     everything else is coming in.
+#   - we already created default-network-drivers() for exactly this use-case
+#   - the ewmm() source below is a pretty limited use-case that is probably
+#     only good enough for testing.
+#   - with this, we have symmetry: ewmm() source and destination. And we
+#     also reserved the name "syslog-ng()" to send messages to an actual
+#     syslog-ng instance.
+#
+# if someone needs a different use-case, the recommended way is to construct
+# the source plus parsing bits at the configuration file level, as that
+# use-case is not generic enough.
+#
+
+block destination syslog-ng(server('127.0.0.1') ...) {
+	ewmm(ip(`server`) `__VARARGS__`);
+};
+
+block destination ewmm(ip('127.0.0.1') transport(tcp) port(514) ...) {
+        network("`ip`" transport(`transport`) port(`port`)
                 template("$(format-ewmm)")
                 frac-digits(3)
 		`__VARARGS__`
         );
 };
 
-block source syslog-ng(
+block source ewmm(
         ip('0.0.0.0')
         port(514)
         transport(tcp)


### PR DESCRIPTION
syslog-ng is just an alias for the ewmm destination there's no syslog-ng()
source and shouldn't be one, even if it sounds asymmetrical.

Rationale:
  - on the source side we want ewmm to be processed on the same channel as
    everything else is coming in.
  - we already created default-network-drivers() for exactly this use-case
  - the ewmm() source below is a pretty limited use-case that is probably
    only good enough for testing.
  - with this, we have symmetry: ewmm() source and destination. And we
    also reserved the name "syslog-ng()" to send messages to an actual
    syslog-ng instance.

if someone needs a different use-case, the recommended way is to construct
the source plus parsing bits at the configuration file level, as that
use-case is not generic enough.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>