### PR TITLE
python-dest: use the compat layer from LogThrDstDriver when accessing…

### DIFF
--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -221,7 +221,7 @@ _py_init_bindings(PythonDestDriver *self)
 
   self->py.log_template_options = py_log_template_options_new(&self->template_options);
   PyObject_SetAttrString(self->py.class, "template_options", self->py.log_template_options);
-  self->py.seqnum = py_integer_pointer_new(&self->super.seq_num);
+  self->py.seqnum = py_integer_pointer_new(&self->super.worker.instance.seq_num);
   PyObject_SetAttrString(self->py.class, "seqnum", self->py.seqnum);
   Py_DECREF(self->py.log_template_options);
 


### PR DESCRIPTION
… seqnum

Signed-off-by: Laszlo Budai <stentor.bgyk@gmail.com>