### PR TITLE
DBLD: Add new target "list-builder-images"

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
-IMAGES=centos-6 centos-7 debian-jessie debian-stretch debian-buster ubuntu-xenial ubuntu-trusty ubuntu-cosmic ubuntu-bionic devshell
+BUILDER_IMAGES=centos-6 centos-7 debian-jessie debian-stretch debian-buster ubuntu-xenial ubuntu-trusty ubuntu-cosmic ubuntu-bionic
+IMAGES=${BUILDER_IMAGES} devshell
 DEFAULT_IMAGE ?= ubuntu-bionic
 DEFAULT_DEB_IMAGE=$(DEFAULT_IMAGE)
 DEFAULT_RPM_IMAGE=centos-7
@@ -126,3 +127,6 @@ setup:
 	@mkdir -p dbld/build || true
 	@mkdir -p dbld/install || true
 	@mkdir -p dbld/release || true
+
+list-builder-images:
+	@echo ${BUILDER_IMAGES}


### PR DESCRIPTION
- this target is useful when we want to query actual
 builder images from CI system
- introduced new BUILDER_IMAGES variable to store
OS images
- extend IMAGES variable with new BUILDER_IMAGES to
not broke old behavior

Signed-off-by: Micek <mitzkia@gmail.com>