### PR TITLE
Fixing some compiler warnings from armv7l

### DIFF
--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -57,7 +57,7 @@ _mmap(gsize len)
       if (logger)
         {
           char reason[32] = { 0 };
-          snprintf(reason, sizeof(reason), "len: %lu, errno: %d\n", len, errno);
+          snprintf(reason, sizeof(reason), "len: %"G_GSIZE_FORMAT", errno: %d\n", len, errno);
           logger("secret storage: cannot mmap buffer", reason);
         }
       return NULL;
@@ -82,7 +82,7 @@ _mmap(gsize len)
         {
           char reason[200] = { 0 };
           gchar *hint = (errno == ENOMEM) ? ". Maybe RLIMIT_MEMLOCK is too small?" : "";
-          snprintf(reason, sizeof(reason), "len: %lu, errno: %d%s\n", len, errno, hint);
+          snprintf(reason, sizeof(reason), "len: %"G_GSIZE_FORMAT", errno: %d%s\n", len, errno, hint);
           logger("secret storage: cannot lock buffer", reason);
         }
       goto err_munmap;

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -36,7 +36,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
   char *buf;
   long bufsize;
   int s;
-  glong d;
+  gint64 d;
   gboolean is_num, r;
 
   bufsize = 16384;

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -39,7 +39,7 @@ tf_getent_passwd(gchar *key, gchar *member_name, GString *result)
   char *buf;
   long bufsize;
   int s;
-  glong d;
+  gint64 d;
   gboolean is_num, r;
 
   bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);

--- a/modules/getent/getent-protocols.c
+++ b/modules/getent/getent-protocols.c
@@ -24,7 +24,7 @@ static gboolean
 tf_getent_protocols(gchar *key, gchar *member_name, GString *result)
 {
   struct protoent proto, *res;
-  glong d;
+  gint64 d;
   gboolean is_num;
   char buf[4096];
 

--- a/modules/getent/getent-services.c
+++ b/modules/getent/getent-services.c
@@ -24,7 +24,7 @@ static gboolean
 tf_getent_services(gchar *key, gchar *member_name, GString *result)
 {
   struct servent serv, *res;
-  glong d;
+  gint64 d;
   gboolean is_num;
   char buf[4096];
 

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -341,7 +341,7 @@ print_statistic(struct timeval *start_time)
 
           if (count > last_count && last_count > 0)
             {
-              fprintf(stderr, "count=%ld, rate = %.2lf msg/sec\n",
+              fprintf(stderr, "count=%"G_GINT64_FORMAT", rate = %.2lf msg/sec\n",
                       count,
                       ((double) (count - last_count) * USEC_PER_SEC) / diff_usec);
             }
@@ -363,7 +363,7 @@ print_statistic(struct timeval *start_time)
           count = thread_stat_count[j];
           g_mutex_unlock(message_counter_lock);
 
-          fprintf(stderr,"%d;%lu.%06lu;%.2lf;%lu\n",
+          fprintf(stderr,"%d;%lu.%06lu;%.2lf;%"G_GINT64_FORMAT"\n",
                   j,
                   (long) diff_tv.tv_sec,
                   (long) diff_tv.tv_usec,
@@ -404,7 +404,7 @@ void wait_all_plugin_to_finish(GPtrArray *plugin_array)
   double total_runtime_sec = time_val_diff_in_sec(&now, &start_time);
   if (total_runtime_sec > 0 && count > 0)
     fprintf(stderr,
-            "average rate = %.2lf msg/sec, count=%ld, time=%g, (average) msg size=%ld, bandwidth=%.2f kB/sec\n",
+            "average rate = %.2lf msg/sec, count=%ld, time=%g, (average) msg size=%"G_GINT64_FORMAT", bandwidth=%.2f kB/sec\n",
             (double)count/total_runtime_sec,
             count,
             total_runtime_sec,


### PR DESCRIPTION
I was compiling syslog-ng on armv7l and I found some warnings, that I intend to fix now. (Probably glong->gint64 change is not arm specific.)

I wanted to add `-Wincompatible-pointer-types` to extra warnings, but 4.8 gcc and clang does not know that warning yet. Though with xenial gcc, I could compile without these warnings.

Besides these, there were  43 instances `warning: cast increases required alignment of target type [-Wcast-align]` that I do not fix for now.