### PR TITLE
ElasticSearchDestination: Display deprecated warning message about us…

### DIFF
--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
@@ -55,6 +55,7 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	@Override
 	protected boolean init() {
+		logger.warn("Using elasticsearch() destination (V1.x) is deprecated. This works as before but it may be removed in the future");
 		boolean result = false;
 		try {
 			options.init();


### PR DESCRIPTION
…ing V1.x

The EOL date of the latest 1.7 Elastic is 2017.01.16.
Because it is not supported by the producer anymore, it is safe to remove from syslog-ng as well.
But before removing, syslog-ng will display a warning message about it.