### PR TITLE
json: fix the literal() type hint

### DIFF
--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -124,6 +124,10 @@ Test(format_json, test_format_json_with_type_hints)
                          "{\"i\":\"ifoo(\"}");
   assert_template_format("$(format-json b=boolean(TRUE))",
                          "{\"b\":true}");
+  assert_template_format("$(format-json b=literal(whatever))",
+                         "{\"b\":whatever}");
+  assert_template_format("$(format-json b=literal($(format-json subkey=bar)))",
+                         "{\"b\":{\"subkey\":\"bar\"}}");
 }
 
 Test(format_json, test_format_json_on_error)


### PR DESCRIPTION
This makes it possible to add snippets of literal values into the
json, without being represented as strings.

$(format-json bar=literal($(format-json --subkeys .foo.)))

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>