### PR TITLE
WIP: Config reload log message improvements

### DIFF
--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -379,7 +379,7 @@ _reenable_worker_jobs(void *s)
 {
   main_loop_workers_quit = FALSE;
   if (is_reloading_scheduled)
-    msg_notice("Configuration reload finished");
+    msg_debug("Configuration reload finished, restarting worker threads");
   is_reloading_scheduled = FALSE;
 }
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -247,13 +247,14 @@ main_loop_reload_config_apply(gpointer user_data)
       cfg_free(self->old_config);
       self->current_configuration = self->new_config;
       service_management_clear_status();
-      msg_notice("Configuration reload request received, reloading configuration");
-
+      msg_notice("Configuration reload request received, configuration successfully reloaded",
+                 evt_tag_str("config", resolvedConfigurablePaths.cfgfilename));
     }
   else
     {
-      msg_error("Error initializing new configuration, reverting to old config");
-      service_management_publish_status("Error initializing new configuration, using the old config");
+      msg_error("Error initializing new configuration, reverting to old config",
+                evt_tag_str("config", resolvedConfigurablePaths.cfgfilename));
+      service_management_publish_status("Error initializing new configuration, reverting to the old config");
       cfg_persist_config_move(self->new_config, self->old_config);
       cfg_deinit(self->new_config);
       if (!cfg_init(self->old_config))
@@ -279,7 +280,6 @@ main_loop_reload_config_apply(gpointer user_data)
 
   return;
 }
-
 
 /* initiate configuration reload */
 gboolean


### PR DESCRIPTION
This is the conslusion of #2367 that cleans up the reload related log messages somewhat, but which
also may cause issues for those who monitor those message for successful reload.

We now have a better method for doing so (e.g. by checking the return value for syslog-ng-ctl reload), but since that's pretty new, let's wait a bit until that trickles down. At that point we can change the messages.
