### PR TITLE
diskq: dqtool cat print backlog items

### DIFF
--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -140,6 +140,9 @@ dqtool_cat(int argc, char *argv[])
       if (!open_queue(argv[i], &lq, &options))
         continue;
 
+      log_queue_set_use_backlog(lq, TRUE);
+      log_queue_rewind_backlog_all(lq);
+
       while ((log_msg = log_queue_pop_head(lq, &local_options)) != NULL)
         {
           /* format log */


### PR DESCRIPTION
The `dqtool` currently does not print out the backlog items from the disk queue file.
This patch allow `dqtool` to use the backlog, and rewinds messages (only in memory), so `dqtool` could access them.