### PR TITLE
tls: disable ssl compression by default

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -66,6 +66,19 @@ typedef enum
   TLS_CONTEXT_PASSWORD_ERROR
 } TLSContextLoadResult;
 
+void
+tls_session_configure_allow_compress(TLSSession *tls_session, gboolean allow_compress)
+{
+  if (allow_compress)
+    {
+      SSL_clear_options(tls_session->ssl, SSL_OP_NO_COMPRESSION);
+    }
+  else
+    {
+      SSL_set_options(tls_session->ssl, SSL_OP_NO_COMPRESSION);
+    }
+}
+
 gboolean
 tls_get_x509_digest(X509 *x, GString *hash_string)
 {

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -108,6 +108,7 @@ TLSVerifier *tls_verifier_ref(TLSVerifier *self);
 void tls_verifier_unref(TLSVerifier *self);
 
 
+void tls_session_configure_allow_compress(TLSSession *tls_session, gboolean allow_compress);
 gboolean tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode_str);
 gboolean tls_context_set_ssl_options_by_name(TLSContext *self, GList *options);
 gint tls_context_get_verify_mode(const TLSContext *self);

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -91,6 +91,8 @@ typedef struct _TLSSession
   } peer_info;
 } TLSSession;
 
+#define TMI_ALLOW_COMPRESS 0x1
+
 void tls_session_set_verifier(TLSSession *self, TLSVerifier *verifier);
 void tls_session_free(TLSSession *self);
 

--- a/lib/transport/transport-factory-tls.c
+++ b/lib/transport/transport-factory-tls.c
@@ -22,23 +22,11 @@
  *
  */
 
+#include "tlscontext.h"
 #include "transport/transport-factory-tls.h"
 #include "transport/transport-tls.h"
 
 DEFINE_TRANSPORT_FACTORY_ID_FUN("tls", transport_factory_tls_id);
-
-static void
-_tls_session_allow_compress(TLSSession *tls_session, gboolean allow_compress)
-{
-  if (!allow_compress)
-    {
-      SSL_set_options(tls_session->ssl, SSL_OP_NO_COMPRESSION);
-    }
-  else
-    {
-      SSL_clear_options(tls_session->ssl, SSL_OP_NO_COMPRESSION);
-    }
-}
 
 static LogTransport *
 _construct_transport(const TransportFactory *s, gint fd)
@@ -49,7 +37,7 @@ _construct_transport(const TransportFactory *s, gint fd)
   if (!tls_session)
     return NULL;
 
-  _tls_session_allow_compress(tls_session, self->allow_compress);
+  tls_session_configure_allow_compress(tls_session, self->allow_compress);
 
   tls_session_set_verifier(tls_session, self->tls_verifier);
 

--- a/lib/transport/transport-factory-tls.c
+++ b/lib/transport/transport-factory-tls.c
@@ -68,7 +68,7 @@ _free(TransportFactory *s)
 }
 
 TransportFactory *
-transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, gboolean allow_compress)
+transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, guint32 flags)
 {
   TransportFactoryTLS *instance = g_new0(TransportFactoryTLS, 1);
 
@@ -79,7 +79,7 @@ transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, gboolean a
   instance->super.construct_transport = _construct_transport;
   instance->super.free_fn = _free;
 
-  if (allow_compress)
+  if (flags & TMI_ALLOW_COMPRESS)
     transport_factory_tls_enable_compression((TransportFactory *)instance);
   else
     transport_factory_tls_disable_compression((TransportFactory *)instance);

--- a/lib/transport/transport-factory-tls.c
+++ b/lib/transport/transport-factory-tls.c
@@ -68,7 +68,7 @@ _free(TransportFactory *s)
 }
 
 TransportFactory *
-transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier)
+transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, gboolean allow_compress)
 {
   TransportFactoryTLS *instance = g_new0(TransportFactoryTLS, 1);
 
@@ -78,6 +78,11 @@ transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier)
   instance->super.id = transport_factory_tls_id();
   instance->super.construct_transport = _construct_transport;
   instance->super.free_fn = _free;
+
+  if (allow_compress)
+    transport_factory_tls_enable_compression((TransportFactory *)instance);
+  else
+    transport_factory_tls_disable_compression((TransportFactory *)instance);
 
   return &instance->super;
 }

--- a/lib/transport/transport-factory-tls.h
+++ b/lib/transport/transport-factory-tls.h
@@ -38,7 +38,7 @@ struct _TransportFactoryTLS
   gboolean allow_compress;
 };
 
-TransportFactory *transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, gboolean allow_compress);
+TransportFactory *transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, guint32 flags);
 
 void transport_factory_tls_enable_compression(TransportFactory *);
 void transport_factory_tls_disable_compression(TransportFactory *);

--- a/lib/transport/transport-factory-tls.h
+++ b/lib/transport/transport-factory-tls.h
@@ -38,7 +38,7 @@ struct _TransportFactoryTLS
   gboolean allow_compress;
 };
 
-TransportFactory *transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier);
+TransportFactory *transport_factory_tls_new(TLSContext *ctx, TLSVerifier *tls_verifier, gboolean allow_compress);
 
 void transport_factory_tls_enable_compression(TransportFactory *);
 void transport_factory_tls_disable_compression(TransportFactory *);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -182,6 +182,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_CIPHER_SUITE
 %token KW_ECDH_CURVE_LIST
 %token KW_SSL_OPTIONS
+%token KW_ALLOW_COMPRESS
 
 /* INCLUDE_DECLS */
 
@@ -817,6 +818,10 @@ tls_option
             CHECK_ERROR(tls_context_set_ssl_options_by_name(last_tls_context, $3), @3,
                         "unknown ssl-options() argument");
 	  }
+        | KW_ALLOW_COMPRESS '(' yesno ')'
+          {
+             transport_mapper_inet_set_allow_compress(last_transport_mapper, $3);
+          }
         | KW_ENDIF {
 }
         ;

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -57,6 +57,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "ecdh_curve_list",    KW_ECDH_CURVE_LIST },
   { "curve_list",         KW_ECDH_CURVE_LIST, KWS_OBSOLETE, "ecdh_curve_list"},
   { "ssl_options",        KW_SSL_OPTIONS },
+  { "allow_compress",     KW_ALLOW_COMPRESS },
 
   { "localip",            KW_LOCALIP },
   { "ip",                 KW_IP },

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -87,8 +87,7 @@ transport_mapper_inet_apply_transport_method(TransportMapper *s, GlobalConfig *c
 static LogTransport *
 _construct_multitransport_with_tls_factory(TransportMapperInet *self, gint fd)
 {
-  TransportFactory *default_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier,
-                                      self->allow_compress);
+  TransportFactory *default_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier, self->flags);
   return multitransport_new(default_factory, fd);
 }
 
@@ -102,7 +101,7 @@ _construct_tls_transport(TransportMapperInet *self, gint fd)
   if (!tls_session)
     return NULL;
 
-  tls_session_configure_allow_compress(tls_session, self->allow_compress);
+  tls_session_configure_allow_compress(tls_session, self->flags & TMI_ALLOW_COMPRESS);
   tls_session_set_verifier(tls_session, self->tls_verifier);
 
   return log_transport_tls_new(tls_session, fd);
@@ -121,7 +120,7 @@ _construct_multitransport_with_plain_and_tls_factories(TransportMapperInet *self
 {
   LogTransport *transport = _construct_multitransport_with_plain_tcp_factory(self, fd);
 
-  TransportFactory *tls_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier, self->allow_compress);
+  TransportFactory *tls_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier, self->flags);
   multitransport_add_factory((MultiTransport *)transport, tls_factory);
 
   return transport;

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -87,7 +87,8 @@ transport_mapper_inet_apply_transport_method(TransportMapper *s, GlobalConfig *c
 static LogTransport *
 _construct_multitransport_with_tls_factory(TransportMapperInet *self, gint fd)
 {
-  TransportFactory *default_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier);
+  TransportFactory *default_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier,
+                                      self->allow_compress);
   return multitransport_new(default_factory, fd);
 }
 
@@ -120,7 +121,7 @@ _construct_multitransport_with_plain_and_tls_factories(TransportMapperInet *self
 {
   LogTransport *transport = _construct_multitransport_with_plain_tcp_factory(self, fd);
 
-  TransportFactory *tls_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier);
+  TransportFactory *tls_factory = transport_factory_tls_new(self->tls_context, self->tls_verifier, self->allow_compress);
   multitransport_add_factory((MultiTransport *)transport, tls_factory);
 
   return transport;

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -101,6 +101,7 @@ _construct_tls_transport(TransportMapperInet *self, gint fd)
   if (!tls_session)
     return NULL;
 
+  tls_session_configure_allow_compress(tls_session, self->allow_compress);
   tls_session_set_verifier(tls_session, self->tls_verifier);
 
   return log_transport_tls_new(tls_session, fd);

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -32,6 +32,7 @@ typedef struct _TransportMapperInet
 
   gint server_port;
   const gchar *server_port_change_warning;
+  gboolean allow_compress;
   gboolean require_tls;
   gboolean allow_tls;
   gboolean require_tls_when_has_tls_context;
@@ -39,6 +40,13 @@ typedef struct _TransportMapperInet
   TLSVerifier *tls_verifier;
   gpointer secret_store_cb_data;
 } TransportMapperInet;
+
+static inline void
+transport_mapper_inet_set_allow_compress(TransportMapper *s, gboolean value)
+{
+  TransportMapperInet *self = (TransportMapperInet *) s;
+  self->allow_compress = value;
+}
 
 static inline gint
 transport_mapper_inet_get_server_port(const TransportMapper *self)

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -32,7 +32,7 @@ typedef struct _TransportMapperInet
 
   gint server_port;
   const gchar *server_port_change_warning;
-  gboolean allow_compress;
+  guint32 flags;
   gboolean require_tls;
   gboolean allow_tls;
   gboolean require_tls_when_has_tls_context;
@@ -45,7 +45,10 @@ static inline void
 transport_mapper_inet_set_allow_compress(TransportMapper *s, gboolean value)
 {
   TransportMapperInet *self = (TransportMapperInet *) s;
-  self->allow_compress = value;
+  if (value)
+    self->flags |= TMI_ALLOW_COMPRESS;
+  else
+    self->flags &= ~TMI_ALLOW_COMPRESS;
 }
 
 static inline gint


### PR DESCRIPTION
Currently syslog-ng does not change the tls compression setting of tls transport. This means the default setting depends on the patch level and compile options of openssl. H̶o̶w̶e̶v̶e̶r̶ ̶t̶h̶e̶ ̶d̶e̶f̶a̶u̶l̶t̶ ̶c̶o̶m̶p̶r̶e̶s̶s̶i̶o̶n̶ ̶s̶e̶t̶t̶i̶n̶g̶ ̶s̶h̶o̶u̶l̶d̶ ̶b̶e̶ ̶d̶i̶s̶a̶b̶l̶e̶d̶ ̶b̶y̶ ̶d̶e̶f̶a̶u̶l̶t̶ ̶t̶o̶ ̶a̶v̶o̶i̶d̶ ̶C̶R̶I̶M̶E̶ ̶v̶u̶l̶n̶e̶r̶a̶b̶i̶l̶i̶t̶y̶.̶ Edit: syslog-ng is not vulnerable to CRIME.

T̶h̶i̶s̶ ̶p̶a̶t̶c̶h̶s̶e̶t̶ ̶e̶x̶p̶l̶i̶c̶i̶t̶e̶l̶y̶ ̶d̶i̶s̶a̶b̶l̶e̶s̶ ̶t̶l̶s̶ ̶c̶o̶m̶p̶r̶e̶s̶s̶i̶o̶n̶ ̶t̶o̶ ̶b̶e̶ ̶s̶u̶r̶e̶.̶
This patchset makes tls compression configurable, with disabled by default.

Note: allow-compress(yes) does not necessarily mean the session will be compressed. It only means endpoints are allowed to choose tls compression during negotiation. For example if the openssl is compiled without zlib either on the local or the remote side, compression will not happen.