### PR TITLE
Base64 encoding template function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,7 @@ script:
       {
         S=$?;
         make V=1 distcheck;
-        find . -name test-suite.log |
-        xargs cat;
+        find . -name test-suite.log | xargs cat;
         return $S;
       };
       find . -name test-suite.log | xargs cat;

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -106,6 +106,7 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "urlencode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "url-encode"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_base64encode, "base64-encode")
 };
 
 gboolean

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -104,7 +104,8 @@ static Plugin basicfuncs_plugins[] =
   /* misc funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_env, "env"),
   TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
-  TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "urlencode")
+  TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "urlencode"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "url-encode"),
 };
 
 gboolean

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -184,6 +184,18 @@ Test(basicfuncs, test_str_funcs)
   assert_template_format("$(binary 1 0x1)", "\1\1");
   assert_template_format("$(binary 0xFF 255 0377)", "\xFF\xFF\xFF");
   assert_template_format_with_len("$(binary 0xFF 0x00 0x40)", "\xFF\000@", 3);
+
+  assert_template_format("[$(base64-encode)]", "[]");
+  assert_template_format("[$(base64-encode abc)]", "[YWJj]");
+  assert_template_format("[$(base64-encode abcxyz)]", "[YWJjeHl6]");
+  assert_template_format("[$(base64-encode abcd)]", "[YWJjZA==]");
+  assert_template_format("[$(base64-encode abcdabcdabcdabcd)]", "[YWJjZGFiY2RhYmNkYWJjZA==]");
+  assert_template_format("[$(base64-encode abcd abcd abcd abcd)]", "[YWJjZGFiY2RhYmNkYWJjZA==]");
+  assert_template_format("[$(base64-encode 'X X')]", "[WCBY]");
+  assert_template_format("[$(base64-encode xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)]",
+                         "[eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+                         "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+                         "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=]");
 }
 
 Test(basicfuncs, test_numeric_funcs)


### PR DESCRIPTION
This patch adds $(base-encode ...) template function, which encodes
the concatenated arguments using base64. No delimiters are added
between strings, so:
    
$(base64-encode foo bar) would encode "foobar".

Originally contributed by Ferenc Sipos <ferenc.sipos@oneidentity.com>
