### PR TITLE
filter: multiple filter ref incorrect loop detection

### DIFF
--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -68,11 +68,12 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
       msg_error("Loop detected in filter rule", evt_tag_str("rule", self->rule));
       return FALSE;
     }
-  self->visited = TRUE;
 
   /* skip initialize if filter_call_init already called. */
   if (self->filter_expr)
     return TRUE;
+
+  self->visited = TRUE;
 
   rule = cfg_tree_get_object(&cfg->tree, ENC_FILTER, self->rule);
   if (rule)


### PR DESCRIPTION
In case of skip initialized the `visited` variable was not set back to `FALSE`, which would cause false loop detection if the same `filter` filter would be used twice.