### PR TITLE
syslog-ng-ctl config to print pre-processed configuration

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -535,16 +535,16 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gboolean syntax_only, gc
   if ((cfg_file = fopen(fname, "r")) != NULL)
     {
       CfgLexer *lexer;
-      GString *preprocess_output = g_string_sized_new(8192);
+      self->preprocess_config = g_string_sized_new(8192);
 
-      lexer = cfg_lexer_new(self, cfg_file, fname, preprocess_output);
+      lexer = cfg_lexer_new(self, cfg_file, fname, self->preprocess_config);
       res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
       fclose(cfg_file);
       if (preprocess_into)
         {
-          cfg_dump_processed_config(preprocess_output, preprocess_into);
+          cfg_dump_processed_config(self->preprocess_config, preprocess_into);
         }
-      g_string_free(preprocess_output, TRUE);
+
       if (res)
         {
           /* successfully parsed */
@@ -587,6 +587,9 @@ cfg_free(GlobalConfig *self)
 
   if (self->state)
     persist_state_free(self->state);
+
+  if (self->preprocess_config)
+    g_string_free(self->preprocess_config, TRUE);
 
   g_free(self);
 }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -524,6 +524,21 @@ cfg_dump_processed_config(GString *preprocess_output, gchar *output_filename)
     }
 }
 
+static GString *
+_load_file_into_string(const gchar *fname)
+{
+  gchar *buff;
+  GString *content = g_string_new("");
+
+  if (g_file_get_contents(fname, &buff, NULL, NULL))
+    {
+      g_string_append(content, buff);
+      g_free(buff);
+    }
+
+  return content;
+}
+
 gboolean
 cfg_read_config(GlobalConfig *self, const gchar *fname, gboolean syntax_only, gchar *preprocess_into)
 {
@@ -536,6 +551,7 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gboolean syntax_only, gc
     {
       CfgLexer *lexer;
       self->preprocess_config = g_string_sized_new(8192);
+      self->original_config = _load_file_into_string(fname);
 
       lexer = cfg_lexer_new(self, cfg_file, fname, self->preprocess_config);
       res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
@@ -590,6 +606,8 @@ cfg_free(GlobalConfig *self)
 
   if (self->preprocess_config)
     g_string_free(self->preprocess_config, TRUE);
+  if (self->original_config)
+    g_string_free(self->original_config, TRUE);
 
   g_free(self);
 }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -525,29 +525,6 @@ cfg_dump_processed_config(GString *preprocess_output, gchar *output_filename)
 }
 
 gboolean
-cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, gchar *preprocess_into)
-{
-  gint res;
-  CfgLexer *lexer;
-  GString *preprocess_output = g_string_sized_new(8192);
-
-  lexer = cfg_lexer_new_buffer(self, config_string, strlen(config_string));
-  lexer->preprocess_output = preprocess_output;
-
-  res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
-  if (preprocess_into)
-    {
-      cfg_dump_processed_config(preprocess_output, preprocess_into);
-    }
-  g_string_free(preprocess_output, TRUE);
-  if (res)
-    {
-      return TRUE;
-    }
-  return FALSE;
-}
-
-gboolean
 cfg_read_config(GlobalConfig *self, const gchar *fname, gboolean syntax_only, gchar *preprocess_into)
 {
   FILE *cfg_file;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -145,7 +145,6 @@ GlobalConfig *cfg_new(gint version);
 GlobalConfig *cfg_new_snippet(void);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
 gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gboolean syntax_only, gchar *preprocess_into);
-gboolean cfg_load_config(GlobalConfig *self, gchar *config_string, gboolean syntax_only, gchar *preprocess_into);
 void cfg_load_forced_modules(GlobalConfig *self);
 void cfg_shutdown(GlobalConfig *self);
 void cfg_free(GlobalConfig *self);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -120,6 +120,7 @@ struct _GlobalConfig
 
   CfgTree tree;
 
+  GString *preprocess_config;
 };
 
 gboolean cfg_load_module(GlobalConfig *cfg, const gchar *module_name);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -121,6 +121,7 @@ struct _GlobalConfig
   CfgTree tree;
 
   GString *preprocess_config;
+  GString *original_config;
 };
 
 gboolean cfg_load_module(GlobalConfig *cfg, const gchar *module_name);

--- a/lib/control/control-commands.c
+++ b/lib/control/control-commands.c
@@ -29,6 +29,7 @@
 #include "apphook.h"
 #include "stats/stats-query-commands.h"
 #include "string.h"
+#include "cfg.h"
 
 static GList *command_list = NULL;
 
@@ -110,6 +111,33 @@ control_connection_stop_process(GString *command, gpointer user_data)
   MainLoop *main_loop = (MainLoop *) user_data;
 
   main_loop_exit(main_loop);
+  return result;
+}
+
+static GString *
+control_connection_config(GString *command, gpointer user_data)
+{
+  MainLoop *main_loop = (MainLoop *) user_data;
+  GlobalConfig *config = main_loop_get_current_config(main_loop);
+  GString *result = g_string_sized_new(128);
+  gchar **arguments = g_strsplit(command->str, " ", 0);
+
+  if (g_str_equal(arguments[1], "PREPROCESSED"))
+    {
+      g_string_assign(result, config->preprocess_config->str);
+      goto exit;
+    }
+
+  if (g_str_equal(arguments[1], "ORIGINAL"))
+    {
+      g_string_assign(result, config->original_config->str);
+      goto exit;
+    }
+
+  g_string_assign(result, "Invalid arguments received");
+
+exit:
+  g_strfreev(arguments);
   return result;
 }
 
@@ -223,6 +251,7 @@ ControlCommand default_commands[] =
   { "REOPEN", NULL, control_connection_reopen },
   { "QUERY", NULL, process_query_command },
   { "PWD", NULL, process_credentials },
+  { "CONFIG", NULL, control_connection_config },
   { NULL, NULL, NULL },
 };
 

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -190,6 +190,20 @@ slng_reload(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
   return _dispatch_command("RELOAD");
 }
 
+static gboolean config_options_preprocessed = FALSE;
+
+static GOptionEntry config_options[] =
+{
+  { "preprocessed", 'p', 0, G_OPTION_ARG_NONE, &config_options_preprocessed, "preprocessed", NULL },
+  { NULL,           0,   0, G_OPTION_ARG_NONE, NULL,                         NULL,           NULL }
+};
+
+static gint
+slng_config(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  return _dispatch_command(config_options_preprocessed ? "CONFIG PREPROCESSED" : "CONFIG ORIGINAL");
+}
+
 static gint
 slng_reopen(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
@@ -556,6 +570,7 @@ static CommandDescriptor modes[] =
   { "query", query_options, "Query syslog-ng statistics. Possible commands: list, get, get --sum", slng_query, NULL },
   { "show-license-info", license_options, "Show information about the license", slng_license, NULL },
   { "credentials", no_options, "Credentials manager", NULL, credentials_commands },
+  { "config", config_options, "Print current config", slng_config, NULL },
   { NULL, NULL },
 };
 


### PR DESCRIPTION
Currently there is no way to tell what configuration syslog-ng has in effect.
Sure the file in the disk can be checked, and most of the time it would be save to assume the active config and the disk content are equal.

This gives an opportunity to both get the content of the top level configuration file and also the preprocessed configuration.

The way it could be queried via `syslog-ng-ctl`:
```
> syslog-ng-ctl 
Syntax: /tmp/install/sbin/syslog-ng-ctl <command> [options]
Possible commands are:
    stats                Get syslog-ng statistics in CSV format
...
    config               Print current config
```

This prints the top level configuration file:
```
> syslog-ng-ctl config
```

With an option `--preprocess` it prints the preprocessed version of the config:
```
> syslog-ng-ctl config --preprocessed
```