### PR TITLE
logthrdestdrv: process flush result after worker thread exits

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -639,7 +639,8 @@ _worker_thread(gpointer arg)
   _schedule_restart(self);
   iv_main();
 
-  log_threaded_dest_worker_flush(self);
+  worker_insert_result_t result = log_threaded_dest_worker_flush(self);
+  _process_result(self, result);
   log_queue_rewind_backlog_all(self->queue);
 
   _disconnect(self);


### PR DESCRIPTION
The messages are ACKed by the `_process_result()` method.
UnACKed messages are move back to the queue to be sent by syslog-ng
later.

Problems the patch fixes in batching mode:
1) when a queue contains unsent items during a stop request, worker
threads are blocked until the batch timer not elapsed

2) when the queue contains items during reload (less then a `batch_lines`), then we perform a flush after the worker thread exits, but as the result was not processed, these messages are never ACKed, so they were moved back to the queue, and could be sent multiple times

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>