### PR TITLE
Message about not supported cap_syslog only at debug level

### DIFF
--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -364,15 +364,21 @@ g_process_check_cap_syslog(void)
   switch (_check_and_get_cap_from_text("cap_syslog", &cap_syslog))
     {
     case CAP_NOT_SUPPORTED_BY_LIBCAP:
-      fprintf (stderr, "The CAP_SYSLOG is not supported by libcap;"
-               "Falling back to CAP_SYS_ADMIN!\n");
+      if (debug_flag)
+        {
+          fprintf (stderr, "The CAP_SYSLOG is not supported by libcap;"
+                   "Falling back to CAP_SYS_ADMIN!\n");
+        }
       return FALSE;
       break;
 
     case CAP_NOT_SUPPORTED_BY_KERNEL:
-      fprintf (stderr, "CAP_SYSLOG seems to be supported by libcap, but "
-               "the kernel does not appear to recognize it. Falling back "
-               "to CAP_SYS_ADMIN!\n");
+      if (debug_flag)
+        {
+          fprintf (stderr, "CAP_SYSLOG seems to be supported by libcap, but "
+                   "the kernel does not appear to recognize it. Falling back "
+                   "to CAP_SYS_ADMIN!\n");
+        }
       return FALSE;
       break;
 

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -43,6 +43,7 @@ typedef enum
 #if SYSLOG_NG_ENABLE_LINUX_CAPS
 
 gboolean g_process_enable_cap(const gchar *cap_name);
+gboolean g_process_is_cap_enabled(void);
 cap_t g_process_cap_save(void);
 void g_process_cap_restore(cap_t r);
 

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -181,6 +181,9 @@ setup_caps (void)
   static gchar *capsstr_syslog = BASE_CAPS "cap_syslog=ep";
   static gchar *capsstr_sys_admin = BASE_CAPS "cap_sys_admin=ep";
 
+  if (!g_process_is_cap_enabled())
+    return;
+
   /* Set up the minimal privilege we'll need
    *
    * NOTE: polling /proc/kmsg requires cap_sys_admin, otherwise it'll always
@@ -210,8 +213,6 @@ main(int argc, char *argv[])
   z_mem_trace_init("syslog-ng.trace");
 
   g_process_set_argv_space(argc, (gchar **) argv);
-
-  setup_caps();
 
   resolved_configurable_paths_init(&resolvedConfigurablePaths);
 
@@ -245,6 +246,8 @@ main(int argc, char *argv[])
       plugin_list_modules(stdout, TRUE);
       return 0;
     }
+
+  setup_caps();
 
   if(startup_debug_flag && debug_flag)
     {


### PR DESCRIPTION
If the syslog-ng was running on a system where `CAP_SYSLOG` is not present, it would print to the `stderr` unconditionally a message about fallbacking to `CAP_SYS_ADMIN`.
This prevent that log by default, and moves it into the debug level.