### PR TITLE
Fix non-reliable disk-queue truncating problem on load

### DIFF
--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -23,6 +23,7 @@
  */
 
 #include "queue_utils_lib.h"
+#include "logmsg/logmsg-serialize.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -31,6 +32,22 @@
 
 int acked_messages = 0;
 int fed_messages = 0;
+
+gsize
+get_one_message_serialized_size(void)
+{
+  GString *serialized = g_string_sized_new(256);
+  SerializeArchive *sa = serialize_string_archive_new(serialized);
+  LogMessage *msg = log_msg_new_empty();
+
+  log_msg_serialize(msg, sa);
+  gsize message_length = serialized->len;
+
+  log_msg_unref(msg);
+  g_string_free(serialized, TRUE);
+  serialize_archive_free(sa);
+  return message_length;
+}
 
 void
 test_ack(LogMessage *msg, AckType ack_type)

--- a/libtest/queue_utils_lib.h
+++ b/libtest/queue_utils_lib.h
@@ -36,4 +36,5 @@ void feed_some_messages(LogQueue *q, int n);
 
 void send_some_messages(LogQueue *q, gint n);
 
+gsize get_one_message_serialized_size(void);
 #endif

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -388,14 +388,15 @@ _load_queue (LogQueueDisk *s, const gchar *filename)
 static gboolean
 _save_queue (LogQueueDisk *s, gboolean *persistent)
 {
+  gboolean success = FALSE;
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
   if (qdisk_save_state (s->qdisk, self->qout, self->qbacklog, self->qoverflow))
     {
       *persistent = TRUE;
-      qdisk_stop (s->qdisk);
-      return TRUE;
+      success = TRUE;
     }
-  return FALSE;
+  qdisk_stop (s->qdisk);
+  return success;
 }
 
 static void

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -380,7 +380,7 @@ static gboolean
 _load_queue (LogQueueDisk *s, const gchar *filename)
 {
   /* qdisk portion is not yet started when this happens */
-  g_assert(!qdisk_initialized (s->qdisk));
+  g_assert(!qdisk_started (s->qdisk));
 
   return _start(s, filename);
 }

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -402,7 +402,7 @@ static void
 _restart(LogQueueDisk *s, DiskQueueOptions *options)
 {
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
-  qdisk_init(self->super.qdisk, options, "SLQF");
+  qdisk_init_instance(self->super.qdisk, options, "SLQF");
 }
 
 static void
@@ -427,7 +427,7 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
   log_queue_disk_init_instance(&self->super, persist_name);
-  qdisk_init(self->super.qdisk, options, "SLQF");
+  qdisk_init_instance(self->super.qdisk, options, "SLQF");
   self->qbacklog = g_queue_new ();
   self->qout = g_queue_new ();
   self->qoverflow = g_queue_new ();

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -339,7 +339,7 @@ _push_tail (LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, con
                          evt_tag_str  ("filename", qdisk_get_filename (self->super.qdisk)),
                          evt_tag_long ("queue_len", _get_length(s)),
                          evt_tag_int  ("mem_buf_length", self->qoverflow_size),
-                         evt_tag_long ("size", qdisk_get_size (self->super.qdisk)),
+                         evt_tag_long ("disk_buf_size", qdisk_get_size (self->super.qdisk)),
                          evt_tag_str  ("persist_name", self->super.super.persist_name));
               return FALSE;
             }

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -392,7 +392,7 @@ _save_queue (LogQueueDisk *s, gboolean *persistent)
   if (qdisk_save_state (s->qdisk, self->qout, self->qbacklog, self->qoverflow))
     {
       *persistent = TRUE;
-      qdisk_deinit (s->qdisk);
+      qdisk_stop (s->qdisk);
       return TRUE;
     }
   return FALSE;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -42,7 +42,7 @@ _skip_message(LogQueueDisk *self)
   GString *serialized;
   SerializeArchive *sa;
 
-  if (!qdisk_initialized(self->qdisk))
+  if (!qdisk_started(self->qdisk))
     return FALSE;
 
   serialized = g_string_sized_new(64);

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -315,7 +315,7 @@ static gboolean
 _save_queue (LogQueueDisk *s, gboolean *persistent)
 {
   *persistent = TRUE;
-  qdisk_deinit (s->qdisk);
+  qdisk_stop (s->qdisk);
   return TRUE;
 }
 

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -323,7 +323,7 @@ static void
 _restart(LogQueueDisk *s, DiskQueueOptions *options)
 {
   LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
-  qdisk_init(self->super.qdisk, options, "SLRQ");
+  qdisk_init_instance(self->super.qdisk, options, "SLRQ");
 }
 
 
@@ -348,7 +348,7 @@ log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name
   g_assert(options->reliable == TRUE);
   LogQueueDiskReliable *self = g_new0(LogQueueDiskReliable, 1);
   log_queue_disk_init_instance(&self->super, persist_name);
-  qdisk_init(self->super.qdisk, options, "SLRQ");
+  qdisk_init_instance(self->super.qdisk, options, "SLRQ");
   if (options->mem_buf_size < 0)
     {
       options->mem_buf_size = PESSIMISTIC_MEM_BUF_SIZE;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -48,7 +48,7 @@ _get_length(LogQueue *s)
   LogQueueDisk *self = (LogQueueDisk *) s;
   gint64 qdisk_length = 0;
 
-  if (qdisk_initialized(self->qdisk) && self->get_length)
+  if (qdisk_started(self->qdisk) && self->get_length)
     {
       qdisk_length = self->get_length(self);
     }
@@ -165,7 +165,7 @@ log_queue_disk_save_queue(LogQueue *s, gboolean *persistent)
 {
   LogQueueDisk *self = (LogQueueDisk *) s;
 
-  if (!qdisk_initialized(self->qdisk))
+  if (!qdisk_started(self->qdisk))
     {
       *persistent = FALSE;
       return TRUE;
@@ -182,7 +182,7 @@ log_queue_disk_load_queue(LogQueue *s, const gchar *filename)
   LogQueueDisk *self = (LogQueueDisk *) s;
 
   /* qdisk portion is not yet started when this happens */
-  g_assert(!qdisk_initialized(self->qdisk));
+  g_assert(!qdisk_started(self->qdisk));
 
   if (self->load_queue)
     return self->load_queue(self, filename);
@@ -227,7 +227,7 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
 
   *msg = NULL;
 
-  if (!qdisk_initialized(self->qdisk))
+  if (!qdisk_started(self->qdisk))
     return FALSE;
 
   serialized = g_string_sized_new(64);
@@ -288,7 +288,7 @@ _write_message(LogQueueDisk *self, LogMessage *msg)
   GString *serialized;
   SerializeArchive *sa;
   gboolean consumed = FALSE;
-  if (qdisk_initialized(self->qdisk) && qdisk_is_space_avail(self->qdisk, 64))
+  if (qdisk_started(self->qdisk) && qdisk_is_space_avail(self->qdisk, 64))
     {
       serialized = g_string_sized_new(64);
       sa = serialize_string_archive_new(serialized);

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -213,7 +213,7 @@ _free(LogQueue *s)
   if (self->free_fn)
     self->free_fn(self);
 
-  qdisk_deinit(self->qdisk);
+  qdisk_stop(self->qdisk);
   qdisk_free(self->qdisk);
 
   log_queue_free_method(s);
@@ -307,7 +307,7 @@ _restart_diskq(LogQueueDisk *self)
   gchar *new_file = NULL;
   DiskQueueOptions *options = qdisk_get_options(self->qdisk);
 
-  qdisk_deinit(self->qdisk);
+  qdisk_stop(self->qdisk);
 
   new_file = g_strdup_printf("%s.corrupted", filename);
   rename(filename, new_file);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -557,27 +557,12 @@ qdisk_header_is_inconsistent(QDisk *self)
 static gboolean
 _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
-  gint64 qout_ofs;
-  gint qout_count;
-  gint64 qbacklog_ofs;
-  gint qbacklog_count;
-  gint64 qoverflow_ofs;
-  gint qoverflow_count;
-  gint64 end_ofs = QDISK_RESERVED_SPACE;
-
   if (memcmp(self->hdr->magic, self->file_id, 4) != 0)
     {
       msg_error("Error reading disk-queue file header",
                 evt_tag_str("filename", self->filename));
       return FALSE;
     }
-
-  qout_count = self->hdr->qout_pos.count;
-  qout_ofs = self->hdr->qout_pos.ofs;
-  qbacklog_count = self->hdr->qbacklog_pos.count;
-  qbacklog_ofs = self->hdr->qbacklog_pos.ofs;
-  qoverflow_count = self->hdr->qoverflow_pos.count;
-  qoverflow_ofs = self->hdr->qoverflow_pos.ofs;
 
   if (qdisk_header_is_inconsistent(self))
     {
@@ -594,6 +579,7 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
       if (!_load_non_reliable_queues(self, qout, qbacklog, qoverflow))
         return FALSE;
 
+      gint64 end_ofs = QDISK_RESERVED_SPACE;
       if (!self->options->read_only)
         {
           qdisk_try_to_truncate_file_to_minimal(self, &end_ofs);
@@ -606,9 +592,9 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 
       msg_info("Disk-buffer state loaded",
                evt_tag_str("filename", self->filename),
-               evt_tag_int("qout_length", qout_count),
-               evt_tag_int("qbacklog_length", qbacklog_count),
-               evt_tag_int("qoverflow_length", qoverflow_count),
+               evt_tag_int("qout_length", self->hdr->qout_pos.count),
+               evt_tag_int("qbacklog_length", self->hdr->qbacklog_pos.count),
+               evt_tag_int("qoverflow_length", self->hdr->qoverflow_pos.count),
                evt_tag_long("qdisk_length", self->hdr->length));
     }
   else

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -906,7 +906,7 @@ qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id
 }
 
 void
-qdisk_deinit(QDisk *self)
+qdisk_stop(QDisk *self)
 {
   if (self->filename)
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -933,29 +933,6 @@ qdisk_stop(QDisk *self)
 }
 
 gssize
-qdisk_read_from_backlog(QDisk *self, gpointer buffer, gsize bytes_to_read)
-{
-  gssize res;
-  res = pread(self->fd, buffer, bytes_to_read, self->hdr->backlog_head);
-  if (res == 0)
-    {
-      self->hdr->backlog_head = QDISK_RESERVED_SPACE;
-      res = pread(self->fd, buffer, bytes_to_read, self->hdr->backlog_head);
-    }
-  if (res != bytes_to_read)
-    {
-      msg_error("Error reading disk-queue file",
-                evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
-                evt_tag_str("filename", self->filename));
-    }
-  if (self->hdr->backlog_head > self->hdr->write_head)
-    {
-      self->hdr->backlog_head = _correct_position_if_eof(self, &self->hdr->backlog_head);
-    }
-  return res;
-}
-
-gssize
 qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position)
 {
   gssize res;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -727,7 +727,7 @@ qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 }
 
 static void
-_reset_backlog(QDisk *self)
+_update_header_with_default_values(QDisk *self)
 {
   self->hdr->big_endian = TRUE;
   self->hdr->version = 1;
@@ -861,7 +861,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
           return FALSE;
         }
       if (self->hdr->version == 0)
-        _reset_backlog(self);
+        _update_header_with_default_values(self);
 
       if ((self->hdr->big_endian && G_BYTE_ORDER == G_LITTLE_ENDIAN) ||
           (!self->hdr->big_endian && G_BYTE_ORDER == G_BIG_ENDIAN))

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -146,7 +146,7 @@ _next_filename(QDisk *self)
 }
 
 gboolean
-qdisk_initialized(QDisk *self)
+qdisk_started(QDisk *self)
 {
   return self->fd >= 0;
 }
@@ -747,7 +747,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
    * it can cause message loosing.
    * We need this assert to detect programming error as soon as possible.
    */
-  g_assert(!qdisk_initialized(self));
+  g_assert(!qdisk_started(self));
 
   if (self->options->disk_buf_size <= 0)
     return TRUE;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -504,6 +504,15 @@ _reset_queue_pointers(QDisk *self)
 };
 
 static gboolean
+qdisk_header_is_inconsistent(QDisk *self)
+{
+  return ((self->hdr->read_head < QDISK_RESERVED_SPACE) ||
+          (self->hdr->write_head < QDISK_RESERVED_SPACE) ||
+          (self->hdr->read_head == self->hdr->write_head && self->hdr->length != 0));
+}
+
+
+static gboolean
 _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
   gint64 qout_ofs;
@@ -528,9 +537,7 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
   qoverflow_count = self->hdr->qoverflow_pos.count;
   qoverflow_ofs = self->hdr->qoverflow_pos.ofs;
 
-  if ((self->hdr->read_head < QDISK_RESERVED_SPACE) ||
-      (self->hdr->write_head < QDISK_RESERVED_SPACE) ||
-      (self->hdr->read_head == self->hdr->write_head && self->hdr->length != 0))
+  if (qdisk_header_is_inconsistent(self))
     {
       msg_error("Inconsistent header data in disk-queue file, ignoring",
                 evt_tag_str("filename", self->filename),

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -593,12 +593,11 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
     {
       if (!_load_non_reliable_queues(self, qout, qbacklog, qoverflow))
         return FALSE;
-    }
 
-  if (!self->options->read_only)
-    {
-      qdisk_try_to_truncate_file_to_minimal(self, &end_ofs);
-    }
+      if (!self->options->read_only)
+        {
+          qdisk_try_to_truncate_file_to_minimal(self, &end_ofs);
+        }
 
   if (!self->options->reliable)
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -584,11 +584,7 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
         {
           qdisk_try_to_truncate_file_to_minimal(self, &end_ofs);
         }
-
-  if (!self->options->reliable)
-    {
       self->file_size = MAX(end_ofs, QDISK_RESERVED_SPACE);
-      _reset_queue_pointers(self);
 
       msg_info("Disk-buffer state loaded",
                evt_tag_str("filename", self->filename),
@@ -596,6 +592,8 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
                evt_tag_int("qbacklog_length", self->hdr->qbacklog_pos.count),
                evt_tag_int("qoverflow_length", self->hdr->qoverflow_pos.count),
                evt_tag_long("qdisk_length", self->hdr->length));
+
+      _reset_queue_pointers(self);
     }
   else
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -896,7 +896,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
 }
 
 void
-qdisk_init(QDisk *self, DiskQueueOptions *options, const gchar *file_id)
+qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id)
 {
   self->fd = -1;
   self->file_size = 0;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -175,6 +175,11 @@ _is_free_space_between_write_head_and_backlog_head(QDisk *self, gint msg_len)
   return self->hdr->write_head + msg_len < self->hdr->backlog_head;
 }
 
+gboolean
+qdisk_is_file_empty(QDisk *self)
+{
+  return self->hdr->length == 0 && self->hdr->backlog_len == 0;
+}
 
 gboolean
 qdisk_is_space_avail(QDisk *self, gint at_least)
@@ -977,7 +982,7 @@ qdisk_set_backlog_count(QDisk *self, gint64 new_value)
 void
 qdisk_reset_file_if_possible(QDisk *self)
 {
-  if (self->hdr->length == 0 && self->hdr->backlog_len == 0)
+  if (qdisk_is_file_empty(self))
     {
       self->hdr->read_head = QDISK_RESERVED_SPACE;
       self->hdr->write_head = QDISK_RESERVED_SPACE;

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -57,7 +57,7 @@ gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *q
 void qdisk_init(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_deinit(QDisk *self);
 void qdisk_reset_file_if_possible(QDisk *self);
-gboolean qdisk_initialized(QDisk *self);
+gboolean qdisk_started(QDisk *self);
 void qdisk_free(QDisk *self);
 
 gboolean qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -79,7 +79,6 @@ gint qdisk_get_memory_size(QDisk *self);
 gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 
-gssize qdisk_read_from_backlog(QDisk *self, gpointer buffer, gsize bytes_to_read);
 gssize qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position);
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
 

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -55,7 +55,7 @@ gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 void qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
-void qdisk_deinit(QDisk *self);
+void qdisk_stop(QDisk *self);
 void qdisk_reset_file_if_possible(QDisk *self);
 gboolean qdisk_started(QDisk *self);
 void qdisk_free(QDisk *self);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -54,7 +54,7 @@ gint64 qdisk_get_empty_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
-void qdisk_init(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
+void qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_deinit(QDisk *self);
 void qdisk_reset_file_if_possible(QDisk *self);
 gboolean qdisk_started(QDisk *self);

--- a/modules/diskq/tests/CMakeLists.txt
+++ b/modules/diskq/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_unit_test(LIBTEST TARGET test_diskq DEPENDS pthread disk-buffer)
 add_unit_test(LIBTEST TARGET test_diskq_full DEPENDS disk-buffer)
 add_unit_test(LIBTEST TARGET test_reliable_backlog DEPENDS disk-buffer)
+add_unit_test(LIBTEST TARGET test_diskq_truncate DEPENDS disk-buffer)

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -5,6 +5,7 @@ DISKQ_TEST_LD_ADD = $(TEST_LDADD)
 modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq \
   modules/diskq/tests/test_diskq_full \
+  modules/diskq/tests/test_diskq_truncate \
   modules/diskq/tests/test_reliable_backlog
 
 check_PROGRAMS += ${modules_diskq_tests_TESTS}
@@ -14,13 +15,17 @@ EXTRA_DIST += modules/diskq/tests/CMakeLists.txt
 modules_diskq_tests_test_diskq_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_diskq_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_diskq_SOURCE = \
+modules_diskq_tests_test_diskq_DEPENDENCIES =	\
+	$(top_builddir)/modules/diskq/libdisk-buffer.la
+modules_diskq_tests_test_diskq_SOURCES = \
 	modules/diskq/tests/test_diskq.c \
 	modules/diskq/tests/test_diskq_tools.h
 
 modules_diskq_tests_test_diskq_full_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_diskq_full_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_full_LDADD = $(DISKQ_TEST_LD_ADD)
+modules_diskq_tests_test_diskq_full_DEPENDENCIES =	\
+	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_diskq_full_SOURCES = \
 	modules/diskq/tests/test_diskq_full.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -28,6 +33,17 @@ modules_diskq_tests_test_diskq_full_SOURCES = \
 modules_diskq_tests_test_reliable_backlog_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_reliable_backlog_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_reliable_backlog_LDADD = $(DISKQ_TEST_LD_ADD)
+modules_diskq_tests_test_reliable_backlog_DEPENDENCIES =	\
+	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_reliable_backlog_SOURCES = \
 	modules/diskq/tests/test_reliable_backlog.c \
+	modules/diskq/tests/test_diskq_tools.h
+
+modules_diskq_tests_test_diskq_truncate_CFLAGS = $(DISKQ_TEST_C_FLAGS)
+modules_diskq_tests_test_diskq_truncate_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
+modules_diskq_tests_test_diskq_truncate_LDADD = $(DISKQ_TEST_LD_ADD)
+modules_diskq_tests_test_diskq_truncate_DEPENDENCIES =	\
+	$(top_builddir)/modules/diskq/libdisk-buffer.la
+modules_diskq_tests_test_diskq_truncate_SOURCES = \
+	modules/diskq/tests/test_diskq_truncate.c \
 	modules/diskq/tests/test_diskq_tools.h

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2018 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logqueue.h"
+#include "logqueue-disk.h"
+#include "logqueue-disk-reliable.h"
+#include "logqueue-disk-non-reliable.h"
+#include "diskq.h"
+#include "qdisk.c"
+#include "apphook.h"
+
+#include "queue_utils_lib.h"
+#include "test_diskq_tools.h"
+#include "testutils.h"
+
+#include <stdlib.h>
+#include <sys/stat.h>
+
+
+static LogQueue *
+_get_diskqueue(gchar *filename, DiskQueueOptions *options)
+{
+  LogQueue *q = log_queue_disk_non_reliable_new(options, NULL);
+  log_queue_set_use_backlog(q, FALSE);
+  log_queue_disk_load_queue(q, filename);
+  return q;
+}
+
+static LogQueue *
+_create_diskqueue(gchar *filename, DiskQueueOptions *options)
+{
+  LogQueue *q;
+  unlink(filename);
+
+  _construct_options(options, 1100000, 0, FALSE);
+  options->qout_size = 40;
+  q = _get_diskqueue(filename, options);
+  return q;
+}
+
+static void
+_save_diskqueue(LogQueue *q)
+{
+  gboolean persistent;
+  log_queue_disk_save_queue(q, &persistent);
+  log_queue_unref(q);
+}
+
+static gsize
+_calculate_expected_file_size(gint number_of_msgs)
+{
+  guint diskq_record_len_size = 4;
+  gsize one_msg_size = get_one_message_serialized_size();
+  return ((one_msg_size + diskq_record_len_size) * number_of_msgs) + QDISK_RESERVED_SPACE;
+}
+
+static void
+_assert_diskq_actual_file_size_with_stored(LogQueue *q)
+{
+  QDisk *qdisk = ((LogQueueDisk *)q)->qdisk;
+  gchar *filename = qdisk->filename;
+
+  struct stat diskq_file_stat;
+  assert_gint(stat(filename, &diskq_file_stat), 0, "Stat call failed, errno:%d", errno);
+  assert_gint(qdisk->file_size, diskq_file_stat.st_size, "File size does not match with stored size");
+  fprintf(stderr, "Actual file size: %ld\n", diskq_file_stat.st_size);
+}
+
+static void
+_assert_diskq_actual_file_size_with_expected(LogQueue *q, gboolean should_file_be_empty,
+                                             gint64 number_of_messages_on_disk)
+{
+  QDisk *qdisk = ((LogQueueDisk *)q)->qdisk;
+  gchar *filename = qdisk->filename;
+
+  struct stat diskq_file_stat;
+  assert_gint(stat(filename, &diskq_file_stat), 0, "Stat call failed, errno:%d", errno);
+
+  if (should_file_be_empty)
+    {
+      assert_gint(diskq_file_stat.st_size, QDISK_RESERVED_SPACE, "Truncate after load failed: file is not empty");
+    }
+  else
+    {
+      // diskq file is truncated on read when it becomes empty,
+      // thus we have to assert to the original file size (after push finished), i.e. the max recorded size
+      assert_gint(diskq_file_stat.st_size, _calculate_expected_file_size(number_of_messages_on_disk),
+                  "Truncate after load failed: expected size differs");
+    }
+}
+
+typedef struct
+{
+  const gchar *test_id;
+  gint number_of_msgs_to_push;
+  gint number_of_msgs_to_pop;
+  gboolean should_file_be_empty_after_truncate;
+} TruncateTestParams;
+
+static void
+_test_diskq_truncate(TruncateTestParams params)
+{
+  LogQueue *q;
+  DiskQueueOptions options;
+  GString *filename = g_string_new("test_dq_truncate.qf");
+  fprintf(stderr, "### Test case starts: %s\n", params.test_id);
+
+  q = _create_diskqueue(filename->str, &options);
+  assert_gint(log_queue_get_length(q), 0, "No messages should be in a newly created disk-queue file!");
+
+  feed_some_messages(q, params.number_of_msgs_to_push);
+  assert_gint(log_queue_get_length(q), params.number_of_msgs_to_push, "Not all messages have been queued!");
+  gint64 messages_on_disk_after_push = qdisk_get_length(((LogQueueDisk *)q)->qdisk);
+  _assert_diskq_actual_file_size_with_stored(q);
+
+  send_some_messages(q, params.number_of_msgs_to_pop);
+  assert_gint(log_queue_get_length(q), params.number_of_msgs_to_push - params.number_of_msgs_to_pop,
+              "Invalid number of messages in disk-queue after messages have been popped!");
+
+  _save_diskqueue(q);
+
+  q = _get_diskqueue(filename->str, &options);
+  assert_gint(log_queue_get_length(q), params.number_of_msgs_to_push - params.number_of_msgs_to_pop,
+              "Invalid number of messages in disk-queue after opened existing one");
+  _assert_diskq_actual_file_size_with_stored(q);
+  _assert_diskq_actual_file_size_with_expected(q, params.should_file_be_empty_after_truncate,
+                                               messages_on_disk_after_push);
+
+
+  unlink(filename->str);
+  g_string_free(filename, TRUE);
+
+  log_queue_unref(q);
+  disk_queue_options_destroy(&options);
+}
+
+static void
+test_diskq_truncate_with_diskbuffer_used(void)
+{
+  _test_diskq_truncate((TruncateTestParams)
+  {
+    .test_id = __func__,
+     .number_of_msgs_to_push = 100,
+      .number_of_msgs_to_pop = 50,
+       .should_file_be_empty_after_truncate = FALSE
+  });
+}
+
+static void
+test_diskq_truncate_without_diskbuffer_used(void)
+{
+  _test_diskq_truncate((TruncateTestParams)
+  {
+    .test_id = __func__,
+     .number_of_msgs_to_push = 100,
+      .number_of_msgs_to_pop = 80,
+       .should_file_be_empty_after_truncate = TRUE
+  });
+}
+
+
+int
+main(void)
+{
+  msg_init(TRUE); // internal messages will go to stderr(), msg_init() is idempotent
+  app_startup();
+
+  configuration = cfg_new_snippet();
+  assert_true(cfg_init(configuration), "cfg_init failed!");
+
+  // Diskbuffer is the part of disk-queue that is used only when qout is full
+  test_diskq_truncate_with_diskbuffer_used();
+  test_diskq_truncate_without_diskbuffer_used();
+
+  app_shutdown();
+  cfg_free(configuration);
+
+  return 0;
+}


### PR DESCRIPTION
On loading exiting disk-queues it was possible that a disk-queue only
contained saved memory queues (e.g. qout, qbacklog) and the disk-buf-size part was empty.

Due to the faulty logic of truncate on load, we could have empty disk-queues with possibly big sizes.

Also, the truncating logic assumed that qout will be the lowest offset among the saved
memory queues, however it is possible that only qbacklog is saved to the disk, which
resulted into a huge, empty disk-queue file.