### PR TITLE
dbld: use upstream gradle binaries

### DIFF
--- a/dbld/images/artful.dockerfile
+++ b/dbld/images/artful.dockerfile
@@ -26,7 +26,7 @@ RUN cat /required-obs/* | grep -v '^$\|^#' | xargs apt-get install --no-install-
 RUN cd /tmp && wget http://ftp.de.debian.org/debian/pool/main/libn/libnative-platform-java/libnative-platform-jni_0.11-5_$(dpkg --print-architecture).deb
 RUN cd /tmp && dpkg -i libnative-platform-jni*.deb
 
-
+RUN /helpers/functions.sh gradle_installer
 # grab gosu for easy step-down from root
 RUN /helpers/functions.sh step_down_from_root_with_gosu $(dpkg --print-architecture)
 

--- a/dbld/images/jessie.dockerfile
+++ b/dbld/images/jessie.dockerfile
@@ -22,6 +22,7 @@ RUN /helpers/functions.sh add_obs_repo ${OBS_REPO}
 COPY required-obs/all.txt required-obs/${DISTRO}*.txt /required-obs/
 RUN cat /required-obs/* | grep -v '^$\|^#' | xargs apt-get install --no-install-recommends -y
 
+RUN /helpers/functions.sh gradle_installer
 
 # grab gosu for easy step-down from root
 RUN /helpers/functions.sh step_down_from_root_with_gosu $(dpkg --print-architecture)

--- a/dbld/images/required-epel/all.txt
+++ b/dbld/images/required-epel/all.txt
@@ -3,5 +3,4 @@ libdbi
 libdbi-drivers
 riemann-c-client-devel
 syslog-ng-java-deps
-gradle
 librabbitmq-devel

--- a/dbld/images/required-obs/all.txt
+++ b/dbld/images/required-obs/all.txt
@@ -1,3 +1,2 @@
 criterion-dev
-gradle
 libmaxminddb-dev

--- a/dbld/images/trusty.dockerfile
+++ b/dbld/images/trusty.dockerfile
@@ -22,6 +22,7 @@ RUN /helpers/functions.sh add_obs_repo ${OBS_REPO}
 COPY required-obs/all.txt required-obs/${DISTRO}*.txt /required-obs/
 RUN cat /required-obs/* | grep -v '^$\|^#' | xargs apt-get install --no-install-recommends -y
 
+RUN /helpers/functions.sh gradle_installer
 
 # grab gosu for easy step-down from root
 RUN /helpers/functions.sh step_down_from_root_with_gosu $(dpkg --print-architecture)

--- a/dbld/images/xenial.dockerfile
+++ b/dbld/images/xenial.dockerfile
@@ -22,6 +22,7 @@ RUN /helpers/functions.sh add_obs_repo ${OBS_REPO}
 COPY required-obs/all.txt required-obs/${DISTRO}*.txt /required-obs/
 RUN cat /required-obs/* | grep -v '^$\|^#' | xargs apt-get install --no-install-recommends -y
 
+RUN /helpers/functions.sh gradle_installer
 
 # grab gosu for easy step-down from root
 RUN /helpers/functions.sh step_down_from_root_with_gosu $(dpkg --print-architecture)


### PR DESCRIPTION
The distribution provided gradle binaries are often not good enough,
either because they are too old or they are buggy.

Use the binary provided by the gradle project.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>