### PR TITLE
 scl: add linux-audit() SCL to make files

### DIFF
--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SCL_DIRS
     hdfs
     iptables
     kafka
+    linux-audit
     loadbalancer
     loggly
     logmatic

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -10,6 +10,7 @@ SCL_SUBDIRS	= \
 	hdfs		\
 	iptables	\
 	kafka		\
+	linux-audit	\
 	loadbalancer	\
 	loggly		\
 	logmatic	\


### PR DESCRIPTION
"Oops!... I Did It Again"
This commit fixes https://github.com/balabit/syslog-ng/pull/2186
where I added a new SCL without adding it to make files. With
this fix the linux-audit SCL is included in the release tgz.

Signed-off-by: Peter Czanik <peter@czanik.hu>