### PR TITLE
amqp configurable max connection and frame size

### DIFF
--- a/modules/afamqp/CMakeLists.txt
+++ b/modules/afamqp/CMakeLists.txt
@@ -16,6 +16,7 @@ set(AFAMQP_HEADERS
 
 set(AFAMQP_SOURCES
     "afamqp-parser.c"
+    "afamqp-plugin.c"
     "afamqp.c"
     "${CMAKE_CURRENT_BINARY_DIR}/afamqp-grammar.c"
 )

--- a/modules/afamqp/Makefile.am
+++ b/modules/afamqp/Makefile.am
@@ -11,7 +11,8 @@ modules_afamqp_libafamqp_la_SOURCES	= 	\
 	modules/afamqp/afamqp.c			\
 	modules/afamqp/afamqp.h			\
 	modules/afamqp/afamqp-parser.c		\
-	modules/afamqp/afamqp-parser.h
+	modules/afamqp/afamqp-parser.h          \
+	modules/afamqp/afamqp-plugin.c
 modules_afamqp_libafamqp_la_LIBADD	= 	\
 	$(MODULE_DEPS_LIBS) $(LIBRABBITMQ_LIBS)
 modules_afamqp_libafamqp_la_LDFLAGS	=	\

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -57,6 +57,8 @@
 %token KW_BODY
 %token KW_PASSWORD
 %token KW_USERNAME
+%token KW_MAX_CHANNEL
+%token KW_FRAME_SIZE
 %token KW_CA_FILE
 %token KW_KEY_FILE
 %token KW_CERT_FILE
@@ -90,6 +92,8 @@ afamqp_option
 	| KW_PERSISTENT '(' yesno ')'             { afamqp_dd_set_persistent(last_driver, $3); }
 	| KW_USERNAME '(' string ')'              { afamqp_dd_set_user(last_driver, $3); free($3); }
 	| KW_PASSWORD '(' string ')'              { afamqp_dd_set_password(last_driver, $3); free($3); }
+	| KW_MAX_CHANNEL '(' positive_integer ')' { afamqp_dd_set_max_channel(last_driver, $3); }
+	| KW_FRAME_SIZE '(' positive_integer ')'  { afamqp_dd_set_frame_size(last_driver, $3); }
 	| value_pair_option                       { afamqp_dd_set_value_pairs(last_driver, $1); }
 	| threaded_dest_driver_option
 	| afamqp_tls_option

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -79,23 +79,23 @@ afamqp_options
 	;
 
 afamqp_option
-        : KW_HOST '(' string ')'		{ afamqp_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' positive_integer ')'		{ afamqp_dd_set_port(last_driver, $3); }
-        | KW_VHOST '(' string ')'		{ afamqp_dd_set_vhost(last_driver, $3); free($3); }
-	| KW_EXCHANGE '(' string ')'		{ afamqp_dd_set_exchange(last_driver, $3); free($3); }
-        | KW_EXCHANGE_DECLARE '(' yesno ')'	{ afamqp_dd_set_exchange_declare(last_driver, $3); }
-	| KW_EXCHANGE_TYPE '(' string ')'	{ afamqp_dd_set_exchange_type(last_driver, $3); free($3); }
-	| KW_ROUTING_KEY '(' string ')'		{ afamqp_dd_set_routing_key(last_driver, $3); free($3); }
-        | KW_BODY '(' string ')'		{ afamqp_dd_set_body(last_driver, $3); free($3); }
-	| KW_PERSISTENT '(' yesno ')'		{ afamqp_dd_set_persistent(last_driver, $3); }
-	| KW_USERNAME '(' string ')'		{ afamqp_dd_set_user(last_driver, $3); free($3); }
-	| KW_PASSWORD '(' string ')'		{ afamqp_dd_set_password(last_driver, $3); free($3); }
-	| value_pair_option			{ afamqp_dd_set_value_pairs(last_driver, $1); }
+	: KW_HOST '(' string ')'                  { afamqp_dd_set_host(last_driver, $3); free($3); }
+	| KW_PORT '(' positive_integer ')'        { afamqp_dd_set_port(last_driver, $3); }
+	| KW_VHOST '(' string ')'                 { afamqp_dd_set_vhost(last_driver, $3); free($3); }
+	| KW_EXCHANGE '(' string ')'              { afamqp_dd_set_exchange(last_driver, $3); free($3); }
+	| KW_EXCHANGE_DECLARE '(' yesno ')'       { afamqp_dd_set_exchange_declare(last_driver, $3); }
+	| KW_EXCHANGE_TYPE '(' string ')'         { afamqp_dd_set_exchange_type(last_driver, $3); free($3); }
+	| KW_ROUTING_KEY '(' string ')'           { afamqp_dd_set_routing_key(last_driver, $3); free($3); }
+	| KW_BODY '(' string ')'                  { afamqp_dd_set_body(last_driver, $3); free($3); }
+	| KW_PERSISTENT '(' yesno ')'             { afamqp_dd_set_persistent(last_driver, $3); }
+	| KW_USERNAME '(' string ')'              { afamqp_dd_set_user(last_driver, $3); free($3); }
+	| KW_PASSWORD '(' string ')'              { afamqp_dd_set_password(last_driver, $3); free($3); }
+	| value_pair_option                       { afamqp_dd_set_value_pairs(last_driver, $1); }
 	| threaded_dest_driver_option
-    | afamqp_tls_option
-    | KW_TLS '(' afamqp_tls_options ')'
+	| afamqp_tls_option
+	| KW_TLS '(' afamqp_tls_options ')'
 	| { last_template_options = afamqp_dd_get_template_options(last_driver); } template_option
-        ;
+	;
 
 
 afamqp_tls_options

--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -42,6 +42,8 @@ static CfgLexerKeyword afamqp_keywords[] =
   { "persistent",   KW_PERSISTENT },
   { "username",     KW_USERNAME },
   { "password",     KW_PASSWORD },
+  { "max_channel",     KW_MAX_CHANNEL },
+  { "frame_size",     KW_FRAME_SIZE },
   { "log_fifo_size",    KW_LOG_FIFO_SIZE  },
   { "body",     KW_BODY },
   { "ca_file",        KW_CA_FILE },

--- a/modules/afamqp/afamqp-plugin.c
+++ b/modules/afamqp/afamqp-plugin.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2018 Kokan
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "afamqp-parser.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser afamqp_dd_parser;
+
+static Plugin afamqp_plugins[] =
+{
+  {
+    .type = LL_CONTEXT_DESTINATION,
+    .name = "amqp",
+    .parser = &afamqp_parser
+  }
+};
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "afamqp",
+  .version = SYSLOG_NG_VERSION,
+  .description = "The afamqp module provides AMQP destination support for syslog-ng.",
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
+  .plugins = afamqp_plugins,
+  .plugins_len = G_N_ELEMENTS(afamqp_plugins),
+};
+
+gboolean
+afamqp_module_init(PluginContext *context, CfgArgs *args)
+{
+  plugin_register(context, afamqp_plugins, G_N_ELEMENTS(afamqp_plugins));
+  return TRUE;
+}
+

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -23,14 +23,11 @@
  */
 
 #include "afamqp.h"
-#include "afamqp-parser.h"
-#include "plugin.h"
 #include "messages.h"
 #include "stats/stats-registry.h"
 #include "logmsg/nvtable.h"
 #include "logqueue.h"
 #include "scratch-buffers.h"
-#include "plugin-types.h"
 #include "logthrdestdrv.h"
 
 #include <amqp.h>
@@ -708,28 +705,3 @@ afamqp_dd_new(GlobalConfig *cfg)
 
   return (LogDriver *) self;
 }
-
-extern CfgParser afamqp_dd_parser;
-
-static Plugin afamqp_plugin =
-{
-  .type = LL_CONTEXT_DESTINATION,
-  .name = "amqp",
-  .parser = &afamqp_parser
-};
-
-gboolean
-afamqp_module_init(PluginContext *context, CfgArgs *args)
-{
-  plugin_register(context, &afamqp_plugin, 1);
-  return TRUE;
-}
-
-const ModuleInfo module_info =
-{
-  .canonical_name = "afamqp",
-  .version = SYSLOG_NG_VERSION,
-  .description = "The afamqp module provides AMQP destination support for syslog-ng.",
-  .core_revision = SYSLOG_NG_SOURCE_REVISION, .plugins = &afamqp_plugin,
-  .plugins_len = 1,
-};

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -444,7 +444,7 @@ afamqp_dd_connect(AMQPDestDriver *self, gboolean reconnect)
       goto exception_amqp_dd_connect_failed_init;
     }
 
-  ret = amqp_login(self->conn, self->vhost, 0, 131072, 0,
+  ret = amqp_login(self->conn, self->vhost, AMQP_DEFAULT_MAX_CHANNELS, AMQP_DEFAULT_FRAME_SIZE, 0,
                    AMQP_SASL_METHOD_PLAIN, self->user, self->password);
   if (!afamqp_is_ok(self, "Error during AMQP login", ret))
     {

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -687,14 +687,15 @@ afamqp_dd_new(GlobalConfig *cfg)
 
   self->routing_key_template = log_template_new(cfg, NULL);
 
-  afamqp_dd_set_vhost((LogDriver *) self, "/");
-  afamqp_dd_set_host((LogDriver *) self, "127.0.0.1");
-  afamqp_dd_set_port((LogDriver *) self, 5672);
-  afamqp_dd_set_exchange((LogDriver *) self, "syslog");
-  afamqp_dd_set_exchange_type((LogDriver *) self, "fanout");
-  afamqp_dd_set_routing_key((LogDriver *) self, "");
-  afamqp_dd_set_persistent((LogDriver *) self, TRUE);
-  afamqp_dd_set_exchange_declare((LogDriver *) self, FALSE);
+  LogDriver *driver = &self->super.super.super;
+  afamqp_dd_set_vhost(driver, "/");
+  afamqp_dd_set_host(driver, "127.0.0.1");
+  afamqp_dd_set_port(driver, 5672);
+  afamqp_dd_set_exchange(driver, "syslog");
+  afamqp_dd_set_exchange_type(driver, "fanout");
+  afamqp_dd_set_routing_key(driver, "");
+  afamqp_dd_set_persistent(driver, TRUE);
+  afamqp_dd_set_exchange_declare(driver, FALSE);
 
   self->max_entries = 256;
   self->entries = g_new(amqp_table_entry_t, self->max_entries);

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -55,6 +55,9 @@ typedef struct
   gchar *user;
   gchar *password;
 
+  gint max_channel;
+  gint frame_size;
+
   LogTemplateOptions template_options;
   ValuePairs *vp;
 
@@ -224,6 +227,22 @@ afamqp_dd_set_peer_verify(LogDriver *d, gboolean verify)
   AMQPDestDriver *self = (AMQPDestDriver *) d;
 
   self->peer_verify = verify;
+}
+
+void
+afamqp_dd_set_max_channel(LogDriver *d, gint max_channel)
+{
+  AMQPDestDriver *self = (AMQPDestDriver *) d;
+
+  self->max_channel = max_channel;
+}
+
+void
+afamqp_dd_set_frame_size(LogDriver *d, gint frame_size)
+{
+  AMQPDestDriver *self = (AMQPDestDriver *) d;
+
+  self->frame_size = frame_size;
 }
 
 /*
@@ -444,7 +463,7 @@ afamqp_dd_connect(AMQPDestDriver *self, gboolean reconnect)
       goto exception_amqp_dd_connect_failed_init;
     }
 
-  ret = amqp_login(self->conn, self->vhost, AMQP_DEFAULT_MAX_CHANNELS, AMQP_DEFAULT_FRAME_SIZE, 0,
+  ret = amqp_login(self->conn, self->vhost, self->max_channel, self->frame_size, 0,
                    AMQP_SASL_METHOD_PLAIN, self->user, self->password);
   if (!afamqp_is_ok(self, "Error during AMQP login", ret))
     {
@@ -696,6 +715,8 @@ afamqp_dd_new(GlobalConfig *cfg)
   afamqp_dd_set_routing_key(driver, "");
   afamqp_dd_set_persistent(driver, TRUE);
   afamqp_dd_set_exchange_declare(driver, FALSE);
+  afamqp_dd_set_max_channel(driver, AMQP_DEFAULT_MAX_CHANNELS);
+  afamqp_dd_set_frame_size(driver, AMQP_DEFAULT_FRAME_SIZE);
 
   self->max_entries = 256;
   self->entries = g_new(amqp_table_entry_t, self->max_entries);

--- a/modules/afamqp/afamqp.h
+++ b/modules/afamqp/afamqp.h
@@ -41,6 +41,8 @@ void afamqp_dd_set_body(LogDriver *d, const gchar *body);
 void afamqp_dd_set_persistent(LogDriver *d, gboolean persistent);
 void afamqp_dd_set_user(LogDriver *d, const gchar *user);
 void afamqp_dd_set_password(LogDriver *d, const gchar *password);
+void afamqp_dd_set_max_channel(LogDriver *d, gint max_channel);
+void afamqp_dd_set_frame_size(LogDriver *d, gint frame_size);
 void afamqp_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
 void afamqp_dd_set_ca_file(LogDriver *d, const gchar *cacrt);
 void afamqp_dd_set_key_file(LogDriver *d, const gchar *key);


### PR DESCRIPTION
It makes possible to configure the `max_channel` and `frame_size` for amqp destination. Also relays on a default value supplied by rabbitmq project.

Fixes #2340 