### PR TITLE
logthrdestdrv: fixing an eventfd leak with ivykis<=0.38

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -650,11 +650,14 @@ _worker_thread(gpointer arg)
             evt_tag_int("index", self->worker_index),
             evt_tag_str("driver", self->owner->super.super.id),
             log_expr_node_location_tag(self->owner->super.super.super.expr_node));
-  iv_deinit();
-  return;
+
+  goto ok;
 
 error:
   _signal_startup_failure(self);
+ok:
+  iv_event_unregister(&self->wake_up_event);
+  iv_event_unregister(&self->shutdown_event);
   iv_deinit();
 }
 


### PR DESCRIPTION
There is an eventfd leak in logthrdestdrv, if syslog-ng is compiled with ivykis<=0.38. One eventfd is leaked per reload per threaded destination driver.

Config example:
```
@version: 3.18
log {
  destination { http(); };
};
```

```
$ lsof -p `cat ../var/syslog-ng.pid`  | grep -F '[eventfd]'
[...]
syslog-ng 18861 furiel   13u  a_inode               0,13        0     12651 [eventfd]
syslog-ng 18861 furiel   15u  a_inode               0,13        0     12651 [eventfd]
syslog-ng 18861 furiel   16u  a_inode               0,13        0     12651 [eventfd]
syslog-ng 18861 furiel   17u  a_inode               0,13        0     12651 [eventfd]
(these lines continue to grow)
```

The root cause seems a pair of missing iv_unregister event, which is added in this patch.

I bisected the code of ivykis and found that
the last commit with leak is: 3cf749082f6799f656e4cf0fccd05f29ad9019f3
the first commit without leak: [2635989a14865f491cf1e2ff8b7ee76fcbce7052](https://github.com/buytenh/ivykis/commit/2635989a14865f491cf1e2ff8b7ee76fcbce7052)
(I am not entirely sure why the ivykis patch above mitigates the leak though).