### PR TITLE
Leak redis connection

### DIFF
--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -178,6 +178,8 @@ redis_dd_connect(RedisDriver *self)
       return TRUE;
     }
 
+  if (self->c)
+    redisFree(self->c);
 
   self->c = redisConnect(self->host, self->port);
 
@@ -322,6 +324,8 @@ redis_worker_thread_deinit(LogThreadedDestDriver *d)
   g_string_free(self->key_str, TRUE);
   g_string_free(self->param1_str, TRUE);
   g_string_free(self->param2_str, TRUE);
+
+  redis_dd_disconnect(d);
 }
 
 /*

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -171,24 +171,15 @@ authenticate_to_redis(RedisDriver *self, const gchar *password)
 }
 
 static gboolean
-redis_dd_connect(RedisDriver *self, gboolean reconnect)
+redis_dd_connect(RedisDriver *self)
 {
-  redisReply *reply;
-
-  if (reconnect && (self->c != NULL))
+  if (self->c && check_connection_to_redis(self))
     {
-      reply = redisCommand(self->c, "ping");
-
-      if (reply)
-        freeReplyObject(reply);
-
-      if (!self->c->err)
-        return TRUE;
-      else
-        self->c = redisConnect(self->host, self->port);
+      return TRUE;
     }
-  else
-    self->c = redisConnect(self->host, self->port);
+
+
+  self->c = redisConnect(self->host, self->port);
 
   if (self->c->err)
     {
@@ -241,7 +232,7 @@ redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   size_t argvlen[5];
   int argc = 2;
 
-  if (!redis_dd_connect(self, TRUE))
+  if (!redis_dd_connect(self))
     return WORKER_INSERT_RESULT_NOT_CONNECTED;
 
   if (self->c->err)
@@ -320,7 +311,7 @@ redis_worker_thread_init(LogThreadedDestDriver *d)
   self->param1_str = g_string_sized_new(1024);
   self->param2_str = g_string_sized_new(1024);
 
-  redis_dd_connect(self, FALSE);
+  redis_dd_connect(self);
 }
 
 static void


### PR DESCRIPTION
* The redis destination leaked the connection at every reconnect and/or reload.
* Removed the `reconnect` arg, that did not prevent reconnection (it is better to check if the connection is alive)
