### PR TITLE
telegram, urlencode: api changes

### DIFF
--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -105,7 +105,6 @@ static Plugin basicfuncs_plugins[] =
   /* misc funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_env, "env"),
   TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
-  TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "urlencode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "url-encode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urldecode, "url-decode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_base64encode, "base64-encode")

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -412,10 +412,10 @@ Test(basicfuncs, test_context_funcs)
 
 Test(basicfuncs, test_tfurlencode)
 {
-  assert_template_format("$(urlencode '')", "");
-  assert_template_format("$(urlencode test)", "test");
-  assert_template_format("$(urlencode <>)", "%3C%3E");
-  assert_template_format("$(urlencode &)", "%26");
+  assert_template_format("$(url-encode '')", "");
+  assert_template_format("$(url-encode test)", "test");
+  assert_template_format("$(url-encode <>)", "%3C%3E");
+  assert_template_format("$(url-encode &)", "%26");
 }
 
 Test(basicfuncs, test_tfurldecode)
@@ -429,4 +429,3 @@ Test(basicfuncs, test_tfurldecode)
   assert_template_format("$(url-decode %)", "");
   assert_template_format("$(url-decode %00a)", "");
 }
-

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -26,7 +26,7 @@
 block destination telegram(
       bot-id()
       chat-id()
-      template("$(urlencode \"${MSG}\")")
+      template("${MSG}")
       parse-mode("none")
       throttle(1)
       disable-web-page-preview("true")
@@ -35,7 +35,7 @@ block destination telegram(
     http(
         url("https://api.telegram.org/bot`bot-id`/sendMessage")
         method("POST")
-        body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=`template`\n")
+        body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode \"`template`\")\n")
         throttle(`throttle`)
         `__VARARGS__`
     );


### PR DESCRIPTION
TLDR;
- `urlencode` removed. One needs to be used `url-encode`
- Telegram automatically encodes message. Users need not and should not do so anymore.

Both are API breaking changes, introduced not long ago, in 3.16. The earliest (3.18) we fix these, the best.

CC: @czanik the telegram blog will need to be updated.

---

When I introduced telegram and urlencode, the following usecase drove me:

I had a program source that fetches multiline notifications that I wanted to send to telegram. Since program sources do not work well with multiline, so an encoding must be used. Since telegram already needs urlencode, I was thinking that if I already receive messages urlencoded from the program source, then I can just simply pass these to telegram, that solves both the encoding requirement and the multiline problem.

That's why the first version of telegram destination received messages urlencoded, which needed to be guaranteed by users.

Retrospective, that was not a good decision. First is, from syslog-ng perspective, it is not clean to pass around encoded messages internally, as no parsing logic etc can be applied to those. Second is, there are other ways to workaround the multiline program source problem: use any encoding-decoding technique, or when python source is introduced, I can bring my code into python etc. On the other hand, forcing users to remember to encode themselves is unfortunate.

With https://github.com/balabit/syslog-ng/pull/2278 from @nobles (thanks again), I can decode the urlencoded program source when entering to syslog-ng.