### PR TITLE
[WIP] kv-parser: stray word contained previouse kv pair

### DIFF
--- a/lib/scanner/kv-scanner/kv-scanner.c
+++ b/lib/scanner/kv-scanner/kv-scanner.c
@@ -266,15 +266,12 @@ _decode_value(KVScanner *self)
   };
 
   self->value_was_quoted = _is_quoted(input);
-  if (str_repr_decode_with_options(self->value, input, &end, &options))
-    {
-      self->input_pos = end - self->input;
-    }
-  else
+  if (!str_repr_decode_with_options(self->value, input, &end, &options))
     {
       /* quotation error, set was_quoted to FALSE */
       self->value_was_quoted = FALSE;
     }
+  self->input_pos = end - self->input;
 }
 
 static void

--- a/lib/str-repr/tests/test_decode.c
+++ b/lib/str-repr/tests/test_decode.c
@@ -136,7 +136,7 @@ test_decode_malformed_strings(void)
   assert_decode_equals("alma\"", "alma\"");
   assert_decode_equals("alma\"korte", "alma\"korte");
   assert_decode_equals("alma\"korte\"", "alma\"korte\"");
-  assert_decode_equals_and_fails("'alma'@korte", "'alma'@korte");
+  assert_decode_equals_and_fails("'alma'@korte", "'alma'");
 }
 
 static void
@@ -145,7 +145,7 @@ test_decode_delimited_strings(void)
   assert_decode_with_three_tabs_as_delimiter_equals("alma\t\t\tkorte", "alma");
 
   assert_decode_with_three_tabs_as_delimiter_equals("'alma\t\t\tkorte'", "alma\t\t\tkorte");
-  assert_decode_with_three_tabs_as_delimiter_equals("'alma\t\t\tkorte'\t\t", "'alma\t\t\tkorte'\t\t");
+  assert_decode_with_three_tabs_as_delimiter_equals("'alma\t\t\tkorte'\t\t", "'alma\t\t\tkorte'");
   assert_decode_with_three_tabs_as_delimiter_equals("'alma\t\t\tkorte'\t\t\t", "alma\t\t\tkorte");
   assert_decode_with_three_tabs_as_delimiter_equals("alma\t\t", "alma\t\t");
 

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -164,6 +164,13 @@ test_kv_parser_extract_stray_words(void)
   assert_log_message_value_by_name(msg, "stray", "\"interzone-emtn_s1_vpn-enodeb_om inbound;\"");
   log_msg_unref(msg);
 
+  kv_parser_set_prefix(kv_parser, ".prefix.");
+  kv_parser_set_pair_separator(kv_parser, " ");
+  kv_parser_set_stray_words_value_name(kv_parser, ".stray");
+  msg = parse_kv_into_log_message("foo='qu'x asd");
+  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.foo"), "'qu'");
+  assert_log_message_value(msg, log_msg_get_value_handle(".stray"), "asd");
+  log_msg_unref(msg);
 }
 
 static void


### PR DESCRIPTION
The stray words in wrongly detected, when the closing character of a quoted string did not followed by a key-value separator. The key-value pair was correct, but the stray word contained the previouse key-value pair as well.

Example:
```
kv-separator: [space]
Input: foo='qu'x asd
```

This PR also causes some regression in case of string parsing (as the function is shared), this break could be avoided with untangling the `str decode` and `kv parser`.

