### PR TITLE
debugger: fix template function evaluation

### DIFF
--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -25,6 +25,7 @@
 #include "debugger/tracer.h"
 #include "logmsg/logmsg.h"
 #include "logpipe.h"
+#include "apphook.h"
 #include "mainloop.h"
 
 #include <stdio.h>
@@ -315,6 +316,7 @@ _handle_interactive_prompt(Debugger *self)
 static gpointer
 _interactive_console_thread_func(Debugger *self)
 {
+  app_thread_start();
   printf("Waiting for breakpoint...\n");
   while (1)
     {
@@ -323,6 +325,7 @@ _interactive_console_thread_func(Debugger *self)
       _handle_interactive_prompt(self);
       tracer_resume_after_breakpoint(self->tracer);
     }
+  app_thread_stop();
   return NULL;
 }
 


### PR DESCRIPTION
The debugger runs in its dedicated thread, so we need to initialize it
as a thread so stuff like template function evaluation works, since
it depends on scratch buffers.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>