### PR TITLE
AFSocket: Make it possible to set the interface for socket.

### DIFF
--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -157,6 +157,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 
 %token KW_LOCALIP
 %token KW_IP
+%token KW_INTERFACE
 %token KW_LOCALPORT
 %token KW_DESTPORT
 %token KW_FAILOVER_SERVERS
@@ -842,6 +843,7 @@ inet_socket_option
 	| KW_IP_TTL '(' nonnegative_integer ')'               { ((SocketOptionsInet *) last_sock_options)->ip_ttl = $3; }
 	| KW_IP_TOS '(' nonnegative_integer ')'               { ((SocketOptionsInet *) last_sock_options)->ip_tos = $3; }
 	| KW_IP_FREEBIND '(' yesno ')'              { ((SocketOptionsInet *) last_sock_options)->ip_freebind = $3; }
+	| KW_INTERFACE '(' string ')'		    { socket_options_inet_set_interface_name((SocketOptionsInet *) last_sock_options, $3); free($3); }
 	| KW_TCP_KEEPALIVE_TIME '(' nonnegative_integer ')'   { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_time = $3; }
 	| KW_TCP_KEEPALIVE_INTVL '(' nonnegative_integer ')'  { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_intvl = $3; }
 	| KW_TCP_KEEPALIVE_PROBES '(' nonnegative_integer ')' { ((SocketOptionsInet *) last_sock_options)->tcp_keepalive_probes = $3; }

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -60,6 +60,7 @@ static CfgLexerKeyword afsocket_keywords[] =
 
   { "localip",            KW_LOCALIP },
   { "ip",                 KW_IP },
+  { "interface",          KW_INTERFACE },
   { "localport",          KW_LOCALPORT },
   { "port",               KW_PORT },
   { "destport",           KW_DESTPORT },

--- a/modules/afsocket/socket-options-inet.c
+++ b/modules/afsocket/socket-options-inet.c
@@ -23,6 +23,7 @@
 #include "socket-options-inet.h"
 #include "gsockaddr.h"
 #include "messages.h"
+#include "gprocess.h"
 
 #include <string.h>
 #include <netinet/tcp.h>
@@ -37,6 +38,22 @@
 
 #ifndef SOL_TCP
 #define SOL_TCP IPPROTO_TCP
+#endif
+
+#ifdef SO_BINDTODEVICE
+static int
+socket_options_inet_set_interface(SocketOptionsInet *self, gint fd)
+{
+  cap_t saved_caps;
+  int result;
+
+  saved_caps = g_process_cap_save();
+  g_process_enable_cap("cap_net_raw");
+  result = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, self->interface_name,
+                      strlen(self->interface_name)) < 0 ? errno : 0;
+  g_process_cap_restore(saved_caps);
+  return result;
+}
 #endif
 
 static gboolean
@@ -73,6 +90,21 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
       setsockopt(fd, SOL_TCP, TCP_KEEPINTVL, &self->tcp_keepalive_intvl, sizeof(self->tcp_keepalive_intvl));
 #else
       msg_error("tcp-keepalive-intvl() is set but no TCP_KEEPINTVL setsockopt on this platform");
+      return FALSE;
+#endif
+    }
+
+  if (self->interface_name)
+    {
+#ifdef SO_BINDTODEVICE
+      int result = socket_options_inet_set_interface(self, fd);
+      if (result != 0)
+        {
+          msg_error("Can't bind to interface", evt_tag_str("interface", self->interface_name), evt_tag_errno("error", result));
+          return FALSE;
+        }
+#else
+      msg_error("interfacel() is set but no SO_BINDTODEVICE setsockopt on this platform");
       return FALSE;
 #endif
     }
@@ -166,6 +198,26 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
   return TRUE;
 }
 
+void
+socket_options_inet_set_interface_name(SocketOptionsInet *self, const gchar *interface_name)
+{
+  if (self->interface_name)
+    {
+      g_free(self->interface_name);
+    }
+  self->interface_name = g_strdup(interface_name);
+}
+
+void
+socket_options_inet_free(gpointer s)
+{
+  SocketOptionsInet *self = (SocketOptionsInet *) s;
+  if (self->interface_name)
+    {
+      g_free(self->interface_name);
+    }
+}
+
 SocketOptionsInet *
 socket_options_inet_new_instance(void)
 {
@@ -179,6 +231,7 @@ socket_options_inet_new_instance(void)
   self->tcp_keepalive_intvl = 10;
   self->tcp_keepalive_probes = 6;
 #endif
+  self->super.free = socket_options_inet_free;
   return self;
 }
 

--- a/modules/afsocket/socket-options-inet.h
+++ b/modules/afsocket/socket-options-inet.h
@@ -35,7 +35,10 @@ typedef struct _SocketOptionsInet
   gint tcp_keepalive_time;
   gint tcp_keepalive_intvl;
   gint tcp_keepalive_probes;
+  char *interface_name;
 } SocketOptionsInet;
+
+void socket_options_inet_set_interface_name(SocketOptionsInet *self, const gchar *interface);
 
 SocketOptionsInet *socket_options_inet_new_instance(void);
 SocketOptions *socket_options_inet_new(void);

--- a/modules/afsocket/socket-options-inet.h
+++ b/modules/afsocket/socket-options-inet.h
@@ -35,7 +35,7 @@ typedef struct _SocketOptionsInet
   gint tcp_keepalive_time;
   gint tcp_keepalive_intvl;
   gint tcp_keepalive_probes;
-  char *interface_name;
+  gchar *interface_name;
 } SocketOptionsInet;
 
 void socket_options_inet_set_interface_name(SocketOptionsInet *self, const gchar *interface);


### PR DESCRIPTION
There are some use cases, when the ip address for the interface isn't known,
or there are more ip addresses for one interface

Also, there are some HA architecture, where the master and standby is on the physical network,
The active's ip address is predefined, but when syslog-ng starts it doesn't know that it runs on the master or on the standby.

This patch helps to define the interface instead of ip addresses in these cases

Usage example: s_network{ tcp(port(6666) interface("wlp3s0")) };

Signed-off-by: Juhasz Viktor <juhasz.viktor81@gmail.com>