### PR TITLE
templates: get rid off the args_lock

### DIFF
--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -99,6 +99,19 @@ log_template_lookup_and_setup_function_call(LogTemplateCompiler *self, LogTempla
   Plugin *p;
 
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+  /* the plus one denotes the function name, which'll be removed from argc
+   * during parsing */
+
+  if (argc > TEMPLATE_INVOKE_MAX_ARGS + 1)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "Too many arguments (%d) to template function \"%s\", "
+                  "maximum number of arguments is %d", argc - 1, argv[0],
+                  TEMPLATE_INVOKE_MAX_ARGS);
+      goto error;
+    }
+
   p = cfg_find_plugin(self->template->cfg, LL_CONTEXT_TEMPLATE_FUNC, argv[0]);
 
   if (!p)

--- a/lib/template/function.h
+++ b/lib/template/function.h
@@ -29,18 +29,14 @@
 #include "plugin-types.h"
 #include "common-template-typedefs.h"
 
+#define TEMPLATE_INVOKE_MAX_ARGS 64
+
 /* This structure contains the arguments for template-function
  * expansion. It is defined in a struct because otherwise a large
  * number of function arguments, that are passed around, possibly
  * several times. */
 typedef struct _LogTemplateInvokeArgs
 {
-  /* scratch buffers, stores GString *, elements are managed by the
-   * function, storage/free is performed by the core. Can be used to
-   * avoid allocating GString buffers in the fast-path. */
-
-  GPtrArray *bufs;
-
   /* context in case of correllation */
   LogMessage **messages;
   gint num_messages;
@@ -50,6 +46,7 @@ typedef struct _LogTemplateInvokeArgs
   gint tz;
   gint seq_num;
   const gchar *context_id;
+  GString *argv[TEMPLATE_INVOKE_MAX_ARGS];
 } LogTemplateInvokeArgs;
 
 typedef struct _LogTemplateFunction LogTemplateFunction;
@@ -67,7 +64,7 @@ struct _LogTemplateFunction
 
   /* evaluate arguments, storing argument buffers in arg_bufs in case it
    * makes sense to reuse those buffers */
-  void (*eval)(LogTemplateFunction *self, gpointer state, const LogTemplateInvokeArgs *args);
+  void (*eval)(LogTemplateFunction *self, gpointer state, LogTemplateInvokeArgs *args);
 
   /* call the function */
   void (*call)(LogTemplateFunction *self, gpointer state, const LogTemplateInvokeArgs *args, GString *result);

--- a/lib/template/simple-function.c
+++ b/lib/template/simple-function.c
@@ -45,16 +45,16 @@ tf_simple_func_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
   gint i;
 
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-  state->argv = g_malloc(sizeof(LogTemplate *) * (argc - 1));
+  state->argv_templates = g_malloc(sizeof(LogTemplate *) * (argc - 1));
 
   /* NOTE: the argv argument contains the function name as argv[0],
    * but the LogTemplate array doesn't. Thus the index is shifted by
    * one. */
   for (i = 0; i < argc - 1; i++)
     {
-      state->argv[i] = log_template_new(parent->cfg, NULL);
-      log_template_set_escape(state->argv[i], parent->escape);
-      if (!log_template_compile(state->argv[i], argv[i + 1], error))
+      state->argv_templates[i] = log_template_new(parent->cfg, NULL);
+      log_template_set_escape(state->argv_templates[i], parent->escape);
+      if (!log_template_compile(state->argv_templates[i], argv[i + 1], error))
         goto error;
     }
   state->argc = argc - 1;
@@ -73,7 +73,7 @@ tf_simple_func_eval(LogTemplateFunction *self, gpointer s, LogTemplateInvokeArgs
   for (i = 0; i < state->argc; i++)
     {
       args->argv[i] = scratch_buffers_alloc();
-      log_template_append_format_recursive(state->argv[i], args, args->argv[i]);
+      log_template_append_format_recursive(state->argv_templates[i], args, args->argv[i]);
     }
 }
 
@@ -94,8 +94,8 @@ tf_simple_func_free_state(gpointer s)
 
   for (i = 0; i < state->argc; i++)
     {
-      if (state->argv[i])
-        log_template_unref(state->argv[i]);
+      if (state->argv_templates[i])
+        log_template_unref(state->argv_templates[i]);
     }
-  g_free(state->argv);
+  g_free(state->argv_templates);
 }

--- a/lib/template/simple-function.h
+++ b/lib/template/simple-function.h
@@ -32,7 +32,7 @@
 typedef struct _TFSimpleFuncState
 {
   gint argc;
-  LogTemplate **argv;
+  LogTemplate **argv_templates;
 } TFSimpleFuncState;
 
 typedef void (*TFSimpleFunc)(LogMessage *msg, gint argc, GString *argv[], GString *result);

--- a/lib/template/simple-function.h
+++ b/lib/template/simple-function.h
@@ -39,7 +39,7 @@ typedef void (*TFSimpleFunc)(LogMessage *msg, gint argc, GString *argv[], GStrin
 
 gboolean tf_simple_func_prepare(LogTemplateFunction *self, gpointer state, LogTemplate *parent, gint argc,
                                 gchar *argv[], GError **error);
-void tf_simple_func_eval(LogTemplateFunction *self, gpointer state, const LogTemplateInvokeArgs *args);
+void tf_simple_func_eval(LogTemplateFunction *self, gpointer state, LogTemplateInvokeArgs *args);
 void tf_simple_func_call(LogTemplateFunction *self, gpointer state, const LogTemplateInvokeArgs *args, GString *result);
 void tf_simple_func_free_state(gpointer state);
 

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -63,8 +63,6 @@ typedef struct _LogTemplate
   gboolean escape;
   gboolean def_inline;
   GlobalConfig *cfg;
-  GStaticMutex arg_lock;
-  GPtrArray *arg_bufs;
   TypeHint type_hint;
 } LogTemplate;
 

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -29,6 +29,7 @@
 #include "parse-number.h"
 #include "str-format.h"
 #include "plugin-types.h"
+#include "scratch-buffers.h"
 
 #include <stdlib.h>
 #include <errno.h>

--- a/modules/basicfuncs/cond-funcs.c
+++ b/modules/basicfuncs/cond-funcs.c
@@ -123,7 +123,9 @@ tf_grep_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs 
                 g_string_append_c(result, ',');
 
               /* NOTE: not recursive, as the message context is just one message */
-              log_template_append_format(state->super.argv[i], msg, args->opts, args->tz, args->seq_num, args->context_id, result);
+              log_template_append_format(state->super.argv_templates[i], msg,
+                                         args->opts, args->tz, args->seq_num, args->context_id,
+                                         result);
               first = FALSE;
             }
           if (state->grep_max_count && count >= state->grep_max_count)
@@ -154,13 +156,17 @@ tf_if_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *a
 
   if (filter_expr_eval_with_context(state->filter, args->messages, args->num_messages))
     {
-      log_template_append_format_with_context(state->super.argv[0], args->messages, args->num_messages, args->opts, args->tz,
-                                              args->seq_num, args->context_id, result);
+      log_template_append_format_with_context(state->super.argv_templates[0],
+                                              args->messages, args->num_messages, args->opts, args->tz,
+                                              args->seq_num, args->context_id,
+                                              result);
     }
   else
     {
-      log_template_append_format_with_context(state->super.argv[1], args->messages, args->num_messages, args->opts, args->tz,
-                                              args->seq_num, args->context_id, result);
+      log_template_append_format_with_context(state->super.argv_templates[1],
+                                              args->messages, args->num_messages, args->opts, args->tz,
+                                              args->seq_num, args->context_id,
+                                              result);
     }
 }
 

--- a/modules/basicfuncs/context-funcs.c
+++ b/modules/basicfuncs/context-funcs.c
@@ -73,7 +73,7 @@ tf_context_lookup_call(LogTemplateFunction *self, gpointer s, const LogTemplateI
                 g_string_append_c(result, ',');
 
               /* NOTE: not recursive, as the message context is just one message */
-              log_template_format(state->super.argv[i], msg, args->opts, args->tz, args->seq_num, args->context_id, buf);
+              log_template_format(state->super.argv_templates[i], msg, args->opts, args->tz, args->seq_num, args->context_id, buf);
               str_repr_encode_append(result, buf->str, buf->len, ",");
 
               first = FALSE;
@@ -110,7 +110,7 @@ tf_context_values_call(LogTemplateFunction *self, gpointer s, const LogTemplateI
             g_string_append_c(result, ',');
 
           /* NOTE: not recursive, as the message context is just one message */
-          log_template_format(state->argv[i], msg, args->opts, args->tz, args->seq_num, args->context_id, buf);
+          log_template_format(state->argv_templates[i], msg, args->opts, args->tz, args->seq_num, args->context_id, buf);
           str_repr_encode_append(result, buf->str, buf->len, ",");
 
           first = FALSE;

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -142,7 +142,7 @@ _tf_num_parse_arg_with_message(const TFSimpleFuncState *state,
   GString *formatted_template = scratch_buffers_alloc();
   gint on_error = args->opts->on_error;
 
-  log_template_format(state->argv[0], message, args->opts, args->tz,
+  log_template_format(state->argv_templates[0], message, args->opts, args->tz,
                       args->seq_num, args->context_id, formatted_template);
 
   if (!parse_number_with_suffix(formatted_template->str, number))

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -133,24 +133,13 @@ tf_num_mod(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
 TEMPLATE_FUNCTION_SIMPLE(tf_num_mod);
 
-
-static GString *
-_get_gstring_scratch_buffer(const LogTemplateInvokeArgs *args,
-                            gsize initial_capacity)
-{
-  if (args->bufs->len == 0)
-    g_ptr_array_add(args->bufs, g_string_sized_new(initial_capacity));
-
-  return (GString *) g_ptr_array_index(args->bufs, 0);
-}
-
 static gboolean
 _tf_num_parse_arg_with_message(const TFSimpleFuncState *state,
                                LogMessage *message,
                                const LogTemplateInvokeArgs *args,
                                gint64 *number)
 {
-  GString *formatted_template = _get_gstring_scratch_buffer(args, 64);
+  GString *formatted_template = scratch_buffers_alloc();
   gint on_error = args->opts->on_error;
 
   log_template_format(state->argv[0], message, args->opts, args->tz,

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -275,17 +275,15 @@ static void
 tf_sanitize_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
   TFSanitizeState *state = (TFSanitizeState *) s;
-  GString **argv;
   gint argc;
   gint i, pos;
 
-  argv = (GString **) args->bufs->pdata;
-  argc = args->bufs->len;
+  argc = state->super.argc;
   for (i = 0; i < argc; i++)
     {
-      for (pos = 0; pos < argv[i]->len; pos++)
+      for (pos = 0; pos < args->argv[i]->len; pos++)
         {
-          guchar last_char = argv[i]->str[pos];
+          guchar last_char = args->argv[i]->str[pos];
 
           if ((state->ctrl_chars && last_char < 32) ||
               (strchr(state->invalid_chars, (gchar) last_char) != NULL))
@@ -473,16 +471,15 @@ static void
 tf_string_padding_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
   TFStringPaddingState *state = (TFStringPaddingState *) s;
-  GString **argv = (GString **) args->bufs->pdata;
 
-  if (argv[0]->len > state->width)
+  if (args->argv[0]->len > state->width)
     {
-      g_string_append_len(result, argv[0]->str, argv[0]->len);
+      g_string_append_len(result, args->argv[0]->str, args->argv[0]->len);
     }
   else
     {
-      g_string_append_len(result, state->padding_pattern->str, state->width - argv[0]->len);
-      g_string_append_len(result, argv[0]->str, argv[0]->len);
+      g_string_append_len(result, state->padding_pattern->str, state->width - args->argv[0]->len);
+      g_string_append_len(result, args->argv[0]->str, args->argv[0]->len);
     }
 }
 

--- a/modules/cryptofuncs/cryptofuncs.c
+++ b/modules/cryptofuncs/cryptofuncs.c
@@ -107,7 +107,7 @@ tf_hash_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
 }
 
 static guint
-_hash(const EVP_MD *md, GString **argv, gint argc, guchar *hash, guint hash_size)
+_hash(const EVP_MD *md, GString *const *argv, gint argc, guchar *hash, guint hash_size)
 {
   gint i;
   guint md_len;
@@ -131,14 +131,13 @@ static void
 tf_hash_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
   TFHashState *state = (TFHashState *) s;
-  GString **argv;
   gint argc;
   guchar hash[EVP_MAX_MD_SIZE];
   gchar hash_str[EVP_MAX_MD_SIZE * 2 + 1];
   guint md_len;
-  argv = (GString **) args->bufs->pdata;
-  argc = args->bufs->len;
-  md_len = _hash(state->md, argv, argc, hash, sizeof(hash));
+
+  argc = state->super.argc;
+  md_len = _hash(state->md, args->argv, argc, hash, sizeof(hash));
   // we fetch the entire hash in a hex format otherwise we cannot truncate at
   // odd character numbers
   format_hex_string(hash, md_len, hash_str, sizeof(hash_str));

--- a/modules/geoip/tfgeoip.c
+++ b/modules/geoip/tfgeoip.c
@@ -150,9 +150,8 @@ static void
 tf_geoip_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
   TFGeoIPState *state = (TFGeoIPState *) s;
-  GString **argv = (GString **) args->bufs->pdata;
 
-  state->add_geoip_result(state, result, argv[0]->str);
+  state->add_geoip_result(state, result, args->argv[0]->str);
 
 }
 

--- a/modules/geoip2/tfgeoip.c
+++ b/modules/geoip2/tfgeoip.c
@@ -113,12 +113,11 @@ error:
 static void
 tf_geoip_maxminddb_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
-  GString **argv = (GString **) args->bufs->pdata;
   TFMaxMindDBState *state = (TFMaxMindDBState *) s;
 
   int _gai_error, mmdb_error;
   MMDB_lookup_result_s mmdb_result =
-    MMDB_lookup_string(state->database, argv[0]->str, &_gai_error, &mmdb_error);
+    MMDB_lookup_string(state->database, args->argv[0]->str, &_gai_error, &mmdb_error);
 
   if (!mmdb_result.found_entry)
     {

--- a/modules/stardate/stardate.c
+++ b/modules/stardate/stardate.c
@@ -108,9 +108,6 @@ tf_stardate_call(LogTemplateFunction *self, gpointer s,
                  const LogTemplateInvokeArgs *args, GString *result)
 {
   TFStardateState  *state = (TFStardateState *) s;
-  GString **argv;
-
-  argv = (GString **) args->bufs->pdata;
 
   char format[7]; // "%0.xlf\0"
   if (g_snprintf(format, sizeof(format),"%%0.%dlf", state->precision) < 0)
@@ -121,11 +118,11 @@ tf_stardate_call(LogTemplateFunction *self, gpointer s,
     }
 
   char *status;
-  time_t time_to_convert = strtol(argv[0]->str, &status, 10);
+  time_t time_to_convert = strtol(args->argv[0]->str, &status, 10);
   if (*status)
     {
       msg_error("stardate: wrong format: expected unixtime like value",
-                evt_tag_str("got:", argv[0]->str));
+                evt_tag_str("got:", args->argv[0]->str));
       return;
     }
 


### PR DESCRIPTION
This patch gets rid off the argument locking in template functions, thereby making the use of the same
template (with template functions) from multiple threads scale.

[Edit by Kokan]
This patch also limits the template function arguments to 64.