### PR TITLE
DBLD: Add missing docbook-xsl packages

### DIFF
--- a/dbld/images/helpers/packages.manifest
+++ b/dbld/images/helpers/packages.manifest
@@ -125,6 +125,10 @@ make                            [centos, debian, ubuntu]
     xsltproc                    [debian, ubuntu]
     libxslt                     [centos]
 
+    # docbook
+    docbook-xsl                 [debian, ubuntu]
+    docbook-style-xsl           [centos]
+
 
 
 


### PR DESCRIPTION
 - it installs required xsl files
 - handy when 'http://docbook.sourceforge.net' is unavailable

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>