### PR TITLE
Revert sticky hook option

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -98,21 +98,18 @@ static void
 _update_current_state(gint type)
 {
   if (AH_REOPEN == type)
-     return;
+    return;
 
   g_assert(current_state <= type);
   current_state = type;
 }
 
 static void
-run_application_hook(gint type, gboolean remove_hook)
+run_application_hook(gint type)
 {
   GList *l, *l_next;
 
-  if (remove_hook)
-    {
-      _update_current_state(type);
-    }
+  _update_current_state(type);
 
   msg_debug("Running application hooks", evt_tag_int("hook", type));
   for (l = application_hooks; l; l = l_next)
@@ -123,12 +120,9 @@ run_application_hook(gint type, gboolean remove_hook)
         {
           l_next = l->next;
           e->func(type, e->user_data);
-          if (remove_hook)
-            {
-              application_hooks = g_list_remove_link(application_hooks, l);
-              g_free(e);
-              g_list_free_1(l);
-            }
+          application_hooks = g_list_remove_link(application_hooks, l);
+          g_free(e);
+          g_list_free_1(l);
         }
       else
         {
@@ -190,7 +184,7 @@ app_finish_app_startup_after_cfg_init(void)
 void
 app_post_daemonized(void)
 {
-  run_application_hook(AH_POST_DAEMONIZED, TRUE);
+  run_application_hook(AH_POST_DAEMONIZED);
 }
 
 void
@@ -202,20 +196,20 @@ app_pre_config_loaded(void)
 void
 app_post_config_loaded(void)
 {
-  run_application_hook(AH_POST_CONFIG_LOADED, TRUE);
+  run_application_hook(AH_POST_CONFIG_LOADED);
   res_init();
 }
 
 void
 app_pre_shutdown(void)
 {
-  run_application_hook(AH_PRE_SHUTDOWN, TRUE);
+  run_application_hook(AH_PRE_SHUTDOWN);
 }
 
 void
 app_shutdown(void)
 {
-  run_application_hook(AH_SHUTDOWN, TRUE);
+  run_application_hook(AH_SHUTDOWN);
   main_loop_thread_resource_deinit();
   secret_storage_deinit();
   scratch_buffers_allocator_deinit();
@@ -254,7 +248,7 @@ app_shutdown(void)
 void
 app_reopen(void)
 {
-  run_application_hook(AH_REOPEN, FALSE);
+  run_application_hook(AH_REOPEN);
 }
 
 void

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -95,14 +95,23 @@ register_application_hook(gint type, ApplicationHookFunc func, gpointer user_dat
 }
 
 static void
+_update_current_state(gint type)
+{
+  if (AH_REOPEN == type)
+     return;
+
+  g_assert(current_state <= type);
+  current_state = type;
+}
+
+static void
 run_application_hook(gint type, gboolean remove_hook)
 {
   GList *l, *l_next;
 
   if (remove_hook)
     {
-      g_assert(current_state <= type);
-      current_state = type;
+      _update_current_state(type);
     }
 
   msg_debug("Running application hooks", evt_tag_int("hook", type));

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_unit_test(CRITERION TARGET test_timeutils)
 add_unit_test(CRITERION TARGET test_messages)
 add_unit_test(CRITERION TARGET test_atomic_gssize)
 add_unit_test(CRITERION TARGET test_window_size_counter)
+add_unit_test(CRITERION TARGET test_apphook)
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES
   ADDITIONAL_MAKE_CLEAN_FILES

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -17,7 +17,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_userdb		\
 	lib/tests/test_str-utils \
 	lib/tests/test_atomic_gssize \
-	lib/tests/test_window_size_counter
+	lib/tests/test_window_size_counter \
+	lib/tests/test_apphook
 
 EXTRA_DIST += lib/tests/CMakeLists.txt
 
@@ -121,6 +122,11 @@ lib_tests_test_atomic_gssize_LDADD	=	\
 lib_tests_test_window_size_counter_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_window_size_counter_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_apphook_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_apphook_LDADD	=	\
 	$(TEST_LDADD)
 
 

--- a/lib/tests/test_apphook.c
+++ b/lib/tests/test_apphook.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "apphook.h"
+
+#include <criterion/criterion.h>
+
+
+Test(test_apphook, app_is_tarting_up)
+{
+  cr_assert(app_is_starting_up());
+  cr_assert_not(app_is_shutting_down());
+}
+
+static void
+_hook_counter(gint type, gpointer user_data)
+{
+  gint *triggered_count = (gboolean *)user_data;
+  (*triggered_count)++;
+}
+
+static void
+_hook_not_reached(gint type, gpointer user_data)
+{
+  cr_assert_fail("This hook should not be triggered!");
+}
+
+Test(test_apphook, post_daemon_hook)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_POST_DAEMONIZED, _hook_counter, (gpointer)&triggered_count);
+  cr_assert(app_is_starting_up());
+  app_post_daemonized();
+
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, post_daemon_triggered_twice)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_POST_DAEMONIZED, _hook_counter, (gpointer)&triggered_count);
+
+  app_post_daemonized();
+  app_post_daemonized();
+
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, pre_config_loaded_no_hook)
+{
+  register_application_hook(AH_PRE_CONFIG_LOADED, _hook_not_reached, NULL);
+
+  app_pre_config_loaded();
+}
+
+Test(test_apphook, post_config_loaded)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_POST_CONFIG_LOADED, _hook_counter, (gpointer)&triggered_count);
+
+  app_post_config_loaded();
+
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, pre_shutdown_hook)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_PRE_SHUTDOWN, _hook_counter, (gpointer)&triggered_count);
+
+  app_pre_shutdown();
+
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, shutdown_hook)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_SHUTDOWN, _hook_counter, (gpointer)&triggered_count);
+
+  app_startup(); //This is needed for shutdown
+  app_shutdown();
+
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, reopen_hook)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_REOPEN, _hook_counter, (gpointer)&triggered_count);
+
+  app_reopen();
+
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, trigger_all_state_hook)
+{
+  gint triggered_count = 0;
+  register_application_hook(AH_POST_DAEMONIZED, _hook_counter, (gpointer)&triggered_count);
+  register_application_hook(AH_PRE_CONFIG_LOADED, _hook_not_reached, NULL);
+  register_application_hook(AH_POST_CONFIG_LOADED, _hook_counter, (gpointer)&triggered_count);
+  register_application_hook(AH_PRE_SHUTDOWN, _hook_counter, (gpointer)&triggered_count);
+  register_application_hook(AH_SHUTDOWN, _hook_counter, (gpointer)&triggered_count);
+  register_application_hook(AH_REOPEN, _hook_counter, (gpointer)&triggered_count);
+
+  app_reopen();
+  app_startup(); //This is needed for app_shutdown
+  app_post_daemonized();
+  app_pre_config_loaded();
+  app_post_config_loaded();
+  app_pre_shutdown();
+  app_shutdown();
+
+  cr_assert_eq(triggered_count, 5);
+}
+

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -377,6 +377,7 @@ static void
 affile_dd_register_reopen_hook(gint hook_type, gpointer user_data)
 {
   g_list_foreach(affile_dest_drivers, affile_dd_reopen_all_writers, NULL);
+  register_application_hook(AH_REOPEN, affile_dd_register_reopen_hook, NULL);
 }
 
 void


### PR DESCRIPTION
The PR which introduced the `reopen` also changes the hook behavior optionally, so the user could register a hook that is not removed after it was triggered.
My issue with that solution that the code that triggered a hooks was responsible to decide if all of the triggered hooks should be removed, or kept.
While I think it would be more reasonable for the code that registers to decide if it want the registered hook to be triggered always or just once.

This PR makes all the hook one shoot again, and registers the `reopen` hook, when it was triggered.