### PR TITLE
Fix memory leak caused by saving stats counter to persist config

### DIFF
--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -168,23 +168,6 @@ log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc para
   return TRUE;
 }
 
-void
-log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages,
-                       StatsCounterItem *memory_usage)
-{
-  self->queued_messages = queued_messages;
-  self->dropped_messages = dropped_messages;
-  self->memory_usage = memory_usage;
-}
-
-void
-log_queue_init_counters(LogQueue *self)
-{
-  stats_counter_set(self->memory_usage,
-                    self->memory_usage_qout_initial_value + self->memory_usage_overflow_initial_value);
-  stats_counter_set(self->queued_messages, log_queue_get_length(self));
-}
-
 static void
 _reset_counters(LogQueue *self)
 {

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -175,6 +175,11 @@ log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsC
   self->queued_messages = queued_messages;
   self->dropped_messages = dropped_messages;
   self->memory_usage = memory_usage;
+}
+
+void
+log_queue_init_counters(LogQueue *self)
+{
   stats_counter_set(self->memory_usage,
                     self->memory_usage_qout_initial_value + self->memory_usage_overflow_initial_value);
   stats_counter_set(self->queued_messages, log_queue_get_length(self));

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -202,9 +202,6 @@ void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel
                                  GDestroyNotify user_data_destroy);
 gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify,
                                gpointer user_data, GDestroyNotify user_data_destroy);
-void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages,
-                            StatsCounterItem *memory_usage);
-void log_queue_init_counters(LogQueue *self);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
 void log_queue_register_stats_counters(LogQueue *self, gint stats_level, const StatsClusterKey *sc_key);
 void log_queue_unregister_stats_counters(LogQueue *self, const StatsClusterKey *sc_key);

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -202,6 +202,7 @@ gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotify
                                gpointer user_data, GDestroyNotify user_data_destroy);
 void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, StatsCounterItem *dropped_messages,
                             StatsCounterItem *memory_usage);
+void log_queue_init_counters(LogQueue *self);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
 void log_queue_free_method(LogQueue *self);
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -68,6 +68,8 @@ struct _LogQueue
   void (*ack_backlog)(LogQueue *self, gint n);
   void (*rewind_backlog)(LogQueue *self, guint rewind_count);
   void (*rewind_backlog_all)(LogQueue *self);
+  void (*register_stats_counters)(LogQueue *self, gint stats_level, const StatsClusterKey *sc_key);
+  void (*unregister_stats_counters)(LogQueue *self, const StatsClusterKey *sc_key);
 
   void (*free_fn)(LogQueue *self);
 };
@@ -204,6 +206,10 @@ void log_queue_set_counters(LogQueue *self, StatsCounterItem *queued_messages, S
                             StatsCounterItem *memory_usage);
 void log_queue_init_counters(LogQueue *self);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
+void log_queue_register_stats_counters(LogQueue *self, gint stats_level, const StatsClusterKey *sc_key);
+void log_queue_unregister_stats_counters(LogQueue *self, const StatsClusterKey *sc_key);
+void log_queue_set_dropped_counter(LogQueue *self, StatsCounterItem *dropped_messages);
+
 void log_queue_free_method(LogQueue *self);
 
 void log_queue_set_max_threads(gint max_threads);

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -710,6 +710,7 @@ log_threaded_dest_driver_init_method(LogPipe *s)
 
   log_queue_set_counters(self->worker.queue, self->queued_messages,
                          self->dropped_messages, self->memory_usage);
+  log_queue_init_counters(self->worker.queue);
   _update_memory_usage_counter_when_fifo_is_used(self);
 
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -71,10 +71,8 @@ struct _LogThreadedDestDriver
   GMutex *lock;
 
   StatsCounterItem *dropped_messages;
-  StatsCounterItem *queued_messages;
   StatsCounterItem *processed_messages;
   StatsCounterItem *written_messages;
-  StatsCounterItem *memory_usage;
 
   gint flush_lines;
   struct timespec last_flush_time;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -67,9 +67,7 @@ struct _LogWriter
   StatsCounterItem *dropped_messages;
   StatsCounterItem *suppressed_messages;
   StatsCounterItem *processed_messages;
-  StatsCounterItem *queued_messages;
   StatsCounterItem *written_messages;
-  StatsCounterItem *memory_usage;
   LogPipe *control;
   LogWriterOptions *options;
   LogMessage *last_msg;
@@ -1337,8 +1335,6 @@ log_writer_init_watches(LogWriter *self)
 static void
 _register_counters(LogWriter *self)
 {
-  gboolean need_to_init_queue_counters = TRUE;
-
   stats_lock();
   {
     StatsClusterKey sc_key;
@@ -1349,17 +1345,11 @@ _register_counters(LogWriter *self)
       stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
     stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
     stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
-    stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
     stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_WRITTEN, &self->written_messages);
-    if (stats_check_level(STATS_LEVEL1))
-      need_to_init_queue_counters = !stats_contains_counter(&sc_key, SC_TYPE_MEMORY_USAGE);
-    stats_register_counter_and_index(STATS_LEVEL1, &sc_key, SC_TYPE_MEMORY_USAGE, &self->memory_usage);
+    log_queue_register_stats_counters(self->queue, self->options->stats_level, &sc_key);
   }
   stats_unlock();
-
-  log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages, self->memory_usage);
-  if (need_to_init_queue_counters)
-    log_queue_init_counters(self->queue);
+  log_queue_set_dropped_counter(self->queue, self->dropped_messages);
 }
 
 static gboolean
@@ -1408,9 +1398,8 @@ _unregister_counters(LogWriter *self)
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
-    stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_WRITTEN, &self->written_messages);
-    stats_unregister_counter(&sc_key, SC_TYPE_MEMORY_USAGE, &self->memory_usage);
+    log_queue_unregister_stats_counters(self->queue, &sc_key);
   }
   stats_unlock();
 
@@ -1441,7 +1430,7 @@ log_writer_deinit(LogPipe *s)
   ml_batched_timer_unregister(&self->mark_timer);
 
   _unregister_counters(self);
-  log_queue_set_counters(self->queue, NULL, NULL, NULL);
+  log_queue_set_dropped_counter(self->queue, NULL);
 
   return TRUE;
 }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1381,6 +1381,7 @@ log_writer_init(LogPipe *s)
     _register_counters(self);
 
   log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages, self->memory_usage);
+  log_queue_init_counters(self->queue);
 
   _update_memory_usage_counter_when_fifo_is_used(self);
 

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -244,7 +244,7 @@ stats_cluster_is_alive(StatsCluster *self, gint type)
 {
   g_assert(type < self->counter_group.capacity);
 
-  return ((1<<type) & self->live_mask);
+  return ((1<<type) & self->live_mask) == (1 << type);
 }
 
 gboolean
@@ -252,7 +252,7 @@ stats_cluster_is_indexed(StatsCluster *self, gint type)
 {
   g_assert(type < self->counter_group.capacity);
 
-  return ((1<<type) & self->indexed_mask);
+  return ((1<<type) & self->indexed_mask) == (1 << type);
 }
 
 StatsCluster *

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -208,6 +208,19 @@ stats_cluster_track_counter(StatsCluster *self, gint type)
   return &self->counter_group.counters[type];
 }
 
+StatsCounterItem *
+stats_cluster_get_counter(StatsCluster *self, gint type)
+{
+  gint type_mask = 1 << type;
+
+  g_assert(type < self->counter_group.capacity);
+
+  if (!(self->live_mask & type_mask))
+    return NULL;
+
+  return &self->counter_group.counters[type];
+}
+
 void
 stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter)
 {

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -143,6 +143,7 @@ gboolean stats_cluster_equal(const StatsCluster *sc1, const StatsCluster *sc2);
 guint stats_cluster_hash(const StatsCluster *self);
 
 StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
+StatsCounterItem *stats_cluster_get_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 gboolean stats_cluster_is_indexed(StatsCluster *self, gint type);

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -304,27 +304,6 @@ stats_get_counter(const StatsClusterKey *sc_key, gint type)
   return stats_cluster_get_counter(sc, type);
 }
 
-void
-save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter)
-{
-  if (counter)
-    {
-      g_assert(counter->name);
-      gssize *orig_value = g_new(gssize, 1);
-      *orig_value = stats_counter_get(counter);
-      cfg_persist_config_add(cfg, counter->name, orig_value, (GDestroyNotify) g_free, FALSE);
-    }
-}
-
-void
-load_counter_from_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter)
-{
-  g_assert(counter->name);
-  gssize *orig_value = cfg_persist_config_fetch(cfg, counter->name);
-  if (orig_value)
-    stats_counter_set(counter, *orig_value);
-}
-
 static void
 _foreach_cluster_helper(gpointer key, gpointer value, gpointer user_data)
 {

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -265,6 +265,45 @@ stats_unregister_dynamic_counter(StatsCluster *sc, gint type, StatsCounterItem *
   stats_cluster_untrack_counter(sc, type, counter);
 }
 
+static StatsCluster *
+_lookup_cluster(const StatsClusterKey *sc_key)
+{
+  g_assert(stats_locked);
+
+  StatsCluster *sc = g_hash_table_lookup(stats_cluster_container.static_clusters, sc_key);
+
+  if (!sc)
+    sc = g_hash_table_lookup(stats_cluster_container.dynamic_clusters, sc_key);
+
+  return sc;
+}
+
+gboolean
+stats_contains_counter(const StatsClusterKey *sc_key, gint type)
+{
+  g_assert(stats_locked);
+
+  StatsCluster *sc = _lookup_cluster(sc_key);
+  if (!sc)
+    {
+      return FALSE;
+    }
+
+  return stats_cluster_is_alive(sc, type);
+}
+
+StatsCounterItem *
+stats_get_counter(const StatsClusterKey *sc_key, gint type)
+{
+  g_assert(stats_locked);
+  StatsCluster *sc = _lookup_cluster(sc_key);
+
+  if (!sc)
+    return NULL;
+
+  return stats_cluster_get_counter(sc, type);
+}
+
 void
 save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter)
 {

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -46,17 +46,12 @@ void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCoun
 gboolean stats_contains_counter(const StatsClusterKey *sc_key, gint type);
 StatsCounterItem *stats_get_counter(const StatsClusterKey *sc_key, gint type);
 
-void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
-
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);
 void stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data);
 void stats_foreach_cluster_remove(StatsForeachClusterRemoveFunc func, gpointer user_data);
 
 void stats_registry_init(void);
 void stats_registry_deinit(void);
-
-void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
-void load_counter_from_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 
 gboolean stats_check_dynamic_clusters_limit(guint number_of_clusters);
 gint stats_number_of_dynamic_clusters_limit(void);

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -43,6 +43,9 @@ void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCou
 void stats_unregister_counter(const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
 void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 
+gboolean stats_contains_counter(const StatsClusterKey *sc_key, gint type);
+StatsCounterItem *stats_get_counter(const StatsClusterKey *sc_key, gint type);
+
 void save_counter_to_persistent_storage(GlobalConfig *cfg, StatsCounterItem *counter);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);

--- a/lib/stats/tests/test_dynamic_ctr_reg.c
+++ b/lib/stats/tests/test_dynamic_ctr_reg.c
@@ -76,9 +76,12 @@ Test(stats_dynamic_clusters, register_limited)
     stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost2");
     sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_not_null(sc);
+    cr_assert_eq(stats_contains_counter(&sc_key, SC_TYPE_PROCESSED), TRUE);
+    cr_assert_eq(counter, stats_get_counter(&sc_key, SC_TYPE_PROCESSED));
     stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost3");
     sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_null(sc);
+    cr_expect_not(stats_contains_counter(&sc_key, SC_TYPE_PROCESSED));
   }
   stats_unlock();
 }

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -232,6 +232,25 @@ test_get_component_name_translates_component_to_name_properly(void)
 }
 
 static void
+test_get_counter(void)
+{
+  StatsClusterKey sc_key;
+  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
+  StatsCluster *sc = stats_cluster_new(&sc_key);
+  StatsCounterItem *processed;
+
+  assert_true(stats_cluster_get_counter(sc, SC_TYPE_PROCESSED) == NULL, "get counter before tracked");
+  processed = stats_cluster_track_counter(sc, SC_TYPE_PROCESSED);
+  assert_true(stats_cluster_get_counter(sc, SC_TYPE_PROCESSED) == processed, "get counter after tracked");
+
+  StatsCounterItem *saved_processed = processed;
+  stats_cluster_untrack_counter(sc, SC_TYPE_PROCESSED, &processed);
+  assert_true(processed == NULL, "untrack counter");
+  assert_true(stats_cluster_get_counter(sc, SC_TYPE_PROCESSED) == saved_processed, "get counter after untracked");
+  stats_cluster_free(sc);
+}
+
+static void
 test_stats_cluster(void)
 {
   STATS_CLUSTER_TESTCASE(test_stats_cluster_new_replaces_NULL_with_an_empty_string);
@@ -242,6 +261,7 @@ test_stats_cluster(void)
   STATS_CLUSTER_TESTCASE(test_stats_cluster_single);
   STATS_CLUSTER_TESTCASE(test_stats_cluster_key_not_equal_when_custom_tags_are_different);
   STATS_CLUSTER_TESTCASE(test_stats_cluster_key_equal_when_custom_tags_are_the_same);
+  STATS_CLUSTER_TESTCASE(test_get_counter);
 }
 
 int

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -176,7 +176,7 @@ Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_proce
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 2,
             "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.seq_num);
 }
@@ -332,7 +332,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11,
             "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.seq_num);
 }
@@ -374,7 +374,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);
   assert_grabbed_log_contains("dropped while sending message");
 }
@@ -440,7 +440,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == dd->super.retries_max * 10 + 1,
             "seq_num needs to be one larger than the number of insert attempts, found %d", dd->super.seq_num);
   assert_grabbed_log_contains("Error occurred while");
@@ -513,7 +513,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == total_attempts * 10 + 1, "%d", dd->super.seq_num);
   assert_grabbed_log_contains("Error occurred while");
 }
@@ -587,7 +587,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == total_attempts * 10 + 1, "%d", dd->super.seq_num);
   assert_grabbed_log_contains("Server disconnected");
 }
@@ -615,7 +615,7 @@ Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_calle
   cr_assert(stats_counter_get(dd->super.processed_messages) == 20);
   cr_assert(stats_counter_get(dd->super.written_messages) == 20);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 21, "%d", dd->super.seq_num);
 }
 
@@ -764,9 +764,9 @@ Test(logthrdestdrv, test_explicit_ack_accept)
 
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.queued_messages) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->queued_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);
 }
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1233,6 +1233,7 @@ afsql_dd_init(LogPipe *s)
         log_queue_set_use_backlog(self->queue, TRUE);
     }
   log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages, self->memory_usage);
+  log_queue_init_counters(self->queue);
   if (!self->fields)
     {
       GList *col, *value;

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1183,6 +1183,34 @@ afsql_dd_format_persist_sequence_number(AFSqlDestDriver *self)
   return persist_name;
 }
 
+static void
+_register_stats(AFSqlDestDriver *self)
+{
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+                                  afsql_dd_format_stats_instance(self) );
+    stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+    log_queue_register_stats_counters(self->queue, 0, &sc_key);
+  }
+  stats_unlock();
+}
+
+static void
+_unregister_stats(AFSqlDestDriver *self)
+{
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
+                                  afsql_dd_format_stats_instance(self) );
+    stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+    log_queue_unregister_stats_counters(self->queue, &sc_key);
+  }
+  stats_unlock();
+}
+
 static gboolean
 afsql_dd_init(LogPipe *s)
 {
@@ -1206,19 +1234,6 @@ afsql_dd_init(LogPipe *s)
                   evt_tag_str("type", self->type));
     }
 
-  gboolean need_to_init_queue_counters = TRUE;
-  stats_lock();
-  {
-    StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
-                                  afsql_dd_format_stats_instance(self) );
-    stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &self->queued_messages);
-    stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-    if (stats_check_level(STATS_LEVEL1))
-      need_to_init_queue_counters = !stats_contains_counter(&sc_key, SC_TYPE_MEMORY_USAGE);
-    stats_register_counter(STATS_LEVEL1, &sc_key, SC_TYPE_MEMORY_USAGE, &self->memory_usage);
-  }
-  stats_unlock();
   self->seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg, afsql_dd_format_persist_sequence_number(self)));
   if (!self->seq_num)
     init_sequence_number(&self->seq_num);
@@ -1229,15 +1244,12 @@ afsql_dd_init(LogPipe *s)
     {
       return FALSE;
     }
-  else
-    {
-      if (self->flags & AFSQL_DDF_EXPLICIT_COMMITS)
-        log_queue_set_use_backlog(self->queue, TRUE);
-      log_queue_set_counters(self->queue, self->queued_messages, self->dropped_messages, self->memory_usage);
-      if (need_to_init_queue_counters)
-        log_queue_init_counters(self->queue);
-    }
 
+  _register_stats(self);
+  log_queue_set_dropped_counter(self->queue, self->dropped_messages);
+
+  if (self->flags & AFSQL_DDF_EXPLICIT_COMMITS)
+    log_queue_set_use_backlog(self->queue, TRUE);
   if (!self->fields)
     {
       GList *col, *value;
@@ -1342,17 +1354,7 @@ afsql_dd_init(LogPipe *s)
   return TRUE;
 
 error:
-
-  stats_lock();
-  {
-    StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
-                                  afsql_dd_format_stats_instance(self) );
-    stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
-    stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-    stats_unregister_counter(&sc_key, SC_TYPE_MEMORY_USAGE, &self->memory_usage);
-  }
-  stats_unlock();
+  _unregister_stats(self);
 
   return FALSE;
 }
@@ -1364,17 +1366,11 @@ afsql_dd_deinit(LogPipe *s)
 
   log_queue_reset_parallel_push(self->queue);
 
-  log_queue_set_counters(self->queue, NULL, NULL, NULL);
+  log_queue_set_dropped_counter(self->queue, NULL);
   cfg_persist_config_add(log_pipe_get_config(s), afsql_dd_format_persist_sequence_number(self),
                          GINT_TO_POINTER(self->seq_num), NULL, FALSE);
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SQL | SCS_DESTINATION, self->super.super.id,
-                                afsql_dd_format_stats_instance(self) );
-  stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &self->queued_messages);
-  stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-  stats_unlock();
+  _unregister_stats(self);
 
   if (!log_dest_driver_deinit_method(s))
     return FALSE;

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -98,8 +98,6 @@ typedef struct _AFSqlDestDriver
   LogTemplateOptions template_options;
 
   StatsCounterItem *dropped_messages;
-  StatsCounterItem *queued_messages;
-  StatsCounterItem *memory_usage;
 
   GHashTable *dbd_options;
   GHashTable *dbd_options_numeric;


### PR DESCRIPTION
Leak:

* start syslog-ng with a simple config

```
@version: 3.17

options {
  time_reopen(5);
  stats-level(3);
};

source s_file {
  file("/tmp/input-logs.txt" log-iw-size(10));
};

destination d_file {
  file("/tmp/output-logs.txt");
};

destination d_net {
 network("localhost" port(5555) 
        );
};

log {
  source (s_file);
  destination (d_net);
};

```

* reload syslog-ng
Each time a memory-usage counter is written into a variable that is dynamically allocated on the heap and not freeing up (on my machine 8 bytes are leaked for each reload).
