### PR TITLE
dbld/images/centos7: add pip update to the dockerfile

### DIFF
--- a/dbld/images/centos7.dockerfile
+++ b/dbld/images/centos7.dockerfile
@@ -14,9 +14,11 @@ RUN yum install -y \
   python-pip \
   python-setuptools
 
+RUN pip install --upgrade pip
+
+
 COPY required-pip/all.txt required-pip/${DISTRO}*.txt /required-pip/
 RUN cat /required-pip/* | grep -v '^$\|^#' | xargs pip install
-
 
 COPY required-yum/all.txt required-yum/${DISTRO}*.txt /required-yum/
 RUN cat /required-yum/* | grep -v '^$\|^#' | xargs yum install -y


### PR DESCRIPTION
Currently we failed to install the latest versions of pip packages in the centos7 image, because epel has an outdated version from pip.

See #2187 for details. (fixes #2187)