### PR TITLE
afinet_dest: add missing libnet_context destroy to afinet

### DIFF
--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -315,6 +315,11 @@ afinet_dd_deinit(LogPipe *s)
   if (_is_failover_used(self))
     afinet_dd_failover_deinit(self->failover);
 
+#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
+  if (self->lnet_ctx)
+    libnet_destroy(self->lnet_ctx);
+#endif
+
   return afsocket_dd_deinit(s);
 }
 

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -307,6 +307,15 @@ afinet_dd_get_dest_name(const AFSocketDestDriver *s)
   return buf;
 }
 
+static inline void
+_libnet_destroy_when_spoof_source_enabled(AFInetDestDriver *self)
+{
+#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
+  if (self->lnet_ctx)
+    libnet_destroy(self->lnet_ctx);
+#endif
+}
+
 static gboolean
 afinet_dd_deinit(LogPipe *s)
 {
@@ -315,10 +324,7 @@ afinet_dd_deinit(LogPipe *s)
   if (_is_failover_used(self))
     afinet_dd_failover_deinit(self->failover);
 
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-  if (self->lnet_ctx)
-    libnet_destroy(self->lnet_ctx);
-#endif
+  _libnet_destroy_when_spoof_source_enabled(self);
 
   return afsocket_dd_deinit(s);
 }


### PR DESCRIPTION
Added missing libnet_destroy() to afinet.

Signed-off-by: Laszlo Szemere <laszlo.szemere@balabit.com>