### PR TITLE
implement flush-timeout() for http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,19 +177,21 @@ matrix:
             --disable-smtp
             --disable-geoip
             --enable-all-modules
-        - make --keep-going -j $(nproc) ||
+        - make --keep-going -j $(sysctl -n hw.physicalcpu) ||
           {
             S=$?;
             make V=1;
             return $S;
           }
       script:
-        - make --keep-going check -j $(nproc) ||
+        - make --keep-going check -j $(sysctl -n hw.physicalcpu) ||
           {
             S=$?;
+            echo "Output of first test invocation:";
+            find . -name test-suite.log | xargs cat;
             make V=1 check;
-            find . -name test-suite.log |
-            xargs cat;
+            echo "Output of second test invocation:";
+            find . -name test-suite.log | xargs cat;
             return $S;
           }
 

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -37,6 +37,14 @@ log_threaded_dest_driver_set_max_retries(LogDriver *s, gint max_retries)
   self->retries_max = max_retries;
 }
 
+void
+log_threaded_dest_driver_set_flush_lines(LogDriver *s, gint flush_lines)
+{
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *) s;
+
+  self->flush_lines = flush_lines;
+}
+
 /* this should be used in combination with WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT to actually confirm message delivery. */
 void
 log_threaded_dest_driver_ack_messages(LogThreadedDestDriver *self, gint batch_size)
@@ -572,6 +580,9 @@ log_threaded_dest_driver_init_method(LogPipe *s)
   if (cfg && self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
+  if (cfg && self->flush_lines == -1)
+    self->flush_lines = cfg->flush_lines;
+
   self->worker.queue = log_dest_driver_acquire_queue(
                          &self->super,
                          s->generate_persist_name(s));
@@ -638,6 +649,7 @@ log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig
   self->super.super.super.free_fn = log_threaded_dest_driver_free;
   self->time_reopen = -1;
   self->batch_size = 0;
+  self->flush_lines = -1;
 
   self->retries_max = MAX_RETRIES_OF_FAILED_INSERT_DEFAULT;
   _init_watches(self);

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -91,6 +91,55 @@ struct _LogThreadedDestDriver
   const gchar *(*format_stats_instance)(LogThreadedDestDriver *s);
 };
 
+static inline void
+log_threaded_dest_worker_thread_init(LogThreadedDestDriver *self)
+{
+  if (self->worker.thread_init)
+    self->worker.thread_init(self);
+}
+
+static inline void
+log_threaded_dest_worker_thread_deinit(LogThreadedDestDriver *self)
+{
+  if (self->worker.thread_deinit)
+    self->worker.thread_deinit(self);
+}
+
+static inline gboolean
+log_threaded_dest_worker_connect(LogThreadedDestDriver *self)
+{
+  if (self->worker.connect)
+    self->worker.connected = self->worker.connect(self);
+  else
+    self->worker.connected = TRUE;
+
+  return self->worker.connected;
+}
+
+static inline void
+log_threaded_dest_worker_disconnect(LogThreadedDestDriver *self)
+{
+  if (self->worker.disconnect)
+    self->worker.disconnect(self);
+  self->worker.connected = FALSE;
+}
+
+static inline worker_insert_result_t
+log_threaded_dest_worker_insert(LogThreadedDestDriver *self, LogMessage *msg)
+{
+  return self->worker.insert(self, msg);
+}
+
+static inline worker_insert_result_t
+log_threaded_dest_worker_flush(LogThreadedDestDriver *self)
+{
+  worker_insert_result_t result = WORKER_INSERT_RESULT_SUCCESS;
+
+  if (self->worker.flush)
+    result = self->worker.flush(self);
+  return result;
+}
+
 void log_threaded_dest_driver_ack_messages(LogThreadedDestDriver *self, gint batch_size);
 void log_threaded_dest_driver_drop_messages(LogThreadedDestDriver *self, gint batch_size);
 void log_threaded_dest_driver_rewind_messages(LogThreadedDestDriver *self, gint batch_size);

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -74,6 +74,7 @@ struct _LogThreadedDestDriver
   StatsCounterItem *written_messages;
   StatsCounterItem *memory_usage;
 
+  gint flush_lines;
   gboolean suspended;
   gboolean under_termination;
   time_t time_reopen;
@@ -151,5 +152,6 @@ void log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalC
 void log_threaded_dest_driver_free(LogPipe *s);
 
 void log_threaded_dest_driver_set_max_retries(LogDriver *s, gint max_retries);
+void log_threaded_dest_driver_set_flush_lines(LogDriver *s, gint flush_lines);
 
 #endif

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -82,7 +82,7 @@ test_threaded_dd_new(GlobalConfig *cfg)
 static void
 _sleep_msec(long msec)
 {
-  struct timespec sleep_time = { 0, msec * 1000000 };
+  struct timespec sleep_time = { msec / 1000, (msec % 1000) * 1000000 };
   nanosleep(&sleep_time, NULL);
 }
 

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -72,6 +72,8 @@ test_threaded_dd_new(GlobalConfig *cfg)
   self->super.worker.connect = _connect_success;
   /* the insert function will be initialized explicitly in testcases */
   self->super.worker.insert = NULL;
+  self->super.flush_timeout = 0;
+  self->super.flush_lines = 0;
   return self;
 }
 
@@ -298,7 +300,7 @@ _insert_batched_message_success(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  if (self->super.batch_size < 5)
+  if (self->super.batch_size < s->flush_lines)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
@@ -319,6 +321,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
 {
   dd->super.worker.insert = _insert_batched_message_success;
   dd->super.worker.flush = _flush_batched_message_success;
+  dd->super.flush_lines = 5;
 
   _generate_messages_and_wait_for_processing(dd, 10, dd->super.written_messages);
   cr_assert(dd->insert_counter == 10,
@@ -340,7 +343,7 @@ _insert_batched_message_drop(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  if (self->super.batch_size < 5)
+  if (self->super.batch_size < s->flush_lines)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
@@ -395,7 +398,7 @@ _insert_batched_message_error_drop(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  if (self->super.batch_size < 5)
+  if (self->super.batch_size < s->flush_lines)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
@@ -466,7 +469,7 @@ _insert_batched_message_error_success(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  if (self->super.batch_size < 5)
+  if (self->super.batch_size < s->flush_lines)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
@@ -540,7 +543,7 @@ _insert_batched_message_not_connected(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  if (self->super.batch_size < 5)
+  if (self->super.batch_size < s->flush_lines)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += self->super.batch_size;
@@ -595,6 +598,7 @@ Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_calle
   log_queue_set_throttle(dd->super.worker.queue, 3);
   dd->super.worker.insert = _insert_batched_message_success;
   dd->super.worker.flush = _flush_batched_message_success;
+  dd->super.flush_lines = 5;
 
   start_stopwatch();
   _generate_messages_and_wait_for_processing(dd, 20, dd->super.written_messages);
@@ -613,6 +617,83 @@ Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_calle
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
   cr_assert(dd->super.seq_num == 21, "%d", dd->super.seq_num);
+}
+
+Test(logthrdestdrv, flush_timeout_delays_flush_to_the_specified_interval)
+{
+  /* 3 messages per second, we need to set this explicitly on the queue as it has already been initialized */
+  dd->super.worker.insert = _insert_batched_message_success;
+  dd->super.worker.flush = _flush_batched_message_success;
+  dd->super.flush_lines = 5;
+  dd->super.flush_timeout = 1000;
+
+  start_stopwatch();
+  _generate_messages(dd, 2);
+  gint flush_counter = dd->flush_counter;
+  guint64 initial_feed_time = stop_stopwatch_and_get_result();
+
+  /* NOTE: this is a racy check. The rationale that this should be safe:
+   *  - we've set flush_timeout to 1 second
+   *  - the sending of two messages to the thread shouldn't take this much
+   *  - we only assert on the flush counter if this assertion does not fail
+   *
+   * if we need, we can always increase flush-timeout() if for some reason 1
+   * seconds wouldn't be enough time to do this validation.
+   */
+  cr_assert(initial_feed_time < 1000000,
+            "The initial feeding took more than flush_timeout(), e.g. 1 seconds. "
+            "We can't validate that no flush happened in this period, check the "
+            "comment above this assert for more information. initial_feed_time=%"
+            G_GUINT64_FORMAT, initial_feed_time);
+
+  cr_assert(flush_counter == 0,
+            "Although the flush time has not yet elapsed, "
+            "flush_counter is not zero, flush_counter=%d, initial_feed_time=%"
+            G_GUINT64_FORMAT, flush_counter, initial_feed_time);
+  _spin_for_counter_value(dd->super.written_messages, 2);
+
+  cr_assert(dd->flush_size == 2);
+  cr_assert(dd->flush_counter == 1);
+}
+
+Test(logthrdestdrv, flush_timeout_limits_flush_frequency)
+{
+  /* 3 messages per second, we need to set this explicitly on the queue as it has already been initialized */
+  dd->super.worker.insert = _insert_batched_message_success;
+  dd->super.worker.flush = _flush_batched_message_success;
+  dd->super.flush_lines = 5;
+  dd->super.flush_timeout = 1000;
+
+  for (gint i = 0; i < 5; i++)
+    {
+      gint flush_counter;
+
+      start_stopwatch();
+      _generate_messages(dd, 2);
+      _sleep_msec(100);
+      flush_counter = dd->flush_counter;
+      guint64 initial_feed_time = stop_stopwatch_and_get_result();
+
+      /* NOTE: the same rationale applies to this assert than in
+       * flush_timeout_delays_flush_to_the_specified_interval() */
+
+      cr_assert(initial_feed_time < 1000000,
+                "The initial feeding took more than flush_timeout(), e.g. 1 seconds. "
+                "We can't validate that no flush happened in this period, check the "
+                "comment above this assert for more information. initial_feed_time=%"
+                G_GUINT64_FORMAT, initial_feed_time);
+      cr_assert(flush_counter == i,
+                "Although the flush time has not yet elapsed, flush_counter has already changed"
+                "flush_counter=%d, expected %d, initial_feed_time=%" G_GUINT64_FORMAT,
+                dd->flush_counter, i, initial_feed_time);
+
+      /* force flush_timeout() to elapse, give some time to the thread to flush */
+      _sleep_msec(1200);
+      cr_assert(dd->flush_counter == i + 1,
+                "The flush time has now been forcibly spent, but the flush has not happened as expected."
+                "flush_counter=%d, expected %d", dd->flush_counter, i + 1);
+    }
+  cr_assert(dd->flush_size == 10);
 }
 
 static gboolean
@@ -653,7 +734,7 @@ _insert_explicit_acks_message_success(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  if (self->super.batch_size < 5)
+  if (self->super.batch_size < s->flush_lines)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += 1;
@@ -675,6 +756,7 @@ Test(logthrdestdrv, test_explicit_ack_accept)
 {
   dd->super.worker.insert = _insert_explicit_acks_message_success;
   dd->super.worker.flush = _flush_explicit_acks_message_success;
+  dd->super.flush_lines = 5;
 
   _generate_messages_and_wait_for_processing(dd, 10, dd->super.written_messages);
   cr_assert(dd->insert_counter == 10, "%d", dd->insert_counter);

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -116,7 +116,7 @@ http_option
     | KW_DELIMITER  '(' string ')'        { http_dd_set_delimiter(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
-    | KW_FLUSH_LINES '(' nonnegative_integer ')' { http_dd_set_flush_lines(last_driver, $3); }
+    | KW_FLUSH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_flush_lines(last_driver, $3); }
     | KW_FLUSH_BYTES '(' nonnegative_integer ')' { http_dd_set_flush_bytes(last_driver, $3); }
     | threaded_dest_driver_option
     | http_tls_option

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -118,6 +118,7 @@ http_option
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_FLUSH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_flush_lines(last_driver, $3); }
     | KW_FLUSH_BYTES '(' nonnegative_integer ')' { http_dd_set_flush_bytes(last_driver, $3); }
+    | KW_FLUSH_TIMEOUT '(' nonnegative_integer ')' { log_threaded_dest_driver_set_flush_timeout(last_driver, $3); }
     | threaded_dest_driver_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -573,7 +573,7 @@ _insert_batched(HTTPDestinationDriver *self, LogMessage *msg)
 
   if (_should_initiate_flush(self))
     {
-      return _flush(&self->super);
+      return log_threaded_dest_worker_flush(&self->super);
     }
   return WORKER_INSERT_RESULT_QUEUED;
 }

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -53,7 +53,6 @@ typedef struct
   gboolean peer_verify;
   short int method_type;
   glong timeout;
-  glong flush_lines;
   glong flush_bytes;
   struct curl_slist *request_headers;
   GString *request_body;
@@ -80,7 +79,6 @@ void http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers);
 void http_dd_set_ssl_version(LogDriver *d, const gchar *value);
 void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
 void http_dd_set_timeout(LogDriver *d, glong timeout);
-void http_dd_set_flush_lines(LogDriver *d, glong flush_lines);
 void http_dd_set_flush_bytes(LogDriver *d, glong flush_bytes);
 void http_dd_set_body_prefix(LogDriver *d, const gchar *body_prefix);
 void http_dd_set_body_suffix(LogDriver *d, const gchar *body_suffix);


### PR DESCRIPTION
This branch implements the flush-timeout() option for LogThreadedDestDriver, which works very similarly to what we had earlier (e.g. pre syslog-ng 3.3).

Then it makes this option available to the HTTP destination driver. This should fix CPU consumption issues for elasticsearch, such as #2131.

After giving some though whether we should simply use the old option name (e.g. flush-timeout()) or introduce a new one, I've finally concluded on simply using the old one, meaning that it should be brought out of deprecation. But looking at it closely, that deprecation wasn't very successful, in the sense it has not been documented.

This also means that the flush-timeout() and flush-lines() options would be inherited automatically from the global options. This branch implements that as well for the generic case, and then disables this inheritance in the http driver, as that would be unexpected.

NOTE: this is not a complete solution for #2131. To solve #2131, we would need to add this option to the Java binding as well, or feed Elastic with the http destination. The latter should be an interesting experiment.

