### PR TITLE
logthrdestdrv infinite loop with ivykis prior 0.39

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -96,7 +96,7 @@ _should_flush_now(LogThreadedDestDriver *self)
   now = iv_now;
   diff = timespec_diff_msec(&now, &self->last_flush_time);
 
-  return (diff > self->flush_timeout);
+  return (diff >= self->flush_timeout);
 }
 
 static gchar *

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -331,6 +331,8 @@ _perform_inserts(LogThreadedDestDriver *self)
           if (self->rewound_batch_size == 0)
             break;
         }
+
+      iv_invalidate_now();
     }
   self->rewound_batch_size = 0;
 }
@@ -353,6 +355,8 @@ _perform_flush(LogThreadedDestDriver *self)
       worker_insert_result_t result = log_threaded_dest_worker_flush(self);
       _process_result(self, result);
     }
+
+  iv_invalidate_now();
 }
 
 /* this callback is invoked by LogQueue and is registered using

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -495,6 +495,16 @@ _perform_work(gpointer data)
     }
 }
 
+static void
+_flush_timer_cb(gpointer data)
+{
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *)data;
+  msg_debug("flush timer expired",
+            evt_tag_str("driver", self->super.super.id),
+            evt_tag_int("batch_size", self->batch_size));
+  _perform_work(data);
+}
+
 /* these are events of the _worker_ thread and are not registered to the
  * actual main thread.  We basically run our workload in the handler of the
  * do_work task, which might be invoked in a number of ways.
@@ -533,7 +543,7 @@ _init_watches(LogThreadedDestDriver *self)
 
   IV_TIMER_INIT(&self->timer_flush);
   self->timer_flush.cookie = self;
-  self->timer_flush.handler = _perform_work;
+  self->timer_flush.handler = _flush_timer_cb;
 
   IV_TASK_INIT(&self->do_work);
   self->do_work.cookie = self;

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -299,6 +299,7 @@ _perform_inserts(LogThreadedDestDriver *self)
        * won't expedite the flush even if the previous one was a long
        * time ago */
 
+      iv_validate_now();
       self->last_flush_time = iv_now;
     }
 
@@ -382,7 +383,6 @@ _schedule_restart_on_suspend_timeout(LogThreadedDestDriver *self)
 static void
 _schedule_restart_on_flush_timeout(LogThreadedDestDriver *self)
 {
-  iv_validate_now();
   self->timer_flush.expires = self->last_flush_time;
   timespec_add_msec(&self->timer_flush.expires, self->flush_timeout);
   iv_timer_register(&self->timer_flush);

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -345,6 +345,10 @@ _perform_flush(LogThreadedDestDriver *self)
    */
   if (!self->suspended)
     {
+      msg_trace("flushing batch",
+                evt_tag_str("driver", self->super.super.id),
+                evt_tag_int("batch_size", self->batch_size));
+
       worker_insert_result_t result = log_threaded_dest_worker_flush(self);
       _process_result(self, result);
     }
@@ -433,6 +437,10 @@ _perform_work(gpointer data)
                                  _message_became_available_callback,
                                  self, NULL))
     {
+
+      msg_trace("message(s) available in queue",
+                evt_tag_str("driver", self->super.super.id));
+
       /* Something is in the queue, buffer them up and flush (if needed) */
       _perform_inserts(self);
       if (_should_flush_now(self))
@@ -447,6 +455,8 @@ _perform_work(gpointer data)
        * everything.  We are awoken either by the
        * _message_became_available_callback() or if the next flush time has
        * arrived.  */
+      msg_trace("queue empty",
+                evt_tag_str("driver", self->super.super.id));
 
       if (_should_flush_now(self))
         _perform_flush(self);
@@ -463,6 +473,10 @@ _perform_work(gpointer data)
        * items in the queue were already accepted by throttling, so they can
        * be flushed.
        */
+      msg_trace("delay due to throttling",
+                evt_tag_int("timeout_msec", timeout_msec),
+                evt_tag_str("driver", self->super.super.id));
+
       _schedule_restart_on_throttle_timeout(self, timeout_msec);
 
     }


### PR DESCRIPTION
I moved some `iv_validate_now` around, added a few `iv_invalidate_now`, but the main root cause was that the function that check if we need to flush expected strictly more time to pass than flush_timeout (> instead of  >=). Although when flush triggered by the timer, in some cases exactly flush_timeout passed, which resulted in skipping the flush and reregistering the same timer in the past, which resulted in an infinite loop.

For more detailed analysis, please check commit messages.