### PR TITLE
dbparser: fix memory leak

### DIFF
--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -477,6 +477,9 @@ _pdbl_rules_start(PDBLoader *state, const gchar *element_name, const gchar **att
 
   if (strcmp(element_name, "rule") == 0)
     {
+      if (state->current_rule)
+        pdb_rule_unref(state->current_rule);
+
       state->current_rule = pdb_rule_new();
       for (i = 0; attribute_names[i]; i++)
         {


### PR DESCRIPTION
We leaked the patterndb file after every reload

Signed-off-by: Tibor Bodnar <tibor.bodnar@balabit.com>