### PR TITLE
Value pairs improvements

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -332,13 +332,14 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_KEY                         10504
 %token KW_SCOPE                       10505
 %token KW_SHIFT                       10506
-%token KW_REKEY                       10507
-%token KW_ADD_PREFIX                  10508
-%token KW_REPLACE_PREFIX              10509
+%token KW_SHIFT_LEVELS                10507
+%token KW_REKEY                       10508
+%token KW_ADD_PREFIX                  10509
+%token KW_REPLACE_PREFIX              10510
 
-%token KW_ON_ERROR                    10510
+%token KW_ON_ERROR                    10511
 
-%token KW_RETRIES                     10511
+%token KW_RETRIES                     10512
 
 /* END_DECLS */
 
@@ -1393,7 +1394,8 @@ vp_rekey_options
 	;
 
 vp_rekey_option
-	: KW_SHIFT '(' LL_NUMBER ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_shift($3)); }
+	: KW_SHIFT '(' positive_integer ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_shift($3)); }
+	| KW_SHIFT_LEVELS '(' positive_integer ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_shift_levels($3)); }
 	| KW_ADD_PREFIX '(' string ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_add_prefix($3)); free($3); }
 	| KW_REPLACE_PREFIX '(' string string ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_replace_prefix($3, $4)); free($3); free($4); }
 	;

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -169,7 +169,7 @@ value_pairs_parse_type(gchar *spec, gchar **value, gchar **type)
       return;
     }
 
-  ep = strchr(sp, ')');
+  ep = strrchr(sp, ')');
   if (ep == NULL || ep[1] != '\0')
     {
       *value = spec;

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -331,6 +331,15 @@ vp_cmdline_parse_rekey_shift (const gchar *option_name, const gchar *value,
   gpointer *args = (gpointer *) data;
   ValuePairsTransformSet *vpts = (ValuePairsTransformSet *) args[2];
   gchar *key = (gchar *) args[3];
+  gchar *end = NULL;
+  gint number_to_shift = strtol(value, &end, 0);
+
+  if (number_to_shift <= 0 || *end != 0)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                   "Error parsing value-pairs, argument to --shift is not numeric or not a positive number");
+      return FALSE;
+    }
 
   vpts = vp_cmdline_rekey_verify (key, vpts, data);
   if (!vpts)
@@ -340,8 +349,38 @@ vp_cmdline_parse_rekey_shift (const gchar *option_name, const gchar *value,
       return FALSE;
     }
 
-  value_pairs_transform_set_add_func
-  (vpts, value_pairs_new_transform_shift (atoi (value)));
+  value_pairs_transform_set_add_func(vpts,
+                                     value_pairs_new_transform_shift (number_to_shift));
+  return TRUE;
+}
+
+static gboolean
+vp_cmdline_parse_rekey_shift_levels (const gchar *option_name, const gchar *value,
+                                     gpointer data, GError **error)
+{
+  gpointer *args = (gpointer *) data;
+  ValuePairsTransformSet *vpts = (ValuePairsTransformSet *) args[2];
+  gchar *key = (gchar *) args[3];
+  gchar *end = NULL;
+  gint number_to_shift = strtol(value, &end, 0);
+
+  if (number_to_shift <= 0 || *end != 0)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                   "Error parsing value-pairs, argument to --shift-levels is not numeric or not a positive number");
+      return FALSE;
+    }
+
+  vpts = vp_cmdline_rekey_verify (key, vpts, data);
+  if (!vpts)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                   "Error parsing value-pairs: --shift-levels used without --key or --rekey");
+      return FALSE;
+    }
+
+  value_pairs_transform_set_add_func(vpts,
+                                     value_pairs_new_transform_shift_levels (number_to_shift));
   return TRUE;
 }
 
@@ -378,6 +417,10 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
     },
     {
       "shift", 'S', 0, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_rekey_shift,
+      NULL, NULL
+    },
+    {
+      "shift-levels", 0, 0, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_rekey_shift_levels,
       NULL, NULL
     },
     {

--- a/lib/value-pairs/transforms.c
+++ b/lib/value-pairs/transforms.c
@@ -49,7 +49,6 @@ struct _ValuePairsTransform
 typedef struct
 {
   ValuePairsTransform super;
-
   gint amount;
 } VPTransShift;
 
@@ -146,6 +145,40 @@ value_pairs_new_transform_shift (gint amount)
   vpt = g_new(VPTransShift, 1);
   vp_trans_init((ValuePairsTransform *)vpt,
                 vp_trans_shift, NULL);
+
+  vpt->amount = amount;
+
+  return (ValuePairsTransform *)vpt;
+}
+
+/* shift-levels() */
+
+static void
+vp_trans_shift_levels(ValuePairsTransform *t, GString *key)
+{
+  VPTransShift *self = (VPTransShift *)t;
+  const gchar *dot;
+  gint levels_left = self->amount - 1;
+
+  dot = strchr(key->str, '.');
+  while (dot && levels_left > 0)
+    {
+      dot = strchr(dot + 1, '.');
+      levels_left--;
+    }
+
+  if (dot)
+    g_string_erase(key, 0, dot + 1 - key->str);
+}
+
+ValuePairsTransform *
+value_pairs_new_transform_shift_levels(gint amount)
+{
+  VPTransShift *vpt;
+
+  vpt = g_new(VPTransShift, 1);
+  vp_trans_init((ValuePairsTransform *)vpt,
+                vp_trans_shift_levels, NULL);
 
   vpt->amount = amount;
 

--- a/lib/value-pairs/transforms.h
+++ b/lib/value-pairs/transforms.h
@@ -33,6 +33,7 @@ typedef struct _ValuePairsTransformSet ValuePairsTransformSet;
 ValuePairsTransform *value_pairs_new_transform_add_prefix (const gchar *prefix);
 ValuePairsTransform *value_pairs_new_transform_shift (gint amount);
 ValuePairsTransform *value_pairs_new_transform_replace_prefix(const gchar *prefix, const gchar *new_prefix);
+ValuePairsTransform *value_pairs_new_transform_shift_levels(gint amount);
 void value_pairs_transform_free(ValuePairsTransform *t);
 
 ValuePairsTransformSet *value_pairs_transform_set_new(const gchar *glob);

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -822,8 +822,17 @@ value_pairs_add_scope(ValuePairs *vp, const gchar *scope)
 {
   gboolean result;
 
-  result = cfg_process_flag(value_pair_scope, vp, scope);
-  vp_update_builtin_list_of_values(vp);
+  if (strcmp(scope, "none") != 0)
+    {
+      result = cfg_process_flag(value_pair_scope, vp, scope);
+      vp_update_builtin_list_of_values(vp);
+    }
+  else
+    {
+      result = TRUE;
+      vp->scopes = 0;
+      vp_update_builtin_list_of_values(vp);
+    }
   return result;
 }
 

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -90,6 +90,8 @@ Test(format_json, test_format_json)
                          "{\".program\":{\"@name\":\"syslog-ng\"}}");
   assert_template_format("$(format-json --leave-initial-dot .program.@name=${PROGRAM} .program.foo .program.bar)",
                          "{\".program\":{\"@name\":\"syslog-ng\"}}");
+  assert_template_format("$(format-json .program.@name=${PROGRAM} .program.foo .program.bar --key .program.* --shift-levels 2 --add-prefix _)",
+                         "{\"_@name\":\"syslog-ng\"}");
 }
 
 Test(format_json, test_format_json_key)


### PR DESCRIPTION
This branch adds a couple of improvements to our value-pairs functionality:

1) adds support for --shift-levels key rewrite method, a bit similar to --shift, but instead of working with characters, it works with dot delimited "levels". --shift-levels 2 drops the prefix up to the second dot in the name of the key. e.g. .iptables.SRC becomes SRC (the initial dot is calculated too).

2) fixes a bug in type hint parsing, in case the hinted template expression contains parenthesis on its own. This is also related to #2286 where we actually make use of literal type hints in connection with $(format-json)

3) it adds a scope named "none" that resets the previously added scopes, making it possible to get rid of automatically added name-value pairs. This is not really changing functionality, however improves performance as the internal table of macros need not be consulted.

The 3rd option works like this:

$(format-welf --scope none .iptables.*)

This way the internal table of macros are not attempted to be matched against the wild-card. This is basically a performance hack, as I think the default behavior is not good.

