### PR TITLE
lib/gsockaddr.c: modify the unix salen calculation

### DIFF
--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -12,6 +12,7 @@ set(COMPAT_HEADERS
     compat/getent.h
     compat/getent-sun.h
     compat/getent-generic.h
+    compat/un.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -16,7 +16,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/pcre.h		\
 	lib/compat/getent.h		\
 	lib/compat/getent-sun.h		\
-	lib/compat/getent-generic.h
+	lib/compat/getent-generic.h	\
+	lib/compat/un.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/un.h
+++ b/lib/compat/un.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2018 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef COMPAT_UN_H_INCLUDED
+#define COMPAT_UN_H_INCLUDED 1
+
+#include <sys/un.h>
+
+/*
+  SUN_LEN is not a POSIX standard, thus not available on all platforms.
+  If it is available we should rely on it. Otherwise we use the formula
+  from the Linux man page.
+*/
+#ifndef SUN_LEN
+#define SUN_LEN(ptr) ((size_t) (((struct sockaddr_un *) 0)->sun_path) + strlen ((ptr)->sun_path))
+#endif
+
+#endif

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -529,21 +529,6 @@ static GSockAddrFuncs unix_sockaddr_funcs =
   .format = g_sockaddr_unix_format
 };
 
-/*
-  SUN_LEN is not a POSIX standard, thus not available on all platforms.
-  If it is available we should rely on it. Otherwise we use the formula
-  from the Linux man page.
-*/
-static int
-_calculate_salen(GSockAddrUnix *addr)
-{
-#ifdef SUN_LEN
-  return SUN_LEN(&(addr->saun));
-#else
-  return sizeof(addr->saun) - sizeof(addr->saun.sun_path) + strlen(addr->saun.sun_path) + 1;
-#endif
-}
-
 /* anonymous if name == NULL */
 
 /*+
@@ -570,7 +555,7 @@ g_sockaddr_unix_new(const gchar *name)
     {
       strncpy(addr->saun.sun_path, name, sizeof(addr->saun.sun_path) - 1);
       addr->saun.sun_path[sizeof(addr->saun.sun_path) - 1] = 0;
-      addr->salen = _calculate_salen(addr);
+      addr->salen = SUN_LEN(&(addr->saun));
     }
   else
     {

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -529,6 +529,21 @@ static GSockAddrFuncs unix_sockaddr_funcs =
   .format = g_sockaddr_unix_format
 };
 
+/*
+  SUN_LEN is not a POSIX standard, thus not available on all platforms.
+  If it is available we should rely on it. Otherwise we use the formula
+  from the Linux man page.
+*/
+static int
+_calculate_salen(GSockAddrUnix *addr)
+{
+#ifdef SUN_LEN
+  return SUN_LEN(&(addr->saun));
+#else
+  return sizeof(addr->saun) - sizeof(addr->saun.sun_path) + strlen(addr->saun.sun_path) + 1;
+#endif
+}
+
 /* anonymous if name == NULL */
 
 /*+
@@ -555,7 +570,7 @@ g_sockaddr_unix_new(const gchar *name)
     {
       strncpy(addr->saun.sun_path, name, sizeof(addr->saun.sun_path) - 1);
       addr->saun.sun_path[sizeof(addr->saun.sun_path) - 1] = 0;
-      addr->salen = sizeof(addr->saun) - sizeof(addr->saun.sun_path) + strlen(addr->saun.sun_path) + 1;
+      addr->salen = _calculate_salen(addr);
     }
   else
     {

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -30,7 +30,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/un.h>
+#include <compat/un.h>
 #include <netinet/in.h>
 
 /* sockaddr public interface */


### PR DESCRIPTION
It is not required on all platforms to add the size of the
terminating null character (+1) to the value of the `addrlen`
parameter during the `bind` system call. Most platforms has a
built in MACRO to calculate the proper value, called `SUN_LEN`.
SUN_LEN is **not** a POSIX standard, so we use the formula from
the Linux man page if it is not available.

Signed-off-by: Laszlo Szemere <laszlo.szemere@balabit.com>