### PR TITLE
app-parser: set ${.app.name} to the application identified

### DIFF
--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -74,8 +74,13 @@ _generate_parser(AppParserGenerator *self, const gchar *parser_expr)
 static void
 _generate_action(AppParserGenerator *self, Application *app)
 {
-  g_string_append_printf(self->block, "    rewrite { set-tag('.app.%s'); };\n", app->name);
-  g_string_append(self->block, "    flags(final);\n");
+  g_string_append_printf(self->block,
+                         "    rewrite {\n"
+                         "       set-tag('.app.%s');\n"
+                         "       set('%s' value('.app.name'));\n"
+                         "    };\n"
+                         "    flags(final);\n",
+                         app->name, app->name);
 }
 
 static gboolean


### PR DESCRIPTION
Rationale:
* whenever we are sending structured data upstream, this name-value tag grabs the "kind" of application we parsed. This could be used as "sourcetype" in splunk. The same information is also available as a tag, however it is not easy to use that in an output template.
