### PR TITLE
Do not ship mongo-c-driver with syslog-ng (remove as submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,3 @@
         path = lib/jsonc
         url = https://github.com/json-c/json-c.git
         ignore = dirty
-[submodule "modules/afmongodb/mongo-c-driver"]
-        path = modules/afmongodb/mongo-c-driver
-        url = https://github.com/mongodb/mongo-c-driver.git
-        branch = 1.2.0-dev
-        ignore = dirty

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
       libhiredis-dev
       libivykis-dev
       librabbitmq-dev
+      libmongoc-dev
       libjson0-dev
       libnet1-dev
       libriemann-client-dev
@@ -47,14 +48,10 @@ before_script:
   - if [ "$CC" = "gcc" ]; then
       EXTRA_WARN="--enable-extra-warnings";
     fi
-  - if [ "$CC" = "clang" ]; then
-      DISABLE_MONGODB="--disable-mongodb";
-    fi
   - CONFIGURE_FLAGS="
       CFLAGS=-Werror
       --prefix=$HOME/install/syslog-ng
       --with-ivykis=internal
-      --with-mongoc=internal
       --with-jsonc=system
       --disable-env-wrapper
       --disable-memtrace

--- a/autogen.sh
+++ b/autogen.sh
@@ -25,7 +25,7 @@
 # This script is needed to setup build environment from checked out
 # source tree.
 #
-SUBMODULES="lib/ivykis modules/afmongodb/mongo-c-driver/src/libbson modules/afmongodb/mongo-c-driver lib/jsonc"
+SUBMODULES="lib/ivykis lib/jsonc"
 GIT=`which git`
 
 include_automake_from_dir_if_exists()
@@ -63,8 +63,7 @@ autogen_submodules()
 		echo "Running autogen in '$submod'..."
 		cd "$submod"
 		if [ -x autogen.sh ]; then
-			# NOCONFIGURE needed by mongo-c-driver
-			NOCONFIGURE=1 ./autogen.sh
+			./autogen.sh
 		elif [ -f configure.in ] || [ -f configure.ac ]; then
 			autoreconf -i
 		else
@@ -73,8 +72,6 @@ autogen_submodules()
 		fi
 
 		CONFIGURE_OPTS="--disable-shared --enable-static --with-pic"
-		# kludge needed by make distcheck in mongo-c-driver
-		CONFIGURE_OPTS="$CONFIGURE_OPTS --enable-man-pages --disable-shm-counters --with-libbson=bundled"
 
 		sed -e "s/@__CONFIGURE_OPTS__@/${CONFIGURE_OPTS}/g" ${origdir}/sub-configure.sh >configure.gnu
 		cd "$origdir"

--- a/configure.ac
+++ b/configure.ac
@@ -236,11 +236,6 @@ AC_ARG_ENABLE(mongodb,
 	      [  --enable-mongodb        Enable mongodb destination (default: auto)]
               ,,enable_mongodb="auto")
 
-AC_ARG_WITH(mongoc,
-              [  --with-mongoc=[system/internal/auto/no]
-                                         Link against the system supplied or the built-in mongo-c-driver library. (default: auto)]
-              ,,with_mongoc="internal")
-
 AC_ARG_ENABLE(legacy-mongodb-options,
               [  --enable-legacy-mongodb-options=[yes/no]
                                          Support libmongo-client non-URI MongoDB options. (default: yes)]
@@ -1194,44 +1189,10 @@ else
 fi
 AC_DEFINE_UNQUOTED(ENABLE_LEGACY_MONGODB_OPTIONS, [$enable_legacy_mongodb_options_bit], [Support libmongo-client non-URI MongoDB options])
 
-if test "x$with_mongoc" = "xauto"; then
-  with_mongoc="system"
-  PKG_CHECK_MODULES(LIBMONGO, libmongoc-1.0 >= $LMC_MIN_VERSION,,with_mongoc="auto-internal")
-elif test "x$with_mongoc" = "xsystem"; then
-  PKG_CHECK_MODULES(LIBMONGO, libmongoc-1.0 >= $LMC_MIN_VERSION)
-fi
+PKG_CHECK_MODULES(LIBMONGO, libmongoc-1.0 >= $LMC_MIN_VERSION, with_mongoc="yes", with_mongoc="no")
 
-if test "x$with_mongoc" = "xinternal" || test "x$with_mongoc" = "xauto-internal"; then
-        with_mongoc="internal"
-	if test -f "$srcdir/modules/afmongodb/mongo-c-driver/src/mongoc/mongoc.h"; then
-		AC_CONFIG_SUBDIRS([modules/afmongodb/mongo-c-driver])
-
-		# these can only be used in modules/mongodb as it assumes
-		# the current directory just one below mongo-c-driver
-
-		LIBMONGO_LIBS="\
-			-L\$(top_builddir)/modules/afmongodb/mongo-c-driver \
-			-L\$(top_builddir)/modules/afmongodb/mongo-c-driver/src/libbson \
-			-lmongoc-1.0 -lbson $OPENSSL_LIBS"
-		LIBMONGO_CFLAGS="\
-			-I\$(top_srcdir)/modules/afmongodb/mongo-c-driver/src/mongoc \
-			-I\$(top_srcdir)/modules/afmongodb/mongo-c-driver/src/libbson/src/bson \
-			-I\$(top_builddir)/modules/afmongodb/mongo-c-driver/src/libbson/src/bson \
-			-I\$(top_builddir)/modules/afmongodb/mongo-c-driver/src/mongoc \
-		"
-		LIBMONGO_SUBDIRS="modules/afmongodb/mongo-c-driver"
-		AC_CHECK_LIB(sasl2, prop_get, LIBMONGO_LIBS="$LIBMONGO_LIBS -lsasl2")
-	else
-		AC_MSG_WARN([Internal mongo-c-driver sources not found in modules/afmongodb/mongo-c-driver])
-		with_mongoc="no"
-	fi
-fi
-
-if test "x$with_mongoc" = "xno"; then
-   if test "x$enable_mongodb" = "xyes"; then
-      AC_MSG_ERROR([Could not find mongo-c-driver, and MongoDB support was explicitly enabled.])
-   fi
-   enable_mongodb="no"
+if test "x$with_mongoc" = "xno" && test "x$enable_mongodb" = "xyes"; then
+   AC_MSG_ERROR([Could not find mongo-c-driver, and MongoDB support was explicitly enabled.])
 fi
 
 dnl ***************************************************************************
@@ -1878,7 +1839,6 @@ echo "  Criterion                   : ${with_criterion:=no}"
 echo "  Unit tests                  : ${enable_tests:=no}"
 echo " Submodules:"
 echo "  ivykis                      : $with_ivykis"
-echo "  mongoc                      : $with_mongoc"
 echo "  jsonc                       : $with_jsonc"
 echo " Features:"
 echo "  Forced server mode          : ${enable_forced_server_mode:=yes}"

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -11,6 +11,7 @@ brew "libtool"
 brew "pkg-config"
 brew "ivykis"
 brew "rabbitmq-c"
+brew "mongo-c-driver"
 brew "openssl"
 # brew "pcre"
 

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -1,12 +1,3 @@
-DIST_SUBDIRS 					+= @LIBMONGO_SUBDIRS@
-
-if LIBMONGO_INTERNAL
-CLEAN_SUBDIRS					+= @LIBMONGO_SUBDIRS@
-lmc_EXTRA_DEPS					= @LIBMONGO_SUBDIRS@/libmongoc-1.0.la
-
-$(lmc_EXTRA_DEPS):
-	${MAKE} -C modules/afmongodb/mongo-c-driver
-endif
 
 if ENABLE_MONGODB
 
@@ -50,13 +41,6 @@ modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb: \
 include modules/afmongodb/tests/Makefile.am
 else
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb:
-endif
-
-if LIBMONGO_INTERNAL
-
-EXTRA_DIST					+=	\
-	modules/afmongodb/mongo-c-driver/configure.gnu
-
 endif
 
 BUILT_SOURCES					+=	\


### PR DESCRIPTION
Fixes #2200 
Follow up for #2052