### PR TITLE
basicfuncs: url-decode template function

### DIFF
--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -106,6 +106,7 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "urlencode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "url-encode"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_urldecode, "url-decode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_base64encode, "base64-encode")
 };
 

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -417,3 +417,16 @@ Test(basicfuncs, test_tfurlencode)
   assert_template_format("$(urlencode <>)", "%3C%3E");
   assert_template_format("$(urlencode &)", "%26");
 }
+
+Test(basicfuncs, test_tfurldecode)
+{
+  assert_template_format("$(url-decode '')", "");
+  assert_template_format("$(url-decode test)", "test");
+  assert_template_format("$(url-decode %3C%3E)", "<>");
+  assert_template_format("$(url-decode %26)", "&");
+  assert_template_format("$(url-decode %26 %26)", "&&");
+
+  assert_template_format("$(url-decode %)", "");
+  assert_template_format("$(url-decode %00a)", "");
+}
+

--- a/modules/basicfuncs/urlencode.c
+++ b/modules/basicfuncs/urlencode.c
@@ -36,3 +36,26 @@ tf_urlencode(LogMessage *msg, gint argc, GString *argv[], GString *result)
 }
 
 TEMPLATE_FUNCTION_SIMPLE(tf_urlencode);
+
+static void
+tf_urldecode(LogMessage *msg, gint argc, GString *argv[], GString *result)
+{
+  if (argc < 1)
+    return;
+
+  for (gint i = 0; i < argc; i++)
+    {
+      gchar *escaped = g_uri_unescape_string(argv[i]->str, NULL);
+      if (escaped)
+        {
+          g_string_append(result, escaped);
+          g_free(escaped);
+        }
+      else
+        {
+          msg_error("Could not urldecode", evt_tag_str("str", argv[i]->str));
+        }
+    }
+}
+
+TEMPLATE_FUNCTION_SIMPLE(tf_urldecode);


### PR DESCRIPTION
This patch adds a new template function: `url-decode`

url-decode can receive arbitrary number of parameters. When multiple parameters are added, each parameters are encoded separately, and simply concatenated.

Example:
```
$(url-decode $MESSAGE)
```
