### PR TITLE
dbld: fix dbld/rules deb failure

### DIFF
--- a/dbld/images/helpers/functions.sh
+++ b/dbld/images/helpers/functions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Helper functions for container creation.
 
 function add_obs_repo {

--- a/dbld/images/required-apt/all.txt
+++ b/dbld/images/required-apt/all.txt
@@ -1,3 +1,6 @@
+# requiled for building docker image
+unzip
+
 # required for autogen
 autoconf-archive
 automake


### PR DESCRIPTION
Due to the missing unzip dependency, gradle could not be installed. Then dh_install failed because it missed some jar files. Then dpkg-buildpackage validation failed because not all packages were installed in the dh_install step.

I added the missing unzip dependency.

Also added set -e to functions.sh. Until now those functions could fail silently.