### PR TITLE
Remove template hex, oct number parse in configuration

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -233,8 +233,20 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 \.\.                       { return LL_DOTDOT; }
 \.\.\.                     { return LL_DOTDOTDOT; }
 (-|\+)?{digit}+\.{digit}+  { yylval->fnum = strtod(yytext, NULL); return LL_FLOAT; }
-0x{xdigit}+ 		   { yylval->num = strtoll(yytext + 2, NULL, 16); return LL_NUMBER; }
-0{odigit}+		   { yylval->num = strtoll(yytext + 1, NULL, 8); return LL_NUMBER; }
+0x{xdigit}+ 		   {
+                             if (!parse_number_with_suffix(yytext, &yylval->num))
+                               {
+                                 return LL_ERROR;
+                               }
+                             return LL_NUMBER;
+                           }
+0{odigit}+		   {
+                             if (!parse_number_with_suffix(yytext, &yylval->num))
+                               {
+                                 return LL_ERROR;
+                               }
+                             return LL_NUMBER;
+                           }
 (-|\+)?{digit}+(M|m|G|g|k|K)?(i|I)?(b|B)? {
                              if (!parse_number_with_suffix(yytext, &yylval->num))
                                {

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -28,6 +28,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
+static const gint DETECT_BASE  = 0;
+
 static gboolean
 _valid_unit(const gchar unit_char)
 {
@@ -144,12 +146,12 @@ _process_suffix(const gchar *suffix, gint64 *d)
 }
 
 static gboolean
-_parse_number(const gchar *s, gchar **endptr, gint64 *d)
+_parse_number(const gchar *s, gchar **endptr, gint base, gint64 *d)
 {
   gint64 val;
 
   errno = 0;
-  val = strtoll(s, endptr, 0);
+  val = strtoll(s, endptr, base);
 
   if (errno == ERANGE || errno == EINVAL)
     return FALSE;
@@ -166,7 +168,7 @@ parse_number(const gchar *s, gint64 *d)
 {
   gchar *endptr;
 
-  if (!_parse_number(s, &endptr, d))
+  if (!_parse_number(s, &endptr, DETECT_BASE, d))
     return FALSE;
   if (*endptr)
     return FALSE;
@@ -178,7 +180,7 @@ parse_number_with_suffix(const gchar *s, gint64 *d)
 {
   gchar *endptr;
 
-  if (!_parse_number(s, &endptr, d))
+  if (!_parse_number(s, &endptr, DETECT_BASE, d))
     return FALSE;
   return _process_suffix(endptr, d);
 }

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
+static const gint DECIMAL_BASE = 10;
 static const gint DETECT_BASE  = 0;
 
 static gboolean
@@ -171,6 +172,16 @@ parse_number(const gchar *s, gint64 *d)
   if (!_parse_number(s, &endptr, DETECT_BASE, d))
     return FALSE;
   if (*endptr)
+    return FALSE;
+  return TRUE;
+}
+
+gboolean
+parse_dec_number(const gchar *s, gint64 *d)
+{
+  gchar *endptr;
+
+  if (!_parse_number(s, &endptr, DECIMAL_BASE, d))
     return FALSE;
   return TRUE;
 }

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -147,12 +147,6 @@ _process_suffix(const gchar *suffix, gint64 *d)
 }
 
 static gboolean
-_no_suffix(const gchar *suffix)
-{
-  return (*suffix == '\0' || g_ascii_isspace(*suffix));
-}
-
-static gboolean
 _parse_number(const gchar *s, gchar **endptr, gint base, gint64 *d)
 {
   gint64 val;
@@ -179,7 +173,7 @@ parse_number(const gchar *s, gint64 *d)
     return FALSE;
   if (*endptr)
     return FALSE;
-  return _no_suffix(endptr);
+  return TRUE;
 }
 
 gboolean
@@ -189,7 +183,9 @@ parse_dec_number(const gchar *s, gint64 *d)
 
   if (!_parse_number(s, &endptr, DECIMAL_BASE, d))
     return FALSE;
-  return _no_suffix(endptr);
+  if (*endptr)
+    return FALSE;
+  return TRUE;
 }
 
 gboolean

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -147,6 +147,12 @@ _process_suffix(const gchar *suffix, gint64 *d)
 }
 
 static gboolean
+_no_suffix(const gchar *suffix)
+{
+  return (*suffix == '\0' || g_ascii_isspace(*suffix));
+}
+
+static gboolean
 _parse_number(const gchar *s, gchar **endptr, gint base, gint64 *d)
 {
   gint64 val;
@@ -173,7 +179,7 @@ parse_number(const gchar *s, gint64 *d)
     return FALSE;
   if (*endptr)
     return FALSE;
-  return TRUE;
+  return _no_suffix(endptr);
 }
 
 gboolean
@@ -183,7 +189,7 @@ parse_dec_number(const gchar *s, gint64 *d)
 
   if (!_parse_number(s, &endptr, DECIMAL_BASE, d))
     return FALSE;
-  return TRUE;
+  return _no_suffix(endptr);
 }
 
 gboolean

--- a/lib/parse-number.h
+++ b/lib/parse-number.h
@@ -29,5 +29,6 @@
 
 gboolean parse_number_with_suffix(const gchar *str, gint64 *result);
 gboolean parse_number(const gchar *str, gint64 *result);
+gboolean parse_dec_number(const gchar *str, gint64 *result);
 
 #endif

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2018 Balabit
  * Copyright (c) 2013 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2018 Kokan <kokaipeter@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -81,8 +82,16 @@ Test(parse_number, test_simple_numbers_are_parsed_properly)
 Test(parse_number,test_c_like_prefixes_select_base)
 {
   assert_parse("0x20", 32);
+  assert_parse("0xFF", 255);
+  assert_parse("-0x09", -9);
+
   assert_parse("020", 16);
+  assert_parse("-010", -8);
+  assert_parse_fails("08");
+  assert_parse_fails("0A");
+
   assert_parse("20", 20);
+  assert_parse_fails("FF");
 }
 
 Test(parse_number_with_suffix, test_simple_numbers_are_parsed_properly)
@@ -95,8 +104,16 @@ Test(parse_number_with_suffix, test_simple_numbers_are_parsed_properly)
 Test(parse_number_with_suffix, test_c_like_prefixes_select_base)
 {
   assert_parse_with_suffix("0x20", 32);
+  assert_parse_with_suffix("0xFF", 255);
+  assert_parse_with_suffix("-0x09", -9);
+
   assert_parse_with_suffix("020", 16);
+  assert_parse_with_suffix("-010", -8);
+  assert_parse_with_suffix_fails("08");
+  assert_parse_with_suffix_fails("0A");
+
   assert_parse_with_suffix("20", 20);
+  assert_parse_with_suffix_fails("FF");
 }
 
 Test(parse_number_with_suffix, test_exponent_suffix_is_parsed_properly)

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -72,6 +72,29 @@ assert_parse_fails(const gchar *str)
   cr_assert_eq(res, FALSE, "Parsing (w/o suffix) %s succeeded, while expecting failure", str);
 }
 
+static void
+assert_parse_dec(const gchar *str, gint64 expected)
+{
+  gint64 n;
+  gboolean res;
+
+  res = parse_dec_number(str, &n);
+
+  cr_assert_eq(res, TRUE, "Parsing (w/o suffix) %s failed", str);
+  cr_assert_eq(n, expected, "Parsing (w/o suffix) %s failed", str);
+}
+
+static void
+assert_parse_dec_fails(const gchar *str)
+{
+  gint64 n;
+  gboolean res;
+
+  res = parse_dec_number(str, &n);
+
+  cr_assert_eq(res, FALSE, "Parsing (w/o suffix) %s succeeded, while expecting failure", str);
+}
+
 Test(parse_number, test_simple_numbers_are_parsed_properly)
 {
   assert_parse("1234", 1234);
@@ -92,6 +115,23 @@ Test(parse_number,test_c_like_prefixes_select_base)
 
   assert_parse("20", 20);
   assert_parse_fails("FF");
+}
+
+Test(parse_number_dec, test_simple_numbers_are_parsed_properly)
+{
+  assert_parse_dec("1234", 1234);
+  assert_parse_dec("+1234", 1234);
+  assert_parse_dec("-1234", -1234);
+}
+
+Test(parse_number_dec, test_c_like_prefixes_select_base)
+{
+  assert_parse_dec("020", 20);
+  assert_parse_dec("-010", -10);
+  assert_parse_dec("08", 8);
+
+  assert_parse_dec("20", 20);
+  assert_parse_dec_fails("FF");
 }
 
 Test(parse_number_with_suffix, test_simple_numbers_are_parsed_properly)

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -115,6 +115,7 @@ Test(parse_number,test_c_like_prefixes_select_base)
 
   assert_parse("20", 20);
   assert_parse_fails("FF");
+  assert_parse_fails("1FF");
 }
 
 Test(parse_number_dec, test_simple_numbers_are_parsed_properly)
@@ -126,9 +127,15 @@ Test(parse_number_dec, test_simple_numbers_are_parsed_properly)
 
 Test(parse_number_dec, test_c_like_prefixes_select_base)
 {
+  assert_parse_dec_fails("1F20");
+  assert_parse_dec_fails("0x20");
+  assert_parse_dec_fails("0xFF");
+  assert_parse_dec_fails("-0x09");
+
   assert_parse_dec("020", 20);
   assert_parse_dec("-010", -10);
   assert_parse_dec("08", 8);
+  assert_parse_fails("0A");
 
   assert_parse_dec("20", 20);
   assert_parse_dec_fails("FF");

--- a/lib/tests/test_parse_number.c
+++ b/lib/tests/test_parse_number.c
@@ -73,11 +73,9 @@ assert_parse_fails(const gchar *str)
 
 Test(parse_number, test_simple_numbers_are_parsed_properly)
 {
-  assert_parse_with_suffix("1234", 1234);
-  assert_parse_with_suffix("+1234", 1234);
-  assert_parse_with_suffix("-1234", -1234);
-
   assert_parse("1234", 1234);
+  assert_parse("+1234", 1234);
+  assert_parse("-1234", -1234);
 }
 
 Test(parse_number,test_c_like_prefixes_select_base)
@@ -85,10 +83,23 @@ Test(parse_number,test_c_like_prefixes_select_base)
   assert_parse("0x20", 32);
   assert_parse("020", 16);
   assert_parse("20", 20);
-  assert_parse_with_suffix("0x20kiB", 32 * 1024);
 }
 
-Test(parse_number,test_exponent_suffix_is_parsed_properly)
+Test(parse_number_with_suffix, test_simple_numbers_are_parsed_properly)
+{
+  assert_parse_with_suffix("1234", 1234);
+  assert_parse_with_suffix("+1234", 1234);
+  assert_parse_with_suffix("-1234", -1234);
+}
+
+Test(parse_number_with_suffix, test_c_like_prefixes_select_base)
+{
+  assert_parse_with_suffix("0x20", 32);
+  assert_parse_with_suffix("020", 16);
+  assert_parse_with_suffix("20", 20);
+}
+
+Test(parse_number_with_suffix, test_exponent_suffix_is_parsed_properly)
 {
   assert_parse_with_suffix("1K", 1000);
   assert_parse_with_suffix("1k", 1000);
@@ -98,7 +109,7 @@ Test(parse_number,test_exponent_suffix_is_parsed_properly)
   assert_parse_with_suffix("1g", 1000 * 1000 * 1000);
 }
 
-Test(parse_number,test_byte_units_are_accepted)
+Test(parse_number_with_suffix, test_byte_units_are_accepted)
 {
   assert_parse_with_suffix("1b", 1);
   assert_parse_with_suffix("1B", 1);
@@ -110,7 +121,7 @@ Test(parse_number,test_byte_units_are_accepted)
   assert_parse_with_suffix("1gB", 1000 * 1000 * 1000);
 }
 
-Test(parse_number,test_base2_is_selected_by_an_i_modifier)
+Test(parse_number_with_suffix, test_base2_is_selected_by_an_i_modifier)
 {
   assert_parse_with_suffix("1Kib", 1024);
   assert_parse_with_suffix("1kiB", 1024);
@@ -123,7 +134,7 @@ Test(parse_number,test_base2_is_selected_by_an_i_modifier)
   assert_parse_with_suffix("1024giB", 1024LL * 1024LL * 1024LL * 1024LL);
 }
 
-Test(parse_number,test_invalid_formats_are_not_accepted)
+Test(parse_number_with_suffix, test_invalid_formats_are_not_accepted)
 {
   assert_parse_with_suffix_fails("1234Z");
   assert_parse_with_suffix_fails("1234kZ");

--- a/modules/basicfuncs/list-funcs.c
+++ b/modules/basicfuncs/list-funcs.c
@@ -199,7 +199,7 @@ tf_list_nth(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
   ndx_spec = argv[0]->str;
   /* get start position from first argument */
-  if (!parse_number(ndx_spec, &ndx))
+  if (!parse_dec_number(ndx_spec, &ndx))
     {
       msg_error("$(list-nth) parsing failed, index must be the first argument",
                 evt_tag_str("ndx", ndx_spec));
@@ -255,7 +255,7 @@ tf_list_slice(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
   /* get start position from first argument */
   if (first_spec && first_spec[0] &&
-      !parse_number(first_spec, &first_ndx))
+      !parse_dec_number(first_spec, &first_ndx))
     {
       msg_error("$(list-slice) parsing failed, first could not be parsed",
                 evt_tag_str("start", first_spec));
@@ -264,7 +264,7 @@ tf_list_slice(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
   /* get last position from second argument */
   if (last_spec && last_spec[0] &&
-      !parse_number(last_spec, &last_ndx))
+      !parse_dec_number(last_spec, &last_ndx))
     {
       msg_error("$(list-slice) parsing failed, last could not be parsed",
                 evt_tag_str("last", last_spec));

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -34,7 +34,7 @@ tf_num_parse(gint argc, GString *argv[],
       return FALSE;
     }
 
-  if (!parse_number_with_suffix(argv[0]->str, n))
+  if (!parse_dec_number(argv[0]->str, n))
     {
       msg_debug("Parsing failed, template function's first argument is not a number",
                 evt_tag_str("function", func_name),
@@ -42,7 +42,7 @@ tf_num_parse(gint argc, GString *argv[],
       return FALSE;
     }
 
-  if (!parse_number_with_suffix(argv[1]->str, m))
+  if (!parse_dec_number(argv[1]->str, m))
     {
       msg_debug("Parsing failed, template function's second argument is not a number",
                 evt_tag_str("function", func_name),
@@ -145,7 +145,7 @@ _tf_num_parse_arg_with_message(const TFSimpleFuncState *state,
   log_template_format(state->argv_templates[0], message, args->opts, args->tz,
                       args->seq_num, args->context_id, formatted_template);
 
-  if (!parse_number_with_suffix(formatted_template->str, number))
+  if (!parse_dec_number(formatted_template->str, number))
     {
       if (!(on_error & ON_ERROR_SILENT))
         msg_error("Parsing failed, template function's argument is not a number",

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -88,7 +88,7 @@ tf_substr(LogMessage *msg, gint argc, GString *argv[], GString *result)
     return;
 
   /* get offset position from second argument */
-  if (!parse_number(argv[1]->str, &start))
+  if (!parse_dec_number(argv[1]->str, &start))
     {
       msg_error("$(substr) parsing failed, start could not be parsed",
                 evt_tag_str("start", argv[1]->str));
@@ -98,7 +98,7 @@ tf_substr(LogMessage *msg, gint argc, GString *argv[], GString *result)
   /* if we were called with >2 arguments, third was desired length */
   if (argc > 2)
     {
-      if (!parse_number(argv[2]->str, &len))
+      if (!parse_dec_number(argv[2]->str, &len))
         {
           msg_error("$(substr) parsing failed, length could not be parsed",
                     evt_tag_str("length", argv[2]->str));
@@ -410,7 +410,7 @@ _padding_prepare_parse_state(TFStringPaddingState *state, gint argc, gchar **arg
       return FALSE;
     }
 
-  if (!parse_number(argv[2], &state->width))
+  if (!parse_dec_number(argv[2], &state->width))
     {
 
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -530,9 +530,16 @@ tf_binary_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gi
       gchar *token = argv[i];
       if (!parse_number(token, &number))
         {
+          gchar *base = "dec";
+
+          if (token[0] == '0')
+            {
+              base = token[1] == 'x' ? "hex" : "oct";
+            }
+
           g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
-                      "$(binary) template function requires list of dec/hex/oct numbers as arguments, unable to parse %s as a number",
-                      token);
+                      "$(binary) template function requires list of dec/hex/oct numbers as arguments, unable to parse %s as a %s number",
+                      token, base);
           goto error;
         }
       if (number > 0xFF)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -182,6 +182,7 @@ Test(basicfuncs, test_str_funcs)
   assert_template_failure("$(binary)", "Incorrect parameters");
   assert_template_failure("$(binary abc)", "unable to parse abc");
   assert_template_failure("$(binary 256)", "256 is above 255");
+  assert_template_failure("$(binary 08)", "unable to parse 08");
   assert_template_format("$(binary 1)", "\1");
   assert_template_format("$(binary 1 0x1)", "\1\1");
   assert_template_format("$(binary 0xFF 255 0377)", "\xFF\xFF\xFF");

--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -43,7 +43,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
 
   buf = g_malloc(bufsize);
 
-  if ((is_num = parse_number(key, &d)) == TRUE)
+  if ((is_num = parse_dec_number(key, &d)) == TRUE)
     s = getgrgid_r((gid_t)d, &grp, buf, bufsize, &res);
   else
     s = getgrnam_r(key, &grp, buf, bufsize, &res);

--- a/modules/getent/getent-passwd.c
+++ b/modules/getent/getent-passwd.c
@@ -48,7 +48,7 @@ tf_getent_passwd(gchar *key, gchar *member_name, GString *result)
 
   buf = g_malloc(bufsize);
 
-  if ((is_num = parse_number(key, &d)) == TRUE)
+  if ((is_num = parse_dec_number(key, &d)) == TRUE)
     s = getpwuid_r((uid_t)d, &pwd, buf, bufsize, &res);
   else
     s = getpwnam_r(key, &pwd, buf, bufsize, &res);

--- a/modules/getent/getent-protocols.c
+++ b/modules/getent/getent-protocols.c
@@ -28,7 +28,7 @@ tf_getent_protocols(gchar *key, gchar *member_name, GString *result)
   gboolean is_num;
   char buf[4096];
 
-  if ((is_num = parse_number(key, &d)) == TRUE)
+  if ((is_num = parse_dec_number(key, &d)) == TRUE)
     getprotobynumber_r((int) d, &proto, buf, sizeof(buf), &res);
   else
     getprotobyname_r(key, &proto, buf, sizeof(buf), &res);

--- a/modules/getent/getent-services.c
+++ b/modules/getent/getent-services.c
@@ -28,7 +28,7 @@ tf_getent_services(gchar *key, gchar *member_name, GString *result)
   gboolean is_num;
   char buf[4096];
 
-  if ((is_num = parse_number(key, &d)) == TRUE)
+  if ((is_num = parse_dec_number(key, &d)) == TRUE)
     getservbyport_r((int)ntohs(d), NULL, &serv, buf, sizeof(buf), &res);
   else
     getservbyname_r(key, NULL, &serv, buf, sizeof(buf), &res);


### PR DESCRIPTION
The #1679 enhanced number parsing, so in configuration a numbers formatted in hexadecimal (`0xFA`) and octal (`07`) could be also interpreted.

But sadly that also broke configuration that try to use `08` numbers like this (not valid octal, but seems like valid), and also in many cases the `010` is not expected to be actually `8`.

The following configuration was accepted by syslog-ng before that patch (3.13)
```
network(port(08));
```
But not after, it says configuration error `08` is not a number.

On the other hand the `$(binary)` function demands those above mentioned formats.

The final solution is:
* The grammar can detect hex, oct, dec; and if a number starts with `0` or `0x`, it must be in the expected format (oct, hex). The `08` is considered invalid in config.
* The template argument: the numbers in template function can only be in dec format, and therefore the `08` is a valid `8` value.

There is an exception for the template argument:
* `$(binary)` accepts hex, dec, oct numbers, and works like in the grammar. (`08` is invalid).

Fixes #2400 
Thanks @vossenjp for reporting the issue, and providing ideas about possible solution.