### PR TITLE
syslog-parser: fix unexpected flag check-hostname

### DIFF
--- a/modules/syslogformat/syslog-parser-grammar.ym
+++ b/modules/syslogformat/syslog-parser-grammar.ym
@@ -81,8 +81,9 @@ parser_syslog_opt
         ;
 
 parser_syslog_opt_flags
-        : string parser_syslog_opt_flags     { CHECK_ERROR(msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, $1), @1, "Unknown flag %s", $1); free($1); }
-	|
+        : string parser_syslog_opt_flags                { CHECK_ERROR(msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, $1), @1, "Unknown flag %s", $1); free($1); }
+        | KW_CHECK_HOSTNAME parser_syslog_opt_flags     { msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, "check-hostname");  }
+        |
 	;
 
 /* INCLUDE_RULES */

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -26,7 +26,7 @@
 
 static gboolean
 syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
-                      gsize input_len G_GNUC_UNUSED)
+                      gsize input_len)
 {
   SyslogParser *self = (SyslogParser *) s;
   LogMessage *msg;
@@ -36,7 +36,7 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 
-  syslog_format_handler(&self->parse_options, (guchar *) input, strlen(input), msg);
+  syslog_format_handler(&self->parse_options, (guchar *) input, input_len, msg);
   return TRUE;
 }
 


### PR DESCRIPTION
The following configuration was not accepted by:
```
parser  { syslog-parser(flags(check-hostname)); };
```

It was not accepted because the lexer has `KW_CHECK_HOSTNAME`, and the logic if something is a keyword or a string is looking up the keyword list. But the flags option expect it to be a string instead of a keyword, therefore the grammer fails.