### PR TITLE
Threaded source and fetcher

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,6 +25,7 @@ add_subdirectory(scanner)
 add_subdirectory(str-repr)
 add_subdirectory(eventlog)
 add_subdirectory(secret-storage)
+add_subdirectory(logthrsource)
 
 set(LIB_SUBDIR_HEADERS
     ${COMPAT_HEADERS}
@@ -43,6 +44,7 @@ set(LIB_SUBDIR_HEADERS
     ${LIST_SCANNER_HEADERS}
     ${KV_SCANNER_HEADERS}
     ${STR_REPR_HEADERS}
+    ${LOGTHRSOURCE_HEADERS}
     ${CMAKE_CURRENT_BINARY_DIR}/filter/filter-expr-grammar.h
     ${CMAKE_CURRENT_BINARY_DIR}/rewrite/rewrite-expr-grammar.h
     ${CMAKE_CURRENT_BINARY_DIR}/parser/parser-expr-grammar.h
@@ -231,6 +233,7 @@ set(LIB_SOURCES
     ${VALUE_PAIRS_SOURCES}
     ${SCANNER_SOURCES}
     ${STR_REPR_SOURCES}
+    ${LOGTHRSOURCE_SOURCES}
     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.c
     ${PROJECT_BINARY_DIR}/lib/block-ref-grammar.c
     ${PROJECT_BINARY_DIR}/lib/cfg-lex.c
@@ -335,6 +338,7 @@ install(FILES ${STATS_HEADERS} DESTINATION include/syslog-ng/stats)
 install(FILES ${TEMPLATE_HEADERS} DESTINATION include/syslog-ng/template)
 install(FILES ${TRANSPORT_HEADERS} DESTINATION include/syslog-ng/transport)
 install(FILES ${CSV_SCANNER_HEADERS} DESTINATION include/syslog-ng/scanner/csv-scanner)
+install(FILES ${LOGTHRSOURCE_HEADERS} DESTINATION include/syslog-ng/logthrsource)
 
 set(TOOLS
     merge-grammar.py

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,6 +19,7 @@ include lib/scanner/list-scanner/Makefile.am
 include lib/scanner/kv-scanner/Makefile.am
 include lib/str-repr/Makefile.am
 include lib/secret-storage/Makefile.am
+include lib/logthrsource/Makefile.am
 
 LSNG_RELEASE		= $(shell echo @PACKAGE_VERSION@ | cut -d. -f1,2)
 
@@ -277,7 +278,8 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(debugger_sources)		\
 	$(compat_sources)     		\
 	$(logmsg_sources)		\
-	$(str_repr_sources)
+	$(str_repr_sources)		\
+	$(logthrsource_sources)
 
 lib_libsyslog_ng_la_CFLAGS		= \
 	$(AM_CFLAGS) \

--- a/lib/logthrsource/CMakeLists.txt
+++ b/lib/logthrsource/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(LOGTHRSOURCE_HEADERS
     logthrsource/logthrsourcedrv.h
+    logthrsource/logthrfetcherdrv.h
     PARENT_SCOPE)
 
 set(LOGTHRSOURCE_SOURCES
     logthrsource/logthrsourcedrv.c
+    logthrsource/logthrfetcherdrv.c
     PARENT_SCOPE)
 
 add_test_subdirectory(tests)

--- a/lib/logthrsource/CMakeLists.txt
+++ b/lib/logthrsource/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(LOGTHRSOURCE_HEADERS
+    logthrsource/logthrsourcedrv.h
+    PARENT_SCOPE)
+
+set(LOGTHRSOURCE_SOURCES
+    logthrsource/logthrsourcedrv.c
+    PARENT_SCOPE)
+
+add_test_subdirectory(tests)

--- a/lib/logthrsource/Makefile.am
+++ b/lib/logthrsource/Makefile.am
@@ -1,0 +1,11 @@
+logthrsourceincludedir = ${pkgincludedir}/logthrsource
+
+EXTRA_DIST += lib/logthrsource/CMakeLists.txt
+
+logthrsourceinclude_HEADERS = \
+  lib/logthrsource/logthrsourcedrv.h
+
+logthrsource_sources = \
+  lib/logthrsource/logthrsourcedrv.c
+
+include lib/logthrsource/tests/Makefile.am

--- a/lib/logthrsource/Makefile.am
+++ b/lib/logthrsource/Makefile.am
@@ -3,9 +3,11 @@ logthrsourceincludedir = ${pkgincludedir}/logthrsource
 EXTRA_DIST += lib/logthrsource/CMakeLists.txt
 
 logthrsourceinclude_HEADERS = \
-  lib/logthrsource/logthrsourcedrv.h
+  lib/logthrsource/logthrsourcedrv.h \
+  lib/logthrsource/logthrfetcherdrv.h
 
 logthrsource_sources = \
-  lib/logthrsource/logthrsourcedrv.c
+  lib/logthrsource/logthrsourcedrv.c \
+  lib/logthrsource/logthrfetcherdrv.c
 
 include lib/logthrsource/tests/Makefile.am

--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -267,9 +267,9 @@ log_threaded_fetcher_driver_init_instance(LogThreadedFetcherDriver *self, Global
 
   _init_watches(self);
 
-  log_threaded_source_driver_set_worker_run(&self->super, _worker_run);
-  log_threaded_source_driver_set_worker_request_exit(&self->super, _worker_request_exit);
-  log_threaded_source_set_wakeup(&self->super, _wakeup);
+  log_threaded_source_driver_set_worker_run_func(&self->super, _worker_run);
+  log_threaded_source_driver_set_worker_request_exit_func(&self->super, _worker_request_exit);
+  log_threaded_source_set_wakeup_func(&self->super, _wakeup);
 
   self->super.super.super.super.init = log_threaded_fetcher_driver_init_method;
   self->super.super.super.super.deinit = log_threaded_fetcher_driver_deinit_method;

--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -26,7 +26,7 @@
 #include "messages.h"
 
 static EVTTAG *
-evt_tag_driver(LogThreadedFetcherDriver *f)
+_tag_driver(LogThreadedFetcherDriver *f)
 {
   return evt_tag_str("driver", f->super.super.super.id);
 }
@@ -34,7 +34,7 @@ evt_tag_driver(LogThreadedFetcherDriver *f)
 static inline void
 _thread_init(LogThreadedFetcherDriver *self)
 {
-  msg_trace("Fetcher thread_init()", evt_tag_driver(self));
+  msg_trace("Fetcher thread_init()", _tag_driver(self));
   if (self->thread_init)
     self->thread_init(self);
 }
@@ -42,7 +42,7 @@ _thread_init(LogThreadedFetcherDriver *self)
 static inline void
 _thread_deinit(LogThreadedFetcherDriver *self)
 {
-  msg_trace("Fetcher thread_deinit()", evt_tag_driver(self));
+  msg_trace("Fetcher thread_deinit()", _tag_driver(self));
   if (self->thread_deinit)
     self->thread_deinit(self);
 }
@@ -50,13 +50,13 @@ _thread_deinit(LogThreadedFetcherDriver *self)
 static inline gboolean
 _connect(LogThreadedFetcherDriver *self)
 {
-  msg_trace("Fetcher connect()", evt_tag_driver(self));
+  msg_trace("Fetcher connect()", _tag_driver(self));
   if (!self->connect)
     return TRUE;
 
   if (!self->connect(self))
     {
-      msg_debug("Error establishing connection", evt_tag_driver(self));
+      msg_debug("Error establishing connection", _tag_driver(self));
       return FALSE;
     }
 
@@ -66,7 +66,7 @@ _connect(LogThreadedFetcherDriver *self)
 static inline void
 _disconnect(LogThreadedFetcherDriver *self)
 {
-  msg_trace("Fetcher disconnect()", evt_tag_driver(self));
+  msg_trace("Fetcher disconnect()", _tag_driver(self));
   if (self->disconnect)
     self->disconnect(self);
 }
@@ -138,21 +138,21 @@ _fetch(gpointer data)
 {
   LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) data;
 
-  msg_trace("Fetcher fetch()", evt_tag_driver(self));
+  msg_trace("Fetcher fetch()", _tag_driver(self));
 
   LogThreadedFetchResult fetch_result = self->fetch(self);
 
   switch (fetch_result.result)
     {
     case THREADED_FETCH_ERROR:
-      msg_error("Error during fetching messages", evt_tag_driver(self));
+      msg_error("Error during fetching messages", _tag_driver(self));
       _disconnect(self);
       _start_reconnect_timer(self);
       break;
 
     case THREADED_FETCH_NOT_CONNECTED:
       msg_info("Fetcher disconnected while receiving messages, reconnecting",
-               evt_tag_driver(self));
+               _tag_driver(self));
       _start_reconnect_timer(self);
       break;
 

--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -85,7 +85,7 @@ _worker_run(LogThreadedSourceDriver *s)
 {
   LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) s;
 
-  iv_init();
+  /* iv_init() and iv_deinit() are called by LogThreadedSourceDriver */
 
   iv_event_register(&self->wakeup_event);
   iv_event_register(&self->shutdown_event);
@@ -100,8 +100,6 @@ _worker_run(LogThreadedSourceDriver *s)
 
   _disconnect(self);
   _thread_deinit(self);
-
-  iv_deinit();
 }
 
 static void

--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logthrfetcherdrv.h"
+#include "messages.h"
+
+static EVTTAG *
+evt_tag_driver(LogThreadedFetcherDriver *f)
+{
+  return evt_tag_str("driver", f->super.super.super.id);
+}
+
+static inline void
+_thread_init(LogThreadedFetcherDriver *self)
+{
+  msg_trace("Fetcher thread_init()", evt_tag_driver(self));
+  if (self->thread_init)
+    self->thread_init(self);
+}
+
+static inline void
+_thread_deinit(LogThreadedFetcherDriver *self)
+{
+  msg_trace("Fetcher thread_deinit()", evt_tag_driver(self));
+  if (self->thread_deinit)
+    self->thread_deinit(self);
+}
+
+static inline gboolean
+_connect(LogThreadedFetcherDriver *self)
+{
+  msg_trace("Fetcher connect()", evt_tag_driver(self));
+  if (!self->connect)
+    return TRUE;
+
+  if (!self->connect(self))
+    {
+      msg_debug("Error establishing connection", evt_tag_driver(self));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static inline void
+_disconnect(LogThreadedFetcherDriver *self)
+{
+  msg_trace("Fetcher disconnect()", evt_tag_driver(self));
+  if (self->disconnect)
+    self->disconnect(self);
+}
+
+static void
+_start_reconnect_timer(LogThreadedFetcherDriver *self)
+{
+  iv_validate_now();
+  self->reconnect_timer.expires  = iv_now;
+  self->reconnect_timer.expires.tv_sec += self->time_reopen;
+  iv_timer_register(&self->reconnect_timer);
+}
+
+static void
+_worker_run(LogThreadedSourceDriver *s)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) s;
+
+  iv_init();
+
+  iv_event_register(&self->wakeup_event);
+  iv_event_register(&self->shutdown_event);
+
+  _thread_init(self);
+  if (_connect(self))
+    iv_task_register(&self->fetch_task);
+  else
+    _start_reconnect_timer(self);
+
+  iv_main();
+
+  _disconnect(self);
+  _thread_deinit(self);
+
+  iv_deinit();
+}
+
+static void
+_worker_request_exit(LogThreadedSourceDriver *s)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) s;
+
+  self->under_termination = TRUE;
+
+  iv_event_post(&self->shutdown_event);
+
+  if (self->request_exit)
+    self->request_exit(self);
+}
+
+static void
+_wakeup(LogThreadedSourceDriver *s)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) s;
+
+  if (!self->under_termination)
+    iv_event_post(&self->wakeup_event);
+}
+
+static inline void
+_schedule_next_fetch_if_free_to_send(LogThreadedFetcherDriver *self)
+{
+  if (log_threaded_source_free_to_send(&self->super))
+    iv_task_register(&self->fetch_task);
+}
+
+static void
+_fetch(gpointer data)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) data;
+
+  msg_trace("Fetcher fetch()", evt_tag_driver(self));
+
+  LogThreadedFetchResult fetch_result = self->fetch(self);
+
+  switch (fetch_result.result)
+    {
+    case THREADED_FETCH_ERROR:
+      msg_error("Error during fetching messages", evt_tag_driver(self));
+      _disconnect(self);
+      _start_reconnect_timer(self);
+      break;
+
+    case THREADED_FETCH_NOT_CONNECTED:
+      msg_info("Fetcher disconnected while receiving messages, reconnecting",
+               evt_tag_driver(self));
+      _start_reconnect_timer(self);
+      break;
+
+    case THREADED_FETCH_SUCCESS:
+      log_threaded_source_post(&self->super, fetch_result.msg);
+      _schedule_next_fetch_if_free_to_send(self);
+      break;
+
+    default:
+      g_assert_not_reached();
+    }
+}
+
+static void
+_wakeup_event_handler(gpointer data)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) data;
+
+  if (!iv_task_registered(&self->fetch_task))
+    iv_task_register(&self->fetch_task);
+}
+
+static void
+_stop_watches(LogThreadedFetcherDriver *self)
+{
+  iv_event_unregister(&self->wakeup_event);
+  iv_event_unregister(&self->shutdown_event);
+
+  if (iv_task_registered(&self->fetch_task))
+    iv_task_unregister(&self->fetch_task);
+
+  if (iv_timer_registered(&self->reconnect_timer))
+    iv_timer_unregister(&self->reconnect_timer);
+}
+
+static void
+_shutdown_event_handler(gpointer data)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) data;
+
+  _stop_watches(self);
+
+  iv_quit();
+}
+
+static void
+_reconnect(gpointer data)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) data;
+
+  if (_connect(self))
+    _schedule_next_fetch_if_free_to_send(self);
+  else
+    _start_reconnect_timer(self);
+}
+
+static void
+_init_watches(LogThreadedFetcherDriver *self)
+{
+  IV_TASK_INIT(&self->fetch_task);
+  self->fetch_task.cookie = self;
+  self->fetch_task.handler = _fetch;
+
+  IV_EVENT_INIT(&self->wakeup_event);
+  self->wakeup_event.cookie = self;
+  self->wakeup_event.handler = _wakeup_event_handler;
+
+  IV_EVENT_INIT(&self->shutdown_event);
+  self->shutdown_event.cookie = self;
+  self->shutdown_event.handler = _shutdown_event_handler;
+
+  IV_TIMER_INIT(&self->reconnect_timer);
+  self->reconnect_timer.cookie = self;
+  self->reconnect_timer.handler = _reconnect;
+}
+
+gboolean
+log_threaded_fetcher_driver_init_method(LogPipe *s)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  if (!log_threaded_source_driver_init_method(s))
+    return FALSE;
+
+  g_assert(self->fetch);
+
+  if (cfg && self->time_reopen == -1)
+    self->time_reopen = cfg->time_reopen;
+
+  return TRUE;
+}
+
+gboolean
+log_threaded_fetcher_driver_deinit_method(LogPipe *s)
+{
+  return log_threaded_source_driver_deinit_method(s);
+}
+
+void
+log_threaded_fetcher_driver_free_method(LogPipe *s)
+{
+  log_threaded_source_driver_free_method(s);
+}
+
+void
+log_threaded_fetcher_driver_init_instance(LogThreadedFetcherDriver *self, GlobalConfig *cfg)
+{
+  log_threaded_source_driver_init_instance(&self->super, cfg);
+
+  self->time_reopen = -1;
+
+  _init_watches(self);
+
+  log_threaded_source_driver_set_worker_run(&self->super, _worker_run);
+  log_threaded_source_driver_set_worker_request_exit(&self->super, _worker_request_exit);
+  log_threaded_source_set_wakeup(&self->super, _wakeup);
+
+  self->super.super.super.super.init = log_threaded_fetcher_driver_init_method;
+  self->super.super.super.super.deinit = log_threaded_fetcher_driver_deinit_method;
+  self->super.super.super.super.free_fn = log_threaded_fetcher_driver_free_method;
+}

--- a/lib/logthrsource/logthrfetcherdrv.h
+++ b/lib/logthrsource/logthrfetcherdrv.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LOGTHRFETCHERDRV_H
+#define LOGTHRFETCHERDRV_H
+
+#include "syslog-ng.h"
+#include "logthrsourcedrv.h"
+#include "logmsg/logmsg.h"
+#include "compat/time.h"
+
+#include <iv.h>
+#include <iv_event.h>
+
+typedef struct _LogThreadedFetcherDriver LogThreadedFetcherDriver;
+
+typedef enum
+{
+  THREADED_FETCH_ERROR,
+  THREADED_FETCH_NOT_CONNECTED,
+  THREADED_FETCH_SUCCESS
+} ThreadedFetchResult;
+
+typedef struct _LogThreadedFetchResult
+{
+  ThreadedFetchResult result;
+  LogMessage *msg;
+} LogThreadedFetchResult;
+
+struct _LogThreadedFetcherDriver
+{
+  LogThreadedSourceDriver super;
+  time_t time_reopen;
+  struct iv_task fetch_task;
+  struct iv_event wakeup_event;
+  struct iv_event shutdown_event;
+  struct iv_timer reconnect_timer;
+  gboolean under_termination;
+
+  void (*thread_init)(LogThreadedFetcherDriver *self);
+  void (*thread_deinit)(LogThreadedFetcherDriver *self);
+  gboolean (*connect)(LogThreadedFetcherDriver *self);
+  void (*disconnect)(LogThreadedFetcherDriver *self);
+  LogThreadedFetchResult (*fetch)(LogThreadedFetcherDriver *self);
+
+  void (*request_exit)(LogThreadedFetcherDriver *self);
+};
+
+void log_threaded_fetcher_driver_init_instance(LogThreadedFetcherDriver *self, GlobalConfig *cfg);
+gboolean log_threaded_fetcher_driver_init_method(LogPipe *s);
+gboolean log_threaded_fetcher_driver_deinit_method(LogPipe *s);
+void log_threaded_fetcher_driver_free_method(LogPipe *s);
+
+#endif

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logthrsourcedrv.h"
+#include "mainloop-worker.h"
+#include "messages.h"
+
+typedef struct _WakeupCondition
+{
+  GMutex *lock;
+  GCond *cond;
+  gboolean awoken;
+} WakeupCondition;
+
+struct _LogThreadedSourceWorker
+{
+  LogSource super;
+  LogThreadedSourceDriver *control;
+  WakeupCondition wakeup_cond;
+  WorkerOptions options;
+
+  LogThreadedSourceWorkerRun run;
+  LogThreadedSourceWorkerRequestExit request_exit;
+  LogThreadedSourceWorkerWakeup wakeup;
+};
+
+static LogPipe *
+log_threaded_source_worker_logpipe(LogThreadedSourceWorker *self)
+{
+  return &self->super.super;
+}
+
+static void
+log_threaded_source_worker_set_options(LogThreadedSourceWorker *self, LogThreadedSourceDriver *control,
+                                       LogThreadedSourceWorkerOptions *options,
+                                       const gchar *stats_id, const gchar *stats_instance)
+{
+  /* TODO: support position tracking */
+  log_source_set_options(&self->super, &options->super, stats_id, stats_instance, TRUE, FALSE,
+                         control->super.super.super.expr_node);
+
+  log_pipe_unref(&self->control->super.super.super);
+  log_pipe_ref(&control->super.super.super);
+  self->control = control;
+}
+
+void
+log_threaded_source_worker_options_defaults(LogThreadedSourceWorkerOptions *options)
+{
+  log_source_options_defaults(&options->super);
+}
+
+void
+log_threaded_source_worker_options_init(LogThreadedSourceWorkerOptions *options, GlobalConfig *cfg,
+                                        const gchar *group_name)
+{
+  log_source_options_init(&options->super, cfg, group_name);
+}
+
+void
+log_threaded_source_worker_options_destroy(LogThreadedSourceWorkerOptions *options)
+{
+  log_source_options_destroy(&options->super);
+}
+
+/* The wakeup lock must be held before calling this function. */
+static void
+log_threaded_source_suspend(LogThreadedSourceDriver *self)
+{
+  LogThreadedSourceWorker *worker = self->worker;
+
+  worker->wakeup_cond.awoken = FALSE;
+  while (!worker->wakeup_cond.awoken)
+    g_cond_wait(worker->wakeup_cond.cond, worker->wakeup_cond.lock);
+}
+
+static void
+log_threaded_source_wakeup(LogThreadedSourceDriver *self)
+{
+  LogThreadedSourceWorker *worker = self->worker;
+
+  g_mutex_lock(worker->wakeup_cond.lock);
+  worker->wakeup_cond.awoken = TRUE;
+  g_cond_signal(worker->wakeup_cond.cond);
+  g_mutex_unlock(worker->wakeup_cond.lock);
+}
+
+static void
+log_threaded_source_worker_run(LogThreadedSourceWorker *self)
+{
+  msg_debug("Worker thread started", evt_tag_str("driver", self->control->super.super.id));
+
+  self->run(self->control);
+
+  msg_debug("Worker thread finished", evt_tag_str("driver", self->control->super.super.id));
+}
+
+static void
+log_threaded_source_worker_request_exit(LogThreadedSourceWorker *self)
+{
+  /* TODO force exit after timeout */
+  msg_debug("Requesting worker thread exit", evt_tag_str("driver", self->control->super.super.id));
+  self->request_exit(self->control);
+  log_threaded_source_wakeup(self->control);
+}
+
+static void
+_worker_wakeup(LogSource *s)
+{
+  LogThreadedSourceWorker *self = (LogThreadedSourceWorker *) s;
+
+  self->wakeup(self->control);
+}
+
+static gboolean
+log_threaded_source_worker_init(LogPipe *s)
+{
+  LogThreadedSourceWorker *self = (LogThreadedSourceWorker *) s;
+  if (!log_source_init(s))
+    return FALSE;
+
+  g_assert(self->run);
+  g_assert(self->request_exit);
+
+  main_loop_create_worker_thread((WorkerThreadFunc) log_threaded_source_worker_run,
+                                 (WorkerExitNotificationFunc) log_threaded_source_worker_request_exit,
+                                 self, &self->options);
+
+  return TRUE;
+}
+
+static void
+log_threaded_source_worker_free(LogPipe *s)
+{
+  LogThreadedSourceWorker *self = (LogThreadedSourceWorker *) s;
+
+  g_cond_free(self->wakeup_cond.cond);
+  g_mutex_free(self->wakeup_cond.lock);
+
+  log_pipe_unref(&self->control->super.super.super);
+  self->control = NULL;
+
+  log_source_free(s);
+}
+
+static LogThreadedSourceWorker *
+log_threaded_source_worker_new(GlobalConfig *cfg)
+{
+  LogThreadedSourceWorker *self = g_new0(LogThreadedSourceWorker, 1);
+  log_source_init_instance(&self->super, cfg);
+
+  self->wakeup_cond.lock = g_mutex_new();
+  self->wakeup_cond.cond = g_cond_new();
+
+  self->options.is_external_input = TRUE;
+
+  self->super.super.init = log_threaded_source_worker_init;
+  self->super.super.free_fn = log_threaded_source_worker_free;
+  self->super.wakeup = _worker_wakeup;
+
+  return self;
+}
+
+
+gboolean
+log_threaded_source_driver_init_method(LogPipe *s)
+{
+  LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  if (!log_src_driver_init_method(s))
+    return FALSE;
+
+  g_assert(self->format_stats_instance);
+
+  log_threaded_source_worker_options_init(&self->worker_options, cfg, self->super.super.group);
+  log_threaded_source_worker_set_options(self->worker, self, &self->worker_options,
+                                         self->super.super.id, self->format_stats_instance(self));
+
+  LogPipe *worker_pipe = log_threaded_source_worker_logpipe(self->worker);
+  log_pipe_append(worker_pipe, s);
+  if (!log_pipe_init(worker_pipe))
+    {
+      log_pipe_unref(worker_pipe);
+      self->worker = NULL;
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
+log_threaded_source_driver_deinit_method(LogPipe *s)
+{
+  LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
+  LogPipe *worker_pipe = log_threaded_source_worker_logpipe(self->worker);
+
+  log_pipe_deinit(worker_pipe);
+  log_pipe_unref(worker_pipe);
+
+  return log_src_driver_deinit_method(s);
+}
+
+void
+log_threaded_source_driver_free_method(LogPipe *s)
+{
+  LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
+
+  log_threaded_source_worker_options_destroy(&self->worker_options);
+
+  log_src_driver_free(s);
+}
+
+void
+log_threaded_source_driver_set_worker_run(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRun run)
+{
+  self->worker->run = run;
+}
+
+void
+log_threaded_source_driver_set_worker_request_exit(LogThreadedSourceDriver *self,
+                                                   LogThreadedSourceWorkerRequestExit request_exit)
+{
+  self->worker->request_exit = request_exit;
+}
+
+LogSource *
+_log_threaded_source_driver_get_source(LogThreadedSourceDriver *self)
+{
+  return &self->worker->super;
+}
+
+void
+log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeup wakeup)
+{
+  self->worker->wakeup = wakeup;
+}
+
+void
+log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg)
+{
+  msg_debug("Incoming log message", evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)));
+
+  /*
+   * TODO: offload (main_loop_io_worker_job_submit)
+   *
+   * In this case, we should modify or split log_source_post(), because
+   * free_to_send() has to be called before log_pipe_queue() but after
+   * decrementing the window.
+   */
+  log_source_post(&self->worker->super, msg);
+}
+
+gboolean
+log_threaded_source_free_to_send(LogThreadedSourceDriver *self)
+{
+  return log_source_free_to_send(&self->worker->super);
+}
+
+void
+log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg)
+{
+  LogThreadedSourceWorker *worker = self->worker;
+
+  log_threaded_source_post(self, msg);
+
+  /*
+   * The wakeup lock must be held before calling free_to_send() and suspend(),
+   * otherwise g_cond_signal() might be called between free_to_send() and
+   * suspend(). We'd hang in that case.
+   *
+   * LogReader does not have such a lock, but this is because it runs an ivykis
+   * loop with a _synchronized_ event queue, where suspend() and the
+   * "schedule_wakeup" event are guaranteed to be scheduled in the right order.
+   */
+
+  g_mutex_lock(worker->wakeup_cond.lock);
+  if (!log_threaded_source_free_to_send(self))
+    log_threaded_source_suspend(self);
+  g_mutex_unlock(worker->wakeup_cond.lock);
+}
+
+void
+log_threaded_source_driver_init_instance(LogThreadedSourceDriver *self, GlobalConfig *cfg)
+{
+  log_src_driver_init_instance(&self->super, cfg);
+
+  log_threaded_source_worker_options_defaults(&self->worker_options);
+
+  self->worker = log_threaded_source_worker_new(cfg);
+  self->worker->wakeup = log_threaded_source_wakeup;
+
+  self->super.super.super.init = log_threaded_source_driver_init_method;
+  self->super.super.super.deinit = log_threaded_source_driver_deinit_method;
+  self->super.super.super.free_fn = log_threaded_source_driver_free_method;
+}

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -41,9 +41,9 @@ struct _LogThreadedSourceWorker
   WakeupCondition wakeup_cond;
   WorkerOptions options;
 
-  LogThreadedSourceWorkerRun run;
-  LogThreadedSourceWorkerRequestExit request_exit;
-  LogThreadedSourceWorkerWakeup wakeup;
+  LogThreadedSourceWorkerRunFunc run;
+  LogThreadedSourceWorkerRequestExitFunc request_exit;
+  LogThreadedSourceWorkerWakeupFunc wakeup;
 };
 
 static LogPipe *
@@ -243,20 +243,20 @@ log_threaded_source_driver_free_method(LogPipe *s)
 }
 
 void
-log_threaded_source_driver_set_worker_run(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRun run)
+log_threaded_source_driver_set_worker_run_func(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRunFunc run)
 {
   self->worker->run = run;
 }
 
 void
-log_threaded_source_driver_set_worker_request_exit(LogThreadedSourceDriver *self,
-                                                   LogThreadedSourceWorkerRequestExit request_exit)
+log_threaded_source_driver_set_worker_request_exit_func(LogThreadedSourceDriver *self,
+                                                        LogThreadedSourceWorkerRequestExitFunc request_exit)
 {
   self->worker->request_exit = request_exit;
 }
 
 void
-log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeup wakeup)
+log_threaded_source_set_wakeup_func(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeupFunc wakeup)
 {
   self->worker->wakeup = wakeup;
 }

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -27,6 +27,8 @@
 #include "messages.h"
 #include "apphook.h"
 
+#include <iv.h>
+
 typedef struct _WakeupCondition
 {
   GMutex *lock;
@@ -152,7 +154,12 @@ log_threaded_source_worker_run(LogThreadedSourceWorker *self)
 {
   msg_debug("Worker thread started", evt_tag_str("driver", self->control->super.super.id));
 
+  /* ivykis is not used here, but mark-freq() requires all source threads to be iv-initialized. */
+  iv_init();
+
   self->run(self->control);
+
+  iv_deinit();
 
   msg_debug("Worker thread finished", evt_tag_str("driver", self->control->super.super.id));
 }

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -120,7 +120,6 @@ log_threaded_source_worker_run(LogThreadedSourceWorker *self)
 static void
 log_threaded_source_worker_request_exit(LogThreadedSourceWorker *self)
 {
-  /* TODO force exit after timeout */
   msg_debug("Requesting worker thread exit", evt_tag_str("driver", self->control->super.super.id));
   self->request_exit(self->control);
   log_threaded_source_wakeup(self->control);

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -255,12 +255,6 @@ log_threaded_source_driver_set_worker_request_exit(LogThreadedSourceDriver *self
   self->worker->request_exit = request_exit;
 }
 
-LogSource *
-_log_threaded_source_driver_get_source(LogThreadedSourceDriver *self)
-{
-  return &self->worker->super;
-}
-
 void
 log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeup wakeup)
 {

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -63,19 +63,16 @@ gboolean log_threaded_source_driver_init_method(LogPipe *s);
 gboolean log_threaded_source_driver_deinit_method(LogPipe *s);
 void log_threaded_source_driver_free_method(LogPipe *s);
 
-void log_threaded_source_driver_set_worker_run(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRun run);
+void log_threaded_source_driver_set_worker_run(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRunFunc run);
 void log_threaded_source_driver_set_worker_request_exit(LogThreadedSourceDriver *self,
-                                                        LogThreadedSourceWorkerRequestExit request_exit);
+                                                        LogThreadedSourceWorkerRequestExitFunc request_exit);
 
 /* blocking API */
 void log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg);
 
 /* non-blocking API, use it wisely (thread boundaries) */
-void log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeup wakeup);
+void log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeupFunc wakeup);
 void log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg);
 gboolean log_threaded_source_free_to_send(LogThreadedSourceDriver *self);
-
-/* for testing */
-LogSource *_log_threaded_source_driver_get_source(LogThreadedSourceDriver *self);
 
 #endif

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LOGTHRSOURCEDRV_H
+#define LOGTHRSOURCEDRV_H
+
+#include "syslog-ng.h"
+#include "driver.h"
+#include "logsource.h"
+#include "cfg.h"
+#include "logpipe.h"
+#include "logmsg/logmsg.h"
+
+typedef struct _LogThreadedSourceDriver LogThreadedSourceDriver;
+typedef struct _LogThreadedSourceWorker LogThreadedSourceWorker;
+
+typedef void (*LogThreadedSourceWorkerRun)(LogThreadedSourceDriver *);
+typedef void (*LogThreadedSourceWorkerRequestExit)(LogThreadedSourceDriver *);
+typedef void (*LogThreadedSourceWorkerWakeup)(LogThreadedSourceDriver *);
+
+typedef struct _LogThreadedSourceWorkerOptions
+{
+  LogSourceOptions super;
+} LogThreadedSourceWorkerOptions;
+
+struct _LogThreadedSourceDriver
+{
+  LogSrcDriver super;
+  LogThreadedSourceWorkerOptions worker_options;
+  LogThreadedSourceWorker *worker;
+
+  const gchar *(*format_stats_instance)(LogThreadedSourceDriver *self);
+};
+
+void log_threaded_source_worker_options_defaults(LogThreadedSourceWorkerOptions *options);
+void log_threaded_source_worker_options_init(LogThreadedSourceWorkerOptions *options, GlobalConfig *cfg,
+                                             const gchar *group_name);
+void log_threaded_source_worker_options_destroy(LogThreadedSourceWorkerOptions *options);
+
+void log_threaded_source_driver_init_instance(LogThreadedSourceDriver *self, GlobalConfig *cfg);
+gboolean log_threaded_source_driver_init_method(LogPipe *s);
+gboolean log_threaded_source_driver_deinit_method(LogPipe *s);
+void log_threaded_source_driver_free_method(LogPipe *s);
+
+void log_threaded_source_driver_set_worker_run(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRun run);
+void log_threaded_source_driver_set_worker_request_exit(LogThreadedSourceDriver *self,
+                                                        LogThreadedSourceWorkerRequestExit request_exit);
+
+/* blocking API */
+void log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg);
+
+/* non-blocking API, use it wisely (thread boundaries) */
+void log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeup wakeup);
+void log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg);
+gboolean log_threaded_source_free_to_send(LogThreadedSourceDriver *self);
+
+/* for testing */
+LogSource *_log_threaded_source_driver_get_source(LogThreadedSourceDriver *self);
+
+#endif

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -67,6 +67,14 @@ void log_threaded_source_driver_set_worker_run_func(LogThreadedSourceDriver *sel
 void log_threaded_source_driver_set_worker_request_exit_func(LogThreadedSourceDriver *self,
     LogThreadedSourceWorkerRequestExitFunc request_exit);
 
+static inline LogSourceOptions *
+log_threaded_source_driver_get_source_options(LogDriver *s)
+{
+  LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
+
+  return &self->worker_options.super;
+}
+
 /* blocking API */
 void log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg);
 

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -35,9 +35,9 @@
 typedef struct _LogThreadedSourceDriver LogThreadedSourceDriver;
 typedef struct _LogThreadedSourceWorker LogThreadedSourceWorker;
 
-typedef void (*LogThreadedSourceWorkerRun)(LogThreadedSourceDriver *);
-typedef void (*LogThreadedSourceWorkerRequestExit)(LogThreadedSourceDriver *);
-typedef void (*LogThreadedSourceWorkerWakeup)(LogThreadedSourceDriver *);
+typedef void (*LogThreadedSourceWorkerRunFunc)(LogThreadedSourceDriver *);
+typedef void (*LogThreadedSourceWorkerRequestExitFunc)(LogThreadedSourceDriver *);
+typedef void (*LogThreadedSourceWorkerWakeupFunc)(LogThreadedSourceDriver *);
 
 typedef struct _LogThreadedSourceWorkerOptions
 {
@@ -63,15 +63,15 @@ gboolean log_threaded_source_driver_init_method(LogPipe *s);
 gboolean log_threaded_source_driver_deinit_method(LogPipe *s);
 void log_threaded_source_driver_free_method(LogPipe *s);
 
-void log_threaded_source_driver_set_worker_run(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRunFunc run);
-void log_threaded_source_driver_set_worker_request_exit(LogThreadedSourceDriver *self,
-                                                        LogThreadedSourceWorkerRequestExitFunc request_exit);
+void log_threaded_source_driver_set_worker_run_func(LogThreadedSourceDriver *self, LogThreadedSourceWorkerRunFunc run);
+void log_threaded_source_driver_set_worker_request_exit_func(LogThreadedSourceDriver *self,
+    LogThreadedSourceWorkerRequestExitFunc request_exit);
 
 /* blocking API */
 void log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg);
 
 /* non-blocking API, use it wisely (thread boundaries) */
-void log_threaded_source_set_wakeup(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeupFunc wakeup);
+void log_threaded_source_set_wakeup_func(LogThreadedSourceDriver *self, LogThreadedSourceWorkerWakeupFunc wakeup);
 void log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg);
 gboolean log_threaded_source_free_to_send(LogThreadedSourceDriver *self);
 

--- a/lib/logthrsource/tests/CMakeLists.txt
+++ b/lib/logthrsource/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(CRITERION LIBTEST TARGET test_logthrsourcedrv)
+add_unit_test(CRITERION LIBTEST TARGET test_logthrfetcherdrv)

--- a/lib/logthrsource/tests/CMakeLists.txt
+++ b/lib/logthrsource/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(CRITERION LIBTEST TARGET test_logthrsourcedrv)

--- a/lib/logthrsource/tests/Makefile.am
+++ b/lib/logthrsource/tests/Makefile.am
@@ -1,0 +1,9 @@
+lib_logthrsource_tests_TESTS = \
+  lib/logthrsource/tests/test_logthrsourcedrv
+
+EXTRA_DIST += lib/logthrsource/tests/CMakeLists.txt
+
+check_PROGRAMS += ${lib_logthrsource_tests_TESTS}
+
+lib_logthrsource_tests_test_logthrsourcedrv_CFLAGS = $(TEST_CFLAGS)
+lib_logthrsource_tests_test_logthrsourcedrv_LDADD = $(TEST_LDADD)

--- a/lib/logthrsource/tests/Makefile.am
+++ b/lib/logthrsource/tests/Makefile.am
@@ -1,5 +1,6 @@
 lib_logthrsource_tests_TESTS = \
-  lib/logthrsource/tests/test_logthrsourcedrv
+  lib/logthrsource/tests/test_logthrsourcedrv \
+  lib/logthrsource/tests/test_logthrfetcherdrv
 
 EXTRA_DIST += lib/logthrsource/tests/CMakeLists.txt
 
@@ -7,3 +8,6 @@ check_PROGRAMS += ${lib_logthrsource_tests_TESTS}
 
 lib_logthrsource_tests_test_logthrsourcedrv_CFLAGS = $(TEST_CFLAGS)
 lib_logthrsource_tests_test_logthrsourcedrv_LDADD = $(TEST_LDADD)
+
+lib_logthrsource_tests_test_logthrfetcherdrv_CFLAGS = $(TEST_CFLAGS)
+lib_logthrsource_tests_test_logthrfetcherdrv_LDADD = $(TEST_LDADD)

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -71,7 +71,7 @@ static void _source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions
 static LogSource *
 _get_source(TestThreadedFetcherDriver *self)
 {
-  return _log_threaded_source_driver_get_source(&self->super.super);
+  return (LogSource *) self->super.super.worker;
 }
 
 static void

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -99,7 +99,7 @@ test_threaded_fetcher_new(GlobalConfig *cfg)
   self->super.super.super.super.super.generate_persist_name = _generate_persist_name;
   self->super.super.super.super.super.free_fn = test_threaded_fetcher_free;
 
-  /* this is extremely ugly, but we want to mock out the hard-coded DNS lookup calls inside log_source_queue() */
+  /* mock out the hard-coded DNS lookup calls inside log_source_queue() */
   _get_source(self)->super.queue = _source_queue_mock;
 
   return self;

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "logthrsource/logthrfetcherdrv.h"
+#include "apphook.h"
+#include "mainloop.h"
+#include "mainloop-worker.h"
+#include "cfg.h"
+#include "stats/stats-counter.h"
+#include "logsource.h"
+#include "cr_template.h"
+
+typedef struct _TestThreadedFetcherDriver
+{
+  LogThreadedFetcherDriver super;
+  gint num_of_messages_to_generate;
+  gint num_of_connection_failures_to_generate;
+  gint connect_counter;
+
+  GMutex *lock;
+  GCond *cond;
+
+} TestThreadedFetcherDriver;
+
+MainLoopOptions main_loop_options = {0};
+MainLoop *main_loop;
+
+static const gchar *
+_generate_persist_name(const LogPipe *s)
+{
+  return "test_threaded_fetcher_driver";
+}
+
+static const gchar *
+_format_stats_instance(LogThreadedSourceDriver *s)
+{
+  return "test_threaded_fetcher_driver_stats";
+}
+
+static void _source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  LogSource *self = (LogSource *) s;
+
+  stats_counter_inc(self->recvd_messages);
+  log_pipe_forward_msg(s, msg, path_options);
+}
+
+static LogSource *
+_get_source(TestThreadedFetcherDriver *self)
+{
+  return _log_threaded_source_driver_get_source(&self->super.super);
+}
+
+static void
+test_threaded_fetcher_free(LogPipe *s)
+{
+  TestThreadedFetcherDriver *self = (TestThreadedFetcherDriver *) s;
+
+  g_cond_free(self->cond);
+  g_mutex_free(self->lock);
+
+  log_threaded_fetcher_driver_free_method(s);
+}
+
+static TestThreadedFetcherDriver *
+test_threaded_fetcher_new(GlobalConfig *cfg)
+{
+  TestThreadedFetcherDriver *self = g_new0(TestThreadedFetcherDriver, 1);
+
+  log_threaded_fetcher_driver_init_instance(&self->super, cfg);
+
+  self->lock = g_mutex_new();
+  self->cond = g_cond_new();
+
+  self->super.super.format_stats_instance = _format_stats_instance;
+  self->super.super.super.super.super.generate_persist_name = _generate_persist_name;
+  self->super.super.super.super.super.free_fn = test_threaded_fetcher_free;
+
+  /* this is extremely ugly, but we want to mock out the hard-coded DNS lookup calls inside log_source_queue() */
+  _get_source(self)->super.queue = _source_queue_mock;
+
+  return self;
+}
+
+static TestThreadedFetcherDriver *
+create_threaded_fetcher(void)
+{
+  return test_threaded_fetcher_new(main_loop_get_current_config(main_loop));
+}
+
+static void
+start_test_threaded_fetcher(TestThreadedFetcherDriver *s)
+{
+  cr_assert(log_pipe_init(&s->super.super.super.super.super));
+  app_post_config_loaded();
+}
+
+static void
+wait_for_messages(TestThreadedFetcherDriver *s)
+{
+  g_mutex_lock(s->lock);
+  while (s->num_of_messages_to_generate > 0)
+    g_cond_wait(s->cond, s->lock);
+  g_mutex_unlock(s->lock);
+}
+
+static void
+stop_test_threaded_fetcher(TestThreadedFetcherDriver *s)
+{
+  main_loop_sync_worker_startup_and_teardown();
+}
+
+static void
+destroy_test_threaded_fetcher(TestThreadedFetcherDriver *s)
+{
+  cr_assert(log_pipe_deinit(&s->super.super.super.super.super));
+  log_pipe_unref(&s->super.super.super.super.super);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  main_loop = main_loop_get_instance();
+  main_loop_init(main_loop, &main_loop_options);
+}
+
+static void
+teardown(void)
+{
+  main_loop_deinit(main_loop);
+  app_shutdown();
+}
+
+static LogThreadedFetchResult
+_fetch(LogThreadedFetcherDriver *s)
+{
+  TestThreadedFetcherDriver *self = (TestThreadedFetcherDriver *) s;
+
+  if (self->num_of_connection_failures_to_generate
+      && self->connect_counter <= self->num_of_connection_failures_to_generate)
+    {
+      return (LogThreadedFetchResult)
+      {
+        THREADED_FETCH_NOT_CONNECTED, NULL
+      };
+    }
+
+  LogMessage *msg = create_sample_message();
+
+  g_mutex_lock(self->lock);
+  if (self->num_of_messages_to_generate <= 0)
+    {
+      g_cond_signal(self->cond);
+      g_mutex_unlock(self->lock);
+      return (LogThreadedFetchResult)
+      {
+        THREADED_FETCH_ERROR, NULL
+      };
+    }
+
+  self->num_of_messages_to_generate--;
+  g_mutex_unlock(self->lock);
+
+  return (LogThreadedFetchResult)
+  {
+    .result = THREADED_FETCH_SUCCESS,
+     .msg = msg
+  };
+}
+
+static gboolean
+_connect_fail_first_time(LogThreadedFetcherDriver *s)
+{
+  TestThreadedFetcherDriver *self = (TestThreadedFetcherDriver *) s;
+
+  self->connect_counter++;
+  if (self->connect_counter == 1)
+    return FALSE;
+
+  return TRUE;
+}
+
+TestSuite(logthrfetcherdrv, .init = setup, .fini = teardown, .timeout = 10);
+
+Test(logthrfetcherdrv, test_simple_fetch)
+{
+  TestThreadedFetcherDriver *s = create_threaded_fetcher();
+
+  s->num_of_messages_to_generate = 10;
+  s->super.fetch = _fetch;
+
+  start_test_threaded_fetcher(s);
+  wait_for_messages(s);
+  stop_test_threaded_fetcher(s);
+
+  StatsCounterItem *recvd_messages = _get_source(s)->recvd_messages;
+  cr_assert(stats_counter_get(recvd_messages) == 10);
+
+  destroy_test_threaded_fetcher(s);
+}
+
+Test(logthrfetcherdrv, test_reconnect)
+{
+  TestThreadedFetcherDriver *s = create_threaded_fetcher();
+
+  s->num_of_messages_to_generate = 10;
+  s->num_of_connection_failures_to_generate = 5;
+  s->super.time_reopen = 0; /* immediate */
+  s->super.connect = _connect_fail_first_time;
+  s->super.fetch = _fetch;
+
+  start_test_threaded_fetcher(s);
+  wait_for_messages(s);
+  stop_test_threaded_fetcher(s);
+
+  StatsCounterItem *recvd_messages = _get_source(s)->recvd_messages;
+  cr_assert(stats_counter_get(recvd_messages) == 10);
+  cr_assert_geq(s->connect_counter, 6);
+
+  destroy_test_threaded_fetcher(s);
+}

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "logthrsource/logthrsourcedrv.h"
+#include "apphook.h"
+#include "mainloop.h"
+#include "mainloop-worker.h"
+#include "cfg.h"
+#include "stats/stats-counter.h"
+#include "logsource.h"
+#include "cr_template.h"
+
+typedef struct _TestThreadedSourceDriver
+{
+  LogThreadedSourceDriver super;
+  gint num_of_messages_to_generate;
+  gboolean suspended;
+  gboolean exit_requested;
+} TestThreadedSourceDriver;
+
+MainLoopOptions main_loop_options = {0};
+MainLoop *main_loop;
+
+static const gchar *
+_generate_persist_name(const LogPipe *s)
+{
+  return "test_threaded_source_driver";
+}
+
+static const gchar *
+_format_stats_instance(LogThreadedSourceDriver *s)
+{
+  return "test_threaded_source_driver_stats";
+}
+
+static void
+_source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  LogSource *self = (LogSource *) s;
+
+  stats_counter_inc(self->recvd_messages);
+  log_pipe_forward_msg(s, msg, path_options);
+}
+
+static LogSource *
+_get_source(TestThreadedSourceDriver *self)
+{
+  return _log_threaded_source_driver_get_source(&self->super);
+}
+
+static TestThreadedSourceDriver *
+test_threaded_sd_new(GlobalConfig *cfg)
+{
+  TestThreadedSourceDriver *self = g_new0(TestThreadedSourceDriver, 1);
+
+  log_threaded_source_driver_init_instance(&self->super, cfg);
+
+  self->super.format_stats_instance = _format_stats_instance;
+  self->super.super.super.super.generate_persist_name = _generate_persist_name;
+
+  /* this is extremely ugly, but we want to mock out the hard-coded DNS lookup calls inside log_source_queue() */
+  _get_source(self)->super.queue = _source_queue_mock;
+
+  return self;
+}
+
+static TestThreadedSourceDriver *
+create_threaded_source(void)
+{
+  return test_threaded_sd_new(main_loop_get_current_config(main_loop));
+}
+
+static void
+start_test_threaded_source(TestThreadedSourceDriver *s)
+{
+  cr_assert(log_pipe_init(&s->super.super.super.super));
+}
+
+static void
+request_exit_and_wait_for_stop(TestThreadedSourceDriver *s)
+{
+  main_loop_sync_worker_startup_and_teardown();
+}
+
+static void
+destroy_test_threaded_source(TestThreadedSourceDriver *s)
+{
+  cr_assert(log_pipe_deinit(&s->super.super.super.super));
+  log_pipe_unref(&s->super.super.super.super);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  main_loop = main_loop_get_instance();
+  main_loop_init(main_loop, &main_loop_options);
+}
+
+static void
+teardown(void)
+{
+  main_loop_deinit(main_loop);
+  app_shutdown();
+}
+
+static void
+_run_using_blocking_posts(LogThreadedSourceDriver *s)
+{
+  TestThreadedSourceDriver *self = (TestThreadedSourceDriver *) s;
+
+  for (gint i = 0; i < self->num_of_messages_to_generate; ++i)
+    {
+      LogMessage *msg = create_sample_message();
+      log_threaded_source_blocking_post(&self->super, msg);
+    }
+}
+
+static void
+_run_simple(LogThreadedSourceDriver *s)
+{
+  TestThreadedSourceDriver *self = (TestThreadedSourceDriver *) s;
+
+  for (gint i = 0; i < self->num_of_messages_to_generate; ++i)
+    {
+      LogMessage *msg = create_sample_message();
+      log_threaded_source_post(&self->super, msg);
+
+      if (!log_threaded_source_free_to_send(&self->super))
+        {
+          self->suspended = TRUE;
+          break;
+        }
+    }
+}
+
+static void
+_request_exit(LogThreadedSourceDriver *s)
+{
+  TestThreadedSourceDriver *self = (TestThreadedSourceDriver *) s;
+  self->exit_requested = TRUE;
+}
+
+static void
+_do_not_ack_messages(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  log_msg_unref(msg);
+}
+
+TestSuite(logthrsourcedrv, .init = setup, .fini = teardown, .timeout = 10);
+
+Test(logthrsourcedrv, test_threaded_source_blocking_post)
+{
+  TestThreadedSourceDriver *s = create_threaded_source();
+
+  s->num_of_messages_to_generate = 10;
+  log_threaded_source_driver_set_worker_run(&s->super, _run_using_blocking_posts);
+  log_threaded_source_driver_set_worker_request_exit(&s->super, _request_exit);
+
+  start_test_threaded_source(s);
+  request_exit_and_wait_for_stop(s);
+
+  StatsCounterItem *recvd_messages = _get_source(s)->recvd_messages;
+  cr_assert(stats_counter_get(recvd_messages) == 10);
+  cr_assert(s->exit_requested);
+
+  destroy_test_threaded_source(s);
+}
+
+Test(logthrsourcedrv, test_threaded_source_suspend)
+{
+  TestThreadedSourceDriver *s = create_threaded_source();
+
+  s->num_of_messages_to_generate = 5;
+  s->super.worker_options.super.init_window_size = 5;
+  s->super.super.super.super.queue = _do_not_ack_messages;
+  log_threaded_source_driver_set_worker_run(&s->super, _run_simple);
+  log_threaded_source_driver_set_worker_request_exit(&s->super, _request_exit);
+
+  start_test_threaded_source(s);
+  request_exit_and_wait_for_stop(s);
+
+  StatsCounterItem *recvd_messages = _get_source(s)->recvd_messages;
+  cr_assert(stats_counter_get(recvd_messages) == 5);
+  cr_assert(s->suspended);
+  cr_assert(s->exit_requested);
+
+  destroy_test_threaded_source(s);
+}

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -97,6 +97,7 @@ static void
 start_test_threaded_source(TestThreadedSourceDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super));
+  app_post_config_loaded();
 }
 
 static void

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -178,8 +178,8 @@ Test(logthrsourcedrv, test_threaded_source_blocking_post)
   TestThreadedSourceDriver *s = create_threaded_source();
 
   s->num_of_messages_to_generate = 10;
-  log_threaded_source_driver_set_worker_run(&s->super, _run_using_blocking_posts);
-  log_threaded_source_driver_set_worker_request_exit(&s->super, _request_exit);
+  log_threaded_source_driver_set_worker_run_func(&s->super, _run_using_blocking_posts);
+  log_threaded_source_driver_set_worker_request_exit_func(&s->super, _request_exit);
 
   start_test_threaded_source(s);
   request_exit_and_wait_for_stop(s);
@@ -198,8 +198,8 @@ Test(logthrsourcedrv, test_threaded_source_suspend)
   s->num_of_messages_to_generate = 5;
   s->super.worker_options.super.init_window_size = 5;
   s->super.super.super.super.queue = _do_not_ack_messages;
-  log_threaded_source_driver_set_worker_run(&s->super, _run_simple);
-  log_threaded_source_driver_set_worker_request_exit(&s->super, _request_exit);
+  log_threaded_source_driver_set_worker_run_func(&s->super, _run_simple);
+  log_threaded_source_driver_set_worker_request_exit_func(&s->super, _request_exit);
 
   start_test_threaded_source(s);
   request_exit_and_wait_for_stop(s);

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -81,7 +81,7 @@ test_threaded_sd_new(GlobalConfig *cfg)
   self->super.format_stats_instance = _format_stats_instance;
   self->super.super.super.super.generate_persist_name = _generate_persist_name;
 
-  /* this is extremely ugly, but we want to mock out the hard-coded DNS lookup calls inside log_source_queue() */
+  /* mock out the hard-coded DNS lookup calls inside log_source_queue() */
   _get_source(self)->super.queue = _source_queue_mock;
 
   return self;

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -68,7 +68,7 @@ _source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions *path_optio
 static LogSource *
 _get_source(TestThreadedSourceDriver *self)
 {
-  return _log_threaded_source_driver_get_source(&self->super);
+  return (LogSource *) self->super.worker;
 }
 
 static TestThreadedSourceDriver *

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -49,7 +49,7 @@ autogen\.sh$
 sub-configure\.sh$
 configure\.ac$
 Makefile\.am$
-lib/(compat|str-repr|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|logmsg|value-pairs|secret-storage|[^/]*$)
+lib/(compat|str-repr|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|logmsg|value-pairs|secret-storage|logthrsource|[^/]*$)
 lib/scanner/(csv-scanner|list-scanner|kv-scanner|[^/]*$)
 libtest
 syslog-ng(-ctl)?


### PR DESCRIPTION
This PR makes it easier to implement log sources that require a dedicated thread.

A dedicated thread is useful when blocking calls have to be used, or when one wants to integrate an external event loop with syslog-ng.

The PR  contains 2 new abstract classes, `LogThreadedSourceDriver` and `LogThreadedFetcherDriver`. They can be used as a base for new threaded sources. 

For example, balabit/syslog-ng#2248.

----

**`LogThreadedSourceDriver`** provides a new thread and a simple interface to forward `LogMessage`s to the next pipeline element. `run()` and `request_exit()` are its main abstract methods. The driver class can be used in two ways:

1. The "blocking API" takes care of the flow control of the source automatically by suspending the thread when the destination queue is full.

2. The "non-blocking API" gives you full control by publishing `free_to_send()` and `wakeup()`. Special caution must be taken when using these methods, because they are based on lockless atomic operations.

**`LogThreadedFetcherDriver`** is an ivykis-based specialization of `LogThreadedSourceDriver`.

It can be also considered as the "reverse" of the threaded destination driver: instead of `insert()`, `fetch()` can be implemented here.

`connect()` and `disconnect()` work the same way as in `LogThreadedDestDriver`.

A `LogThreadedFetcherDriver`-based source is easier to implement, but you won't have full control over the thread. It is useful when you want to connect to a service and fetch logs in a blocking manner.

----

![threaded-source](https://user-images.githubusercontent.com/3130044/44610495-b419ff80-a7fc-11e8-9290-a27bb7897855.png)