### PR TITLE
MADV_DONTDUMP and portability

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -139,7 +139,7 @@ app_fatal(const char *msg)
 }
 
 void
-nondumpable_allocator_logger(gchar *summary, gchar *reason)
+nondumpable_allocator_logger_fatal(gchar *summary, gchar *reason)
 {
   msg_fatal(summary, evt_tag_str("reason", reason));
 }
@@ -168,7 +168,7 @@ app_startup(void)
   service_management_init();
   scratch_buffers_allocator_init();
   main_loop_thread_resource_init();
-  nondumpable_setlogger(nondumpable_allocator_logger);
+  nondumpable_setlogger(nondumpable_allocator_logger_fatal);
   secret_storage_init();
   transport_factory_id_global_init();
 }

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -138,11 +138,15 @@ app_fatal(const char *msg)
   fprintf(stderr, "%s\n", msg);
 }
 
-void
-nondumpable_allocator_logger_fatal(gchar *summary, gchar *reason)
-{
-  msg_fatal(summary, evt_tag_str("reason", reason));
+#define construct_nondumpable_logger(logger) \
+void \
+nondumpable_allocator_ ## logger (gchar *summary, gchar *reason) \
+{ \
+  logger(summary, evt_tag_str("reason", reason)); \
 }
+
+construct_nondumpable_logger(msg_debug);
+construct_nondumpable_logger(msg_fatal);
 
 void
 app_startup(void)
@@ -168,7 +172,7 @@ app_startup(void)
   service_management_init();
   scratch_buffers_allocator_init();
   main_loop_thread_resource_init();
-  nondumpable_setlogger(nondumpable_allocator_logger_fatal);
+  nondumpable_setlogger(nondumpable_allocator_msg_debug, nondumpable_allocator_msg_fatal);
   secret_storage_init();
   transport_factory_id_global_init();
 }

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -42,8 +42,9 @@ NonDumpableLogger logger_debug INTERNAL = _silent;
 NonDumpableLogger logger_fatal INTERNAL = _silent;
 
 void
-nondumpable_setlogger(NonDumpableLogger _fatal)
+nondumpable_setlogger(NonDumpableLogger _debug, NonDumpableLogger _fatal)
 {
+  logger_debug = _debug;
   logger_fatal = _fatal;
 }
 

--- a/lib/secret-storage/nondumpable-allocator.h
+++ b/lib/secret-storage/nondumpable-allocator.h
@@ -36,6 +36,6 @@ void nondumpable_buffer_free(gpointer buffer) PUBLIC;
 gpointer nondumpable_buffer_realloc(gpointer buffer, gsize len) PUBLIC;
 gpointer nondumpable_memcpy(gpointer dest, gpointer src, gsize len) PUBLIC;
 void nondumpable_mem_zero(gpointer s, gsize len) PUBLIC;
-void nondumpable_setlogger(NonDumpableLogger _fatal) PUBLIC;
+void nondumpable_setlogger(NonDumpableLogger _debug, NonDumpableLogger _fatal) PUBLIC;
 
 #endif

--- a/lib/secret-storage/nondumpable-allocator.h
+++ b/lib/secret-storage/nondumpable-allocator.h
@@ -29,11 +29,13 @@
 #define PUBLIC __attribute__ ((visibility ("default")))
 #define INTERNAL __attribute__ ((visibility ("hidden")))
 
+typedef void(*NonDumpableLogger)(gchar *summary, gchar *reason);
+
 gpointer nondumpable_buffer_alloc(gsize len) PUBLIC;
 void nondumpable_buffer_free(gpointer buffer) PUBLIC;
 gpointer nondumpable_buffer_realloc(gpointer buffer, gsize len) PUBLIC;
 gpointer nondumpable_memcpy(gpointer dest, gpointer src, gsize len) PUBLIC;
 void nondumpable_mem_zero(gpointer s, gsize len) PUBLIC;
-void nondumpable_setlogger(void(*logger)(gchar *summary, gchar *reason)) PUBLIC;
+void nondumpable_setlogger(NonDumpableLogger _fatal) PUBLIC;
 
 #endif

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -39,7 +39,7 @@ void
 secret_storage_testsuite_init(void)
 {
   secret_storage_init();
-  nondumpable_setlogger(logger);
+  nondumpable_setlogger(logger, logger);
 }
 
 void


### PR DESCRIPTION
This patchset fixes a problem, when syslog-ng password protected ssl keys with credential storage did not work, if the syslog-ng binary is compiled with centos6, but used on ubuntu precise.

syslog-ng uses MADV_DONTDUMP to avoid writing credentials store data into core dump. Though this feature is available only from kernel 3.4, centos6 team backported this feature with https://access.redhat.com/errata/RHBA-2013:0279.

As a result, if the binary is built with centos6, syslog-ng tries to uses this option. But ubuntu precise has older kernel version 3.2, which does not support this option, so madvise() will return with errno == EINVAL. In the end syslog-ng fails to initialize.

This patch checks if errno == EINVAL is received, and in that case a debug log is written about the case, otherwise secret storage allocation continues. Debug loglevel is needed so not to emit an error that cannot be handled on ubuntu precise.
