### PR TITLE
wildcard-file: poll method directory delete related leak

### DIFF
--- a/modules/affile/directory-monitor-poll.c
+++ b/modules/affile/directory-monitor-poll.c
@@ -23,6 +23,7 @@
 #include <collection-comparator.h>
 #include "directory-monitor-poll.h"
 #include "timeutils.h"
+#include "messages.h"
 
 #include <iv.h>
 
@@ -99,6 +100,9 @@ _rescan_directory(DirectoryMonitorPoll *self)
     {
       collection_comparator_stop(self->comparator);
       _handle_deleted_self(self);
+      msg_debug("Error while opening directory",
+                evt_tag_str("dirname", self->super.real_path),
+                evt_tag_str("error", error->message));
       g_clear_error(&error);
     }
 }

--- a/modules/affile/directory-monitor-poll.c
+++ b/modules/affile/directory-monitor-poll.c
@@ -99,6 +99,7 @@ _rescan_directory(DirectoryMonitorPoll *self)
     {
       collection_comparator_stop(self->comparator);
       _handle_deleted_self(self);
+      g_clear_error(&error);
     }
 }
 

--- a/modules/affile/directory-monitor-poll.c
+++ b/modules/affile/directory-monitor-poll.c
@@ -121,8 +121,7 @@ _start_watches(DirectoryMonitor *s)
 {
   DirectoryMonitorPoll *self = (DirectoryMonitorPoll *)s;
   GDir *directory = NULL;
-  GError *error = NULL;
-  directory = g_dir_open(self->super.real_path, 0, &error);
+  directory = g_dir_open(self->super.real_path, 0, NULL);
   if (directory)
     {
       const gchar *filename = g_dir_read_name(directory);


### PR DESCRIPTION
With monitor_method(poll), when a tracked directory is deleted: g_dir_open allocated a
GError structure with the error: No such file or directory. This
must be freed by syslog-ng.
