### PR TITLE
Http multi threading

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -653,7 +653,7 @@ _worker_thread(gpointer arg)
   iv_deinit();
   return;
 
- error:
+error:
   _signal_startup_failure(self);
   iv_deinit();
 }
@@ -661,9 +661,8 @@ _worker_thread(gpointer arg)
 gboolean
 log_threaded_dest_worker_init_method(LogThreadedDestWorker *self)
 {
-  self->queue = log_dest_driver_acquire_queue(
-                         &self->owner->super,
-                         _format_queue_persist_name(self));
+  self->queue = log_dest_driver_acquire_queue(&self->owner->super,
+                                              _format_queue_persist_name(self));
 
   if (!self->queue)
     return FALSE;
@@ -937,7 +936,7 @@ log_threaded_dest_driver_init_method(LogPipe *s)
   _register_stats(self);
 
   self->shared_seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
-                                                                  _format_seqnum_persist_name(self)));
+                                         _format_seqnum_persist_name(self)));
   if (!self->shared_seq_num)
     init_sequence_number(&self->shared_seq_num);
 

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -591,8 +591,16 @@ _worker_thread(gpointer arg)
 
   _signal_startup_finished(self);
 
+  /* if we have anything on the backlog, that was a partial, potentially
+   * not-flushed batch.  Rewind it, so we start with that */
+
+  log_queue_rewind_backlog_all(self->worker.queue);
+
   _schedule_restart(self);
   iv_main();
+
+  log_threaded_dest_worker_flush(self);
+  log_queue_rewind_backlog_all(self->worker.queue);
 
   _disconnect(self);
 

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -66,9 +66,10 @@ struct _LogThreadedDestWorker
   gboolean enable_flush_timeout;
   gboolean suspended;
   gboolean startup_finished;
+  gboolean startup_failure;
   GCond *started_up;
 
-  void (*thread_init)(LogThreadedDestWorker *s);
+  gboolean (*thread_init)(LogThreadedDestWorker *s);
   void (*thread_deinit)(LogThreadedDestWorker *s);
   gboolean (*connect)(LogThreadedDestWorker *s);
   void (*disconnect)(LogThreadedDestWorker *s);
@@ -113,11 +114,12 @@ struct _LogThreadedDestDriver
   const gchar *(*format_stats_instance)(LogThreadedDestDriver *s);
 };
 
-static inline void
+static inline gboolean
 log_threaded_dest_worker_thread_init(LogThreadedDestWorker *self)
 {
   if (self->thread_init)
-    self->thread_init(self);
+    return self->thread_init(self);
+  return TRUE;
 }
 
 static inline void

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -199,7 +199,9 @@ void log_threaded_dest_worker_drop_messages(LogThreadedDestWorker *self, gint ba
 void log_threaded_dest_worker_rewind_messages(LogThreadedDestWorker *self, gint batch_size);
 gboolean log_threaded_dest_worker_init_method(LogThreadedDestWorker *self);
 void log_threaded_dest_worker_deinit_method(LogThreadedDestWorker *self);
-void log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self, LogThreadedDestDriver *owner, gint worker_index);
+void log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self,
+                                            LogThreadedDestDriver *owner,
+                                            gint worker_index);
 void log_threaded_dest_worker_free_method(LogThreadedDestWorker *self);
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -75,6 +75,7 @@ struct _LogThreadedDestWorker
   void (*disconnect)(LogThreadedDestWorker *s);
   worker_insert_result_t (*insert)(LogThreadedDestWorker *s, LogMessage *msg);
   worker_insert_result_t (*flush)(LogThreadedDestWorker *s);
+  void (*free_fn)(LogThreadedDestWorker *s);
 };
 
 struct _LogThreadedDestDriver
@@ -176,6 +177,10 @@ log_threaded_dest_driver_flush(LogThreadedDestDriver *self)
 void log_threaded_dest_worker_ack_messages(LogThreadedDestWorker *self, gint batch_size);
 void log_threaded_dest_worker_drop_messages(LogThreadedDestWorker *self, gint batch_size);
 void log_threaded_dest_worker_rewind_messages(LogThreadedDestWorker *self, gint batch_size);
+gboolean log_threaded_dest_worker_init_method(LogThreadedDestWorker *self);
+void log_threaded_dest_worker_deinit_method(LogThreadedDestWorker *self);
+void log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self, LogThreadedDestDriver *owner);
+void log_threaded_dest_worker_free_method(LogThreadedDestWorker *self);
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);
 gboolean log_threaded_dest_driver_init_method(LogPipe *s);

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -65,7 +65,7 @@ struct _LogThreadedDestWorker
   gint batch_size;
   gint rewound_batch_size;
   gint retries_counter;
-  gint seq_num;
+  gint32 seq_num;
   struct timespec last_flush_time;
   gboolean enable_flush_timeout;
   gboolean suspended;

--- a/lib/seqnum.h
+++ b/lib/seqnum.h
@@ -32,12 +32,20 @@ init_sequence_number(gint32 *seqnum)
   *seqnum = 1;
 }
 
-static inline void
+static inline gint32
 step_sequence_number(gint32 *seqnum)
 {
+  gint32 old_value = *seqnum;
   (*seqnum)++;
   if (*seqnum < 0)
     *seqnum = 1;
+  return old_value;
+}
+
+static inline gint32
+step_sequence_number_atomic(gint32 *seqnum)
+{
+  return (gint32) g_atomic_int_exchange_and_add(seqnum, 1);
 }
 
 

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -177,8 +177,8 @@ Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_proce
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == 2,
-            "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 2,
+            "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.shared_seq_num);
 }
 
 static worker_insert_result_t
@@ -202,8 +202,8 @@ Test(logthrdestdrv, message_drops_are_accounted_in_the_drop_counter_and_are_repo
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 1);
-  cr_assert(dd->super.seq_num == 2,
-            "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 2,
+            "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("dropped while sending");
 }
 
@@ -230,8 +230,8 @@ Test(logthrdestdrv, connection_failure_is_considered_an_error_and_retried_indefi
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(dd->super.seq_num == 12,
-            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 12,
+            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Server disconnected");
 }
 
@@ -258,8 +258,8 @@ Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_drops)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 1);
-  cr_assert(dd->super.seq_num == 6,
-            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 6,
+            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Error occurred while");
   assert_grabbed_log_contains("Multiple failures while sending");
 }
@@ -289,8 +289,8 @@ Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_accept
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(dd->super.seq_num == 6,
-            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 6,
+            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Error occurred while");
 }
 
@@ -333,8 +333,8 @@ Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == 11,
-            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 11,
+            "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
 }
 
 static worker_insert_result_t
@@ -375,7 +375,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 11, "%d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("dropped while sending message");
 }
 
@@ -440,8 +440,8 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == dd->super.retries_max * 10 + 1,
-            "seq_num needs to be one larger than the number of insert attempts, found %d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == dd->super.retries_max * 10 + 1,
+            "seq_num needs to be one larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Error occurred while");
   assert_grabbed_log_contains("Multiple failures while sending");
 }
@@ -513,7 +513,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == total_attempts * 10 + 1, "%d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == total_attempts * 10 + 1, "%d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Error occurred while");
 }
 
@@ -587,7 +587,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == total_attempts * 10 + 1, "%d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == total_attempts * 10 + 1, "%d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Server disconnected");
 }
 
@@ -615,7 +615,7 @@ Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_calle
   cr_assert(stats_counter_get(dd->super.written_messages) == 20);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == 21, "%d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 21, "%d", dd->super.shared_seq_num);
 }
 
 Test(logthrdestdrv, flush_timeout_delays_flush_to_the_specified_interval)
@@ -766,7 +766,7 @@ Test(logthrdestdrv, test_explicit_ack_accept)
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->queued_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
-  cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);
+  cr_assert(dd->super.shared_seq_num == 11, "%d", dd->super.shared_seq_num);
 }
 
 MainLoopOptions main_loop_options = {0};

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -413,7 +413,6 @@ _flush_batched_message_error_drop(LogThreadedDestDriver *s)
 
   self->flush_size += self->super.worker.instance.batch_size;
   _expect_batch_size_remains_the_same_across_retries(self);
-
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.worker.instance.batch_size == 0)
     return WORKER_INSERT_RESULT_SUCCESS;
@@ -738,7 +737,7 @@ _insert_explicit_acks_message_success(LogThreadedDestDriver *s, LogMessage *msg)
     return WORKER_INSERT_RESULT_QUEUED;
 
   self->flush_size += 1;
-  log_threaded_dest_driver_ack_messages(s, 1);
+  log_threaded_dest_worker_ack_messages(&s->worker.instance, 1);
   return WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT;
 }
 
@@ -748,7 +747,7 @@ _flush_explicit_acks_message_success(LogThreadedDestDriver *s)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->flush_size += 1;
-  log_threaded_dest_driver_ack_messages(s, 1);
+  log_threaded_dest_worker_ack_messages(&s->worker.instance, 1);
   return WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT;
 }
 

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -176,7 +176,7 @@ Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_proce
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 2,
             "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.seq_num);
 }
@@ -332,7 +332,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11,
             "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.seq_num);
 }
@@ -374,7 +374,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);
   assert_grabbed_log_contains("dropped while sending message");
 }
@@ -440,7 +440,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == dd->super.retries_max * 10 + 1,
             "seq_num needs to be one larger than the number of insert attempts, found %d", dd->super.seq_num);
   assert_grabbed_log_contains("Error occurred while");
@@ -513,7 +513,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == total_attempts * 10 + 1, "%d", dd->super.seq_num);
   assert_grabbed_log_contains("Error occurred while");
 }
@@ -587,7 +587,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == total_attempts * 10 + 1, "%d", dd->super.seq_num);
   assert_grabbed_log_contains("Server disconnected");
 }
@@ -595,7 +595,7 @@ Test(logthrdestdrv,
 Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_called_more_often)
 {
   /* 3 messages per second, we need to set this explicitly on the queue as it has already been initialized */
-  log_queue_set_throttle(dd->super.worker.queue, 3);
+  log_queue_set_throttle(dd->super.worker.instance.queue, 3);
   dd->super.worker.insert = _insert_batched_message_success;
   dd->super.worker.flush = _flush_batched_message_success;
   dd->super.flush_lines = 5;
@@ -615,7 +615,7 @@ Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_calle
   cr_assert(stats_counter_get(dd->super.processed_messages) == 20);
   cr_assert(stats_counter_get(dd->super.written_messages) == 20);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 21, "%d", dd->super.seq_num);
 }
 
@@ -764,9 +764,9 @@ Test(logthrdestdrv, test_explicit_ack_accept)
 
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.worker.queue->queued_messages) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->queued_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.seq_num == 11, "%d", dd->super.seq_num);
 }
 

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -534,7 +534,7 @@ afamqp_worker_publish(AMQPDestDriver *self, LogMessage *msg)
   gpointer user_data[] = { &self->entries, &pos, &self->max_entries };
 
   value_pairs_foreach(self->vp, afamqp_vp_foreach, msg,
-                      self->super.seq_num,
+                      self->super.worker.instance.seq_num,
                       LTZ_SEND, &self->template_options, user_data);
 
   table.num_entries = pos;
@@ -547,13 +547,13 @@ afamqp_worker_publish(AMQPDestDriver *self, LogMessage *msg)
   props.headers = table;
 
   log_template_format(self->routing_key_template, msg, &self->template_options, LTZ_LOCAL,
-                      self->super.seq_num,
+                      self->super.worker.instance.seq_num,
                       NULL, routing_key);
 
   if (self->body_template)
     {
       log_template_format(self->body_template, msg, &self->template_options, LTZ_LOCAL,
-                          self->super.seq_num,
+                          self->super.worker.instance.seq_num,
                           NULL, body);
       body_bytes = amqp_cstring_bytes(body->str);
     }

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -376,7 +376,7 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
                              _vp_obj_start,
                              _vp_process_value,
                              _vp_obj_end,
-                             msg, self->super.seq_num,
+                             msg, self->super.worker.instance.seq_num,
                              LTZ_SEND,
                              &self->template_options,
                              self);
@@ -386,7 +386,7 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
       if (!drop_silently)
         {
           msg_error("Failed to format message for MongoDB, dropping message",
-                    evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num,
+                    evt_tag_value_pairs("message", self->vp, msg, self->super.worker.instance.seq_num,
                                         LTZ_SEND, &self->template_options),
                     evt_tag_str("driver", self->super.super.super.id));
         }
@@ -394,7 +394,7 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
     }
 
   msg_debug("Outgoing message to MongoDB destination",
-            evt_tag_value_pairs("message", self->vp, msg, self->super.seq_num, LTZ_SEND,
+            evt_tag_value_pairs("message", self->vp, msg, self->super.worker.instance.seq_num, LTZ_SEND,
                                 &self->template_options),
             evt_tag_str("driver", self->super.super.super.id));
 

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -258,7 +258,7 @@ _smtp_message_add_recipient_from_template(smtp_message_t self, AFSMTPDriver *dri
                                           LogMessage *msg)
 {
   log_template_format(template, msg, &driver->template_options, LTZ_SEND,
-                      driver->super.seq_num, NULL, driver->str);
+                      driver->super.worker.instance.seq_num, NULL, driver->str);
   smtp_add_recipient(self, afsmtp_wash_string (driver->str->str));
 }
 
@@ -281,7 +281,7 @@ afsmtp_dd_msg_add_header(AFSMTPHeader *hdr, gpointer user_data)
   smtp_message_t message = ((gpointer *)user_data)[2];
 
   log_template_format(hdr->template, msg, &self->template_options, LTZ_LOCAL,
-                      self->super.seq_num, NULL, self->str);
+                      self->super.worker.instance.seq_num, NULL, self->str);
 
   smtp_set_header(message, hdr->name, afsmtp_wash_string (self->str->str), NULL);
   smtp_set_header_option(message, hdr->name, Hdr_OVERRIDE, 1);
@@ -398,7 +398,7 @@ __build_message(AFSMTPDriver *self, LogMessage *msg, smtp_session_t session)
   message = smtp_add_message(session);
 
   log_template_format(self->mail_from->template, msg, &self->template_options, LTZ_SEND,
-                      self->super.seq_num, NULL, self->str);
+                      self->super.worker.instance.seq_num, NULL, self->str);
   smtp_set_reverse_path(message, afsmtp_wash_string(self->str->str));
 
   /* Defaults */
@@ -406,7 +406,7 @@ __build_message(AFSMTPDriver *self, LogMessage *msg, smtp_session_t session)
   smtp_set_header(message, "From", NULL, NULL);
 
   log_template_format(self->subject_template, msg, &self->template_options, LTZ_SEND,
-                      self->super.seq_num, NULL, self->str);
+                      self->super.worker.instance.seq_num, NULL, self->str);
   smtp_set_header(message, "Subject", afsmtp_wash_string(self->str->str));
   smtp_set_header_option(message, "Subject", Hdr_OVERRIDE, 1);
 
@@ -427,7 +427,7 @@ __build_message(AFSMTPDriver *self, LogMessage *msg, smtp_session_t session)
    */
   g_string_assign(self->str, "X-Mailer: syslog-ng " SYSLOG_NG_VERSION "\r\n\r\n");
   log_template_append_format(self->body_template, msg, &self->template_options,
-                             LTZ_SEND, self->super.seq_num,
+                             LTZ_SEND, self->super.worker.instance.seq_num,
                              NULL, self->str);
   smtp_set_message_str(message, self->str->str);
   return message;

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -267,7 +267,7 @@ afstomp_set_frame_body(STOMPDestDriver *self, GString *body, stomp_frame *frame,
   if (self->body_template)
     {
       log_template_format(self->body_template, msg, &self->template_options, LTZ_LOCAL,
-                          self->super.seq_num, NULL, body);
+                          self->super.worker.instance.seq_num, NULL, body);
       stomp_frame_set_body(frame, body->str, body->len);
     }
 }
@@ -296,12 +296,12 @@ afstomp_worker_publish(STOMPDestDriver *self, LogMessage *msg)
   stomp_frame_add_header(&frame, "destination", self->destination);
   if (self->ack_needed)
     {
-      g_snprintf(seq_num, sizeof(seq_num), "%i", self->super.seq_num);
+      g_snprintf(seq_num, sizeof(seq_num), "%i", self->super.worker.instance.seq_num);
       stomp_frame_add_header(&frame, "receipt", seq_num);
     };
 
   value_pairs_foreach(self->vp, afstomp_vp_foreach, msg,
-                      self->super.seq_num, LTZ_SEND,
+                      self->super.worker.instance.seq_num, LTZ_SEND,
                       &self->template_options, &frame);
 
   afstomp_set_frame_body(self, body, &frame, msg);

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -69,6 +69,7 @@
 %token KW_BODY_PREFIX
 %token KW_BODY_SUFFIX
 %token KW_DELIMITER
+%token KW_WORKERS
 
 %type   <ptr> driver
 %type   <ptr> http_destination
@@ -119,6 +120,7 @@ http_option
     | KW_FLUSH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_flush_lines(last_driver, $3); }
     | KW_FLUSH_BYTES '(' nonnegative_integer ')' { http_dd_set_flush_bytes(last_driver, $3); }
     | KW_FLUSH_TIMEOUT '(' nonnegative_integer ')' { log_threaded_dest_driver_set_flush_timeout(last_driver, $3); }
+    | KW_WORKERS '(' nonnegative_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
     | threaded_dest_driver_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -111,9 +111,9 @@ http_option
     | KW_USER_AGENT '(' string ')'            { http_dd_set_user_agent(last_driver, $3); free($3); }
     | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free_full($3, free); }
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
-    | KW_BODY_PREFIX '(' string ')'        { http_dd_set_body_prefix(last_driver, $3); free($3); }
-    | KW_BODY_SUFFIX '(' string ')'        { http_dd_set_body_suffix(last_driver, $3); free($3); }
-    | KW_DELIMITER  '(' string ')'        { http_dd_set_delimiter(last_driver, $3); free($3); }
+    | KW_BODY_PREFIX '(' string ')'           { http_dd_set_body_prefix(last_driver, $3); free($3); }
+    | KW_BODY_SUFFIX '(' string ')'           { http_dd_set_body_suffix(last_driver, $3); free($3); }
+    | KW_DELIMITER  '(' string ')'            { http_dd_set_delimiter(last_driver, $3); free($3); }
     | KW_BODY       '(' template_content ')'  { http_dd_set_body(last_driver, $3); log_template_unref($3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_FLUSH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_flush_lines(last_driver, $3); }

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -51,6 +51,7 @@ static CfgLexerKeyword http_keywords[] =
   { "body_prefix",  KW_BODY_PREFIX },
   { "body_suffix",  KW_BODY_SUFFIX },
   { "delimiter",    KW_DELIMITER },
+  { "workers",      KW_WORKERS },
   { NULL }
 };
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -565,7 +565,7 @@ _insert_batched(HTTPDestinationDriver *self, LogMessage *msg)
 
   if (_should_initiate_flush(self))
     {
-      return log_threaded_dest_worker_flush(&self->super);
+      return log_threaded_dest_worker_flush(&self->super.worker.instance);
     }
   return WORKER_INSERT_RESULT_QUEUED;
 }

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -440,7 +440,7 @@ _add_message_to_batch(HTTPDestinationDriver *self, LogMessage *msg)
   if (self->body_template)
     {
       log_template_append_format(self->body_template, msg, &self->template_options, LTZ_SEND,
-                                 self->super.seq_num, NULL, self->request_body);
+                                 self->super.shared_seq_num, NULL, self->request_body);
     }
   else
     {

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -433,7 +433,7 @@ _format_request_headers(HTTPDestinationDriver *self, LogMessage *msg)
 static void
 _add_message_to_batch(HTTPDestinationDriver *self, LogMessage *msg)
 {
-  if (self->super.batch_size > 1)
+  if (self->super.worker.instance.batch_size > 1)
     {
       g_string_append_len(self->request_body, self->delimiter->str, self->delimiter->len);
     }
@@ -495,7 +495,7 @@ _flush(LogThreadedDestDriver *s)
   CURLcode ret;
   worker_insert_result_t retval;
 
-  if (self->super.batch_size == 0)
+  if (self->super.worker.instance.batch_size == 0)
     return WORKER_INSERT_RESULT_SUCCESS;
 
   _finish_request_body(self);
@@ -535,7 +535,7 @@ _flush(LogThreadedDestDriver *s)
                 evt_tag_str("url", self->url),
                 evt_tag_int("status_code", http_code),
                 evt_tag_int("body_size", self->request_body->len),
-                evt_tag_int("batch_size", self->super.batch_size),
+                evt_tag_int("batch_size", self->super.worker.instance.batch_size),
                 evt_tag_int("redirected", redirect_count != 0),
                 evt_tag_printf("total_time", "%.3f", total_time));
     }
@@ -552,7 +552,7 @@ static gboolean
 _should_initiate_flush(HTTPDestinationDriver *self)
 {
   return (self->flush_bytes && self->request_body->len + self->body_suffix->len >= self->flush_bytes) ||
-         (self->super.flush_lines && self->super.batch_size >= self->super.flush_lines);
+         (self->super.flush_lines && self->super.worker.instance.batch_size >= self->super.flush_lines);
 }
 
 static worker_insert_result_t

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -210,6 +210,13 @@ _map_http_status_to_worker_status(HTTPDestinationWorker *self, glong http_code)
   switch (http_code/100)
     {
     case 1:
+      msg_error("Server returned with a 1XX (continuation) status code, which was not handled by curl. "
+                "Trying again",
+                evt_tag_str("url", owner->url),
+                evt_tag_int("status_code", http_code),
+                log_pipe_location_tag(&owner->super.super.super.super));
+      retval = WORKER_INSERT_RESULT_ERROR;
+      break;
     case 2:
       retval = WORKER_INSERT_RESULT_SUCCESS;
       break;

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -33,10 +33,17 @@
 #define CURL_NO_OLDIES 1
 #include <curl/curl.h>
 
+typedef struct _HTTPDestinationWorker
+{
+  LogThreadedDestWorker super;
+  CURL *curl;
+  GString *request_body;
+  struct curl_slist *request_headers;
+} HTTPDestinationWorker;
+
 typedef struct
 {
   LogThreadedDestDriver super;
-  CURL *curl;
   gchar *url;
   gchar *user;
   gchar *password;
@@ -49,14 +56,12 @@ typedef struct
   gchar *ciphers;
   GString *body_prefix;
   GString *body_suffix;
+  GString *delimiter;
   int ssl_version;
   gboolean peer_verify;
   short int method_type;
   glong timeout;
   glong flush_bytes;
-  struct curl_slist *request_headers;
-  GString *request_body;
-  GString *delimiter;
   LogTemplate *body_template;
   LogTemplateOptions template_options;
 } HTTPDestinationDriver;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -68,7 +68,7 @@ JNIEXPORT jint JNICALL
 Java_org_syslog_1ng_LogDestination_getSeqNum(JNIEnv *env, jobject obj, jlong handle)
 {
   JavaDestDriver *self = (JavaDestDriver *)handle;
-  return (jint)(self->super.seq_num);
+  return (jint)(self->super.worker.instance.seq_num);
 }
 
 JNIEXPORT jlong JNICALL
@@ -131,7 +131,7 @@ java_dd_init(LogPipe *s)
 
   const gchar *jvm_options = java_config_get_jvm_options(cfg);
   self->proxy = java_destination_proxy_new(self->class_name, self->class_path->str, self, self->template,
-                                           &self->super.seq_num, jvm_options);
+                                           &self->super.worker.instance.seq_num, jvm_options);
   if (!self->proxy)
     return FALSE;
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -278,7 +278,7 @@ _py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_ob
 
   if (self->vp)
     {
-      success = py_value_pairs_apply(self->vp, &self->template_options, self->super.seq_num, msg, msg_object);
+      success = py_value_pairs_apply(self->vp, &self->template_options, self->super.worker.instance.seq_num, msg, msg_object);
       if (!success && (self->template_options.on_error & ON_ERROR_DROP_MESSAGE))
         return FALSE;
     }

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -254,14 +254,14 @@ redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
     }
 
   log_template_format(self->key, msg, &self->template_options, LTZ_SEND,
-                      self->super.seq_num, NULL, self->key_str);
+                      self->super.worker.instance.seq_num, NULL, self->key_str);
 
   if (self->param1)
     log_template_format(self->param1, msg, &self->template_options, LTZ_SEND,
-                        self->super.seq_num, NULL, self->param1_str);
+                        self->super.worker.instance.seq_num, NULL, self->param1_str);
   if (self->param2)
     log_template_format(self->param2, msg, &self->template_options, LTZ_SEND,
-                        self->super.seq_num, NULL, self->param2_str);
+                        self->super.worker.instance.seq_num, NULL, self->param2_str);
 
   argv[0] = self->command->str;
   argvlen[0] = self->command->len;

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -398,7 +398,7 @@ static gboolean
 riemann_add_metric_to_event(RiemannDestDriver *self, riemann_event_t *event, LogMessage *msg, GString *str)
 {
   log_template_format(self->fields.metric, msg, &self->template_options,
-                      LTZ_SEND, self->super.seq_num, NULL, str);
+                      LTZ_SEND, self->super.worker.instance.seq_num, NULL, str);
 
   if (str->len == 0)
     return TRUE;
@@ -445,7 +445,7 @@ riemann_add_ttl_to_event(RiemannDestDriver *self, riemann_event_t *event, LogMes
   gdouble d;
 
   log_template_format(self->fields.ttl, msg, &self->template_options,
-                      LTZ_SEND, self->super.seq_num, NULL,
+                      LTZ_SEND, self->super.worker.instance.seq_num, NULL,
                       str);
 
   if (str->len == 0)
@@ -493,23 +493,23 @@ riemann_worker_insert_one(RiemannDestDriver *self, LogMessage *msg)
       riemann_dd_field_string_maybe_add(event, msg, self->fields.host,
                                         &self->template_options,
                                         RIEMANN_EVENT_FIELD_HOST,
-                                        self->super.seq_num, str);
+                                        self->super.worker.instance.seq_num, str);
       riemann_dd_field_string_maybe_add(event, msg, self->fields.service,
                                         &self->template_options,
                                         RIEMANN_EVENT_FIELD_SERVICE,
-                                        self->super.seq_num, str);
+                                        self->super.worker.instance.seq_num, str);
       riemann_dd_field_integer_maybe_add(event, msg, self->fields.event_time,
                                          &self->template_options,
                                          self->fields.event_time_unit,
-                                         self->super.seq_num, str);
+                                         self->super.worker.instance.seq_num, str);
       riemann_dd_field_string_maybe_add(event, msg, self->fields.description,
                                         &self->template_options,
                                         RIEMANN_EVENT_FIELD_DESCRIPTION,
-                                        self->super.seq_num, str);
+                                        self->super.worker.instance.seq_num, str);
       riemann_dd_field_string_maybe_add(event, msg, self->fields.state,
                                         &self->template_options,
                                         RIEMANN_EVENT_FIELD_STATE,
-                                        self->super.seq_num, str);
+                                        self->super.worker.instance.seq_num, str);
 
       if (self->fields.tags)
         g_list_foreach(self->fields.tags, riemann_dd_field_add_tag,
@@ -521,7 +521,7 @@ riemann_worker_insert_one(RiemannDestDriver *self, LogMessage *msg)
       if (self->fields.attributes)
         value_pairs_foreach(self->fields.attributes,
                             riemann_dd_field_add_attribute_vp,
-                            msg, self->super.seq_num, LTZ_SEND,
+                            msg, self->super.worker.instance.seq_num, LTZ_SEND,
                             &self->template_options, event);
       msg_trace("riemann: adding message to Riemann event",
                 evt_tag_str("server", self->server),

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -591,7 +591,7 @@ _insert_single(LogThreadedDestDriver *s, LogMessage *msg)
       return WORKER_INSERT_RESULT_DROP;
     }
 
-  return riemann_worker_flush(&self->super);
+  return log_threaded_dest_driver_flush(&self->super);
 }
 
 static worker_insert_result_t
@@ -615,9 +615,9 @@ _insert_batch(LogThreadedDestDriver *s, LogMessage *msg)
        */
     }
 
-  if (self->super.flush_lines > 1 && self->super.batch_size >= self->super.flush_lines)
+  if (self->super.flush_lines > 1 && self->super.worker.instance.batch_size >= self->super.flush_lines)
     {
-      return log_threaded_dest_worker_flush(&self->super);
+      return log_threaded_dest_driver_flush(&self->super);
     }
   return WORKER_INSERT_RESULT_QUEUED;
 }


### PR DESCRIPTION
This branch implements multithreaded http destination, that uses the specified number of worker threads to send messages to an upstream HTTP server.

This should drastically improve performance of HTTP based transports, especially if combined with #2289, #2287, #2286 