### PR TITLE
Custom LGTM.com query for detecting uses of gmtime that are not covered by a lock

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+# Disable LGTM's built-in query to detect unsafe uses of gmtime; there's a
+# custom query to check for that
+queries:
+  - exclude: cpp/potentially-dangerous-function

--- a/.lgtm/cpp-queries/call-to-gmtime-without-lock.ql
+++ b/.lgtm/cpp-queries/call-to-gmtime-without-lock.ql
@@ -1,0 +1,31 @@
+/**
+ * @name Use of gmtime without proper lock
+ * @description In the absence of the safer gmtime_r function, any call to
+ * gmtime should be protected by a lock
+ * Based on LGTM's built-in query 'cpp/potentially-dangerous-function'
+ * (https://lgtm.com/rules/2154840805) after discussion here:
+ * https://discuss.lgtm.com/t/suppressions-in-c-code/1525
+ *
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id cpp/call-to-gmtime-without-lock
+ * @tags reliability
+ *       security
+ *       external/cwe/cwe-676
+ */
+import cpp
+import semmle.code.cpp.controlflow.Dominance
+
+predicate isLockedUseOfFunction(FunctionCall call){
+	exists (FunctionCall lockCall |
+		lockCall.getTarget().getQualifiedName() = "g_mutex_lock"
+		and dominates(lockCall, call)
+	)
+}
+
+from FunctionCall call
+where call.getTarget().getName() = "gmtime"
+and isLockedUseOfFunction(call)
+
+select call, "Call to gmtime is not protected by a lock"


### PR DESCRIPTION
Here's an example of how to use LGTM's custom queries after a discussion here: https://discuss.lgtm.com/t/suppressions-in-c-code/1525/10

If you like the custom query: feel free to merge this so it's automatically run by LGTM.com. If you'd rather not have a custom query: feel fee to close this PR.