### PR TITLE
early-ack-tracker: do not wakeup source when the ack type is SUSPENDED

### DIFF
--- a/lib/early_ack_tracker.c
+++ b/lib/early_ack_tracker.c
@@ -61,10 +61,10 @@ early_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_typ
 {
   EarlyAckTracker *self = (EarlyAckTracker *)s;
 
+  log_source_flow_control_adjust(self->super.source, 1);
+
   if (ack_type == AT_SUSPENDED)
     log_source_flow_control_suspend(self->super.source);
-
-  log_source_flow_control_adjust(self->super.source, 1);
 
   log_msg_unref(msg);
   log_pipe_unref((LogPipe *)self->super.source);


### PR DESCRIPTION
Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>