### PR TITLE
[WIP]Resolve circular dep ack tracker logsource

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -134,6 +134,7 @@ set (LIB_HEADERS
     host-id.h
     resolved-configurable-paths.h
     window-size-counter.h
+    ack-type.h
     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.h
     ${PROJECT_BINARY_DIR}/lib/block-ref-grammar.h
     ${PROJECT_BINARY_DIR}/lib/cfg-lex.h

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -176,7 +176,8 @@ pkginclude_HEADERS			+= \
 	lib/host-id.h			\
 	lib/resolved-configurable-paths.h \
 	lib/pe-versioning.h \
-	lib/window-size-counter.h
+	lib/window-size-counter.h \
+	lib/ack-type.h
 
 # this is intentionally formatted so conflicts are less likely to arise. one name in every line.
 lib_libsyslog_ng_la_SOURCES		= \

--- a/lib/ack-type.h
+++ b/lib/ack-type.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2014 Balabit
- * Copyright (c) 2014 Laszlo Budai
+ * Copyright (c) 2002-2018 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,36 +21,15 @@
  *
  */
 
-#ifndef BOOKMARK_H_INCLUDED
-#define BOOKMARK_H_INCLUDED
+#ifndef ACK_TYPE_H_INCLUDED
+#define ACK_TYPE_H_INCLUDED
 
-#include "syslog-ng.h"
-#include "persist-state.h"
-
-#define MAX_BOOKMARK_DATA_LENGTH (128)
-
-typedef struct _Bookmark Bookmark;
-
-typedef struct _BookmarkContainer
+typedef enum AckType
 {
-  /* Bookmark structure should be aligned (ie. HPUX-11v2 ia64) */
-  gint64 other_state[MAX_BOOKMARK_DATA_LENGTH/sizeof(gint64)];
-} BookmarkContainer;
-
-struct _Bookmark
-{
-  PersistState *persist_state;
-  void (*save)(Bookmark *self);
-  void (*destroy)(Bookmark *self);
-  BookmarkContainer container;
-};
-
-static inline void
-bookmark_init(Bookmark *self)
-{
-  self->persist_state = NULL;
-  self->save = NULL;
-  self->destroy = NULL;
-}
+  AT_UNDEFINED,
+  AT_PROCESSED,
+  AT_ABORTED,
+  AT_SUSPENDED
+} AckType;
 
 #endif

--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -26,7 +26,12 @@
 #define ACK_TRACKER_H_INCLUDED
 
 #include "syslog-ng.h"
-#include "logsource.h"
+#include "ack-type.h"
+#include "bookmark.h"
+
+typedef struct _AckTracker AckTracker;
+typedef struct _AckRecord AckRecord;
+typedef struct _LogSource LogSource;
 
 struct _AckTracker
 {

--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -35,6 +35,7 @@ struct _AckTracker
   Bookmark *(*request_bookmark)(AckTracker *self);
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, AckType ack_type);
+  void (*free_fn)(AckTracker *self);
 };
 
 struct _AckRecord
@@ -45,18 +46,12 @@ struct _AckRecord
 AckTracker *late_ack_tracker_new(LogSource *source);
 AckTracker *early_ack_tracker_new(LogSource *source);
 
-void late_ack_tracker_free(AckTracker *self);
-void early_ack_tracker_free(AckTracker *self);
-
 static inline void
 ack_tracker_free(AckTracker *self)
 {
-  if (self)
+  if (self && self->free_fn)
     {
-      if (self->late)
-        late_ack_tracker_free(self);
-      else
-        early_ack_tracker_free(self);
+      self->free_fn(self);
     }
 }
 

--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -34,7 +34,6 @@ typedef struct _AckRecord AckRecord;
 
 struct _AckTracker
 {
-  gboolean late;
   Bookmark *(*request_bookmark)(AckTracker *self);
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, AckType ack_type);
@@ -56,12 +55,6 @@ ack_tracker_free(AckTracker *self)
     {
       self->free_fn(self);
     }
-}
-
-static inline gboolean
-ack_tracker_is_late(AckTracker *self)
-{
-  return self->late;
 }
 
 static inline Bookmark *

--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -31,12 +31,10 @@
 
 typedef struct _AckTracker AckTracker;
 typedef struct _AckRecord AckRecord;
-typedef struct _LogSource LogSource;
 
 struct _AckTracker
 {
   gboolean late;
-  LogSource *source;
   Bookmark *(*request_bookmark)(AckTracker *self);
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, AckType ack_type);
@@ -48,8 +46,8 @@ struct _AckRecord
   AckTracker *tracker;
 };
 
-AckTracker *late_ack_tracker_new(LogSource *source);
-AckTracker *early_ack_tracker_new(LogSource *source);
+AckTracker *late_ack_tracker_new(gint init_window_size);
+AckTracker *early_ack_tracker_new(void);
 
 static inline void
 ack_tracker_free(AckTracker *self)

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -51,22 +51,18 @@ static void
 early_ack_tracker_track_msg(AckTracker *s, LogMessage *msg)
 {
   EarlyAckTracker *self = (EarlyAckTracker *)s;
-  log_pipe_ref((LogPipe *)self->super.source);
   msg->ack_record = (AckRecord *)(&self->ack_record_storage);
 }
 
 static void
 early_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type)
 {
-  EarlyAckTracker *self = (EarlyAckTracker *)s;
-
   if (ack_type == AT_SUSPENDED)
-    log_source_flow_control_suspend(self->super.source);
+    log_source_flow_control_suspend(msg->source);
 
-  log_source_flow_control_adjust(self->super.source, 1);
+  log_source_flow_control_adjust(msg->source, 1);
 
   log_msg_unref(msg);
-  log_pipe_unref((LogPipe *)self->super.source);
 }
 
 static void
@@ -87,21 +83,19 @@ _setup_callbacks(EarlyAckTracker *self)
 }
 
 static void
-early_ack_tracker_init_instance(EarlyAckTracker *self, LogSource *source)
+early_ack_tracker_init_instance(EarlyAckTracker *self)
 {
   self->super.late = FALSE;
-  self->super.source = source;
-  source->ack_tracker = (AckTracker *)self;
   self->ack_record_storage.super.tracker = (AckTracker *)self;
   _setup_callbacks(self);
 }
 
 AckTracker *
-early_ack_tracker_new(LogSource *source)
+early_ack_tracker_new(void)
 {
   EarlyAckTracker *self = (EarlyAckTracker *)g_new0(EarlyAckTracker, 1);
 
-  early_ack_tracker_init_instance(self, source);
+  early_ack_tracker_init_instance(self);
 
   return (AckTracker *)self;
 }

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -23,8 +23,7 @@
  */
 
 #include "ack_tracker.h"
-#include "bookmark.h"
-#include "syslog-ng.h"
+#include "logsource.h"
 
 typedef struct _EarlyAckRecord
 {

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -85,7 +85,6 @@ _setup_callbacks(EarlyAckTracker *self)
 static void
 early_ack_tracker_init_instance(EarlyAckTracker *self)
 {
-  self->super.late = FALSE;
   self->ack_record_storage.super.tracker = (AckTracker *)self;
   _setup_callbacks(self);
 }

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -79,16 +79,22 @@ early_ack_tracker_free(AckTracker *s)
 }
 
 static void
+_setup_callbacks(EarlyAckTracker *self)
+{
+  self->super.request_bookmark = early_ack_tracker_request_bookmark;
+  self->super.track_msg = early_ack_tracker_track_msg;
+  self->super.manage_msg_ack = early_ack_tracker_manage_msg_ack;
+  self->super.free_fn = early_ack_tracker_free;
+}
+
+static void
 early_ack_tracker_init_instance(EarlyAckTracker *self, LogSource *source)
 {
   self->super.late = FALSE;
   self->super.source = source;
   source->ack_tracker = (AckTracker *)self;
-  self->super.request_bookmark = early_ack_tracker_request_bookmark;
-  self->super.track_msg = early_ack_tracker_track_msg;
-  self->super.manage_msg_ack = early_ack_tracker_manage_msg_ack;
-  self->super.free_fn = early_ack_tracker_free;
   self->ack_record_storage.super.tracker = (AckTracker *)self;
+  _setup_callbacks(self);
 }
 
 AckTracker *

--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -71,6 +71,14 @@ early_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_typ
 }
 
 static void
+early_ack_tracker_free(AckTracker *s)
+{
+  EarlyAckTracker *self = (EarlyAckTracker *)s;
+
+  g_free(self);
+}
+
+static void
 early_ack_tracker_init_instance(EarlyAckTracker *self, LogSource *source)
 {
   self->super.late = FALSE;
@@ -79,6 +87,7 @@ early_ack_tracker_init_instance(EarlyAckTracker *self, LogSource *source)
   self->super.request_bookmark = early_ack_tracker_request_bookmark;
   self->super.track_msg = early_ack_tracker_track_msg;
   self->super.manage_msg_ack = early_ack_tracker_manage_msg_ack;
+  self->super.free_fn = early_ack_tracker_free;
   self->ack_record_storage.super.tracker = (AckTracker *)self;
 }
 
@@ -92,10 +101,3 @@ early_ack_tracker_new(LogSource *source)
   return (AckTracker *)self;
 }
 
-void
-early_ack_tracker_free(AckTracker *s)
-{
-  EarlyAckTracker *self = (EarlyAckTracker *)s;
-
-  g_free(self);
-}

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -239,18 +239,25 @@ late_ack_tracker_free(AckTracker *s)
   ring_buffer_free(&self->ack_record_storage);
   g_free(self);
 }
+
+static void
+_setup_callbacks(LateAckTracker *self)
+{
+  self->super.request_bookmark = late_ack_tracker_request_bookmark;
+  self->super.track_msg = late_ack_tracker_track_msg;
+  self->super.manage_msg_ack = late_ack_tracker_manage_msg_ack;
+  self->super.free_fn = late_ack_tracker_free;
+}
+
 static void
 late_ack_tracker_init_instance(LateAckTracker *self, LogSource *source)
 {
   self->super.late = TRUE;
   self->super.source = source;
   source->ack_tracker = (AckTracker *)self;
-  self->super.request_bookmark = late_ack_tracker_request_bookmark;
-  self->super.track_msg = late_ack_tracker_track_msg;
-  self->super.manage_msg_ack = late_ack_tracker_manage_msg_ack;
-  self->super.free_fn = late_ack_tracker_free;
   ring_buffer_alloc(&self->ack_record_storage, sizeof(LateAckRecord), log_source_get_init_window_size(source));
   g_static_mutex_init(&self->storage_mutex);
+  _setup_callbacks(self);
 }
 
 AckTracker *

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -246,7 +246,6 @@ _setup_callbacks(LateAckTracker *self)
 static void
 late_ack_tracker_init_instance(LateAckTracker *self, gint init_window_size)
 {
-  self->super.late = TRUE;
   ring_buffer_alloc(&self->ack_record_storage, sizeof(LateAckRecord), init_window_size);
   g_static_mutex_init(&self->storage_mutex);
   _setup_callbacks(self);

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -23,9 +23,8 @@
  */
 
 #include "late_ack_tracker.h"
-#include "bookmark.h"
 #include "ringbuffer.h"
-#include "syslog-ng.h"
+#include "logsource.h"
 
 typedef struct _LateAckRecord
 {

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -220,29 +220,6 @@ late_ack_tracker_request_bookmark(AckTracker *s)
 }
 
 static void
-late_ack_tracker_init_instance(LateAckTracker *self, LogSource *source)
-{
-  self->super.late = TRUE;
-  self->super.source = source;
-  source->ack_tracker = (AckTracker *)self;
-  self->super.request_bookmark = late_ack_tracker_request_bookmark;
-  self->super.track_msg = late_ack_tracker_track_msg;
-  self->super.manage_msg_ack = late_ack_tracker_manage_msg_ack;
-  ring_buffer_alloc(&self->ack_record_storage, sizeof(LateAckRecord), log_source_get_init_window_size(source));
-  g_static_mutex_init(&self->storage_mutex);
-}
-
-AckTracker *
-late_ack_tracker_new(LogSource *source)
-{
-  LateAckTracker *self = g_new0(LateAckTracker, 1);
-
-  late_ack_tracker_init_instance(self, source);
-
-  return (AckTracker *)self;
-}
-
-void
 late_ack_tracker_free(AckTracker *s)
 {
   LateAckTracker *self = (LateAckTracker *)s;
@@ -262,3 +239,27 @@ late_ack_tracker_free(AckTracker *s)
   ring_buffer_free(&self->ack_record_storage);
   g_free(self);
 }
+static void
+late_ack_tracker_init_instance(LateAckTracker *self, LogSource *source)
+{
+  self->super.late = TRUE;
+  self->super.source = source;
+  source->ack_tracker = (AckTracker *)self;
+  self->super.request_bookmark = late_ack_tracker_request_bookmark;
+  self->super.track_msg = late_ack_tracker_track_msg;
+  self->super.manage_msg_ack = late_ack_tracker_manage_msg_ack;
+  self->super.free_fn = late_ack_tracker_free;
+  ring_buffer_alloc(&self->ack_record_storage, sizeof(LateAckRecord), log_source_get_init_window_size(source));
+  g_static_mutex_init(&self->storage_mutex);
+}
+
+AckTracker *
+late_ack_tracker_new(LogSource *source)
+{
+  LateAckTracker *self = g_new0(LateAckTracker, 1);
+
+  late_ack_tracker_init_instance(self, source);
+
+  return (AckTracker *)self;
+}
+

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -33,20 +33,13 @@
 #include "logmsg/nvtable.h"
 #include "msg-format.h"
 #include "logmsg/tags.h"
+#include "ack-type.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/time.h>
 #include <iv_list.h>
-
-typedef enum
-{
-  AT_UNDEFINED,
-  AT_PROCESSED,
-  AT_ABORTED,
-  AT_SUSPENDED
-} AckType;
 
 #define IS_ACK_ABORTED(x) ((x) == AT_ABORTED ? 1 : 0)
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -163,6 +163,7 @@ struct _LogMessage
   gint ack_and_ref_and_abort_and_suspended;
 
   AckRecord *ack_record;
+  LogSource *source;
   LMAckFunc ack_func;
   LogMessage *original;
   gsize allocated_bytes;

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -28,6 +28,7 @@
 #include "logproto.h"
 #include "persist-state.h"
 #include "transport/transport-aux-data.h"
+#include "ack_tracker.h"
 #include "bookmark.h"
 
 typedef struct _LogProtoServer LogProtoServer;

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -266,6 +266,7 @@ log_source_post(LogSource *self, LogMessage *msg)
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   gint old_window_size;
 
+  msg->source = (LogSource *)log_pipe_ref(&self->super);
   ack_tracker_track_msg(self->ack_tracker, msg);
 
   /* NOTE: we start by enabling flow-control, thus we need an acknowledgement */
@@ -429,9 +430,9 @@ _create_ack_tracker_if_not_exists(LogSource *self, gboolean pos_tracked)
   if (!self->ack_tracker)
     {
       if (pos_tracked)
-        self->ack_tracker = late_ack_tracker_new(self);
+        self->ack_tracker = late_ack_tracker_new(log_source_get_init_window_size(self));
       else
-        self->ack_tracker = early_ack_tracker_new(self);
+        self->ack_tracker = early_ack_tracker_new();
     }
 }
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -28,6 +28,7 @@
 #include "logpipe.h"
 #include "stats/stats-registry.h"
 #include "window-size-counter.h"
+#include "ack_tracker.h"
 
 typedef struct _LogSourceOptions
 {

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -50,8 +50,6 @@ typedef struct _LogSourceOptions
   gint stats_source;
 } LogSourceOptions;
 
-typedef struct _LogSource LogSource;
-
 /**
  * LogSource:
  *

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -50,6 +50,7 @@ typedef struct _GlobalConfig GlobalConfig;
 typedef struct _CfgLexer CfgLexer;
 typedef struct _PluginContext PluginContext;
 typedef struct _StatsClusterKey StatsClusterKey;
+typedef struct _LogSource LogSource;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -49,9 +49,6 @@ typedef struct _LogMessage LogMessage;
 typedef struct _GlobalConfig GlobalConfig;
 typedef struct _CfgLexer CfgLexer;
 typedef struct _PluginContext PluginContext;
-typedef struct _Bookmark Bookmark;
-typedef struct _AckTracker AckTracker;
-typedef struct _AckRecord AckRecord;
 typedef struct _StatsClusterKey StatsClusterKey;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */


### PR DESCRIPTION
This was a side effect of another work, but it can be handled separately from that.

@MrAnno : I know that we need to follow up these changes on some internal branches where we have a session cache which is based on the fact that we store a pointer to a `LogSource` instance in the `AckTracker`... 
