### PR TITLE
afsocket: implemented min_iw_size_per_connection global option

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -197,6 +197,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_ENCODING                    10082
 %token KW_TYPE                        10083
 %token KW_STATS_MAX_DYNAMIC           10084
+%token KW_MIN_IW_SIZE_PER_READER      10085
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -975,6 +976,7 @@ options_item
 	| KW_FILE_TEMPLATE '(' string ')'	{ configuration->file_template_name = g_strdup($3); free($3); }
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
 	| KW_RECV_TIME_ZONE '(' string ')'      { configuration->recv_time_zone = g_strdup($3); free($3); }
+	| KW_MIN_IW_SIZE_PER_READER '(' positive_integer ')' { configuration->min_iw_size_per_reader = $3; }
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -90,6 +90,7 @@ static CfgLexerKeyword main_keywords[] =
   { "stats_level",        KW_STATS_LEVEL },
   { "stats",              KW_STATS_FREQ, KWS_OBSOLETE, "stats_freq" },
   { "stats_max_dynamics", KW_STATS_MAX_DYNAMIC },
+  { "min_iw_size_per_reader", KW_MIN_IW_SIZE_PER_READER },
   { "flush_lines",        KW_FLUSH_LINES },
   { "flush_timeout",      KW_FLUSH_TIMEOUT },
   { "suppress",           KW_SUPPRESS },

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -448,6 +448,8 @@ cfg_new(gint version)
 
   stats_options_defaults(&self->stats_options);
 
+  self->min_iw_size_per_reader = 100;
+
   cfg_tree_init_instance(&self->tree, self);
   plugin_context_init_instance(&self->plugin_context);
   self->use_plugin_discovery = TRUE;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -112,6 +112,8 @@ struct _GlobalConfig
   LogTemplate *file_template;
   LogTemplate *proto_template;
 
+  guint min_iw_size_per_reader;
+
   PersistConfig *persist;
   PersistState *state;
   GHashTable *module_config;

--- a/modules/affile/tests/test_wildcard_source.c
+++ b/modules/affile/tests/test_wildcard_source.c
@@ -145,7 +145,7 @@ Test(wildcard_source, test_minimum_window_size)
                                                              "recursive(yes)"
                                                              "max_files(100)"
                                                              "log_iw_size(1000)");
-  cr_assert_eq(driver->file_reader_options.reader_options.super.init_window_size, MINIMUM_WINDOW_SIZE);
+  cr_assert_eq(driver->file_reader_options.reader_options.super.init_window_size, 100);
 }
 
 Test(wildcard_source, test_window_size)

--- a/modules/affile/wildcard-source.h
+++ b/modules/affile/wildcard-source.h
@@ -29,7 +29,6 @@
 #include "directory-monitor.h"
 #include "directory-monitor-factory.h"
 
-#define MINIMUM_WINDOW_SIZE 100
 #define DEFAULT_MAX_FILES 100
 
 typedef struct _WildcardSourceDriver

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -474,20 +474,21 @@ afsocket_sd_setup_reader_options(AFSocketSourceDriver *self)
 
   if (self->transport_mapper->sock_type == SOCK_STREAM && !self->window_size_initialized)
     {
-      /* distribute the window evenly between each of our possible
+      /* Distribute the window evenly between each of our possible
        * connections.  This is quite pessimistic and can result in very low
-       * window sizes. Increase that but warn the user at the same time
+       * window sizes. Increase that but warn the user at the same time.
        */
 
       self->reader_options.super.init_window_size /= self->max_connections;
-      if (self->reader_options.super.init_window_size < 100)
+      if (self->reader_options.super.init_window_size < cfg->min_iw_size_per_reader)
         {
           msg_warning("WARNING: window sizing for tcp sources were changed in " VERSION_3_3
-                      ", the configuration value was divided by the value of max-connections(). The result was too small, clamping to 100 entries. Ensure you have a proper log_fifo_size setting to avoid message loss.",
+                      ", the configuration value was divided by the value of max-connections(). The result was too small, clamping to value of min_iw_size_per_reader. Ensure you have a proper log_fifo_size setting to avoid message loss.",
                       evt_tag_int("orig_log_iw_size", self->reader_options.super.init_window_size),
-                      evt_tag_int("new_log_iw_size", 100),
-                      evt_tag_int("min_log_fifo_size", 100 * self->max_connections));
-          self->reader_options.super.init_window_size = 100;
+                      evt_tag_int("new_log_iw_size", cfg->min_iw_size_per_reader),
+                      evt_tag_int("min_iw_size_per_reader", cfg->min_iw_size_per_reader),
+                      evt_tag_int("min_log_fifo_size", cfg->min_iw_size_per_reader * self->max_connections));
+          self->reader_options.super.init_window_size = cfg->min_iw_size_per_reader;
         }
       self->window_size_initialized = TRUE;
     }


### PR DESCRIPTION
Decreasing log_iw_size to a low value could cause performance regression in
syslog-ng, but in some cases in order to reduce the memory consumption, we need
to reduce it to a certain value.

To preserve backward compatibility, a new global option has been introduced to
mitigate this issue. Using min_iw_size_per_connection we can lower that limit
from the previously hard-coded value.

Warning: lowering this value could cause performance degradation.

Signed-off-by: Peter Gyorko <peter.gyorko@balabit.com>