### PR TITLE
Allow ipv4 mapped addresses in ipv6 mode

### DIFF
--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -144,6 +144,7 @@ resolve_hostname_to_sockaddr_using_getaddrinfo(GSockAddr **addr, gint family, co
   hints.ai_family = family;
   hints.ai_socktype = 0;
   hints.ai_protocol = 0;
+  hints.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG;
 
   if (getaddrinfo(name, NULL, &hints, &res) == 0)
     {


### PR DESCRIPTION
Pass AI_V4MAPPED | AI_ADDRCONFIG as hints to getaddrinfo() explicitly, which
allows ip-protocol(6) destinations to fall back to ipv4, should the
ipv6 stack not be available or if the server does not have an ipv6 address.

This would allow the user to use either ipv4 or ipv6, depending on the
ipv6 connectivity and the contents of DNS.

See getaddrinfo() manual page for more information.
