### PR TITLE
Update data type to avoid conversion.

### DIFF
--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -75,7 +75,7 @@ stats_counter_set(StatsCounterItem *counter, gsize value)
 static inline gsize
 stats_counter_get(StatsCounterItem *counter)
 {
-  gssize result = 0;
+  gsize result = 0;
 
   if (counter)
     result = atomic_gssize_get_unsigned(&counter->value);


### PR DESCRIPTION
The output of atomic_gssize_get_unsigned is gsize, and output of stats_counter_get is also gsize. Instead of gssize, declare result as gsize matches the unsigned type of the return value.

This fixes an alignment trap on ARMv5 when using with glib-2.56.x.