### PR TITLE
Add support for whitespace in template fns

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -129,7 +129,7 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size)
 
 
 static void
-_cfg_lex_new_line(CfgLexer *lexer)
+_cfg_lex_move_token_location_to_new_line(CfgLexer *lexer)
 {
   CfgIncludeLevel *level = &lexer->include_stack[lexer->include_depth];
 
@@ -143,6 +143,32 @@ _cfg_lex_new_line(CfgLexer *lexer)
   level->lloc.last_column = 1;
 }
 
+static void
+_cfg_lex_extend_token_location_to_next_line(CfgLexer *lexer)
+{
+  CfgIncludeLevel *level = &lexer->include_stack[lexer->include_depth];
+
+  /* this function is used when encountering an NL character within a
+   * multi-line string literal.
+   *
+   * Example:
+   * |    "this is the start of the literal\
+   * |    and this is the end"
+   *
+   *
+   * In this case the string contains a escaped NL character, causing the
+   * literal to span two distinct lines in the source file, which would be
+   * dropped from the parsed string.
+   *
+   * In this case, we need to move yylloc to point from the end of the
+   * current line to the beginning of the next line.  This way, by the time
+   * we return the entire token, yylloc would be spanning the
+   * starting-ending lines of the string literal as needed.
+   * */
+
+  level->lloc.last_line++;
+  level->lloc.last_column = 1;
+}
 %}
 
 %option bison-bridge bison-locations reentrant
@@ -188,9 +214,11 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 ^@                         {
                              return LL_PRAGMA;
                            }
+
+<*>\\\r?\n                 { _cfg_lex_extend_token_location_to_next_line(yyextra); }
 <*>\r?\n                   {
                              *yylloc = yyextra->include_stack[yyextra->include_depth].lloc;
-                             _cfg_lex_new_line(yyextra);
+                             _cfg_lex_move_token_location_to_new_line(yyextra);
                              if (yyextra->tokenize_eol)
                                return LL_EOL;
                              else

--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -305,7 +305,7 @@ log_template_compiler_process_arg_list(LogTemplateCompiler *self, GPtrArray *res
   gint parens = 1;
   self->cursor++;
 
-  while (*self->cursor && *self->cursor == ' ')
+  while (*self->cursor && g_ascii_isspace(*self->cursor))
     self->cursor++;
 
   while(*self->cursor)
@@ -337,12 +337,12 @@ log_template_compiler_process_arg_list(LogTemplateCompiler *self, GPtrArray *res
           arg_buf_has_a_value = TRUE;
           continue;
         }
-      else if (parens == 1 && (*self->cursor == ' ' || *self->cursor == '\t'))
+      else if (parens == 1 && g_ascii_isspace(*self->cursor))
         {
           g_ptr_array_add(result, g_strndup(arg_buf->str, arg_buf->len));
           g_string_truncate(arg_buf, 0);
           arg_buf_has_a_value = FALSE;
-          while (*self->cursor && (*self->cursor == ' ' || *self->cursor == '\t'))
+          while (*self->cursor && g_ascii_isspace(*self->cursor))
             self->cursor++;
           continue;
         }

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -244,6 +244,7 @@ Test(template, test_template_functions)
 {
   /* template functions */
   assert_template_format("$(echo $HOST $PID)", "bzorp 23323");
+  assert_template_format("$(echo\n$HOST\n$PID)", "bzorp 23323");
   assert_template_format("$(echo \"$(echo $HOST)\" $PID)", "bzorp 23323");
   assert_template_format("$(echo \"$(echo '$(echo $HOST)')\" $PID)", "bzorp 23323");
   assert_template_format("$(echo \"$(echo '$(echo $HOST)')\" $PID)", "bzorp 23323");

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -237,6 +237,15 @@ Test(lexer, test_location_tracking)
   assert_location_tag("location='#buffer:3:1'");
 }
 
+Test(lexer, test_multiline_string_literals)
+{
+  _input("\"test another\\\nfoo\"\nbar");
+  assert_parser_string("test anotherfoo");
+  assert_location(1, 1);
+  assert_parser_identifier("bar");
+  assert_location(3, 1);
+}
+
 Test(lexer, defined_variables_are_substituted_when_enclosed_in_backticks)
 {
   parser->lexer->ignore_pragma = FALSE;


### PR DESCRIPTION
This branch allows one to embed newline characters in template function invocation so they become more readable.

for instance, with this patch this specification works:

```
file("whatever" 
    template("$(format-json
                     foo=$FOO
                     bar=$BAR)\n"));
```
Earlier the embedded NL character was not recognized a separator between the name of the
template function and its arguments.

Also, this patch adds support for escaping the terminating NL character in the input text, making it possible to avoid the NL character in strings, even though they are included in the source text.

For instance:
```
http(headers("Authorization: \
basic abcdeffe"));
```

So even though there's a newline in the input text, it wouldn't be embedded in the resulting string. It's as if it wasn't even there. This convention is used in bash, C and a lot of similar grammars, so should come as a natural extension of the syslog-ng.conf file syntax.

It also makes  long templates specifications a lot easier to read.