### PR TITLE
Fix telegram dst default ca dir

### DIFF
--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -61,6 +61,7 @@
 %token KW_CERT_FILE
 %token KW_KEY_FILE
 %token KW_CIPHER_SUITE
+%token KW_USE_SYSTEM_CERT_STORE
 %token KW_SSL_VERSION
 %token KW_PEER_VERIFY
 %token KW_TIMEOUT
@@ -138,6 +139,7 @@ http_tls_option
     | KW_CERT_FILE  '(' string ')'            { http_dd_set_cert_file(last_driver, $3); free($3); }
     | KW_KEY_FILE   '(' string ')'            { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
+    | KW_USE_SYSTEM_CERT_STORE '(' yesno ')'  { http_dd_set_use_system_cert_store(last_driver, $3); }
     | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
     ;

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -43,6 +43,7 @@ static CfgLexerKeyword http_keywords[] =
   { "cert_file",        KW_CERT_FILE },
   { "key_file",         KW_KEY_FILE },
   { "cipher_suite",     KW_CIPHER_SUITE },
+  { "use_system_cert_store", KW_USE_SYSTEM_CERT_STORE },
   { "ssl_version",      KW_SSL_VERSION },
   { "peer_verify",      KW_PEER_VERIFY },
   { "accept_redirects", KW_ACCEPT_REDIRECTS },

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -103,9 +103,11 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
   if (owner->user_agent)
     curl_easy_setopt(self->curl, CURLOPT_USERAGENT, owner->user_agent);
 
-  curl_easy_setopt(self->curl, CURLOPT_CAPATH, owner->ca_dir);
+  if (owner->ca_dir || !owner->use_system_cert_store)
+    curl_easy_setopt(self->curl, CURLOPT_CAPATH, owner->ca_dir);
 
-  curl_easy_setopt(self->curl, CURLOPT_CAINFO, owner->ca_file);
+  if (owner->ca_file || !owner->use_system_cert_store)
+    curl_easy_setopt(self->curl, CURLOPT_CAINFO, owner->ca_file);
 
   if (owner->cert_file)
     curl_easy_setopt(self->curl, CURLOPT_SSLCERT, owner->cert_file);
@@ -522,6 +524,14 @@ http_dd_set_ca_dir(LogDriver *d, const gchar *ca_dir)
 
   g_free(self->ca_dir);
   self->ca_dir = g_strdup(ca_dir);
+}
+
+void
+http_dd_set_use_system_cert_store(LogDriver *d, gboolean enable)
+{
+  HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
+
+  self->use_system_cert_store = enable;
 }
 
 void

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -50,6 +50,7 @@ typedef struct
   GList *headers;
   gchar *user_agent;
   gchar *ca_dir;
+  gboolean use_system_cert_store;
   gchar *ca_file;
   gchar *cert_file;
   gchar *key_file;
@@ -79,6 +80,7 @@ void http_dd_set_headers(LogDriver *d, GList *headers);
 void http_dd_set_body(LogDriver *d, LogTemplate *body);
 void http_dd_set_accept_redirects(LogDriver *d, gboolean accept_redirects);
 void http_dd_set_ca_dir(LogDriver *d, const gchar *ca_dir);
+void http_dd_set_use_system_cert_store(LogDriver *d, gboolean enable);
 void http_dd_set_ca_file(LogDriver *d, const gchar *ca_file);
 void http_dd_set_cert_file(LogDriver *d, const gchar *cert_file);
 void http_dd_set_key_file(LogDriver *d, const gchar *key_file);

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -30,6 +30,7 @@ block destination telegram(
       parse-mode("none")
       throttle(1)
       disable-web-page-preview("true")
+      use_system_cert_store("yes")
       ...)
 {
     http(
@@ -37,6 +38,7 @@ block destination telegram(
         method("POST")
         body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode \"`template`\")\n")
         throttle(`throttle`)
+        use_system_cert_store(`use_system_cert_store`)
         `__VARARGS__`
     );
 };


### PR DESCRIPTION
PR #2410 breaks the Telegram destination.

This patch adds new option to HTTP destination (`enable-default-ca-dir`).
When defaults are enabled and the user does not set the `ca-dir` option,a default ca-dir is used, provided by the CURL library.

When both options are set (`ca-dir` and `enable-default-ca-dir`), of course, `ca-dir` will be used.
