### PR TITLE
logthrsource: fix wakeup

### DIFF
--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -129,6 +129,8 @@ _schedule_next_fetch_if_free_to_send(LogThreadedFetcherDriver *self)
 {
   if (log_threaded_source_free_to_send(&self->super))
     iv_task_register(&self->fetch_task);
+  else
+    self->suspended = TRUE;
 }
 
 static void
@@ -186,8 +188,13 @@ _wakeup_event_handler(gpointer data)
 {
   LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) data;
 
-  if (!iv_task_registered(&self->fetch_task))
-    iv_task_register(&self->fetch_task);
+  if (self->suspended && log_threaded_source_free_to_send(&self->super))
+    {
+      self->suspended = FALSE;
+
+      if (!iv_task_registered(&self->fetch_task))
+        iv_task_register(&self->fetch_task);
+    }
 }
 
 static void

--- a/lib/logthrsource/logthrfetcherdrv.h
+++ b/lib/logthrsource/logthrfetcherdrv.h
@@ -56,6 +56,7 @@ struct _LogThreadedFetcherDriver
   struct iv_event wakeup_event;
   struct iv_event shutdown_event;
   struct iv_timer reconnect_timer;
+  gboolean suspended;
   gboolean under_termination;
 
   void (*thread_init)(LogThreadedFetcherDriver *self);

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -88,8 +88,12 @@ static inline void
 wakeup_cond_signal(WakeupCondition *cond)
 {
   g_mutex_lock(cond->lock);
-  cond->awoken = TRUE;
-  g_cond_signal(cond->cond);
+
+  if (!cond->awoken)
+    {
+      cond->awoken = TRUE;
+      g_cond_signal(cond->cond);
+    }
   g_mutex_unlock(cond->lock);
 }
 


### PR DESCRIPTION
Source implementations have to implement a funcionality called
"suspend".

This is usually achieved by calling free_to_send(). The source should
stop fetching messages when free_to_send() returns false.

The inverse of this operation is "wakeup", which is coming from the
destination thread, usually implemented using iv_event.

Since the suspend mechanism is based on polling, and wakeup is
event-based, it is possible that the source misses a
free->not_free->free oscillation. In such case, the corresponding wakeup
event must be ignored by the source to prevent an erroneous wakeup.

To ignore those wakeup events, an internal state (suspended flag) might
be enough.

Unfortunately, there is a rare occurrence of thread scheduling, when a
simple flag won't be enough:

0. start state: default IW size is 2, current window is 0; 2 messages
are waiting in the destination queue, the source is suspended

1. a message is acked, wakeup() is called, scheduled and the source
starts to fetch messages again

2. source thread: a new message is posted, the window is decremented
back to 0, but free_to_send is not called yet

context switch

3. dest thread: 2 messages are in the destination queue again, 1 is
acked, but wakeup() is not called yet

context switch

4. source thread: free_to_send() is called, returns TRUE, so it starts
fetching new messages

context switch

5. dest thread: because of step 3 (the window is changed from 0 to 1), wakeup()
is called, which generates an event that will be scheduled to the source event
queue

context switch

6. source thread: the source posts a new message, checks free_to_send
which returns FALSE, so the source will be suspended

7. source thread: the wakeup event from step 5 is scheduled, and the
source is in "suspended" state, so this wakeup event will be considered as
a "real" wakeup.

In fact, step 7 is just the consequence of step 5, so the scheduled wakeup
event should have been ignored.

Calling an extra free_to_send() in wakeup() fixes this issue.