### PR TITLE
http: when ca-file() is not set, unset CURLOPT_CAINFO

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -106,8 +106,7 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
   if (owner->ca_dir)
     curl_easy_setopt(self->curl, CURLOPT_CAPATH, owner->ca_dir);
 
-  if (owner->ca_file)
-    curl_easy_setopt(self->curl, CURLOPT_CAINFO, owner->ca_file);
+  curl_easy_setopt(self->curl, CURLOPT_CAINFO, owner->ca_file);
 
   if (owner->cert_file)
     curl_easy_setopt(self->curl, CURLOPT_SSLCERT, owner->cert_file);


### PR DESCRIPTION
Reason:
 * when ca-dir() is set but ca-file() is not, AND the default cert file
   does not exist, syslog-ng cannot establish the SSL connection
   (could be a typical problem when syslog-ng is built on a different distrib)

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>