### PR TITLE
python: include python2/3 in plugin description

### DIFF
--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -29,10 +29,12 @@
 
 #if (SYSLOG_NG_ENABLE_PYTHONv2)
 #define PYTHON_BUILTIN_MODULE_NAME "__builtin__"
+#define PYTHON_MODULE_VERSION "python2"
 #endif
 
 #if (SYSLOG_NG_ENABLE_PYTHONv3)
 #define PYTHON_BUILTIN_MODULE_NAME "builtins"
+#define PYTHON_MODULE_VERSION "python3"
 #endif
 
 void py_init_argv(void);

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -89,7 +89,7 @@ const ModuleInfo module_info =
 {
   .canonical_name = "python",
   .version = SYSLOG_NG_VERSION,
-  .description = "The python module provides Python scripted destination support for syslog-ng.",
+  .description = "The python ("PYTHON_MODULE_VERSION") module provides Python scripted destination support for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = python_plugins,
   .plugins_len = G_N_ELEMENTS(python_plugins),


### PR DESCRIPTION
This changes the plugin description, so it includes the python main version (3/2 as of now).
The user could query which version was the python module compiled:
```
syslog-ng --module-registry
...
Module: mod-python
Status: ok
Version: 3.17.2
Core-Revision: 3.17
Description:
  The python (python2) module provides Python scripted destination support for syslog-ng.
Plugins:
  destination     python
  root            python
  parser          python
  template-func   python
...
```

* Should it include also the minor/patch version of the python ?

Fixes #2336