### PR TITLE
logwriter, affile, afsocket: fixing "internal overflow".

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -365,7 +365,7 @@ log_writer_update_fd_callbacks(LogWriter *self, GIOCondition cond)
 }
 
 static void
-log_writer_arm_suspend_timer(LogWriter *self, void (*handler)(void *), gint timeout_msec)
+log_writer_arm_suspend_timer(LogWriter *self, void (*handler)(void *), glong timeout_msec)
 {
   main_loop_assert_main_thread();
 
@@ -422,7 +422,7 @@ log_writer_suspend(LogWriter *self)
   /* flush code indicates that we need to suspend our writing activities
    * until time_reopen elapses */
 
-  log_writer_arm_suspend_timer(self, log_writer_error_suspend_elapsed, (gint)(self->options->time_reopen * 1e3));
+  log_writer_arm_suspend_timer(self, log_writer_error_suspend_elapsed, self->options->time_reopen * 1000L);
   self->suspended = TRUE;
 }
 
@@ -454,7 +454,7 @@ log_writer_update_watches(LogWriter *self)
 
       log_writer_update_fd_callbacks(self, 0);
       self->waiting_for_throttle = TRUE;
-      log_writer_arm_suspend_timer(self, (void (*)(void *)) log_writer_update_watches, timeout_msec);
+      log_writer_arm_suspend_timer(self, (void (*)(void *)) log_writer_update_watches, (glong)timeout_msec);
     }
   else
     {

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -119,7 +119,7 @@ affile_dw_arm_reaper(AFFileDestWriter *self)
   /* not yet reaped, set up the next callback */
   iv_validate_now();
   self->reap_timer.expires = iv_now;
-  timespec_add_msec(&self->reap_timer.expires, self->owner->time_reap * 1000);
+  timespec_add_msec(&self->reap_timer.expires, self->owner->time_reap * 1000L);
   iv_timer_register(&self->reap_timer);
 }
 

--- a/modules/afsocket/afinet-dest-failover.c
+++ b/modules/afsocket/afinet-dest-failover.c
@@ -87,9 +87,9 @@ _start_failback_timer(AFInetDestDriverFailover *self)
   elapsed_time = timespec_diff_msec(&iv_now, &(self->timer.expires));
   self->timer.expires = iv_now;
 
-  if (elapsed_time < (self->probe_interval*1000))
+  if (elapsed_time < (self->probe_interval*1000L))
     {
-      timespec_add_msec(&self->timer.expires, (self->probe_interval*1000 - elapsed_time));
+      timespec_add_msec(&self->timer.expires, (self->probe_interval*1000L - elapsed_time));
     }
   iv_timer_register(&self->timer);
 }

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -194,7 +194,7 @@ afsocket_dd_start_reconnect_timer(AFSocketDestDriver *self)
   iv_validate_now();
 
   self->reconnect_timer.expires = iv_now;
-  timespec_add_msec(&self->reconnect_timer.expires, self->time_reopen * 1000);
+  timespec_add_msec(&self->reconnect_timer.expires, self->time_reopen * 1000L);
   iv_timer_register(&self->reconnect_timer);
 }
 


### PR DESCRIPTION
Thank you @mitzkia for the finding!

While the timer values are "NONNEGATIVE_INTEGER"s from the config, (so potentially overflowing values are causing config errors), we multiply them (usually with 1000 to get msec from sec) as integers before passing it as long to timespec_add_msec which might cause integer overflow. As a result these timers expires immediatelly as they set.