### PR TITLE
filter: detect loop

### DIFF
--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -30,6 +30,7 @@ typedef struct _FilterCall
   FilterExprNode super;
   FilterExprNode *filter_expr;
   gchar *rule;
+  gboolean visited; /* Used for filter call loop detection */
 } FilterCall;
 
 static gboolean
@@ -61,6 +62,13 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
 {
   FilterCall *self = (FilterCall *) s;
   LogExprNode *rule;
+
+  if (self->visited)
+    {
+      msg_error("Loop detected in filter rule", evt_tag_str("rule", self->rule));
+      return FALSE;
+    }
+  self->visited = TRUE;
 
   /* skip initialize if filter_call_init already called. */
   if (self->filter_expr)
@@ -94,6 +102,8 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
                 evt_tag_str("rule", self->rule));
       return FALSE;
     }
+
+  self->visited = FALSE;
 
   return TRUE;
 }


### PR DESCRIPTION
The following config would cause stack overflow because of recursive function call:
```
@version: 3.17

source s_inter { internal(); };

filter f { filter(f); };

log { source(s_inter); filter(f); };
```
Edit:
You should start `syslog-ng -F` (without enabling either of those switches: `-d -e -t -v`)