### PR TITLE
java-modules, elasticsearch: maven repository link has changed

### DIFF
--- a/modules/java-modules/build.gradle
+++ b/modules/java-modules/build.gradle
@@ -15,9 +15,6 @@ subprojects {
             dirs syslogBuildDir + '/common/gradle/libs'
         }
       mavenCentral()
-      maven {
-        url "http://maven.elasticsearch.org/releases"
-      }
     }
 
     compileJava {


### PR DESCRIPTION
The maven repository url for elasticsearch has changed. For historical reason I updated it first. However the central maven repository for gradle now contains the needed elasticsearch packages, so removed the unnecessary private repo url.

The attention was drew by this issue: #2390