### PR TITLE
basicfuncs: fix $(basename) and $(dirname) in the presence of a prefix

### DIFF
--- a/modules/basicfuncs/fname-funcs.c
+++ b/modules/basicfuncs/fname-funcs.c
@@ -30,7 +30,7 @@ tf_basename(LogMessage *msg, gint argc, GString *argv[], GString *result)
   gchar *base;
 
   base = g_path_get_basename(argv[0]->str);
-  g_string_assign(result, base);
+  g_string_append(result, base);
   g_free(base);
 }
 
@@ -42,7 +42,7 @@ tf_dirname(LogMessage *msg, gint argc, GString *argv[], GString *result)
   gchar *dir;
 
   dir = g_path_get_dirname(argv[0]->str);
-  g_string_assign(result, dir);
+  g_string_append(result, dir);
   g_free(dir);
 }
 

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -222,11 +222,19 @@ Test(basicfuncs, test_fname_funcs)
   assert_template_format("$(basename foo)", "foo");
   assert_template_format("$(basename /foo/bar)", "bar");
   assert_template_format("$(basename /foo/bar/baz)", "baz");
+  assert_template_format("/prefix/$(basename foo)", "/prefix/foo");
+  assert_template_format("/prefix/$(basename /foo/bar)", "/prefix/bar");
+  assert_template_format("/prefix/$(basename /foo/bar/baz)", "/prefix/baz");
 
   assert_template_format("$(dirname foo)", ".");
   assert_template_format("$(dirname /foo/bar)", "/foo");
   assert_template_format("$(dirname /foo/bar/)", "/foo/bar");
   assert_template_format("$(dirname /foo/bar/baz)", "/foo/bar");
+
+  assert_template_format("/prefix/$(dirname foo)", "/prefix/.");
+  assert_template_format("/prefix/$(dirname /foo/bar)", "/prefix//foo");
+  assert_template_format("/prefix/$(dirname /foo/bar/)", "/prefix//foo/bar");
+  assert_template_format("/prefix/$(dirname /foo/bar/baz)", "/prefix//foo/bar");
 }
 
 typedef struct


### PR DESCRIPTION
This should fix #2361 