### PR TITLE
Decorating generated configuration

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -38,7 +38,14 @@ gboolean
 cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
                              const gchar *reference)
 {
-  return self->generate(self, cfg, args, result, reference);
+  gchar block_name[1024];
+  cfg_block_generator_format_name(self, block_name, sizeof(block_name)/sizeof(block_name[0]));
+
+  g_string_append_printf(result, "\n#Start Block %s\n", block_name);
+  const gboolean res = self->generate(self, cfg, args, result, reference);
+  g_string_append_printf(result, "\n#End Block %s\n", block_name);
+
+  return res;
 }
 
 void

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -178,7 +178,7 @@ cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GStri
       return FALSE;
     }
 
-  g_string_assign_len(result, value, length);
+  g_string_append_len(result, value, length);
   g_free(value);
   return TRUE;
 }

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -109,11 +109,13 @@ _generate_application(Application *app, Application *base_app, gpointer user_dat
   if (_is_application_excluded(self, app))
     return;
 
+  g_string_append_printf(self->block, "\n#Start Application %s\n",app->name);
   g_string_append(self->block, "channel {\n");
   _generate_filter(self, _get_filter_expr(app, base_app));
   _generate_parser(self, _get_parser_expr(app, base_app));
   _generate_action(self, app);
   g_string_append(self->block, "};\n");
+  g_string_append_printf(self->block, "\n#End Application %s\n",app->name);
 
 }
 


### PR DESCRIPTION
There are configuration features, that in the background generates additional configuration. They are pretty cool, but sometimes hard to debug as a user.

A good example is the `system` source, there is a script to print out what is generated emplace of the `system` source: `modules/system-source/system-expand.sh`

The result is going to be the following: (good luck with that)
```

channel {
    source {
channel {
    source { unix-dgram("/dev/log" so_rcvbuf(8192));
 };
    rewrite { set("${.unix.pid}" value("PID") condition("${.unix.pid}" ne "")); };
};
file("/dev/kmsg" program-override("kernel") flags(kernel) format(linux-kmsg) keep-timestamp(no));
    }; # source
channel {
  channel {
    parser {
       
channel {
    junction {
    };
}
;
       
channel {
    junction {
channel {
    parser {  json-parser(prefix('.cim.') marker('@cim:'));  };
    rewrite { set-tag('.app.cim'); };
    flags(final);
};
channel {
    filter {  facility(kern) and
                 program("kernel" type(string)) and
                 message("PROTO=" type(string) flags(substring));  };
    parser {  
	kv-parser(prefix('.iptables.'));
;  };
    rewrite { set-tag('.app.iptables'); };
    flags(final);
};
channel {
    filter {  program("sudo" type(string));  };
    parser {  
    channel {
        parser {
            kv-parser(prefix('.sudo.') pair-separator(';') extract-stray-words-into('0'));
            csv-parser(columns(".sudo.SUBJECT") template("$(list-head $0)") delimiters(' '));
        };
	# drop everything which does not have a command (to exclude pam
	# related logs)
        filter { not match("" value(".sudo.COMMAND") type(string)); };
    };
;  };
    rewrite { set-tag('.app.sudo'); };
    flags(final);
};
    };
}
;
    };
    flags(final);
  };
  channel { flags(final); };
};
}; # channel
;
```
This modification actually decorates with **Start** and **End** in case of generated configuration, so it helps to identify the origin of the lines:

The above example after the patch:
```## system() expands to:

#Start Block source generator system
channel {
    source {
channel {
    source { unix-dgram("/dev/log" so_rcvbuf(8192));
 };
    rewrite { set("${.unix.pid}" value("PID") condition("${.unix.pid}" ne "")); };
};
file("/dev/kmsg" program-override("kernel") flags(kernel) format(linux-kmsg) keep-timestamp(no));
    }; # source
channel {
  channel {
    parser {
       
#Start Block parser generator app-parser
channel {
    junction {
    };
}
#End Block parser generator app-parser
;
       
#Start Block parser generator app-parser
channel {
    junction {
#Start Application cim
channel {
    parser {  json-parser(prefix('.cim.') marker('@cim:'));  };
    rewrite { set-tag('.app.cim'); };
    flags(final);
};
#End Application cim
#Start Application iptables
channel {
    filter {  facility(kern) and
                 program("kernel" type(string)) and
                 message("PROTO=" type(string) flags(substring));  };
    parser {  
#Start Block block parser iptables-parser() at /tmp/install/share/syslog-ng/include/scl/iptables/iptables.conf:23
	kv-parser(prefix('.iptables.'));
#End Block block parser iptables-parser() at /tmp/install/share/syslog-ng/include/scl/iptables/iptables.conf:23
;  };
    rewrite { set-tag('.app.iptables'); };
    flags(final);
};
#End Application iptables
#Start Application sudo
channel {
    filter {  program("sudo" type(string));  };
    parser {  
#Start Block block parser sudo-parser() at /tmp/install/share/syslog-ng/include/scl/sudo/sudo.conf:23
    channel {
        parser {
            kv-parser(prefix('.sudo.') pair-separator(';') extract-stray-words-into('0'));
            csv-parser(columns(".sudo.SUBJECT") template("$(list-head $0)") delimiters(' '));
        };
	# drop everything which does not have a command (to exclude pam
	# related logs)
        filter { not match("" value(".sudo.COMMAND") type(string)); };
    };
#End Block block parser sudo-parser() at /tmp/install/share/syslog-ng/include/scl/sudo/sudo.conf:23
;  };
    rewrite { set-tag('.app.sudo'); };
    flags(final);
};
#End Application sudo
    };
}
#End Block parser generator app-parser
;
    };
    flags(final);
  };
  channel { flags(final); };
};
}; # channel
#End Block source generator system
;
```
