### PR TITLE
Use msg_trace() when emitting trace information

### DIFF
--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -49,7 +49,7 @@ filter_call_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     stats_counter_inc(self->super.not_matched);
 
-  msg_debug("filter() evaluation started",
+  msg_trace("filter() evaluation started",
             evt_tag_str("called-rule", self->rule),
             evt_tag_printf("msg", "%p", msgs[num_msg - 1]));
 

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -85,7 +85,7 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       result = self->cmp_op & FCMP_GT || self->cmp_op == 0;
     }
 
-  msg_debug("cmp() evaluation started",
+  msg_trace("cmp() evaluation started",
             evt_tag_str("left", left_buf->str),
             evt_tag_str("operator", self->super.type),
             evt_tag_str("right", right_buf->str),

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -50,7 +50,7 @@ filter_in_list_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   APPEND_ZERO(value, value, len);
 
   gboolean result = (g_tree_lookup(self->tree, value) != NULL);
-  msg_debug("in-list() evaluation started",
+  msg_trace("in-list() evaluation started",
             evt_tag_str("value", value),
             evt_tag_printf("msg", "%p", msg));
 

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -63,7 +63,7 @@ filter_netmask_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     res = FALSE;
 
-  msg_debug("netmask() evaluation started",
+  msg_trace("netmask() evaluation started",
             evt_tag_inaddr("msg_address", addr),
             evt_tag_inaddr("address", &self->address),
             evt_tag_inaddr("netmask", &self->netmask),

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -128,7 +128,7 @@ _eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
   else
     result = FALSE;
 
-  msg_debug("netmask6() evaluation started",
+  msg_trace("netmask6() evaluation started",
             evt_tag_inaddr6("msg_address", address),
             evt_tag_inaddr6("address", &self->address),
             evt_tag_int("prefix", self->prefix),

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -56,7 +56,7 @@ log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   gboolean res;
   gchar *filter_result;
 
-  msg_debug(">>>>>> filter rule evaluation begin",
+  msg_trace(">>>>>> filter rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
@@ -77,7 +77,7 @@ log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
       log_msg_drop(msg, path_options, AT_PROCESSED);
       stats_counter_inc(self->not_matched);
     }
-  msg_debug("<<<<<< filter rule evaluation result",
+  msg_trace("<<<<<< filter rule evaluation result",
             evt_tag_str("result", filter_result),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),

--- a/lib/filter/filter-pri.c
+++ b/lib/filter/filter-pri.c
@@ -49,7 +49,7 @@ filter_facility_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
     {
       res = !!(self->valid & (1 << fac_num));
     }
-  msg_debug("facility() evaluation started",
+  msg_trace("facility() evaluation started",
             evt_tag_int("fac", fac_num),
             evt_tag_printf("valid_fac", "%08x", self->valid),
             evt_tag_printf("msg", "%p", msg));
@@ -79,7 +79,7 @@ filter_level_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 
   res = !!((1 << pri) & self->valid);
 
-  msg_debug("level() evaluation started",
+  msg_trace("level() evaluation started",
             evt_tag_int("pri", pri),
             evt_tag_printf("valid_pri", "%08x", self->valid),
             evt_tag_printf("msg", "%p", msg));

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -37,7 +37,7 @@ filter_re_eval_string(FilterExprNode *s, LogMessage *msg, gint value_handle, con
   if (str_len < 0)
     str_len = strlen(str);
   result = log_matcher_match(self->matcher, msg, value_handle, str, str_len);
-  msg_debug("match() evaluation started",
+  msg_trace("match() evaluation started",
             evt_tag_str("input", str),
             evt_tag_str("pattern", self->matcher->pattern),
             evt_tag_str("value", log_msg_get_value_name(value_handle, NULL)),

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -46,7 +46,7 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
       if (log_msg_is_tag_by_id(msg, tag_id))
         {
           res = TRUE;
-          msg_debug("tags() evaluation started",
+          msg_trace("tags() evaluation started",
                     evt_tag_str("tag", log_tags_get_by_id(tag_id)),
                     evt_tag_printf("msg", "%p", msg));
           return res ^ s->comp;
@@ -54,7 +54,7 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
     }
 
   res = FALSE;
-  msg_debug("tags() evaluation started",
+  msg_trace("tags() evaluation started",
             evt_tag_printf("msg", "%p", msg));
   return res ^ s->comp;
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -523,7 +523,7 @@ log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *value, gssize 
 
   if (_log_name_value_updates(self))
     {
-      msg_debug("Setting value",
+      msg_trace("Setting value",
                 evt_tag_str("name", name),
                 evt_tag_printf("value", "%.*s", (gint) value_len, value),
                 evt_tag_printf("msg", "%p", self));
@@ -599,7 +599,7 @@ log_msg_set_value_indirect(LogMessage *self, NVHandle handle, NVHandle ref_handl
 
   if (_log_name_value_updates(self))
     {
-      msg_debug("Setting indirect value",
+      msg_trace("Setting indirect value",
                 evt_tag_printf("msg", "%p", self),
                 evt_tag_str("name", name),
                 evt_tag_int("ref_handle", ref_handle),
@@ -1275,7 +1275,7 @@ log_msg_new(const gchar *msg, gint length,
 
   if (G_LIKELY(parse_options->format_handler))
     {
-      msg_debug("Initial message parsing follows");
+      msg_trace("Initial message parsing follows");
       parse_options->format_handler->parse(parse_options, (guchar *) msg, length, self);
     }
   else

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -351,11 +351,8 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 
       local_path_options.flow_control_requested = 1;
       path_options = &local_path_options;
-      if (G_UNLIKELY(debug_flag))
-        {
-          msg_debug("Requesting flow control",
-                    log_pipe_location_tag(s));
-        }
+
+      msg_debug("Requesting flow control", log_pipe_location_tag(s));
     }
 
   if (s->queue)

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -58,7 +58,7 @@ _flow_control_window_size_adjust(LogSource *self, guint32 window_size_increment,
   gboolean suspended;
   gsize old_window_size = window_size_counter_add(&self->window_size, window_size_increment, &suspended);
 
-  msg_debug("Window size adjustment",
+  msg_trace("Window size adjustment",
             evt_tag_int("old_window_size", old_window_size),
             evt_tag_int("window_size_increment", window_size_increment),
             evt_tag_str("suspended_before_increment", suspended ? "TRUE" : "FALSE"),
@@ -351,7 +351,7 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   LogSource *self = (LogSource *) s;
   gint i;
 
-  msg_debug(">>>>>> Source side message processing begin",
+  msg_trace(">>>>>> Source side message processing begin",
             evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
@@ -416,7 +416,7 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       ts.tv_nsec = self->window_full_sleep_nsec;
       nanosleep(&ts, NULL);
     }
-  msg_debug("<<<<<< Source side message processing finish",
+  msg_trace("<<<<<< Source side message processing finish",
             evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -99,16 +99,12 @@ void msg_add_option_group(GOptionContext *ctx);
             msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
   } while (0)
 
-#if SYSLOG_NG_ENABLE_DEBUG
 #define msg_trace(desc, tags...)              \
   do {                    \
     if (G_UNLIKELY(trace_flag))                     \
-            msg_event_suppress_recursions_and_send(                               \
-                  msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
+      msg_event_suppress_recursions_and_send(                               \
+            msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
   } while (0)
-#else
-#define msg_trace(desc, tags...)
-#endif
 
 #define __once()          \
         ({            \

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -83,7 +83,7 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   gboolean success;
   gchar *parser_result;
 
-  msg_debug(">>>>>> parser rule evaluation begin",
+  msg_trace(">>>>>> parser rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
@@ -102,7 +102,7 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
         (*path_options->matched) = FALSE;
       log_msg_drop(msg, path_options, AT_PROCESSED);
     }
-  msg_debug("<<<<<< parser rule evaluation result",
+  msg_trace("<<<<<< parser rule evaluation result",
             evt_tag_str("result", parser_result),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),

--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -37,13 +37,13 @@ log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_option
 {
   LogRewrite *self = (LogRewrite *) s;
 
-  msg_debug(">>>>>> rewrite rule evaluation begin",
+  msg_trace(">>>>>> rewrite rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
   if (self->condition && !filter_expr_eval_root(self->condition, &msg, path_options))
     {
-      msg_debug("Rewrite condition unmatched, skipping rewrite",
+      msg_trace("Rewrite condition unmatched, skipping rewrite",
                 evt_tag_str("value", log_msg_get_value_name(self->value_handle, NULL)),
                 evt_tag_str("rule", self->name),
                 log_pipe_location_tag(s),
@@ -53,7 +53,7 @@ log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_option
     {
       self->process(self, &msg, path_options);
     }
-  msg_debug("<<<<<< rewrite rule evaluation finished",
+  msg_trace("<<<<<< rewrite rule evaluation finished",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -126,7 +126,7 @@ _process(LogParser *s, LogMessage **pmsg,
 {
   AddContextualData *self = (AddContextualData *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("add-contextual-data message processing started",
+  msg_trace("add-contextual-data message processing started",
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
   gchar *resolved_selector = add_contextual_data_selector_resolve(self->selector, msg);

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -125,7 +125,7 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
   CSVParser *self = (CSVParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
 
-  msg_debug("csv-parser message processing started",
+  msg_trace("csv-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
             evt_tag_printf("msg", "%p", *pmsg));

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -183,7 +183,7 @@ date_parser_process(LogParser *s,
 {
   DateParser *self = (DateParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("date-parser message processing started",
+  msg_trace("date-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("format", self->date_format),
             evt_tag_printf("msg", "%p", *pmsg));

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -209,7 +209,7 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   if (self->db)
     {
       log_msg_make_writable(pmsg, path_options);
-      msg_debug("db-parser message processing started",
+      msg_trace("db-parser message processing started",
                 evt_tag_str ("input", input),
                 evt_tag_printf("msg", "%p", *pmsg));
       if (G_UNLIKELY(self->super.super.template))

--- a/modules/geoip/geoip-parser.c
+++ b/modules/geoip/geoip-parser.c
@@ -126,7 +126,7 @@ geoip_parser_process(LogParser *s, LogMessage **pmsg,
 {
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("geoip-parser message processing started",
+  msg_trace("geoip-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
             evt_tag_printf("msg", "%p", *pmsg));

--- a/modules/geoip2/geoip-parser.c
+++ b/modules/geoip2/geoip-parser.c
@@ -96,7 +96,7 @@ maxminddb_parser_process(LogParser *s, LogMessage **pmsg,
 {
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("geoip2-parser message processing started",
+  msg_trace("geoip2-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
             evt_tag_printf("msg", "%p", *pmsg));

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -147,7 +147,7 @@ void _http_trace_sanitize_dump(const gchar *text, gchar *data, size_t size)
       sanitized[i] = g_ascii_isprint(data[i]) ? data[i] : '.';
     }
   sanitized[i] = 0;
-  msg_debug("curl trace log",
+  msg_trace("curl trace log",
             evt_tag_str("curl_info_type", text),
             evt_tag_str("data", sanitized));
   g_free(sanitized);
@@ -169,7 +169,7 @@ gint _http_trace(CURL *handle, curl_infotype type,
                  char *data, size_t size,
                  void *userp)
 {
-  if (!G_UNLIKELY(debug_flag))
+  if (!G_UNLIKELY(trace_flag))
     return 0;
 
   g_assert(type < sizeof(curl_infotype_to_text)/sizeof(curl_infotype_to_text[0]));

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -215,7 +215,7 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   struct json_object *jso;
   struct json_tokener *tok;
 
-  msg_debug("json-parser message processing started",
+  msg_trace("json-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
             evt_tag_str ("marker", self->marker),

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -110,7 +110,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
   GString *formatted_key = scratch_buffers_alloc();
 
   log_msg_make_writable(pmsg, path_options);
-  msg_debug("kv-parser message processing started",
+  msg_trace("kv-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
             evt_tag_printf("msg", "%p", *pmsg));

--- a/modules/map-value-pairs/map-value-pairs.c
+++ b/modules/map-value-pairs/map-value-pairs.c
@@ -41,7 +41,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
   MapValuePairs *self = (MapValuePairs *) s;
   GlobalConfig *cfg = log_pipe_get_config(&s->super);
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("value-pairs message processing started",
+  msg_trace("value-pairs message processing started",
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -182,7 +182,7 @@ python_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   {
     LogMessage *msg = log_msg_make_writable(pmsg, path_options);
 
-    msg_debug("python-parser message processing started",
+    msg_trace("python-parser message processing started",
               evt_tag_str ("input", input),
               evt_tag_str("parser", self->super.name),
               evt_tag_str("class", self->class),

--- a/modules/snmptrapd-parser/snmptrapd-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-parser.c
@@ -176,7 +176,7 @@ snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *
   ScratchBuffersMarker marker;
 
   log_msg_make_writable(pmsg, path_options);
-  msg_debug("snmptrapd-parser message processing started",
+  msg_trace("snmptrapd-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix->str),
             evt_tag_printf("msg", "%p", *pmsg));

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -32,7 +32,7 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   LogMessage *msg;
 
   msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("syslog-parser message processing started",
+  msg_trace("syslog-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 

--- a/modules/tagsparser/tags-parser.c
+++ b/modules/tagsparser/tags-parser.c
@@ -38,7 +38,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
          gsize input_len)
 {
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("tags-parser message processing started",
+  msg_trace("tags-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -210,7 +210,7 @@ xml_parser_process(LogParser *s, LogMessage **pmsg,
 {
   XMLParser *self = (XMLParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
-  msg_debug("xml-parser message processing started",
+  msg_trace("xml-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
             evt_tag_printf("msg", "%p", *pmsg));


### PR DESCRIPTION
I think our debug log is flooded, so I've opened this PR to
- make it possible to enable trace messages with the `--trace` or `-t` command line flag, even if syslog-ng was not compiled in debug mode
- move frequent, per-message internal messages to the trace log level.

This won't have any performance implications, because we already have 166 debug messages compared to 10 existing trace messages.

My intention is to make our debug logs manageable in case there are more than 10-20 messages passing through syslog-ng. This way we can ask for debug logs from production environments without generating ~15-50 lines of debug information for each incoming message (15 using a trivial configuration, 50 with a non-trivial one).

But of course, when trace is required, it can be enabled without recompiling syslog-ng:
```sh
sbin/syslog-ng -Fdevt
# or
sbin/syslog-ng-ctl --set=1 trace
```

My guidelines I followed:
1. Leave all nonfrequent events on debug level, they are extremely useful.
2. Leave a few frequent (per-message) debug messages that are absolutely necessary for debugging.
   For example: source suspend/wakeup events, incoming/outgoing log entries, destination queue full events, the result of filters/parsers, throttling information, etc.
3. Move all other per-message "trace information" to the trace level.
   For example: starting/ending filters/parsers/rewrites/etc, setting an NV-pair in a message, ... 

Questions:
- **What do you think of the guidelines above?**
- **Please have a look at the output of `git grep msg_debug` and `git grep msg_trace` executed on my branch. Do you agree with those changes?**