### PR TITLE
http: do not load certs from default CURL ca-dir

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -103,8 +103,7 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
   if (owner->user_agent)
     curl_easy_setopt(self->curl, CURLOPT_USERAGENT, owner->user_agent);
 
-  if (owner->ca_dir)
-    curl_easy_setopt(self->curl, CURLOPT_CAPATH, owner->ca_dir);
+  curl_easy_setopt(self->curl, CURLOPT_CAPATH, owner->ca_dir);
 
   curl_easy_setopt(self->curl, CURLOPT_CAINFO, owner->ca_file);
 


### PR DESCRIPTION
when ca-dir() is not set, syslog-ng uses the default ca-dir, provided by
CURL (on my machine: /etc/ssl/certs)

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>