### PR TITLE
msg parameters: remove last NULL parameter from msg_ macros

### DIFF
--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -172,8 +172,7 @@ cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GStri
     {
       msg_warning("Syntax error while resolving backtick references in block",
                   evt_tag_str("block_definition", cfg_block_generator_format_name(s, buf, sizeof(buf))),
-                  evt_tag_str("error", error->message),
-                  NULL);
+                  evt_tag_str("error", error->message));
       g_clear_error(&error);
       return FALSE;
     }

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -123,8 +123,7 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size)
     struct yyguts_t * __yyg = (struct yyguts_t*) yyscanner;		\
                                                                         \
     msg_error("Fatal error in configuration lexer, giving up",		\
-              evt_tag_str("error", msg),				\
-              NULL);							\
+              evt_tag_str("error", msg));							\
     longjmp(__yyg->yyextra_r->fatal_error, 1);				\
   } while(0)
 

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -193,8 +193,7 @@ _increase_file_size(PersistState *self, guint32 new_size)
       msg_error("Can't grow the persist file",
                 evt_tag_int("old_size", self->current_size),
                 evt_tag_int("new_size", new_size),
-                evt_tag_str("error", rc < 0 ? g_strerror(errno) : "short write"),
-                NULL);
+                evt_tag_str("error", rc < 0 ? g_strerror(errno) : "short write"));
       result = FALSE;
     }
   g_free(pad_buffer);
@@ -296,7 +295,7 @@ _alloc_value(PersistState *self, guint32 orig_size, gboolean in_use, guint8 vers
 
   if (!_check_free_space(self, size))
     {
-      msg_error("No more free space exhausted in persist file", NULL);
+      msg_error("No more free space exhausted in persist file");
       return 0;
     }
 

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -247,8 +247,7 @@ plugin_dlopen_module_as_filename(const gchar *module_file_name, const gchar *mod
 
   msg_trace("Trying to open module",
             evt_tag_str("module", module_name),
-            evt_tag_str("filename", module_file_name),
-            NULL);
+            evt_tag_str("filename", module_file_name));
 
   mod = g_module_open(module_file_name, G_MODULE_BIND_LAZY);
   if (!mod)

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -480,8 +480,7 @@ _load_dh_from_file(TLSContext *self, const gchar *dhparam_file)
   if (!_is_dh_valid(dh))
     {
       msg_error("Error setting up TLS session context, invalid DH parameters",
-                evt_tag_str("dhparam_file", dhparam_file),
-                NULL);
+                evt_tag_str("dhparam_file", dhparam_file));
 
       DH_free(dh);
       return NULL;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -585,8 +585,7 @@ qdisk_write_serialized_string_to_file(QDisk *self, GString const *serialized, gi
     {
       msg_error("Error writing in-memory buffer of disk-queue to disk",
                 evt_tag_str("filename", self->filename),
-                evt_tag_error("error"),
-                NULL);
+                evt_tag_error("error"));
       return FALSE;
     }
   return TRUE;

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -52,8 +52,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
     {
       msg_error("$(getent group) failed",
                 evt_tag_str("key", key),
-                evt_tag_error("errno"),
-                NULL);
+                evt_tag_error("errno"));
       g_free(buf);
       return FALSE;
     }
@@ -78,8 +77,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
     {
       msg_error("$(getent group): unknown member",
                 evt_tag_str("key", key),
-                evt_tag_str("member", member_name),
-                NULL);
+                evt_tag_str("member", member_name));
       g_free(buf);
       return FALSE;
     }

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -57,8 +57,7 @@ tf_getent_passwd(gchar *key, gchar *member_name, GString *result)
     {
       msg_error("$(getent passwd) failed",
                 evt_tag_str("key", key),
-                evt_tag_error("errno"),
-                NULL);
+                evt_tag_error("errno"));
       g_free(buf);
       return FALSE;
     }
@@ -83,8 +82,7 @@ tf_getent_passwd(gchar *key, gchar *member_name, GString *result)
     {
       msg_error("$(getent passwd): unknown member",
                 evt_tag_str("key", key),
-                evt_tag_str("member", member_name),
-                NULL);
+                evt_tag_str("member", member_name));
       g_free(buf);
       return FALSE;
     }

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -167,8 +167,7 @@ tf_getent(LogMessage *msg, gint argc, GString *argv[], GString *result)
   if (argc != 2 && argc != 3)
     {
       msg_error("$(getent) takes either two or three arguments",
-                evt_tag_int("argc", argc),
-                NULL);
+                evt_tag_int("argc", argc));
       return FALSE;
     }
 
@@ -176,8 +175,7 @@ tf_getent(LogMessage *msg, gint argc, GString *argv[], GString *result)
   if (!lookup)
     {
       msg_error("Unsupported $(getent) NSS service",
-                evt_tag_str("service", argv[0]->str),
-                NULL);
+                evt_tag_str("service", argv[0]->str));
       return FALSE;
     }
 


### PR DESCRIPTION
msg_* macros put a NULL at the end of parameter list when call msg_event_suppress_recursions_and_send()