### PR TITLE
 non-reliable diskq: fixing a false positive corruption detection

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -399,6 +399,13 @@ _save_queue (LogQueueDisk *s, gboolean *persistent)
 }
 
 static void
+_restart(LogQueueDisk *s, DiskQueueOptions *options)
+{
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  qdisk_init(self->super.qdisk, options, "SLQF");
+}
+
+static void
 _set_virtual_functions (LogQueueDisk *self)
 {
   self->get_length = _get_length;
@@ -411,6 +418,7 @@ _set_virtual_functions (LogQueueDisk *self)
   self->free_fn = _freefn;
   self->load_queue = _load_queue;
   self->save_queue = _save_queue;
+  self->restart = _restart;
 }
 
 LogQueue *
@@ -419,7 +427,7 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
   log_queue_disk_init_instance(&self->super, persist_name);
-  qdisk_init (self->super.qdisk, options);
+  qdisk_init(self->super.qdisk, options, "SLQF");
   self->qbacklog = g_queue_new ();
   self->qout = g_queue_new ();
   self->qoverflow = g_queue_new ();

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -301,19 +301,17 @@ _write_message(LogQueueDisk *self, LogMessage *msg)
 }
 
 static void
-_restart_diskq(LogQueueDisk *self, gboolean corrupted)
+_restart_diskq(LogQueueDisk *self)
 {
   gchar *filename = g_strdup(qdisk_get_filename(self->qdisk));
   gchar *new_file = NULL;
   DiskQueueOptions *options = qdisk_get_options(self->qdisk);
 
   qdisk_deinit(self->qdisk);
-  if (corrupted)
-    {
-      new_file = g_strdup_printf("%s.corrupted",filename);
-      rename(filename,new_file);
-      g_free(new_file);
-    }
+
+  new_file = g_strdup_printf("%s.corrupted", filename);
+  rename(filename, new_file);
+  g_free(new_file);
 
   if (self->restart)
     self->restart(self, options);
@@ -328,7 +326,7 @@ _restart_diskq(LogQueueDisk *self, gboolean corrupted)
 void
 log_queue_disk_restart_corrupted(LogQueueDisk *self)
 {
-  _restart_diskq(self, TRUE);
+  _restart_diskq(self);
 }
 
 

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -49,8 +49,7 @@ struct _LogQueueDisk
   gboolean (*is_reliable)(LogQueueDisk *s);
   LogMessage *(*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
   gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
-  void (*restart)(LogQueueDisk *self);
-  void (*restart_corrupted)(LogQueueDisk *self);
+  void (*restart)(LogQueueDisk *self, DiskQueueOptions *options);
 };
 
 extern QueueType log_queue_disk_type;
@@ -60,5 +59,6 @@ const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
 void log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name);
+void log_queue_disk_restart_corrupted(LogQueueDisk *self);
 
 #endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -204,10 +204,24 @@ _truncate_file(QDisk *self, gint64 new_size)
   if (ftruncate(self->fd, (glong)new_size) < 0)
     {
       success = FALSE;
+      off_t file_size = -1;
+
+      struct stat st;
+      if (fstat(self->fd, &st) < 0)
+        {
+          msg_error("truncate file: cannot stat",
+                    evt_tag_error("error"));
+        }
+      else
+        {
+          file_size = st.st_size;
+        }
+
       msg_error("Error truncating disk-queue file",
                 evt_tag_error("error"),
                 evt_tag_str("filename", self->filename),
-                evt_tag_long("newsize", self->hdr->write_head),
+                evt_tag_long("expected-size", new_size),
+                evt_tag_long("file_size", file_size),
                 evt_tag_int("fd", self->fd));
     }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -469,6 +469,7 @@ _try_to_load_queue(QDisk *self, GQueue *queue, QDiskQueuePosition *pos, gchar *t
     {
       msg_error("Inconsistent header data in disk-queue file, ignoring queue",
                 evt_tag_str("filename", self->filename),
+                evt_tag_long("write_head", self->hdr->write_head),
                 evt_tag_str("type", type),
                 evt_tag_long("ofs", ofs),
                 evt_tag_long("qdisk_length",  self->hdr->length));

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -477,16 +477,16 @@ _try_to_load_queue(QDisk *self, GQueue *queue, QDiskQueuePosition *pos, gchar *t
   return TRUE;
 }
 
+#define try_load_queue(self, queue) _try_to_load_queue(self, queue, &self->hdr->queue ##_pos, #queue)
+
 static gboolean
 _load_non_reliable_queues(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
-  if (!_try_to_load_queue(self, qout, &self->hdr->qout_pos, "qout"))
+  if (!try_load_queue(self, qout))
     return FALSE;
-
-  if (!_try_to_load_queue(self, qbacklog, &self->hdr->qbacklog_pos, "qbacklog"))
+  if (!try_load_queue(self, qbacklog))
     return FALSE;
-
-  if (!_try_to_load_queue(self, qoverflow, &self->hdr->qoverflow_pos, "qoverflow"))
+  if (!try_load_queue(self, qoverflow))
     return FALSE;
 
   return TRUE;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -391,7 +391,7 @@ qdisk_pop_head(QDisk *self, GString *record)
           self->hdr->backlog_head = self->hdr->read_head;
         }
 
-      if (self->hdr->length == 0 && !self->options->reliable)
+      if (!self->options->read_only && self->hdr->length == 0 && !self->options->reliable)
         {
           msg_debug("Queue file became empty, truncating file",
                     evt_tag_str("filename", self->filename));

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -43,9 +43,6 @@
 #define MADV_RANDOM 1
 #endif
 
-/*pessimistic default for reliable disk queue 10000 x 16 kbyte*/
-#define PESSIMISTIC_MEM_BUF_SIZE 10000 * 16 *1024
-
 #define MAX_RECORD_LENGTH 100 * 1024 * 1024
 
 #define PATH_QDISK              PATH_LOCALSTATEDIR
@@ -890,21 +887,13 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
 }
 
 void
-qdisk_init(QDisk *self, DiskQueueOptions *options)
+qdisk_init(QDisk *self, DiskQueueOptions *options, const gchar *file_id)
 {
   self->fd = -1;
   self->file_size = 0;
   self->options = options;
-  if (!self->options->reliable)
-    self->file_id = "SLQF";
-  else
-    {
-      self->file_id = "SLRQ";
-      if (self->options->mem_buf_size < 0)
-        {
-          self->options->mem_buf_size = PESSIMISTIC_MEM_BUF_SIZE;
-        }
-    }
+
+  self->file_id = file_id;
 }
 
 void

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -492,6 +492,16 @@ _load_non_reliable_queues(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *q
   return TRUE;
 }
 
+#define _clear(obj) memset(&obj, 0, sizeof(obj));
+
+static void
+_reset_queue_pointers(QDisk *self)
+{
+  _clear(self->hdr->qout_pos);
+  _clear(self->hdr->qbacklog_pos);
+  _clear(self->hdr->qoverflow_pos);
+};
+
 static gboolean
 _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
@@ -549,6 +559,7 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
   if (!self->options->reliable)
     {
       self->file_size = qout_ofs;
+      _reset_queue_pointers(self);
 
       msg_info("Disk-buffer state loaded",
                evt_tag_str("filename", self->filename),

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -37,6 +37,14 @@
  */
 #define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) (lpo)->ack_needed = (GPOINTER_TO_INT(ptr) & ~0x80000000)
 
+typedef struct
+{
+  gint64 ofs;
+  gint32 len;
+  gint32 count;
+}
+QDiskQueuePosition;
+
 typedef struct _QDisk QDisk;
 
 QDisk *qdisk_new(void);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -46,7 +46,7 @@ gint64 qdisk_get_empty_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
-void qdisk_init(QDisk *self, DiskQueueOptions *options);
+void qdisk_init(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_deinit(QDisk *self);
 void qdisk_reset_file_if_possible(QDisk *self);
 gboolean qdisk_initialized(QDisk *self);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -354,7 +354,7 @@ testcase_diskbuffer_restart_corrupted(void)
       assert_gint(fed_messages, 100, "Failed to push all messages to the disk-queue!\n");
 
       LogQueueDisk *disk_queue = (LogQueueDisk *)q;
-      disk_queue->restart_corrupted(disk_queue);
+      log_queue_disk_restart_corrupted(disk_queue);
 
       struct stat file_stat;
       assert_gint(stat(filename, &file_stat), 0,


### PR DESCRIPTION
This patchset addreses the following problems:
For users:
- When diskqueue was read by dqtool cat, syslog-ng tried to truncate the file even though it was opened as readonly, hence an error message was emitted. The code is fixed that syslog-ng will not try to truncate with readonly mode
- Fixed the dumped variables in the error log that is emitted when a truncate was unsuccessful
- Removing a false positive corruption detection error log.

For developers
- When corruption was detected, the error message was missing the write_head variable that is important information from debugging point of view.
- qdisk_init contained a branching based on reliable-non-reliable queue, that I could eliminate (refactor)
- _load_state contained a large chunk of code that was responsible for loading the queues of a non-reliable diskqueue, with a little code repetition. I could factor out a function, and eliminate the code duplications

A little more information about the corruption detection problem:

Previously, when a non-reliable diskqueue file is loaded, even though the qout, qbacklog qoverflow queues were truncated from the file, their pointers were not reset. As a consequence, the diskqueue file is kept in an invalid state while syslog-ng was running. These pointers were only set to valid values only when syslog-ng stopped gracefully, while saving the diskqueue. Suppose more messages are added to the queue, so that the write_head passes the invalid qout_ofs, then crash syslog-ng. In that case, the original invalid qout_ofs was kept in the diskqueue file, which is detected as a corruption at the next start, though the content of the disk queue was valid: at least the memory queue point of view, as everything in the memory was lost. 

Reproduction steps:
```
log {
    source { tcp(port(4444) flags(no-parse)); };
    destination { tcp(127.0.0.1 port(5555)
    disk-buffer(disk-buf-size(31457280) reliable(no)
    qout_size(64)));
  };
  flags(flow-control);
};
```

The destination must **NOT** be reachable.

Send in 128 messages:
```
for i in `seq 1 128`; do echo "hello AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" | nc localhost 4444; done
```

As qout is 64, 64 messages will be put into qout, 64 messages will be put into the disk queue.

Stop syslog-ng gracefully, with syslog-ng-ctl stop or ctrl-c. Then the qout will be written into the end of the diskqueue file, meaning qout will be larger than write_head.

Start syslog-ng again, and send in more messages that are stored in qout, for example again:
```
for i in `seq 1 128`; do echo "hello AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" | nc localhost 4444; done
```

In this case the write_head will go past qout. Note qout is not changed only when the queue is saved.

Then kill syslog-ng: for example with pkill -9 syslog-ng.

The result will be:
```

Inconsistent header data in disk-queue file, ignoring qout; filename='[...]', qout_ofs='35328', write_head='97792', qdisk_length='192'
--
Disk-buffer state loaded; filename='[...]', qout_length='64', qbacklog_length='0', qoverflow_length='0', qdisk_length='192'
Oct 12 13:28:09.084 localhost hello AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
[...]
```