### PR TITLE
Hdfs: disable archive when append-enabled is configured

### DIFF
--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -77,6 +77,11 @@ public class HdfsDestination extends StructuredLogDestination {
         }
         appendEnabled = options.getAppendEnabled();
         archiveDir = options.getArchiveDir();
+        if(appendEnabled && archiveDir != null) {
+            logger.warn("Archiving is not allowed when append-enabled() is configured. "
+                        + "Archiving disabled.");
+            archiveDir = null;
+        }
         return true;
     }
 


### PR DESCRIPTION
Archiving and append are 2 conflicting use cases.
Archiving is for moving closed file to a dir declaring that processing on that file have finished.
If we would allow appending an archived file it would not really be archived.

Originally I suspected a bug when the two options used simultaneously,
however the rename() call from hdfs lib prevents overwriting an existing file.
This patch fixes the current issue of archiving a file once, then using
the original file indefinitely.