### PR TITLE
Python source

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -40,6 +40,7 @@
 #include "rewrite/rewrite-expr-parser.h"
 #include "logmatcher.h"
 #include "logthrdestdrv.h"
+#include "logthrsource/logthrsourcedrv.h"
 #include "str-utils.h"
 
 /* uses struct declarations instead of the typedefs to avoid having to
@@ -1191,6 +1192,23 @@ threaded_dest_driver_option
         | dest_driver_option
         ;
 
+/* implies source_driver_option and source_option */
+threaded_source_driver_option
+	: KW_FORMAT '(' string ')' { log_threaded_source_driver_get_parse_options(last_driver)->format = g_strdup($3); free($3); }
+        | KW_FLAGS '(' threaded_source_driver_option_flags ')'
+        | { last_msg_format_options = log_threaded_source_driver_get_parse_options(last_driver); } msg_format_option
+        | { last_source_options = log_threaded_source_driver_get_source_options(last_driver); } source_option
+        | source_driver_option
+        ;
+
+threaded_source_driver_option_flags
+	: string threaded_source_driver_option_flags
+        {
+          CHECK_ERROR(msg_format_options_process_flag(log_threaded_source_driver_get_parse_options(last_driver), $1), @1, "Unknown flag %s", $1);
+          free($1);
+        }
+        |
+        ;
 
 /* LogSource related options */
 source_option

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -63,7 +63,6 @@ LogReader *log_reader_new(GlobalConfig *cfg);
 void log_reader_options_defaults(LogReaderOptions *options);
 void log_reader_options_init(LogReaderOptions *options, GlobalConfig *cfg, const gchar *group_name);
 void log_reader_options_destroy(LogReaderOptions *options);
-gint log_reader_options_lookup_flag(const gchar *flag);
 void log_reader_options_set_tags(LogReaderOptions *options, GList *tags);
 gboolean log_reader_options_process_flag(LogReaderOptions *options, const gchar *flag);
 

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -42,6 +42,7 @@ struct _LogThreadedSourceWorker
   LogThreadedSourceDriver *control;
   WakeupCondition wakeup_cond;
   WorkerOptions options;
+  gboolean under_termination;
 
   LogThreadedSourceWorkerRunFunc run;
   LogThreadedSourceWorkerRequestExitFunc request_exit;
@@ -88,12 +89,8 @@ static inline void
 wakeup_cond_signal(WakeupCondition *cond)
 {
   g_mutex_lock(cond->lock);
-
-  if (!cond->awoken)
-    {
-      cond->awoken = TRUE;
-      g_cond_signal(cond->cond);
-    }
+  cond->awoken = TRUE;
+  g_cond_signal(cond->cond);
   g_mutex_unlock(cond->lock);
 }
 
@@ -142,7 +139,8 @@ log_threaded_source_suspend(LogThreadedSourceDriver *self)
 {
   LogThreadedSourceWorker *worker = self->worker;
 
-  wakeup_cond_wait(&worker->wakeup_cond);
+  while (!log_threaded_source_free_to_send(self) && !worker->under_termination)
+    wakeup_cond_wait(&worker->wakeup_cond);
 }
 
 static void
@@ -172,6 +170,7 @@ static void
 log_threaded_source_worker_request_exit(LogThreadedSourceWorker *self)
 {
   msg_debug("Requesting worker thread exit", evt_tag_str("driver", self->control->super.super.id));
+  self->under_termination = TRUE;
   self->request_exit(self->control);
   log_threaded_source_wakeup(self->control);
 }
@@ -313,14 +312,6 @@ void
 log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg)
 {
   msg_debug("Incoming log message", evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)));
-
-  /*
-   * TODO: offload (main_loop_io_worker_job_submit)
-   *
-   * In this case, we should modify or split log_source_post(), because
-   * free_to_send() has to be called before log_pipe_queue() but after
-   * decrementing the window.
-   */
   log_source_post(&self->worker->super, msg);
 }
 

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -118,6 +118,8 @@ void
 log_threaded_source_worker_options_defaults(LogThreadedSourceWorkerOptions *options)
 {
   log_source_options_defaults(&options->super);
+  msg_format_options_defaults(&options->parse_options);
+  options->parse_options.flags |= LP_SYSLOG_PROTOCOL;
 }
 
 void
@@ -125,12 +127,14 @@ log_threaded_source_worker_options_init(LogThreadedSourceWorkerOptions *options,
                                         const gchar *group_name)
 {
   log_source_options_init(&options->super, cfg, group_name);
+  msg_format_options_init(&options->parse_options, cfg);
 }
 
 void
 log_threaded_source_worker_options_destroy(LogThreadedSourceWorkerOptions *options)
 {
   log_source_options_destroy(&options->super);
+  msg_format_options_destroy(&options->parse_options);
 }
 
 /* The wakeup lock must be held before calling this function. */

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -42,6 +42,7 @@ typedef void (*LogThreadedSourceWorkerWakeupFunc)(LogThreadedSourceDriver *);
 typedef struct _LogThreadedSourceWorkerOptions
 {
   LogSourceOptions super;
+  MsgFormatOptions parse_options;
 } LogThreadedSourceWorkerOptions;
 
 struct _LogThreadedSourceDriver
@@ -73,6 +74,14 @@ log_threaded_source_driver_get_source_options(LogDriver *s)
   LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
 
   return &self->worker_options.super;
+}
+
+static inline MsgFormatOptions *
+log_threaded_source_driver_get_parse_options(LogDriver *s)
+{
+  LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
+
+  return &self->worker_options.parse_options;
 }
 
 /* blocking API */

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source-grammar.ym
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source-grammar.ym
@@ -69,7 +69,6 @@ threaded_diskq_source
   : KW_DISKQ_SOURCE
     {
       last_driver = *instance = threaded_diskq_sd_new(configuration);
-      last_source_options = log_threaded_source_driver_get_source_options(last_driver);
     }
     '(' threaded_diskq_source_options ')' { $$ = last_driver; }
   ;
@@ -85,8 +84,7 @@ threaded_diskq_source_option
       threaded_diskq_sd_set_file(last_driver, $3);
       free($3);
     }
-  | source_option
-  | source_driver_option
+  | threaded_source_driver_option
   ;
 
 /* INCLUDE_RULES */

--- a/modules/examples/sources/threaded-random-generator/threaded-random-generator-grammar.ym
+++ b/modules/examples/sources/threaded-random-generator/threaded-random-generator-grammar.ym
@@ -71,7 +71,6 @@ source_threaded_random_generator
   : KW_RANDOM_GENERATOR
     {
       last_driver = *instance = threaded_random_generator_sd_new(configuration);
-      last_source_options = log_threaded_source_driver_get_source_options(last_driver);
     }
     '(' source_threaded_random_generator_options ')' { $$ = last_driver; }
   ;
@@ -99,8 +98,7 @@ source_threaded_random_generator_option
       CHECK_ERROR(threaded_random_generator_sd_set_type(last_driver, $3), @3, "unknown type() argument");
       free($3);
     }
-  | source_option
-  | source_driver_option
+  | threaded_source_driver_option
   ;
 
 /* INCLUDE_RULES */

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -45,6 +45,8 @@ set(PYTHON_SOURCES
     python-logparser.c
     python-integerpointer.h
     python-integerpointer.c
+    python-source.h
+    python-source.c
     compat/compat-python.c
     ${CMAKE_CURRENT_BINARY_DIR}/python-grammar.c
     ${CMAKE_CURRENT_BINARY_DIR}/python-grammar.h

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -47,6 +47,8 @@ set(PYTHON_SOURCES
     python-integerpointer.c
     python-source.h
     python-source.c
+    python-fetcher.h
+    python-fetcher.c
     compat/compat-python.c
     ${CMAKE_CURRENT_BINARY_DIR}/python-grammar.c
     ${CMAKE_CURRENT_BINARY_DIR}/python-grammar.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -55,7 +55,9 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-logparser.h	  \
 	modules/python/python-logparser.c	  \
 	modules/python/python-source.h	  \
-	modules/python/python-source.c
+	modules/python/python-source.c	  \
+	modules/python/python-fetcher.h	  \
+	modules/python/python-fetcher.c
 
 modules_python_libmod_python_la_LDFLAGS		 = \
 	$(MODULE_LDFLAGS) \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -53,7 +53,9 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-debugger.h	  \
 	modules/python/python-debugger.c	  \
 	modules/python/python-logparser.h	  \
-	modules/python/python-logparser.c
+	modules/python/python-logparser.c	  \
+	modules/python/python-source.h	  \
+	modules/python/python-source.c
 
 modules_python_libmod_python_la_LDFLAGS		 = \
 	$(MODULE_LDFLAGS) \

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -22,6 +22,9 @@
  */
 
 #include "compat-python.h"
+#include "python-helpers.h"
+
+#include <datetime.h>
 
 void
 py_init_argv(void)
@@ -35,3 +38,43 @@ int_as_pyobject(gint num)
 {
   return PyInt_FromLong(num);
 };
+
+void
+py_datetime_init(void)
+{
+  PyDateTime_IMPORT;
+}
+
+gboolean
+py_datetime_to_logstamp(PyObject *py_timestamp, LogStamp *logstamp)
+{
+  if (!PyDateTime_Check(py_timestamp))
+    {
+      PyErr_Format(PyExc_TypeError, "datetime expected in the first parameter");
+      return FALSE;
+    }
+
+  PyObject *py_epoch = PyDateTime_FromDateAndTime(1970, 1, 1, 0, 0, 0, 0);
+  PyObject *py_delta = _py_invoke_method_by_name(py_timestamp, "__sub__", py_epoch,
+                                                 "PyDateTime", "py_datetime_to_logstamp");
+  if (!py_delta)
+    {
+      Py_XDECREF(py_epoch);
+      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
+      return FALSE;
+    }
+
+  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_delta, "total_seconds", NULL,
+                                                           "PyDateTime", "py_datetime_to_logstamp");
+  gdouble posix_timestamp = PyFloat_AsDouble(py_posix_timestamp);
+
+  Py_XDECREF(py_posix_timestamp);
+  Py_XDECREF(py_delta);
+  Py_XDECREF(py_epoch);
+
+  logstamp->tv_sec = (time_t) posix_timestamp;
+  logstamp->tv_usec = posix_timestamp * 10e5 - logstamp->tv_sec * 10e5;
+  logstamp->zone_offset = 0;
+
+  return TRUE;
+}

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -22,6 +22,9 @@
  */
 
 #include "compat-python.h"
+#include "python-helpers.h"
+
+#include <datetime.h>
 
 void
 py_init_argv(void)
@@ -35,3 +38,48 @@ int_as_pyobject(gint num)
 {
   return PyLong_FromLong(num);
 };
+
+void
+py_datetime_init(void)
+{
+  PyDateTime_IMPORT;
+}
+
+gboolean
+py_datetime_to_logstamp(PyObject *py_timestamp, LogStamp *logstamp)
+{
+  if (!PyDateTime_Check(py_timestamp))
+    {
+      PyErr_Format(PyExc_TypeError, "datetime expected in the first parameter");
+      return FALSE;
+    }
+
+  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_timestamp, "timestamp", NULL,
+                                                           "PyDateTime", "py_datetime_to_logstamp");
+  if (!py_posix_timestamp)
+    {
+      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
+      return FALSE;
+    }
+
+  PyObject *py_utcoffset = _py_invoke_method_by_name(py_timestamp, "utcoffset", NULL,
+                                                     "PyDateTime", "py_datetime_to_logstamp");
+  if (!py_utcoffset)
+    {
+      Py_DECREF(py_posix_timestamp);
+      PyErr_Format(PyExc_ValueError, "Error retrieving utcoffset");
+      return FALSE;
+    }
+
+  gdouble posix_timestamp = PyFloat_AsDouble(py_posix_timestamp);
+  gint zone_offset = py_utcoffset == Py_None ? 0 : PyDateTime_DELTA_GET_SECONDS(py_utcoffset);
+
+  Py_DECREF(py_utcoffset);
+  Py_DECREF(py_posix_timestamp);
+
+  logstamp->tv_sec = (time_t) posix_timestamp;
+  logstamp->tv_usec = posix_timestamp * 10e5 - logstamp->tv_sec * 10e5;
+  logstamp->zone_offset = zone_offset;
+
+  return TRUE;
+}

--- a/modules/python/compat/compat-python.c
+++ b/modules/python/compat/compat-python.c
@@ -21,7 +21,7 @@
  *
  */
 
-#include "compat-python.h"
+#include "python-module.h"
 
 #if SYSLOG_NG_ENABLE_PYTHONv2
 #include "compat-python-v2.c"

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -26,6 +26,7 @@
 
 #include <Python.h>
 #include "syslog-ng.h"
+#include "logstamp.h"
 
 #if (SYSLOG_NG_ENABLE_PYTHONv2)
 #define PYTHON_BUILTIN_MODULE_NAME "__builtin__"
@@ -39,5 +40,8 @@
 
 void py_init_argv(void);
 PyObject *int_as_pyobject(gint num);
+
+void py_datetime_init(void);
+gboolean py_datetime_to_logstamp(PyObject *py_timestamp, LogStamp *logstamp);
 
 #endif

--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -34,7 +34,9 @@ _add_nv_keys_to_list(gpointer key, gpointer value, gpointer user_data)
   PyObject *list = (PyObject *) user_data;
   const gchar *name = (const gchar *) key;
 
-  PyList_Append(list, PyBytes_FromString(name));
+  PyObject *py_name = PyBytes_FromString(name);
+  PyList_Append(list, py_name);
+  Py_XDECREF(py_name);
 }
 
 static PyObject *

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -454,6 +454,8 @@ python_dd_free(LogPipe *d)
   if (self->options)
     g_hash_table_unref(self->options);
 
+  string_list_free(self->loaders);
+
   log_threaded_dest_driver_free(d);
 }
 

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -1,0 +1,510 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-fetcher.h"
+#include "python-logmsg.h"
+#include "python-helpers.h"
+#include "logthrsource/logthrfetcherdrv.h"
+#include "str-utils.h"
+#include "string-list.h"
+
+typedef struct _PythonFetcherDriver
+{
+  LogThreadedFetcherDriver super;
+
+  gchar *class;
+  GList *loaders;
+  GHashTable *options;
+
+  struct
+  {
+    PyObject *class;
+    PyObject *instance;
+    PyObject *fetch_method;
+    PyObject *open_method;
+    PyObject *close_method;
+    PyObject *request_exit_method;
+  } py;
+} PythonFetcherDriver;
+
+typedef struct _PyLogFetcher
+{
+  PyObject_HEAD
+  PythonFetcherDriver *driver;
+} PyLogFetcher;
+
+static PyTypeObject py_log_fetcher_type;
+
+
+void
+python_fetcher_set_class(LogDriver *s, gchar *filename)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  g_free(self->class);
+  self->class = g_strdup(filename);
+}
+
+void
+python_fetcher_set_option(LogDriver *s, gchar *key, gchar *value)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+  gchar *normalized_key = __normalize_key(key);
+  g_hash_table_insert(self->options, normalized_key, g_strdup(value));
+}
+
+void
+python_fetcher_set_loaders(LogDriver *s, GList *loaders)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  string_list_free(self->loaders);
+  self->loaders = loaders;
+}
+
+static const gchar *
+python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+  static gchar persist_name[1024];
+
+  if (s->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "python-fetcher,%s", s->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "python-fetcher,%s", self->class);
+
+  return persist_name;
+}
+
+static void
+_pf_py_invoke_void_method_by_name(PythonFetcherDriver *self, const gchar *method_name)
+{
+  _py_invoke_void_method_by_name(self->py.instance, method_name, self->class, self->super.super.super.super.id);
+}
+
+static gboolean
+_pf_py_invoke_bool_method_by_name_with_args(PythonFetcherDriver *self, const gchar *method_name)
+{
+  return _py_invoke_bool_method_by_name_with_args(self->py.instance, method_name, self->options, self->class,
+                                                  self->super.super.super.super.id);
+}
+
+static void
+_pf_py_invoke_void_function(PythonFetcherDriver *self, PyObject *func, PyObject *arg)
+{
+  return _py_invoke_void_function(func, arg, self->class, self->super.super.super.super.id);
+}
+
+static gboolean
+_pf_py_invoke_bool_function(PythonFetcherDriver *self, PyObject *func, PyObject *arg)
+{
+  return _py_invoke_bool_function(func, arg, self->class, self->super.super.super.super.id);
+}
+
+static gboolean
+_py_invoke_init(PythonFetcherDriver *self)
+{
+  return _pf_py_invoke_bool_method_by_name_with_args(self, "init");
+}
+
+static void
+_py_invoke_deinit(PythonFetcherDriver *self)
+{
+  _pf_py_invoke_void_method_by_name(self, "deinit");
+}
+
+static void
+_py_invoke_request_exit(PythonFetcherDriver *self)
+{
+  _pf_py_invoke_void_function(self, self->py.request_exit_method, NULL);
+}
+
+static gboolean
+_py_invoke_open(PythonFetcherDriver *self)
+{
+  return _pf_py_invoke_bool_function(self, self->py.open_method, NULL);
+}
+
+static void
+_py_invoke_close(PythonFetcherDriver *self)
+{
+  _pf_py_invoke_void_function(self, self->py.close_method, NULL);
+}
+
+static inline gboolean
+_ulong_to_fetch_result(unsigned long ulong, ThreadedFetchResult *result)
+{
+  switch (ulong)
+    {
+    case THREADED_FETCH_ERROR:
+    case THREADED_FETCH_NOT_CONNECTED:
+    case THREADED_FETCH_SUCCESS:
+      *result = (ThreadedFetchResult) ulong;
+      return TRUE;
+
+    default:
+      return FALSE;
+    }
+}
+
+static LogThreadedFetchResult
+_py_invoke_fetch(PythonFetcherDriver *self)
+{
+  PyObject *ret = _py_invoke_function(self->py.fetch_method, NULL, self->class, self->super.super.super.super.id);
+
+  if (!ret || !PyTuple_Check(ret) || PyTuple_Size(ret) > 2)
+    goto error;
+
+  PyObject *result = PyTuple_GetItem(ret, 0);
+  PyLogMessage *pymsg = (PyLogMessage *) PyTuple_GetItem(ret, 1);
+
+  if (!result || !PyLong_Check(result))
+    goto error;
+
+  LogThreadedFetchResult fetch_result = { .msg = NULL };
+  if (!_ulong_to_fetch_result(PyLong_AsUnsignedLong(result), &fetch_result.result))
+    goto error;
+
+  if (fetch_result.result == THREADED_FETCH_SUCCESS)
+    {
+      if (!pymsg || !py_is_log_message((PyObject *) pymsg))
+        goto error;
+
+      /* keep a reference until the PyLogMessage instance is freed */
+      fetch_result.msg = log_msg_ref(pymsg->msg);
+    }
+
+  Py_XDECREF(ret);
+  PyErr_Clear();
+  return fetch_result;
+
+error:
+  msg_error("Error in Python fetcher, fetch() must return a tuple (FetchResult, LogMessage)",
+            evt_tag_str("driver", self->super.super.super.super.id),
+            evt_tag_str("class", self->class));
+
+  Py_XDECREF(ret);
+  PyErr_Clear();
+
+  LogThreadedFetchResult result_error = { THREADED_FETCH_ERROR, NULL };
+  return result_error;
+}
+
+static gboolean
+_py_is_log_fetcher(PyObject *obj)
+{
+  return PyType_IsSubtype(Py_TYPE(obj), &py_log_fetcher_type);
+}
+
+static gboolean
+_py_init_bindings(PythonFetcherDriver *self)
+{
+  self->py.class = _py_resolve_qualified_name(self->class);
+  if (!self->py.class)
+    {
+      gchar buf[256];
+
+      msg_error("Error looking Python driver class",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      return FALSE;
+    }
+
+  self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.super.id);
+  if (!self->py.instance)
+    {
+      gchar buf[256];
+
+      msg_error("Error instantiating Python driver class",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      return FALSE;
+    }
+
+  if (!_py_is_log_fetcher(self->py.instance))
+    {
+      msg_error("Error initializing Python fetcher, class is not a subclass of LogFetcher",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+
+  ((PyLogFetcher *) self->py.instance)->driver = self;
+
+  self->py.fetch_method = _py_get_attr_or_null(self->py.instance, "fetch");
+  if (!self->py.fetch_method)
+    {
+      msg_error("Error initializing Python fetcher, class does not have a fetch() method",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+
+  self->py.request_exit_method = _py_get_attr_or_null(self->py.instance, "request_exit");
+  self->py.open_method = _py_get_attr_or_null(self->py.instance, "open");
+  self->py.close_method = _py_get_attr_or_null(self->py.instance, "close");
+
+  return TRUE;
+}
+
+static void
+_py_free_bindings(PythonFetcherDriver *self)
+{
+  Py_CLEAR(self->py.class);
+  Py_CLEAR(self->py.instance);
+  Py_CLEAR(self->py.fetch_method);
+  Py_CLEAR(self->py.open_method);
+  Py_CLEAR(self->py.close_method);
+  Py_CLEAR(self->py.request_exit_method);
+}
+
+static gboolean
+_py_init_object(PythonFetcherDriver *self)
+{
+  if (!_py_get_attr_or_null(self->py.instance, "init"))
+    {
+      msg_debug("Missing Python method, init()",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class));
+      return TRUE;
+    }
+
+  if (!_py_invoke_init(self))
+    {
+      msg_error("Error initializing Python driver object, init() returned FALSE",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_py_set_parse_options(PythonFetcherDriver *self)
+{
+  MsgFormatOptions *parse_options = log_threaded_source_driver_get_parse_options(&self->super.super.super.super);
+
+  PyObject *py_parse_options = PyCapsule_New(parse_options, NULL, NULL);
+
+  if (!py_parse_options)
+    {
+      gchar buf[256];
+
+      msg_error("Error creating capsule for message parse options",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      return FALSE;
+    }
+
+  if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
+    {
+      gchar buf[256];
+
+      msg_error("Error setting attribute message parse options",
+                evt_tag_str("driver", self->super.super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+
+      Py_DECREF(py_parse_options);
+      return FALSE;
+    }
+
+  Py_DECREF(py_parse_options);
+  return TRUE;
+}
+
+static gboolean
+python_fetcher_open(LogThreadedFetcherDriver *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  gboolean result = _py_invoke_open(self);
+  PyGILState_Release(gstate);
+
+  return result;
+}
+
+static void
+python_fetcher_close(LogThreadedFetcherDriver *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_close(self);
+  PyGILState_Release(gstate);
+}
+
+static LogThreadedFetchResult
+python_fetcher_fetch(LogThreadedFetcherDriver *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  LogThreadedFetchResult result = _py_invoke_fetch(self);
+  PyGILState_Release(gstate);
+
+  return result;
+}
+
+static void
+python_fetcher_request_exit(LogThreadedFetcherDriver *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_request_exit(self);
+  PyGILState_Release(gstate);
+}
+
+static gboolean
+python_fetcher_init(LogPipe *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  if (!self->class)
+    {
+      msg_error("Error initializing Python fetcher: no script specified!",
+                evt_tag_str("driver", self->super.super.super.super.id));
+      return FALSE;
+    }
+
+  self->super.time_reopen = 1;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  _py_perform_imports(self->loaders);
+  if (!_py_init_bindings(self))
+    goto fail;
+
+  if (self->py.open_method)
+    self->super.connect = python_fetcher_open;
+
+  if (self->py.close_method)
+    self->super.disconnect = python_fetcher_close;
+
+  if (self->py.request_exit_method)
+    self->super.request_exit = python_fetcher_request_exit;
+
+  if (!_py_init_object(self))
+    goto fail;
+
+  if (!_py_set_parse_options(self))
+    goto fail;
+
+  PyGILState_Release(gstate);
+
+  msg_verbose("Python fetcher initialized",
+              evt_tag_str("driver", self->super.super.super.super.id),
+              evt_tag_str("class", self->class));
+
+  return log_threaded_fetcher_driver_init_method(s);
+
+fail:
+  PyGILState_Release(gstate);
+  return FALSE;
+}
+
+static gboolean
+python_fetcher_deinit(LogPipe *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_deinit(self);
+  PyGILState_Release(gstate);
+
+  return log_threaded_fetcher_driver_deinit_method(s);
+}
+
+static void
+python_fetcher_free(LogPipe *s)
+{
+  PythonFetcherDriver *self = (PythonFetcherDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_free_bindings(self);
+  PyGILState_Release(gstate);
+
+  g_free(self->class);
+  g_hash_table_unref(self->options);
+  string_list_free(self->loaders);
+
+  log_threaded_fetcher_driver_free_method(s);
+}
+
+LogDriver *
+python_fetcher_new(GlobalConfig *cfg)
+{
+  PythonFetcherDriver *self = g_new0(PythonFetcherDriver, 1);
+
+  log_threaded_fetcher_driver_init_instance(&self->super, cfg);
+  self->super.super.super.super.super.init = python_fetcher_init;
+  self->super.super.super.super.super.deinit = python_fetcher_deinit;
+  self->super.super.super.super.super.free_fn = python_fetcher_free;
+
+  self->super.super.format_stats_instance = python_fetcher_format_stats_instance;
+  self->super.super.worker_options.super.stats_level = STATS_LEVEL0;
+  self->super.super.worker_options.super.stats_source = SCS_PYTHON;
+
+  self->super.fetch = python_fetcher_fetch;
+
+  self->options = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+  return &self->super.super.super.super;
+}
+
+
+static PyTypeObject py_log_fetcher_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "LogFetcher",
+  .tp_basicsize = sizeof(PyLogFetcher),
+  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "The LogFetcher class is a base class for custom Python fetchers.",
+  .tp_new = PyType_GenericNew,
+  0,
+};
+
+void
+py_log_fetcher_init(void)
+{
+  py_log_fetcher_type.tp_dict = PyDict_New();
+  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_ERROR",
+                       PyLong_FromLong(THREADED_FETCH_ERROR));
+  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_NOT_CONNECTED",
+                       PyLong_FromLong(THREADED_FETCH_NOT_CONNECTED));
+  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_SUCCESS",
+                       PyLong_FromLong(THREADED_FETCH_SUCCESS));
+
+  PyType_Ready(&py_log_fetcher_type);
+  PyModule_AddObject(PyImport_AddModule("syslogng"), "LogFetcher", (PyObject *) &py_log_fetcher_type);
+}

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -340,11 +340,9 @@ _py_init_object(PythonFetcherDriver *self)
   return TRUE;
 }
 
-static gboolean
-_py_set_parse_options(PythonFetcherDriver *self)
+static PyObject *
+_py_parse_options_new(PythonFetcherDriver *self, MsgFormatOptions *parse_options)
 {
-  MsgFormatOptions *parse_options = log_threaded_source_driver_get_parse_options(&self->super.super.super.super);
-
   PyObject *py_parse_options = PyCapsule_New(parse_options, NULL, NULL);
 
   if (!py_parse_options)
@@ -356,8 +354,20 @@ _py_set_parse_options(PythonFetcherDriver *self)
                 evt_tag_str("class", self->class),
                 evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
-      return FALSE;
+      return NULL;
     }
+
+  return py_parse_options;
+}
+
+static gboolean
+_py_set_parse_options(PythonFetcherDriver *self)
+{
+  MsgFormatOptions *parse_options = log_threaded_source_driver_get_parse_options(&self->super.super.super.super);
+
+  PyObject *py_parse_options = _py_parse_options_new(self, parse_options);
+  if (!py_parse_options)
+    return FALSE;
 
   if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
     {

--- a/modules/python/python-fetcher.h
+++ b/modules/python/python-fetcher.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_PYTHON_FETCHER_H
+#define SNG_PYTHON_FETCHER_H
+
+#include "python-module.h"
+#include "driver.h"
+
+LogDriver *python_fetcher_new(GlobalConfig *cfg);
+void python_fetcher_set_loaders(LogDriver *d, GList *loaders);
+void python_fetcher_set_class(LogDriver *d, gchar *class_name);
+void python_fetcher_set_option(LogDriver *d, gchar *key, gchar *value);
+
+void py_log_fetcher_init(void);
+
+#endif

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -25,9 +25,11 @@
 
 #include "python-parser.h"
 #include "python-dest.h"
+#include "python-source.h"
 #include "python-logparser.h"
 #include "python-main.h"
 #include "value-pairs/value-pairs.h"
+#include "logthrsource/logthrsourcedrv.h"
 
 }
 
@@ -64,6 +66,12 @@ start
 	    last_parser = *instance = python_parser_new(configuration);
           }
           '(' python_parser_options ')' { YYACCEPT; }
+        | LL_CONTEXT_SOURCE KW_PYTHON
+          {
+            last_driver = *instance = python_sd_new(configuration);
+            last_source_options = log_threaded_source_driver_get_source_options(last_driver);
+          }
+          '(' python_sd_options ')'         { YYACCEPT; }
 	| LL_CONTEXT_ROOT KW_PYTHON
           { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "Python code"); }
           LL_BLOCK
@@ -115,6 +123,39 @@ python_dd_custom_option
         }
         ;
 
+
+python_sd_options
+        : python_sd_option python_sd_options
+        |
+        ;
+
+python_sd_option
+        : KW_CLASS '(' string ')'
+          {
+            python_sd_set_class(last_driver, $3);
+            free($3);
+          }
+        | KW_LOADERS python_sd_loaders
+        | KW_OPTIONS '(' python_sd_custom_options ')'
+        | source_option
+        | source_driver_option
+        ;
+
+python_sd_custom_options
+        : python_sd_custom_option python_sd_custom_options
+        |
+        ;
+
+python_sd_custom_option
+        : string string_or_number
+        {
+          python_sd_set_option(last_driver, $1, $2);
+          free($1);
+          free($2);
+        }
+        ;
+
+
 python_parser_options
         : python_parser_option python_parser_options
         |
@@ -149,6 +190,12 @@ python_dd_loaders
           : '(' string_list ')'
           {
             python_dd_set_loaders(last_driver, $2);
+          }
+
+python_sd_loaders
+          : '(' string_list ')'
+          {
+            python_sd_set_loaders(last_driver, $2);
           }
 
 python_parser_loaders

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -39,6 +39,7 @@
 #include "cfg-grammar.h"
 #include "cfg-parser.h"
 #include "plugin.h"
+#include "syslog-names.h"
 }
 
 %name-prefix "python_"
@@ -71,13 +72,11 @@ start
         | LL_CONTEXT_SOURCE KW_PYTHON
           {
             last_driver = *instance = python_sd_new(configuration);
-            last_source_options = log_threaded_source_driver_get_source_options(last_driver);
           }
           '(' python_sd_options ')'         { YYACCEPT; }
         | LL_CONTEXT_SOURCE KW_PYTHON_FETCHER
           {
             last_driver = *instance = python_fetcher_new(configuration);
-            last_source_options = log_threaded_source_driver_get_source_options(last_driver);
           }
           '(' python_fetcher_options ')'         { YYACCEPT; }
 	| LL_CONTEXT_ROOT KW_PYTHON
@@ -145,8 +144,7 @@ python_sd_option
           }
         | KW_LOADERS python_sd_loaders
         | KW_OPTIONS '(' python_sd_custom_options ')'
-        | source_option
-        | source_driver_option
+        | threaded_source_driver_option
         ;
 
 python_sd_custom_options
@@ -177,8 +175,7 @@ python_fetcher_option
           }
         | KW_LOADERS python_fetcher_loaders
         | KW_OPTIONS '(' python_fetcher_custom_options ')'
-        | source_option
-        | source_driver_option
+        | threaded_source_driver_option
         ;
 
 python_fetcher_custom_options

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -26,6 +26,7 @@
 #include "python-parser.h"
 #include "python-dest.h"
 #include "python-source.h"
+#include "python-fetcher.h"
 #include "python-logparser.h"
 #include "python-main.h"
 #include "value-pairs/value-pairs.h"
@@ -49,6 +50,7 @@
 /* INCLUDE_DECLS */
 
 %token KW_PYTHON
+%token KW_PYTHON_FETCHER
 %token KW_CLASS
 %token KW_IMPORTS
 %token KW_LOADERS
@@ -72,6 +74,12 @@ start
             last_source_options = log_threaded_source_driver_get_source_options(last_driver);
           }
           '(' python_sd_options ')'         { YYACCEPT; }
+        | LL_CONTEXT_SOURCE KW_PYTHON_FETCHER
+          {
+            last_driver = *instance = python_fetcher_new(configuration);
+            last_source_options = log_threaded_source_driver_get_source_options(last_driver);
+          }
+          '(' python_fetcher_options ')'         { YYACCEPT; }
 	| LL_CONTEXT_ROOT KW_PYTHON
           { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "Python code"); }
           LL_BLOCK
@@ -156,6 +164,38 @@ python_sd_custom_option
         ;
 
 
+python_fetcher_options
+        : python_fetcher_option python_fetcher_options
+        |
+        ;
+
+python_fetcher_option
+        : KW_CLASS '(' string ')'
+          {
+            python_fetcher_set_class(last_driver, $3);
+            free($3);
+          }
+        | KW_LOADERS python_fetcher_loaders
+        | KW_OPTIONS '(' python_fetcher_custom_options ')'
+        | source_option
+        | source_driver_option
+        ;
+
+python_fetcher_custom_options
+        : python_fetcher_custom_option python_fetcher_custom_options
+        |
+        ;
+
+python_fetcher_custom_option
+        : string string_or_number
+        {
+          python_fetcher_set_option(last_driver, $1, $2);
+          free($1);
+          free($2);
+        }
+        ;
+
+
 python_parser_options
         : python_parser_option python_parser_options
         |
@@ -196,6 +236,12 @@ python_sd_loaders
           : '(' string_list ')'
           {
             python_sd_set_loaders(last_driver, $2);
+          }
+
+python_fetcher_loaders
+          : '(' string_list ')'
+          {
+            python_fetcher_set_loaders(last_driver, $2);
           }
 
 python_parser_loaders

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -275,6 +275,21 @@ _py_get_optional_method(PyObject *instance, const gchar *class, const gchar *met
   return method;
 }
 
+PyObject *
+_py_invoke_method_by_name(PyObject *instance, const gchar *method_name, PyObject *arg, const gchar *class,
+                          const gchar *module)
+{
+  PyObject *method = _py_get_optional_method(instance, class, method_name, module);
+
+  if (!method)
+    return NULL;
+
+  PyObject *ret = _py_invoke_function(method, arg, class, module);
+  Py_DECREF(method);
+
+  return ret;
+}
+
 void
 _py_invoke_void_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class, const gchar *module)
 {

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -37,6 +37,8 @@ PyObject *_py_invoke_function(PyObject *func, PyObject *arg, const gchar *class,
 void _py_invoke_void_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 gboolean _py_invoke_bool_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 PyObject *_py_get_method(PyObject *instance, const gchar *method_name, const gchar *module);
+PyObject *_py_invoke_method_by_name(PyObject *instance, const gchar *method_name, PyObject *arg, const gchar *class,
+                                    const gchar *module);
 void _py_invoke_void_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class,
                                     const gchar *module);
 gboolean _py_invoke_bool_method_by_name_with_args(PyObject *instance, const gchar *method_name, GHashTable *args,

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -170,7 +170,10 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
                                   gpointer user_data)
 {
   PyObject *list = (PyObject *)user_data;
-  PyList_Append(list, PyBytes_FromString(name));
+
+  PyObject *py_name = PyBytes_FromString(name);
+  PyList_Append(list, py_name);
+  Py_XDECREF(py_name);
 
   return FALSE;
 }
@@ -209,7 +212,9 @@ _collect_macro_names(gpointer key, gpointer value, gpointer user_data)
 
   if (_is_macro_name_visible_to_user(logmsg, name))
     {
-      PyList_Append(list, PyBytes_FromString(name));
+      PyObject *py_name = PyBytes_FromString(name);
+      PyList_Append(list, py_name);
+      Py_XDECREF(py_name);
     }
 }
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -142,7 +142,7 @@ static void
 py_log_message_free(PyLogMessage *self)
 {
   log_msg_unref(self->msg);
-  PyObject_Del(self);
+  Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
 PyObject *

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -255,7 +255,7 @@ _logmessage_get_keys_method(PyLogMessage *self)
   return keys;
 }
 
-static PyLogMessage *
+static PyObject *
 py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 {
   guint pri;
@@ -266,11 +266,10 @@ py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 
   self->msg->pri = pri;
 
-  Py_INCREF(self);
-  return self;
+  Py_RETURN_NONE;
 }
 
-static PyLogMessage *
+static PyObject *
 py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 {
   PyObject *py_timestamp;
@@ -282,8 +281,7 @@ py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds
   if (!py_datetime_to_logstamp((PyObject *) py_timestamp, &self->msg->timestamps[LM_TS_STAMP]))
     return NULL;
 
-  Py_INCREF(self);
-  return self;
+  Py_RETURN_NONE;
 }
 
 static PyObject *

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -158,6 +158,29 @@ py_log_message_new(LogMessage *msg)
   return (PyObject *) self;
 }
 
+static PyObject *
+py_log_message_new_empty(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
+{
+  const gchar *message = NULL;
+  gint message_length = 0;
+
+  static const gchar *kwlist[] = {"message", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|z#", (gchar **) kwlist, &message, &message_length))
+    return NULL;
+
+  PyLogMessage *self = (PyLogMessage *) subtype->tp_alloc(subtype, 0);
+  if (!self)
+    return NULL;
+
+  self->msg = log_msg_new_empty();
+  invalidate_cached_time();
+
+  if (message)
+    log_msg_set_value(self->msg, LM_V_MESSAGE, message, message_length);
+
+  return (PyObject *) self;
+}
+
 static PyMappingMethods py_log_message_mapping =
 {
   .mp_length = NULL,
@@ -248,7 +271,7 @@ PyTypeObject py_log_message_type =
   .tp_dealloc = (destructor) py_log_message_free,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_doc = "LogMessage class encapsulating a syslog-ng log message",
-  .tp_new = PyType_GenericNew,
+  .tp_new = py_log_message_new_empty,
   .tp_as_mapping = &py_log_message_mapping,
   .tp_methods = py_log_message_methods,
   0,

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -254,12 +254,25 @@ _logmessage_get_keys_method(PyLogMessage *self)
   return keys;
 }
 
+static PyLogMessage *
+py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
+{
+  guint pri;
+
+  static const gchar *kwlist[] = {"pri", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "I", (gchar **) kwlist, &pri))
+    return NULL;
+
+  self->msg->pri = pri;
+
+  Py_INCREF(self);
+  return self;
+}
+
 static PyMethodDef py_log_message_methods[] =
 {
-  {
-    "keys", (PyCFunction)_logmessage_get_keys_method,
-    METH_NOARGS, "Return keys."
-  },
+  { "keys", (PyCFunction)_logmessage_get_keys_method, METH_NOARGS, "Return keys." },
+  { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set priority" },
   {NULL}
 };
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -258,4 +258,5 @@ void
 py_log_message_init(void)
 {
   PyType_Ready(&py_log_message_type);
+  PyModule_AddObject(PyImport_AddModule("syslogng"), "LogMessage", (PyObject *) &py_log_message_type);
 }

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -26,6 +26,7 @@
 #include "logmsg/logmsg.h"
 #include "messages.h"
 #include "str-utils.h"
+#include "logstamp.h"
 
 int
 py_is_log_message(PyObject *obj)
@@ -269,10 +270,27 @@ py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
   return self;
 }
 
+static PyLogMessage *
+py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds)
+{
+  PyObject *py_timestamp;
+
+  static const gchar *kwlist[] = {"timestamp", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "O", (gchar **) kwlist, &py_timestamp))
+    return NULL;
+
+  if (!py_datetime_to_logstamp((PyObject *) py_timestamp, &self->msg->timestamps[LM_TS_STAMP]))
+    return NULL;
+
+  Py_INCREF(self);
+  return self;
+}
+
 static PyMethodDef py_log_message_methods[] =
 {
   { "keys", (PyCFunction)_logmessage_get_keys_method, METH_NOARGS, "Return keys." },
   { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set priority" },
+  { "set_timestamp", (PyCFunction)py_log_message_set_timestamp, METH_VARARGS | METH_KEYWORDS, "Set timestamp" },
   {NULL}
 };
 

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -32,6 +32,7 @@ int python_parse(CfgLexer *lexer, void **instance, gpointer arg);
 static CfgLexerKeyword python_keywords[] =
 {
   { "python",                   KW_PYTHON  },
+  { "python_fetcher",           KW_PYTHON_FETCHER },
   { "class",                    KW_CLASS   },
   {
     "imports",                  KW_IMPORTS, KWS_OBSOLETE,

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -30,6 +30,7 @@
 #include "python-logtemplate.h"
 #include "python-integerpointer.h"
 #include "python-source.h"
+#include "python-fetcher.h"
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
 
@@ -49,6 +50,11 @@ static Plugin python_plugins[] =
   {
     .type = LL_CONTEXT_SOURCE,
     .name = "python",
+    .parser = &python_parser,
+  },
+  {
+    .type = LL_CONTEXT_SOURCE,
+    .name = "python_fetcher",
     .parser = &python_parser,
   },
   {
@@ -81,6 +87,7 @@ _py_init_interpreter(void)
       py_log_template_init();
       py_integer_pointer_init();
       py_log_source_init();
+      py_log_fetcher_init();
       py_global_code_loader_init();
       PyEval_SaveThread();
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -70,6 +70,7 @@ _py_init_interpreter(void)
       py_init_argv();
 
       PyEval_InitThreads();
+      py_datetime_init();
       py_log_message_init();
       py_log_template_init();
       py_integer_pointer_init();

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -29,6 +29,7 @@
 #include "python-logmsg.h"
 #include "python-logtemplate.h"
 #include "python-integerpointer.h"
+#include "python-source.h"
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
 
@@ -42,6 +43,11 @@ static Plugin python_plugins[] =
 {
   {
     .type = LL_CONTEXT_DESTINATION,
+    .name = "python",
+    .parser = &python_parser,
+  },
+  {
+    .type = LL_CONTEXT_SOURCE,
     .name = "python",
     .parser = &python_parser,
   },
@@ -74,6 +80,7 @@ _py_init_interpreter(void)
       py_log_message_init();
       py_log_template_init();
       py_integer_pointer_init();
+      py_log_source_init();
       py_global_code_loader_init();
       PyEval_SaveThread();
 

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-source.h"
+#include "python-logmsg.h"
+#include "python-helpers.h"
+#include "logthrsource/logthrsourcedrv.h"
+#include "str-utils.h"
+#include "string-list.h"
+
+typedef struct _PythonSourceDriver PythonSourceDriver;
+
+struct _PythonSourceDriver
+{
+  LogThreadedSourceDriver super;
+
+  gchar *class;
+  GList *loaders;
+  GHashTable *options;
+
+  void (*post_message)(PythonSourceDriver *self, LogMessage *msg);
+
+  struct
+  {
+    PyObject *class;
+    PyObject *instance;
+    PyObject *run_method;
+    PyObject *request_exit_method;
+    PyObject *suspend_method;
+    PyObject *wakeup_method;
+  } py;
+};
+
+typedef struct _PyLogSource
+{
+  PyObject_HEAD
+  PythonSourceDriver *driver;
+} PyLogSource;
+
+static PyTypeObject py_log_source_type;
+
+
+void
+python_sd_set_class(LogDriver *s, gchar *filename)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  g_free(self->class);
+  self->class = g_strdup(filename);
+}
+
+void
+python_sd_set_option(LogDriver *s, gchar *key, gchar *value)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+  gchar *normalized_key = __normalize_key(key);
+  g_hash_table_insert(self->options, normalized_key, g_strdup(value));
+}
+
+void
+python_sd_set_loaders(LogDriver *s, GList *loaders)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  string_list_free(self->loaders);
+  self->loaders = loaders;
+}
+
+static const gchar *
+python_sd_format_stats_instance(LogThreadedSourceDriver *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+  static gchar persist_name[1024];
+
+  if (s->super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "python,%s", s->super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "python,%s", self->class);
+
+  return persist_name;
+}
+
+static void
+_ps_py_invoke_void_method_by_name(PythonSourceDriver *self, const gchar *method_name)
+{
+  _py_invoke_void_method_by_name(self->py.instance, method_name, self->class, self->super.super.super.id);
+}
+
+static gboolean
+_ps_py_invoke_bool_method_by_name_with_args(PythonSourceDriver *self, const gchar *method_name)
+{
+  return _py_invoke_bool_method_by_name_with_args(self->py.instance, method_name, self->options, self->class,
+                                                  self->super.super.super.id);
+}
+
+static void
+_ps_py_invoke_void_function(PythonSourceDriver *self, PyObject *func, PyObject *arg)
+{
+  return _py_invoke_void_function(func, arg, self->class, self->super.super.super.id);
+}
+
+static gboolean
+_py_invoke_init(PythonSourceDriver *self)
+{
+  return _ps_py_invoke_bool_method_by_name_with_args(self, "init");
+}
+
+static void
+_py_invoke_deinit(PythonSourceDriver *self)
+{
+  _ps_py_invoke_void_method_by_name(self, "deinit");
+}
+
+static void
+_py_invoke_run(PythonSourceDriver *self)
+{
+  _ps_py_invoke_void_function(self, self->py.run_method, NULL);
+}
+
+static void
+_py_invoke_request_exit(PythonSourceDriver *self)
+{
+  _ps_py_invoke_void_function(self, self->py.request_exit_method, NULL);
+}
+
+static void
+_py_invoke_suspend(PythonSourceDriver *self)
+{
+  _ps_py_invoke_void_function(self, self->py.suspend_method, NULL);
+}
+
+static void
+_py_invoke_wakeup(PythonSourceDriver *self)
+{
+  _ps_py_invoke_void_function(self, self->py.wakeup_method, NULL);
+}
+
+static gboolean
+_py_is_log_source(PyObject *obj)
+{
+  return PyType_IsSubtype(Py_TYPE(obj), &py_log_source_type);
+}
+
+static gboolean
+_py_init_bindings(PythonSourceDriver *self)
+{
+  self->py.class = _py_resolve_qualified_name(self->class);
+  if (!self->py.class)
+    {
+      gchar buf[256];
+
+      msg_error("Error looking Python driver class",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      return FALSE;
+    }
+
+  self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.id);
+  if (!self->py.instance)
+    {
+      gchar buf[256];
+
+      msg_error("Error instantiating Python driver class",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      return FALSE;
+    }
+
+  if (!_py_is_log_source(self->py.instance))
+    {
+      msg_error("Error initializing Python source, class is not a subclass of LogSource",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+
+  ((PyLogSource *) self->py.instance)->driver = self;
+
+  self->py.run_method = _py_get_attr_or_null(self->py.instance, "run");
+  self->py.request_exit_method = _py_get_attr_or_null(self->py.instance, "request_exit");
+  if (!self->py.run_method)
+    {
+      msg_error("Error initializing Python source, class does not have a run() method",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+
+  if (!self->py.request_exit_method)
+    {
+      msg_error("Error initializing Python source, class does not have a request_exit() method",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+
+  self->py.suspend_method = _py_get_attr_or_null(self->py.instance, "suspend");
+  if (self->py.suspend_method)
+    {
+      self->py.wakeup_method = _py_get_attr_or_null(self->py.instance, "wakeup");
+      if (!self->py.wakeup_method)
+        {
+          msg_error("Error initializing Python source, class implements suspend() but wakeup() is missing",
+                    evt_tag_str("driver", self->super.super.super.id),
+                    evt_tag_str("class", self->class));
+          return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
+static void
+_py_free_bindings(PythonSourceDriver *self)
+{
+  Py_CLEAR(self->py.class);
+  Py_CLEAR(self->py.instance);
+  Py_CLEAR(self->py.run_method);
+  Py_CLEAR(self->py.request_exit_method);
+  Py_CLEAR(self->py.suspend_method);
+  Py_CLEAR(self->py.wakeup_method);
+}
+
+static gboolean
+_py_init_object(PythonSourceDriver *self)
+{
+  if (!_py_get_attr_or_null(self->py.instance, "init"))
+    {
+      msg_debug("Missing Python method, init()",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class));
+      return TRUE;
+    }
+
+  if (!_py_invoke_init(self))
+    {
+      msg_error("Error initializing Python driver object, init() returned FALSE",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_py_set_parse_options(PythonSourceDriver *self)
+{
+  MsgFormatOptions *parse_options = log_threaded_source_driver_get_parse_options(&self->super.super.super);
+
+  PyObject *py_parse_options = PyCapsule_New(parse_options, NULL, NULL);
+
+  if (!py_parse_options)
+    {
+      gchar buf[256];
+
+      msg_error("Error creating capsule for message parse options",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      return FALSE;
+    }
+
+  if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
+    {
+      gchar buf[256];
+
+      msg_error("Error setting attribute message parse options",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class),
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+
+      Py_DECREF(py_parse_options);
+      return FALSE;
+    }
+
+  Py_DECREF(py_parse_options);
+  return TRUE;
+}
+
+static PyObject *
+py_log_source_post(PyObject *s, PyObject *args, PyObject *kwrds)
+{
+  PyLogSource *self = (PyLogSource *) s;
+  PythonSourceDriver *sd = self->driver;
+
+  PyLogMessage *pymsg;
+
+  static const gchar *kwlist[] = {"msg", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "O", (gchar **) kwlist, &pymsg))
+    return NULL;
+
+  if (!py_is_log_message((PyObject *) pymsg))
+    {
+      PyErr_Format(PyExc_TypeError, "LogMessage expected in the first parameter");
+      return NULL;
+    }
+
+  /* keep a reference until the PyLogMessage instance is freed */
+  LogMessage *message = log_msg_ref(pymsg->msg);
+  sd->post_message(sd, message);
+
+  Py_RETURN_NONE;
+}
+
+static void
+python_sd_run(LogThreadedSourceDriver *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_run(self);
+  PyGILState_Release(gstate);
+}
+
+static void
+python_sd_request_exit(LogThreadedSourceDriver *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_request_exit(self);
+  PyGILState_Release(gstate);
+}
+
+static void
+python_sd_suspend(PythonSourceDriver *self)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_suspend(self);
+  PyGILState_Release(gstate);
+}
+
+static void
+python_sd_wakeup(LogThreadedSourceDriver *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_wakeup(self);
+  PyGILState_Release(gstate);
+}
+
+static void
+_post_message_non_blocking(PythonSourceDriver *self, LogMessage *msg)
+{
+  PyThreadState *state = PyEval_SaveThread();
+  log_threaded_source_post(&self->super, msg);
+  PyEval_RestoreThread(state);
+
+  /* GIL is used to synchronize free_to_send(), suspend() and wakeup() */
+  if (!log_threaded_source_free_to_send(&self->super))
+    python_sd_suspend(self);
+}
+
+static void
+_post_message_blocking(PythonSourceDriver *self, LogMessage *msg)
+{
+  PyThreadState *state = PyEval_SaveThread();
+  log_threaded_source_blocking_post(&self->super, msg);
+  PyEval_RestoreThread(state);
+}
+
+static gboolean
+python_sd_init(LogPipe *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  if (!self->class)
+    {
+      msg_error("Error initializing Python source: no script specified!",
+                evt_tag_str("driver", self->super.super.super.id));
+      return FALSE;
+    }
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  _py_perform_imports(self->loaders);
+  if (!_py_init_bindings(self))
+    goto fail;
+
+  if (self->py.suspend_method && self->py.wakeup_method)
+    {
+      self->post_message = _post_message_non_blocking;
+      log_threaded_source_set_wakeup_func(&self->super, python_sd_wakeup);
+    }
+
+  if (!_py_init_object(self))
+    goto fail;
+
+  if (!_py_set_parse_options(self))
+    goto fail;
+
+  PyGILState_Release(gstate);
+
+  msg_verbose("Python source initialized",
+              evt_tag_str("driver", self->super.super.super.id),
+              evt_tag_str("class", self->class));
+
+  return log_threaded_source_driver_init_method(s);
+
+fail:
+  PyGILState_Release(gstate);
+  return FALSE;
+}
+
+static gboolean
+python_sd_deinit(LogPipe *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_invoke_deinit(self);
+  PyGILState_Release(gstate);
+
+  return log_threaded_source_driver_deinit_method(s);
+}
+
+static void
+python_sd_free(LogPipe *s)
+{
+  PythonSourceDriver *self = (PythonSourceDriver *) s;
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_free_bindings(self);
+  PyGILState_Release(gstate);
+
+  g_free(self->class);
+  g_hash_table_unref(self->options);
+  string_list_free(self->loaders);
+
+  log_threaded_source_driver_free_method(s);
+}
+
+LogDriver *
+python_sd_new(GlobalConfig *cfg)
+{
+  PythonSourceDriver *self = g_new0(PythonSourceDriver, 1);
+
+  log_threaded_source_driver_init_instance(&self->super, cfg);
+  self->super.super.super.super.init = python_sd_init;
+  self->super.super.super.super.deinit = python_sd_deinit;
+  self->super.super.super.super.free_fn = python_sd_free;
+  self->super.format_stats_instance = python_sd_format_stats_instance;
+
+  log_threaded_source_driver_set_worker_request_exit_func(&self->super, python_sd_request_exit);
+  log_threaded_source_driver_set_worker_run_func(&self->super, python_sd_run);
+
+  self->options = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+  self->post_message = _post_message_blocking;
+
+  return &self->super.super.super;
+}
+
+
+static PyMethodDef py_log_source_methods[] =
+{
+  { "post_message", (PyCFunction) py_log_source_post, METH_VARARGS | METH_KEYWORDS, "Post message" },
+  {NULL}
+};
+
+static PyTypeObject py_log_source_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "LogSource",
+  .tp_basicsize = sizeof(PyLogSource),
+  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "The LogSource class is a base class for custom Python sources.",
+  .tp_new = PyType_GenericNew,
+  .tp_methods = py_log_source_methods,
+  0,
+};
+
+void
+py_log_source_init(void)
+{
+  PyType_Ready(&py_log_source_type);
+  PyModule_AddObject(PyImport_AddModule("syslogng"), "LogSource", (PyObject *) &py_log_source_type);
+}

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -321,6 +321,13 @@ py_log_source_post(PyObject *s, PyObject *args, PyObject *kwrds)
       return NULL;
     }
 
+  if (!log_threaded_source_free_to_send(&sd->super))
+    {
+      msg_error("Incorrectly suspended source, dropping message",
+                evt_tag_str("driver", sd->super.super.super.id));
+      Py_RETURN_NONE;
+    }
+
   /* keep a reference until the PyLogMessage instance is freed */
   LogMessage *message = log_msg_ref(pymsg->msg);
   sd->post_message(sd, message);

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -466,7 +466,10 @@ python_sd_new(GlobalConfig *cfg)
   self->super.super.super.super.init = python_sd_init;
   self->super.super.super.super.deinit = python_sd_deinit;
   self->super.super.super.super.free_fn = python_sd_free;
+
   self->super.format_stats_instance = python_sd_format_stats_instance;
+  self->super.worker_options.super.stats_level = STATS_LEVEL0;
+  self->super.worker_options.super.stats_source = SCS_PYTHON;
 
   log_threaded_source_driver_set_worker_request_exit_func(&self->super, python_sd_request_exit);
   log_threaded_source_driver_set_worker_run_func(&self->super, python_sd_run);

--- a/modules/python/python-source.h
+++ b/modules/python/python-source.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 László Várady <laszlo.varady@balabit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_PYTHON_SOURCE_H
+#define SNG_PYTHON_SOURCE_H
+
+#include "python-module.h"
+#include "driver.h"
+
+LogDriver *python_sd_new(GlobalConfig *cfg);
+void python_sd_set_loaders(LogDriver *d, GList *loaders);
+void python_sd_set_class(LogDriver *d, gchar *class_name);
+void python_sd_set_option(LogDriver *d, gchar *key, gchar *value);
+
+void py_log_source_init(void);
+
+#endif

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_unit_test(LIBTEST CRITERION
   TARGET test_python_logmsg
   INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
-  DEPENDS mod-python "${PYTHON_LIBRARIES}")
+  DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
 
 add_unit_test(LIBTEST CRITERION
   TARGET test_python_template

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -8,6 +8,7 @@ modules_python_tests_TESTS = \
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PREOPEN_SYSLOGFORMAT) \
 	$(PYTHON_LIBS)
 
 modules_python_tests_test_python_template_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -212,3 +212,23 @@ Test(python_log_message, test_py_log_message_constructor_with_binary)
   Py_DECREF(py_msg);
   PyGILState_Release(gstate);
 }
+
+Test(python_log_message, test_py_log_message_set_pri)
+{
+  gint pri = 165;
+
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *arg = Py_BuildValue("i", pri);
+  PyLogMessage *py_msg = _construct_py_log_msg(NULL);
+  Py_DECREF(arg);
+
+  PyObject *ret = _py_invoke_method_by_name((PyObject *) py_msg, "set_pri", arg, NULL, NULL);
+  Py_XDECREF(ret);
+
+  cr_assert_eq(py_msg->msg->pri, pri);
+
+  Py_DECREF(py_msg);
+  PyGILState_Release(gstate);
+}


### PR DESCRIPTION
## Python source

Two types of Python source can be implemented:

- Python `LogSource`:
  - You have 2 mandatory operations to implement, `run()` and `request_exit()`.
  - You can implement your own event loop, or integrate an external framework's or library's event loop (Kafka consumer, HTTP server, Flask, Twisted engine, etc).
  - You can post messages from `run()` using `LogSource::post_message()`.

- Python `LogFetcher`:
  - Easier to implement, the event loop and the entire scheduling is done automatically by syslog-ng.
  - You can use simple blocking server/client libraries to receive/fetch logs.
  - The following operations can be implemented: `open()`, `close()` and `fetch()`.


### Python `LogSource`
- A custom Python source implementation must be inherited from `syslogng.LogSource`. Multiple inheritance is allowed, but only for pure Python super classes.
- Mandatory methods: `run()`, `request_exit()`
- Optional methods: `init()`, `deinit()`, `suspend()`, `wakeup()`

`run()` can be used to implement an event loop or start a server framework/library. `LogMessage` instances can be created here. Messages can be sent using `LogSource::post_message()`.

`request_exit()` must shut down the event loop or framework, so the `run()` method can return gracefully. When blocking operations are used inside `run()`, `request_exit()` can be used to interrupt those operations and to set an exit flag.
`request_exit()` is called from a different thread (not from the source thread).


When `suspend()` and `wakeup()` are both implemented, they will be called when the source has to be suspended/resumed. If they are not specified, the entire source thread will be suspended automatically.

`suspend()` should prevent the source from posting new messages until `wakeup()` is called.
If this rule is violated, messages will be dropped with an error message: `Incorrectly suspended source, dropping message`.

Currently, `run()` stops permanently if an exception is propagated back to the C side (a `time-reopen()`-like retry mechanism can be implemented in the future).

```
    python(
        class("MySource")
        options(
            "option1" "value1",
            "option2" "value2"
        )
        # loaders("...")
        # log-iw-size(...)
        # persist-name(...)
        # flags(...)
    );
```

#### Example interface:
```python
from syslogng import LogSource
from syslogng import LogMessage
 
class MySource(LogSource):
    def init(self, options): # optional
        print("init")
        print(options)
        return True
 
    def deinit(self): # optional
        print("deinit")

    def run(self): # mandatory
        print("run")
        while not self.exit:
            # ...
            self.post_message(msg)
 
    def request_exit(self): # mandatory
        print("exit")
        self.exit = True
```

### Python `LogFetcher`

- A custom Python fetcher implementation must be inherited from `syslogng.LogFetcher`. 
- Mandatory methods: `fetch()`
- Optional methods: `init()`, `deinit()`, `open()`, `close()`, `request_exit()`
  - `request_exit()` is absolutely optional. You should use it only if `fetch()` has blocking operations and it has to be interrupted when shutting down syslog-ng. `request_exit()` is called from a different thread (not from the source thread).

![image](https://user-images.githubusercontent.com/3130044/45978024-6f77c300-c04b-11e8-87de-20836107a9c4.png)

(`connect()` means `open()` on the Python side, `disconnect()` = `close()`)

```
    python-fetcher(
        class("MyFetcher")
        options(
            "option1" "value1",
            "option2" "value2"
        )
        # loaders("...")
        # log-iw-size(...)
        # persist-name(...)
        # flags(...)
    );
```

#### Example interface
```python
from syslogng import LogFetcher
from syslogng import LogMessage
 
class MyFetcher(LogFetcher):
    def init(self, options): # optional
        print("init")
        print(options)
        return True
 
    def deinit(self): # optional
        print("deinit")
 
    def open(self): # optional
        print("open")
        return True
 
    def close(self): # optional
        print("close")
 
    def fetch(self): # mandatory
        print("fetch")
        # return LogFetcher.FETCH_ERROR,
        # return LogFetcher.FETCH_NOT_CONNECTED,
        return LogFetcher.FETCH_SUCCESS, msg
```

### `LogMessage` API

```python
msg = LogMessage() # empty message with good defaults (recvd timestamp, rcptid, hostid, ...)
msg = LogMessage("string or bytes-like object") # sets the $MESSAGE field

msg_ietf = LogMessage.parse('<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] An application event log entry', self.parse_options)
msg_bsd = LogMessage.parse('<34>Oct 11 22:14:15 mymachine su: \'su root\' failed for lonvick on /dev/pts/8', self.parse_options)
 
msg["HOST"] = "hostname" # keep-hostname(), use-dns(), use-fqdn(), chain-hostnames() will be taken into account by the source
msg["MESSAGE"] = "message"
 
msg.set_pri(165)
 
timestamp = datetime.fromisoformat("2018-09-11T14:49:02.100+02:00")
msg.set_timestamp(timestamp) # datetime object, includes timezone information
```

Reusing/storing `LogMessage` objects after they have been posted (calling `post_message()` or returning the message from `fetch()`) is not recommended.

`set_timestamp()` works differently in Python 2 and Python 3.

- In Python 2, timezone information can not be attached to the datetime instance without using an external library. Naive datetime objects are supported, they are represented in UTC inside syslog-ng.
- In Python 3, naive and timezone-aware datetime objects are both supported.

These sources create structured `LogMessage` instances, so it is not necessarily a good idea to force `log-msg-size()` on the `MESSAGE` field or on the entire message. Currently, we can't return multiple messages, so splitting a message is not really possible, I would just ignore `log-msg-size()`.

----

Questions:

TODO:

- must haves:
  - [x] finish `LogMessage.parse("ietf or bsd raw message", self.parse_options)`
  - [x] finish `log_message.set_timestamp(ts)` (python2 compatibility is required)
  - [x] fix a IW-related crash
  - [x] `PyLogMessage` unit tests
- nice to haves
  - [ ] merge grammar keywords: `python()` and `python-fetcher()` --> `python()`
    - python-source and python-fetcher should be unified (1 source driver, 2 different worker implementations) so we can remove duplicated code and merge the grammar keywords as well.
  - [ ] implement `MainLoopWorker` timeout (shutdown)
  - [ ] `run()` time-reopen() restart when exception is propagated back to the C side