### PR TITLE
DBLD: Moved all kira deps to images

### DIFF
--- a/dbld/images/required-apt/xenial.txt
+++ b/dbld/images/required-apt/xenial.txt
@@ -20,3 +20,8 @@ libmongoc-dev
 # kira
 netbase
 faketime
+python-yaml
+python-numpy
+netcat
+lsof
+openssh-client

--- a/dbld/images/required-epel/all.txt
+++ b/dbld/images/required-epel/all.txt
@@ -4,3 +4,5 @@ libdbi-drivers
 riemann-c-client-devel
 syslog-ng-java-deps
 librabbitmq-devel
+python-yaml
+lsof

--- a/dbld/images/required-pip/xenial.txt
+++ b/dbld/images/required-pip/xenial.txt
@@ -4,3 +4,4 @@ pep8==1.7.1
 pylint==1.8.2
 astroid==1.6.1
 logilab-common<=0.63.0
+hy>=0.15.0


### PR DESCRIPTION
It's better to use them in the image by default instead of apt-get/pip install via kira in every time