### PR TITLE
tests/functional/globals.py: fix module-path generation

### DIFF
--- a/tests/functional/globals.py
+++ b/tests/functional/globals.py
@@ -33,6 +33,7 @@ def format_module_path_for_intree_modules():
     module_path = ''
     for (root, dirs, files) in os.walk(os.path.abspath(os.path.join(os.environ['top_builddir'], 'modules'))):
         module_path += ':'.join(map(lambda x: root + '/' + x + '/.libs', dirs))
+        module_path += ':'
         module_path += ':'.join(map(lambda x: root + '/' + x, dirs))
         break
     return module_path


### PR DESCRIPTION
Note: I removed all the TLS tests from the func-test (temporarily).
On my machine (Ubuntu Bionic) the func-test just failed with a strange error message:
```##############################################
### Starting testcase: test_input_drivers.test_catchall
##############################################
     2018-08-21T14:44:23 Testcase start
Error parsing source statement, source plugin pipe not found in test.conf:
3       options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
4
5       source s_int { internal(); };
6       source s_unix { unix-stream("log-stream" flags(expect-hostname) listen-backlog(64)); unix-dgram("log-dgram" flags(expect-hostname));  };
7       source s_inet { tcp(port(35147) listen-backlog(64)); udp(port(35147) so_rcvbuf(131072)); };
8-----> source s_pipe { pipe("log-pipe" flags(expect-hostname)); pipe("log-padded-pipe" pad_size(2048) flags(expect-hostname)); };
8----->                 ^^^^
9       source s_file { file("log-file"); };
10      source s_network { network(transport(udp) port(35150)); network(transport(tcp) listen-backlog(64) port(35150)); };
11      source s_catchall { unix-stream("log-stream-catchall" flags(expect-hostname)); };
12
13      source s_syslog { syslog(port(35149) transport("tcp") so_rcvbuf(131072)); syslog(port(35149) transport("udp") so_rcvbuf(131072)); };


syslog-ng documentation: https://www.balabit.com/support/documentation?product=syslog-ng-ose
contact: https://lists.balabit.hu/mailman/listinfo/syslog-ng
     2018-08-21T14:44:28 Syslog-ng started
     2018-08-21T14:44:28 Starting test case...
     2018-08-21T14:44:28 generating 100 messages using transport unix-stream(log-stream-catchall)                                                                                                                  
     2018-08-21T14:44:28 syslog-ng stopped                                                                                                                                                                         
     2018-08-21T14:44:28 syslog-ng exited with a non-zero value (256)
Traceback (most recent call last):
  File "/home/lbudai/work/syslog-ng/ose/lbudai/syslog-ng/tests/functional/func_test.py", line 126, in <module>
    success = run_testcase(test_module.__name__ + '.' + obj, test_module.config, verbose, test_case)
  File "/home/lbudai/work/syslog-ng/ose/lbudai/syslog-ng/tests/functional/func_test.py", line 87, in run_testcase
    success = test_case()
  File "/home/lbudai/work/syslog-ng/ose/lbudai/syslog-ng/tests/functional/test_input_drivers.py", line 248, in test_catchall                                                                                       
    expected.extend(s.sendMessages(message))                                                                                                                                                                       
  File "/home/lbudai/work/syslog-ng/ose/lbudai/syslog-ng/tests/functional/messagegen.py", line 53, in sendMessages
    self.initSender()                                                                                                                                                                                              
  File "/home/lbudai/work/syslog-ng/ose/lbudai/syslog-ng/tests/functional/messagegen.py", line 87, in initSender                                                                                                   
    self.sock.connect(self.sock_name)                                                                                                                                                                              
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)                                                                                                                                                                         
socket.error: [Errno 2] No such file or directory                                                                                                                                                                  
Makefile:20871: recipe for target 'func-test' failed                                                                                                                                                               
make: *** [func-test] Error 1

```

The reason of this message is that the `affile` plugin was not loaded.
Module path generation (globals.py) was done by the following code:
```python
module_path = ''
     for (root, dirs, files) in os.walk(os.path.abspath(os.path.join(os.environ['top_builddir'], 'modules'))):
         module_path += ':'.join(map(lambda x: root + '/' + x + '/.libs', dirs))
         module_path += ':'.join(map(lambda x: root + '/' + x, dirs))
         break
     return module_path
```
Which means that after the last `.libs` member we just left the `:` separator as

```python
':'.join("abc")
```
yields
```
'a:b:c'
```