### PR TITLE
DBLD: Remove "proposed" Ubuntu repository from enable_dbgsyms()

### DIFF
--- a/dbld/images/helpers/dependencies.sh
+++ b/dbld/images/helpers/dependencies.sh
@@ -129,10 +129,8 @@ function install_pip_packages {
 }
 
 function enable_dbgsyms {
-    echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse
-deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
-deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
-    tee -a /etc/apt/sources.list.d/ddebs.list
+    echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse" | tee -a /etc/apt/sources.list.d/ddebs.list
+    echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse" | tee -a /etc/apt/sources.list.d/ddebs.list
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 428D7C01 C8CAB6595FDFF622
 }
 


### PR DESCRIPTION
- this repository is not needed for installing required devshell packages

Signed-off-by: Micek <mitzkia@gmail.com>