### PR TITLE
Move some messages to trace

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1214,7 +1214,7 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
   memcpy(self, msg, sizeof(*msg));
   msg->allocated_bytes = allocated_bytes;
 
-  msg_debug("Message was cloned",
+  msg_trace("Message was cloned",
             evt_tag_printf("original_msg", "%p", msg),
             evt_tag_printf("new_msg", "%p", self));
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -354,7 +354,7 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
       local_path_options.flow_control_requested = 1;
       path_options = &local_path_options;
 
-      msg_debug("Requesting flow control", log_pipe_location_tag(s));
+      msg_trace("Requesting flow control", log_pipe_location_tag(s));
     }
 
   if (s->queue)

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -667,8 +667,8 @@ log_proto_buffered_server_fetch_into_buffer(LogProtoBufferedServer *self)
   else if (rc == 0)
     {
       /* EOF read */
-      msg_verbose("EOF occurred while reading",
-                  evt_tag_int(EVT_TAG_FD, self->super.transport->fd));
+      msg_trace("EOF occurred while reading",
+                evt_tag_int(EVT_TAG_FD, self->super.transport->fd));
       if (state->raw_buffer_leftover_size > 0)
         {
           msg_error("EOF read on a channel with leftovers from previous character conversion, dropping input");

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -110,8 +110,8 @@ log_proto_framed_server_fetch_data(LogProtoFramedServer *self, gboolean *may_rea
     }
   else if (rc == 0)
     {
-      msg_verbose("EOF occurred while reading",
-                  evt_tag_int(EVT_TAG_FD, self->super.transport->fd));
+      msg_trace("EOF occurred while reading",
+                evt_tag_int(EVT_TAG_FD, self->super.transport->fd));
       return LPS_EOF;
     }
   else

--- a/lib/transport/logtransport.c
+++ b/lib/transport/logtransport.c
@@ -32,8 +32,8 @@ log_transport_free_method(LogTransport *s)
 {
   if (s->fd != -1)
     {
-      msg_verbose("Closing log transport fd",
-                  evt_tag_int("fd", s->fd));
+      msg_trace("Closing log transport fd",
+                evt_tag_int("fd", s->fd));
       close(s->fd);
     }
 }


### PR DESCRIPTION
I find the latest messages clutter up debug messages a lot, so move some of the less interesting ones
to msg_trace(), now that we have that.