### PR TITLE
DBLD: update make target, support make-check target

### DIFF
--- a/dbld/make
+++ b/dbld/make
@@ -4,3 +4,4 @@ set -e
 
 cd /build
 make "$@"
+make install

--- a/dbld/make-check
+++ b/dbld/make-check
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cd /build
+make check ; ret=$? ; if [ $ret -ne 0 ]; then cat test-suite.log ; exit $ret ; fi
+make func-test ; ret=$? ; if [ $ret -ne 0 ]; then cat test-suite.log ; exit $ret ; fi

--- a/dbld/rules
+++ b/dbld/rules
@@ -66,6 +66,10 @@ make: setup-$(DEFAULT_IMAGE)
 make-%: setup
 	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti  balabit/syslog-ng-$* /source/dbld/make $(MAKE_ARGS)
 
+make-check: setup-$(DEFAULT_IMAGE)
+make-check-%: setup
+	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti  balabit/syslog-ng-$* /source/dbld/make-check
+
 tarball: tarball-$(DEFAULT_IMAGE)
 tarball-%: setup
 	if [ -f $(TARBALL) ]; then \

--- a/dbld/rules
+++ b/dbld/rules
@@ -62,8 +62,9 @@ bootstrap: bootstrap-$(DEFAULT_IMAGE)
 bootstrap-%: setup
 	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -e CONFIGURE_OPTS="$${CONFIGURE_OPTS:-$(CONFIGURE_OPTS)}" -ti  balabit/syslog-ng-$* /source/dbld/bootstrap
 
+make: setup-$(DEFAULT_IMAGE)
 make-%: setup
-	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti  balabit/syslog-ng-$(DEFAULT_IMAGE) /source/dbld/make $(MAKE_ARGS) $*
+	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti  balabit/syslog-ng-$* /source/dbld/make $(MAKE_ARGS)
 
 tarball: tarball-$(DEFAULT_IMAGE)
 tarball-%: setup


### PR DESCRIPTION
- Added some minor changes to `dbld/rules make`
- Support to run `dbld/rules make-check`
- Goal of this changes is to run following commands from CI easily
$ dbld/rules make-[image] 
$ dbld/rules make-check-[image] 

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>