### PR TITLE
Fix threaded destination test cases

### DIFF
--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -377,7 +377,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
 }
 
 static inline void
-_assert_batch_size_remains_the_same_accross_retries(TestThreadedDestDriver *self)
+_assert_batch_size_remains_the_same_across_retries(TestThreadedDestDriver *self)
 {
   if (self->super.retries_counter > 0)
     cr_assert(self->super.batch_size == self->prev_flush_size);
@@ -395,7 +395,7 @@ _insert_batched_message_error_drop(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_accross_retries(self);
+  _assert_batch_size_remains_the_same_across_retries(self);
   return WORKER_INSERT_RESULT_ERROR;
 }
 
@@ -405,7 +405,7 @@ _flush_batched_message_error_drop(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_accross_retries(self);
+  _assert_batch_size_remains_the_same_across_retries(self);
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.batch_size == 0)
@@ -466,7 +466,7 @@ _insert_batched_message_error_success(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_accross_retries(self);
+  _assert_batch_size_remains_the_same_across_retries(self);
   return _inject_error_a_few_times(self);
 }
 
@@ -476,7 +476,7 @@ _flush_batched_message_error_success(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_accross_retries(self);
+  _assert_batch_size_remains_the_same_across_retries(self);
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.batch_size == 0)
@@ -540,7 +540,7 @@ _insert_batched_message_not_connected(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_accross_retries(self);
+  _assert_batch_size_remains_the_same_across_retries(self);
   return _inject_not_connected_a_few_times(self);
 }
 
@@ -550,7 +550,7 @@ _flush_batched_message_not_connected(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_accross_retries(self);
+  _assert_batch_size_remains_the_same_across_retries(self);
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.batch_size == 0)

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -377,10 +377,14 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
 }
 
 static inline void
-_assert_batch_size_remains_the_same_across_retries(TestThreadedDestDriver *self)
+_expect_batch_size_remains_the_same_across_retries(TestThreadedDestDriver *self)
 {
   if (self->super.retries_counter > 0)
-    cr_assert(self->super.batch_size == self->prev_flush_size);
+    {
+      cr_expect(self->super.batch_size == self->prev_flush_size,
+                "batch_size has to remain the same across retries, batch_size=%d, prev_flush_size=%d",
+                self->super.batch_size, self->prev_flush_size);
+    }
   else
     self->prev_flush_size = self->super.batch_size;
 }
@@ -395,7 +399,7 @@ _insert_batched_message_error_drop(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_across_retries(self);
+  _expect_batch_size_remains_the_same_across_retries(self);
   return WORKER_INSERT_RESULT_ERROR;
 }
 
@@ -405,7 +409,7 @@ _flush_batched_message_error_drop(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_across_retries(self);
+  _expect_batch_size_remains_the_same_across_retries(self);
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.batch_size == 0)
@@ -466,7 +470,7 @@ _insert_batched_message_error_success(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_across_retries(self);
+  _expect_batch_size_remains_the_same_across_retries(self);
   return _inject_error_a_few_times(self);
 }
 
@@ -476,7 +480,7 @@ _flush_batched_message_error_success(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_across_retries(self);
+  _expect_batch_size_remains_the_same_across_retries(self);
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.batch_size == 0)
@@ -540,7 +544,7 @@ _insert_batched_message_not_connected(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_across_retries(self);
+  _expect_batch_size_remains_the_same_across_retries(self);
   return _inject_not_connected_a_few_times(self);
 }
 
@@ -550,7 +554,7 @@ _flush_batched_message_not_connected(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += self->super.batch_size;
-  _assert_batch_size_remains_the_same_across_retries(self);
+  _expect_batch_size_remains_the_same_across_retries(self);
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.batch_size == 0)

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -657,13 +657,13 @@ Test(logthrdestdrv, test_explicit_ack_accept)
   dd->super.worker.insert = _insert_explicit_acks_message_success;
   dd->super.worker.flush = _flush_explicit_acks_message_success;
 
-  _generate_messages(dd, 10);
-  _spin_for_counter_value(dd->super.queued_messages, 0);
+  _generate_messages_and_wait_for_processing(dd, 10, dd->super.written_messages);
   cr_assert(dd->insert_counter == 10, "%d", dd->insert_counter);
   cr_assert(dd->flush_size == 10);
 
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
+  cr_assert(stats_counter_get(dd->super.queued_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -406,6 +406,11 @@ _flush_batched_message_error_drop(LogThreadedDestDriver *s)
 
   self->flush_size += self->super.batch_size;
   _assert_batch_size_remains_the_same_accross_retries(self);
+
+  /* see the note in logthrdestdrv.c:_perform_flush() */
+  if (self->super.batch_size == 0)
+    return WORKER_INSERT_RESULT_SUCCESS;
+
   return WORKER_INSERT_RESULT_ERROR;
 }
 
@@ -472,6 +477,11 @@ _flush_batched_message_error_success(LogThreadedDestDriver *s)
 
   self->flush_size += self->super.batch_size;
   _assert_batch_size_remains_the_same_accross_retries(self);
+
+  /* see the note in logthrdestdrv.c:_perform_flush() */
+  if (self->super.batch_size == 0)
+    return WORKER_INSERT_RESULT_SUCCESS;
+
   return _inject_error_a_few_times(self);
 }
 
@@ -541,6 +551,11 @@ _flush_batched_message_not_connected(LogThreadedDestDriver *s)
 
   self->flush_size += self->super.batch_size;
   _assert_batch_size_remains_the_same_accross_retries(self);
+
+  /* see the note in logthrdestdrv.c:_perform_flush() */
+  if (self->super.batch_size == 0)
+    return WORKER_INSERT_RESULT_SUCCESS;
+
   return _inject_not_connected_a_few_times(self);
 }
 


### PR DESCRIPTION
1. The queued counter is decremented before calling `insert()` or `flush()`. Therefore, `queued_messages` is not suitable for conditional waiting in `test_explicit_ack_accept`.

2. `flush()` is called after every `_perform_inserts()` even when the batch size is 0.
    Because 3 batch-related test cases check whether the batch size remains the same across retries, `WORKER_INSERT_RESULT_SUCCESS` should be returned from `flush()` in case of an empty batch.
    
Reproduction: 
```sh
while lib/tests/test_logthrdestdrv --filter "logthrdestdrv/when_batched_*"; do :; done
```

From `_perform_flush`:

>  NOTE: earlier we had a condition on only calling flush() if batch_size is non-zero.  This was removed, as the language bindings that were done  _before_ the batching support in LogThreadedDestDriver relies on  flush() being called always, even if WORKER_INSERT_RESULT_SUCCESS is returned, in which case batch_size is already zero at this point.
