### PR TITLE
Undefined filter reference

### DIFF
--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -39,18 +39,20 @@ struct _FilterExprNode
   guint32 comp:1,   /* this not is negated */
           modify:1; /* this filter changes the log message */
   const gchar *type;
-  void (*init)(FilterExprNode *self, GlobalConfig *cfg);
+  gboolean (*init)(FilterExprNode *self, GlobalConfig *cfg);
   gboolean (*eval)(FilterExprNode *self, LogMessage **msg, gint num_msg);
   void (*free_fn)(FilterExprNode *self);
   StatsCounterItem *matched;
   StatsCounterItem *not_matched;
 };
 
-static inline void
+static inline gboolean
 filter_expr_init(FilterExprNode *self, GlobalConfig *cfg)
 {
   if (self->init)
-    self->init(self, cfg);
+    return self->init(self, cfg);
+
+  return TRUE;
 }
 
 gboolean filter_expr_eval(FilterExprNode *self, LogMessage *msg);

--- a/lib/filter/filter-op.c
+++ b/lib/filter/filter-op.c
@@ -29,7 +29,7 @@ typedef struct _FilterOp
   FilterExprNode *left, *right;
 } FilterOp;
 
-static void
+static gboolean
 fop_init(FilterExprNode *s, GlobalConfig *cfg)
 {
   FilterOp *self = (FilterOp *) s;
@@ -37,10 +37,15 @@ fop_init(FilterExprNode *s, GlobalConfig *cfg)
   g_assert(self->left);
   g_assert(self->right);
 
-  filter_expr_init(self->left, cfg);
-  filter_expr_init(self->right, cfg);
+  if (!filter_expr_init(self->left, cfg))
+    return FALSE;
+
+  if (!filter_expr_init(self->right, cfg))
+    return FALSE;
 
   self->super.modify = self->left->modify || self->right->modify;
+
+  return TRUE;
 }
 
 static void

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -35,7 +35,9 @@ log_filter_pipe_init(LogPipe *s)
   LogFilterPipe *self = (LogFilterPipe *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  filter_expr_init(self->expr, cfg);
+  if (!filter_expr_init(self->expr, cfg))
+    return FALSE;
+
   if (!self->name)
     self->name = cfg_tree_get_rule_name(&cfg->tree, ENC_FILTER, s->expr_node);
 

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -68,13 +68,15 @@ filter_re_free(FilterExprNode *s)
   log_matcher_options_destroy(&self->matcher_options);
 }
 
-static void
+static gboolean
 filter_re_init(FilterExprNode *s, GlobalConfig *cfg)
 {
   FilterRE *self = (FilterRE *) s;
 
   if (self->matcher_options.flags & LMF_STORE_MATCHES)
     self->super.modify = TRUE;
+
+  return TRUE;
 }
 
 gboolean

--- a/lib/filter/tests/CMakeLists.txt
+++ b/lib/filter/tests/CMakeLists.txt
@@ -5,3 +5,5 @@ add_unit_test(LIBTEST TARGET test_filters_in_list DEPENDS syslogformat)
 add_unit_test(LIBTEST CRITERION TARGET test_filters_netmask6)
 
 add_unit_test(CRITERION TARGET test_filters_statistics DEPENDS syslogformat)
+
+add_unit_test(CRITERION TARGET test_filter_call)

--- a/lib/filter/tests/Makefile.am
+++ b/lib/filter/tests/Makefile.am
@@ -1,5 +1,6 @@
 lib_filter_tests_TESTS		 =              \
     lib/filter/tests/test_filters               \
+    lib/filter/tests/test_filter_call           \
     lib/filter/tests/test_filters_in_list
 
 EXTRA_DIST += lib/filter/tests/CMakeLists.txt
@@ -35,5 +36,9 @@ lib_filter_tests_test_filters_statistics_CFLAGS  = $(TEST_CFLAGS) \
     -I${top_srcdir}/lib/filter/tests
 lib_filter_tests_test_filters_statistics_LDADD     = $(TEST_LDADD)  \
     $(PREOPEN_SYSLOGFORMAT)
+
+lib_filter_tests_test_filter_call_CFLAGS  = $(TEST_CFLAGS) \
+    -I${top_srcdir}/lib/filter/tests
+lib_filter_tests_test_filter_call_LDADD   = $(TEST_LDADD)
 
 include lib/filter/tests/filters-in-list/Makefile.am

--- a/lib/filter/tests/test_filter_call.c
+++ b/lib/filter/tests/test_filter_call.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filter/filter-call.h"
+#include "filter/filter-expr.h"
+#include "apphook.h"
+
+#include <criterion/criterion.h>
+
+
+Test(filter_call, undefined_filter_ref)
+{
+  FilterExprNode *filter = filter_call_new("undefined_filter", configuration);
+  cr_assert_not_null(filter);
+
+  cr_assert_not(filter_expr_init(filter, configuration));
+
+  filter_expr_unref(filter);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+static void
+teardown(void)
+{
+  app_shutdown();
+  cfg_free(configuration);
+}
+
+TestSuite(filter_call, .init = setup, .fini = teardown);
+

--- a/lib/filter/tests/test_filters.c
+++ b/lib/filter/tests/test_filters.c
@@ -120,9 +120,14 @@ testcase(const gchar *msg,
   gboolean res;
   static gint testno = 0;
 
-  filter_expr_init(f, configuration);
-
   testno++;
+
+  if (!filter_expr_init(f, configuration))
+    {
+      fprintf(stderr, "Filter init failed; num='%d', msg='%s'\n", testno, msg);
+      exit(1);
+    }
+
   logmsg = log_msg_new(msg, strlen(msg), NULL, &parse_options);
   logmsg->saddr = g_sockaddr_ref(sender_saddr);
 


### PR DESCRIPTION
The `filter` filter could refer to other filter, which is checked during the initialization time instead of configuration parse time. But at this point for some reason syslog-ng only reported as an error message:
`Referenced filter rule not found in filter() expression ...`

The syslog-ng should not start in this case, and this patch solves that.