### PR TITLE
Hdfs time-reap

### DIFF
--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -232,14 +232,11 @@ public class HdfsDestination extends StructuredLogDestination {
 
         logger.debug("Flushing hdfs");
         for (Map.Entry<String, HdfsFile> entry : openedFiles.entrySet()) {
-            FSDataOutputStream outputStream = entry.getValue().getFsDataOutputStream();
-            if (outputStream != null) {
-                try {
-                    outputStream.hflush();
-                    outputStream.hsync();
-                } catch (IOException e) {
-                    logger.debug(String.format("Flush failed on file %s, reason: %s", entry.getKey(), e.getMessage()));
-                }
+            HdfsFile hdfsfile = entry.getValue();
+            try {
+                hdfsfile.flush();
+            } catch (IOException e) {
+                logger.debug(String.format("Flush failed on file %s, reason: %s", entry.getKey(), e.getMessage()));
             }
         }
     }

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -144,7 +144,7 @@ public class HdfsDestination extends StructuredLogDestination {
         HdfsFile hdfsfile = getHdfsFile(resolvedFileName);
         if (hdfsfile == null) {
             // Unable to open file
-            closeAll(archiveDir != null);
+            closeAll(true);
             return false;
         }
 
@@ -245,7 +245,7 @@ public class HdfsDestination extends StructuredLogDestination {
     @Override
     public void close() {
         logger.debug("Closing hdfs");
-        closeAll(archiveDir != null);
+        closeAll(true);
         isOpened = false;
     }
 

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -289,20 +289,25 @@ public class HdfsDestination extends StructuredLogDestination {
         }
     }
 
+    private void archiveFile(HdfsFile hdfsfile) {
+        Path filePath = hdfsfile.getPath();
+        logger.debug(String.format("Trying to archive %s to %s", filePath.getName(), archiveDir));
+        Path archiveDirPath = new Path(String.format("%s/%s", options.getUri(), archiveDir));
+
+        try {
+           hdfs.mkdirs(archiveDirPath);
+           hdfs.rename(filePath, archiveDirPath);
+        } catch (IOException e) {
+            logger.debug(String.format("Unable to archive, reason: %s", e.getMessage()));
+        }
+    }
+
     private void archiveFiles() {
         if (archiveDir == null)
            return;
 
         for (Map.Entry<String, HdfsFile> entry : openedFiles.entrySet()) {
-            Path filePath = entry.getValue().getPath();
-            logger.debug(String.format("Trying to archive %s to %s", filePath.getName(), archiveDir));
-            Path archiveDirPath = new Path(String.format("%s/%s", options.getUri(), archiveDir));
-            try {
-                hdfs.mkdirs(archiveDirPath);
-                hdfs.rename(filePath, archiveDirPath);
-            } catch (IOException e) {
-                logger.debug(String.format("Unable to archive, reason: %s", e.getMessage()));
-            }
+            archiveFile( entry.getValue() );
         }
     }
 

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -388,6 +388,7 @@ public class HdfsDestination extends StructuredLogDestination {
             HdfsFile hdfsfile = entry.getValue();
             try {
                 logger.debug(String.format("Closing file: %s", entry.getKey()));
+                hdfsfile.flush();
                 hdfsfile.close();
             } catch (IOException e) {
                 printStackTrace(e);

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -172,10 +172,11 @@ public class HdfsDestination extends StructuredLogDestination {
     }
 
     private HdfsFile createHdfsFile(String resolvedFileName) {
-        HdfsFile hdfsFile = new HdfsFile();
         Path filePath = getFilePath(resolvedFileName);
-        hdfsFile.setPath(filePath);
-        hdfsFile.setFsDataOutputStream(createFsDataOutputStream(hdfs, filePath));
+        FSDataOutputStream fsDataOutputStream = createFsDataOutputStream(hdfs, filePath);
+
+        HdfsFile hdfsFile = new HdfsFile(filePath, fsDataOutputStream);
+
         return hdfsFile;
     }
 

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -249,7 +249,7 @@ public class HdfsDestination extends StructuredLogDestination {
     }
 
     private void closeAll(boolean isArchiving) {
-        closeDataOutputStreams();
+        closeAllHdfsFiles();
 
         if (isArchiving) {
             archiveFiles();
@@ -259,18 +259,15 @@ public class HdfsDestination extends StructuredLogDestination {
         isOpened = false;
     }
 
-    private void closeDataOutputStreams() {
+    private void closeAllHdfsFiles() {
         for (Map.Entry<String, HdfsFile> entry : openedFiles.entrySet()) {
-            FSDataOutputStream outputStream = entry.getValue().getFsDataOutputStream();
-            if (outputStream != null) {
-                try {
-                    logger.debug(String.format("Closing file: %s", entry.getKey()));
-                    outputStream.close();
-                } catch (IOException e) {
-                    printStackTrace(e);
-                }
+            HdfsFile hdfsfile = entry.getValue();
+            try {
+                logger.debug(String.format("Closing file: %s", entry.getKey()));
+                hdfsfile.close();
+            } catch (IOException e) {
+                printStackTrace(e);
             }
-            entry.getValue().setFsDataOutputStream(null);
         }
     }
 

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -150,8 +150,12 @@ public class HdfsDestination extends StructuredLogDestination {
 
         try {
             String formattedMessage = options.getTemplate().getResolvedString(logMessage);
+
             logger.debug("Outgoing message: " + formattedMessage);
-            hdfsfile.getFsDataOutputStream().write(formattedMessage.getBytes(Charset.forName("UTF-8")));
+
+            byte[] rawMessage = formattedMessage.getBytes(Charset.forName("UTF-8"));
+
+            hdfsfile.write(rawMessage);
         } catch (IOException e) {
             printStackTrace(e);
             closeAll(false);

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -54,20 +54,15 @@ public class HdfsDestination extends StructuredLogDestination {
     private static final String HADOOP_SECURITY_AUTH_KEY = "hadoop.security.authentication";
     private static final String DFS_SUPPORT_APPEND_KEY = "dfs.support.append";
 
-    HdfsOptions options;
-    Logger logger;
-
+    private HdfsOptions options;
+    private Logger logger;
     private FileSystem hdfs;
-
     private boolean isOpened;
     private int maxFileNameLength = 255;
     private boolean appendEnabled;
     private String archiveDir;
-
-    HashMap<String, HdfsFile> openedFiles;
-
+    private HashMap<String, HdfsFile> openedFiles;
     private Timer timeReap;
-
     private Lock lock;
 
     class TimeReapTask extends TimerTask {

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -272,31 +272,33 @@ public class HdfsDestination extends StructuredLogDestination {
     }
 
     private void closeHdfs() {
-        if (hdfs != null) {
-            try {
-                hdfs.close();
-            } catch (IOException e) {
-                hdfs = null;
-                printStackTrace(e);
-            }
+        if (hdfs == null)
+           return;
+
+        try {
+            hdfs.close();
+        } catch (IOException e) {
+            printStackTrace(e);
+        } finally {
+            hdfs = null;
         }
     }
 
     private void archiveFiles() {
-        if (archiveDir != null) {
-            for (Map.Entry<String, HdfsFile> entry : openedFiles.entrySet()) {
-                Path filePath = entry.getValue().getPath();
-                logger.debug(String.format("Trying to archive %s to %s", filePath.getName(), archiveDir));
-                Path archiveDirPath = new Path(String.format("%s/%s", options.getUri(), archiveDir));
-                try {
-                    hdfs.mkdirs(archiveDirPath);
-                    hdfs.rename(filePath, archiveDirPath);
-                } catch (IOException e) {
-                    logger.debug(String.format("Unable to archive, reason: %s", e.getMessage()));
-                }
+        if (archiveDir == null)
+           return;
+
+        for (Map.Entry<String, HdfsFile> entry : openedFiles.entrySet()) {
+            Path filePath = entry.getValue().getPath();
+            logger.debug(String.format("Trying to archive %s to %s", filePath.getName(), archiveDir));
+            Path archiveDirPath = new Path(String.format("%s/%s", options.getUri(), archiveDir));
+            try {
+                hdfs.mkdirs(archiveDirPath);
+                hdfs.rename(filePath, archiveDirPath);
+            } catch (IOException e) {
+                logger.debug(String.format("Unable to archive, reason: %s", e.getMessage()));
             }
         }
-
     }
 
     private void printStackTrace(Throwable e) {

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -168,7 +168,7 @@ public class HdfsDestination extends StructuredLogDestination {
 
     private HdfsFile getHdfsFile(String resolvedFileName) {
         HdfsFile hdfsFile = openedFiles.get(resolvedFileName);
-        if (hdfsFile == null) {
+        if (hdfsFile == null || !hdfsFile.isOpen()) {
             hdfsFile = createHdfsFile(resolvedFileName);
             openedFiles.put(resolvedFileName, hdfsFile);
         }

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -141,8 +141,8 @@ public class HdfsDestination extends StructuredLogDestination {
     public boolean send(LogMessage logMessage) {
         isOpened = false;
         String resolvedFileName = options.getFileNameTemplate().getResolvedString(logMessage);
-        FSDataOutputStream fsDataOutputStream = getFSDataOutputStream(resolvedFileName);
-        if (fsDataOutputStream == null) {
+        HdfsFile hdfsfile = getHdfsFile(resolvedFileName);
+        if (hdfsfile == null) {
             // Unable to open file
             closeAll(archiveDir != null);
             return false;
@@ -151,7 +151,7 @@ public class HdfsDestination extends StructuredLogDestination {
         try {
             String formattedMessage = options.getTemplate().getResolvedString(logMessage);
             logger.debug("Outgoing message: " + formattedMessage);
-            fsDataOutputStream.write(formattedMessage.getBytes(Charset.forName("UTF-8")));
+            hdfsfile.getFsDataOutputStream().write(formattedMessage.getBytes(Charset.forName("UTF-8")));
         } catch (IOException e) {
             printStackTrace(e);
             closeAll(false);
@@ -162,13 +162,13 @@ public class HdfsDestination extends StructuredLogDestination {
         return true;
     }
 
-    private FSDataOutputStream getFSDataOutputStream(String resolvedFileName) {
+    private HdfsFile getHdfsFile(String resolvedFileName) {
         HdfsFile hdfsFile = openedFiles.get(resolvedFileName);
         if (hdfsFile == null) {
             hdfsFile = createHdfsFile(resolvedFileName);
             openedFiles.put(resolvedFileName, hdfsFile);
         }
-        return hdfsFile.getFsDataOutputStream();
+        return hdfsFile;
     }
 
     private HdfsFile createHdfsFile(String resolvedFileName) {

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
@@ -31,10 +31,12 @@ import java.io.IOException;
 public class HdfsFile {
     private FSDataOutputStream fsDataOutputStream;
     private Path path;
+    private long lastWrite;
 
     public HdfsFile(Path filepath, FSDataOutputStream outputstream) {
         this.path = filepath;
         this.fsDataOutputStream = outputstream;
+        this.lastWrite = 0;
     }
 
     public Path getPath() {
@@ -58,6 +60,15 @@ public class HdfsFile {
             throw new IOException("File is not open: "+path);
 
          fsDataOutputStream.write(message);
+
+         lastWrite = System.currentTimeMillis();
+    }
+
+    public long timeSinceLastWrite() {
+       if (!isOpen())
+          return 0;
+
+       return System.currentTimeMillis() - lastWrite;
     }
 
     public void close() throws IOException {
@@ -66,5 +77,6 @@ public class HdfsFile {
 
           fsDataOutputStream.close();
           fsDataOutputStream = null;
+          lastWrite = 0;
     }
 }

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
@@ -26,6 +26,8 @@ package org.syslog_ng.hdfs;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 
+import java.io.IOException;
+
 public class HdfsFile {
     private FSDataOutputStream fsDataOutputStream;
     private Path path;
@@ -44,5 +46,13 @@ public class HdfsFile {
 
     public void setPath(Path path) {
         this.path = path;
+    }
+
+    public void flush() throws IOException {
+         if (fsDataOutputStream == null)
+            return;
+
+         fsDataOutputStream.hflush();
+         fsDataOutputStream.hsync();
     }
 }

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
@@ -41,8 +41,12 @@ public class HdfsFile {
         return path;
     }
 
+    public boolean isOpen() {
+        return fsDataOutputStream != null;
+    }
+
     public void flush() throws IOException {
-         if (fsDataOutputStream == null)
+         if (!isOpen())
             return;
 
          fsDataOutputStream.hflush();
@@ -50,11 +54,14 @@ public class HdfsFile {
     }
 
     public void write(byte[] message) throws IOException {
+         if (!isOpen())
+            throw new IOException("File is not open: "+path);
+
          fsDataOutputStream.write(message);
     }
 
     public void close() throws IOException {
-         if (fsDataOutputStream == null)
+         if (!isOpen())
             return;
 
           fsDataOutputStream.close();

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
@@ -55,4 +55,12 @@ public class HdfsFile {
          fsDataOutputStream.hflush();
          fsDataOutputStream.hsync();
     }
+
+    public void close() throws IOException {
+         if (fsDataOutputStream == null)
+            return;
+
+          fsDataOutputStream.close();
+          fsDataOutputStream = null;
+    }
 }

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
@@ -37,10 +37,6 @@ public class HdfsFile {
         this.fsDataOutputStream = outputstream;
     }
 
-    public FSDataOutputStream getFsDataOutputStream() {
-        return fsDataOutputStream;
-    }
-
     public Path getPath() {
         return path;
     }
@@ -51,6 +47,10 @@ public class HdfsFile {
 
          fsDataOutputStream.hflush();
          fsDataOutputStream.hsync();
+    }
+
+    public void write(byte[] message) throws IOException {
+         fsDataOutputStream.write(message);
     }
 
     public void close() throws IOException {

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsFile.java
@@ -32,20 +32,17 @@ public class HdfsFile {
     private FSDataOutputStream fsDataOutputStream;
     private Path path;
 
+    public HdfsFile(Path filepath, FSDataOutputStream outputstream) {
+        this.path = filepath;
+        this.fsDataOutputStream = outputstream;
+    }
+
     public FSDataOutputStream getFsDataOutputStream() {
         return fsDataOutputStream;
     }
 
-    public void setFsDataOutputStream(FSDataOutputStream fsDataOutputStream) {
-        this.fsDataOutputStream = fsDataOutputStream;
-    }
-
     public Path getPath() {
         return path;
-    }
-
-    public void setPath(Path path) {
-        this.path = path;
     }
 
     public void flush() throws IOException {

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsOptions.java
@@ -43,6 +43,8 @@ public class HdfsOptions {
     public static String TEMPLATE_DEFAULT = "${ISODATE} ${HOST} ${MSGHDR}${MSG}\n";
     public static String APPEND_ENABLED = "hdfs_append_enabled";
     public static String APPEND_ENABLED_DEFAULT = "false";
+    public static String TIME_REAP = "time_reap";
+    public static String TIME_REAP_DEFAULT = "0";
 
     private LogDestination owner;
     private Options options;
@@ -107,6 +109,10 @@ public class HdfsOptions {
         return options.get(APPEND_ENABLED).getValueAsBoolean();
     }
 
+    public int getTimeReap() {
+        return 1000 * options.get(TIME_REAP).getValueAsInteger();
+    }
+
     private void fillStringOptions() {
         options.put(new RequiredOptionDecorator(new StringOption(owner, URI)));
         options.put(new StringOption(owner, ARCHIVE_DIR));
@@ -114,6 +120,7 @@ public class HdfsOptions {
         options.put(new StringOption(owner, MAX_FILENAME_LENGTH, MAX_FILENAME_LENGTH_DEFAULT));
         options.put(new StringOption(owner, KERBEROS_PRINCIPAL));
         options.put(new StringOption(owner, KERBEROS_KEYTAB_FILE));
+        options.put(new IntegerRangeCheckOptionDecorator(new StringOption(owner, TIME_REAP, TIME_REAP_DEFAULT), 0, Integer.MAX_VALUE));
     }
 
     private void fillBooleanOptions() {

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -42,8 +42,7 @@ Java_org_syslog_1ng_LogDestination_getOption(JNIEnv *env, jobject obj, jlong s, 
     {
       return NULL;
     }
-  gchar *normalized_key = g_strdup(key_str);
-  normalized_key = __normalize_key(normalized_key);
+  gchar *normalized_key = __normalize_key(key_str);
   value = g_hash_table_lookup(self->options, normalized_key);
   (*env)->ReleaseStringUTFChars(env, key, key_str);  // release resources
   g_free(normalized_key);
@@ -82,9 +81,8 @@ Java_org_syslog_1ng_LogPipe_getConfigHandle(JNIEnv *env, jobject obj, jlong hand
 void java_dd_set_option(LogDriver *s, const gchar *key, const gchar *value)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;
-  gchar *normalized_key = g_strdup(key);
-  normalized_key = __normalize_key(normalized_key);
-  g_hash_table_insert(self->options, g_strdup(normalized_key), g_strdup(value));
+  gchar *normalized_key = __normalize_key(key);
+  g_hash_table_insert(self->options, normalized_key, g_strdup(value));
 }
 
 

--- a/scl/hdfs/plugin.conf
+++ b/scl/hdfs/plugin.conf
@@ -32,6 +32,7 @@ block destination hdfs(
   kerberos_keytab_file("")
   template("")
   hdfs_append_enabled("")
+  time_reap("")
   ...
 )
 {
@@ -47,6 +48,7 @@ block destination hdfs(
     option("kerberos_keytab_file", "`kerberos_keytab_file`")
     option("template", "`template`")
     option("hdfs_append_enabled", "`hdfs_append_enabled`")
+    option("time_reap", "`time_reap`")
     `__VARARGS__`
   );
 };


### PR DESCRIPTION
This patchset introduces the `time_reap` option for the `hdfs` destination. The user could simply set this option in seconds after that every file that has not been written since `time_reap` seconds is going to be closed.
(Note: In case of archive is configured it also triggers the archiving mechanism for that file only.)
```
  hdfs( ... time_reap(60));
```

The option default value is `0`, which means disable the timeout.

The `java: option set/get key leaked` commit fixes a general java based option leak, every get/set option leaked per call.
Fixes #917