### PR TITLE
Adding build flag -Wmissing-format-attribute and -Wsuggest-attribute=noreturn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,8 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wfloat-equal
     -Wpointer-arith
     -Wpointer-sign
-    -Wmissing-format-attribute)
+    -Wmissing-format-attribute
+    -Wsuggest-attribute=noreturn)
 endif()
 
 add_compile_options(${IMPORTANT_WARNINGS} ${ACCEPTABLE_WARNINGS} ${EXTRA_WARNINGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,8 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wdouble-promotion
     -Wfloat-equal
     -Wpointer-arith
-    -Wpointer-sign)
+    -Wpointer-sign
+    -Wmissing-format-attribute)
 endif()
 
 add_compile_options(${IMPORTANT_WARNINGS} ${ACCEPTABLE_WARNINGS} ${EXTRA_WARNINGS})

--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,8 @@ AM_CFLAGS += \
 	-Wfloat-equal \
 	-Wpointer-arith \
 	-Wpointer-sign \
-	-Wmissing-format-attribute
+	-Wmissing-format-attribute \
+	-Wsuggest-attribute=noreturn
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest -DTOP_SRCDIR=\"$(abs_top_srcdir)\" $(AM_CFLAGS) $(CRITERION_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,8 @@ AM_CFLAGS += \
 	-Wdouble-promotion \
 	-Wfloat-equal \
 	-Wpointer-arith \
-	-Wpointer-sign
+	-Wpointer-sign \
+	-Wmissing-format-attribute
 endif
 
 TEST_CFLAGS		= -I$(top_srcdir)/libtest -DTOP_SRCDIR=\"$(abs_top_srcdir)\" $(AM_CFLAGS) $(CRITERION_CFLAGS)

--- a/lib/eventlog/CMakeLists.txt
+++ b/lib/eventlog/CMakeLists.txt
@@ -8,7 +8,18 @@ add_library(eventlog SHARED
   src/evttags.c
 )
 
-target_include_directories(eventlog SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(eventlog
+  SYSTEM
+  INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  PRIVATE
+    ${GLIB_INCLUDE_DIRS}
+)
+
+target_link_libraries(eventlog
+  PRIVATE
+    ${GLIB_LIBRARIES}
+)
 
 install(TARGETS eventlog DESTINATION lib)
 

--- a/lib/eventlog/src/Makefile.am
+++ b/lib/eventlog/src/Makefile.am
@@ -27,6 +27,8 @@ lib_eventlog_src_libevtlog_la_LDFLAGS = -no-undefined -release ${LSNG_RELEASE} \
 
 lib_eventlog_src_libevtlog_la_CFLAGS = $(AM_CFLAGS)
 
+lib_eventlog_src_libevtlog_la_LIBADD = @GLIB_LIBS@
+
 
 noinst_HEADERS = lib/eventlog/src/evt_internals.h
 

--- a/lib/eventlog/src/evt_internals.h
+++ b/lib/eventlog/src/evt_internals.h
@@ -71,7 +71,7 @@ struct __evtsyslogopts
 {
   void (*es_openlog)(const char *ident, int option, int facility);
   void (*es_closelog)(void);
-  void (*es_syslog)(int priority, const char *format, ...);
+  void (*es_syslog)(int priority, const char *format, ...) G_GNUC_PRINTF(2, 3);
   int es_options;
 };
 

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -48,6 +48,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <glib.h>
 
 #include "evtmaps.h"
 
@@ -82,12 +83,6 @@
 #define EVT_FAC_LOCAL5      (21<<3) /* reserved for local use */
 #define EVT_FAC_LOCAL6      (22<<3) /* reserved for local use */
 #define EVT_FAC_LOCAL7      (23<<3) /* reserved for local use */
-
-#ifdef __GNUC__
-#define EVT_GNUC_PRINTF_FUNC(format_idx, first_arg_idx)  __attribute__((format(printf, format_idx, first_arg_idx)))
-#else
-#define EVT_GNUC_PRINTF_FUNC(format_idx, first_arg_idx)
-#endif
 
 /* EVTCONTEXT encapsulates logging specific parameters like the
  * program name and facility to use */
@@ -148,7 +143,7 @@ EVTTAG *evt_tag_str(const char *tag, const char *value);
 EVTTAG *evt_tag_int(const char *tag, int value);
 EVTTAG *evt_tag_long(const char *tag, long long value);
 EVTTAG *evt_tag_errno(const char *tag, int err);
-EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) EVT_GNUC_PRINTF_FUNC(2, 3);
+EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) G_GNUC_PRINTF(2, 3);
 EVTTAG *evt_tag_inaddr(const char *tag, const struct in_addr *addr);
 EVTTAG *evt_tag_inaddr6(const char *tag, const struct in6_addr *addr);
 
@@ -180,8 +175,8 @@ int evt_log(EVTREC *e);
 /* syslog wrapper */
 void evt_openlog(const char *ident, int option, int facility);
 void evt_closelog(void);
-void evt_vsyslog(int pri, const char *format, va_list ap);
-void evt_syslog(int pri, const char *format, ...) EVT_GNUC_PRINTF_FUNC(2, 3);
+void evt_vsyslog(int pri, const char *format, va_list ap) G_GNUC_PRINTF(2, 0);
+void evt_syslog(int pri, const char *format, ...) G_GNUC_PRINTF(2, 3);
 
 #ifdef EVENTLOG_SYSLOG_MACROS
 

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -28,6 +28,7 @@
 #include "syslog-ng.h"
 
 #include <sys/types.h>
+#include <glib.h>
 
 #if SYSLOG_NG_ENABLE_LINUX_CAPS
 #  include <sys/capability.h>
@@ -57,7 +58,7 @@ typedef gpointer cap_t;
 
 #endif
 
-void g_process_message(const gchar *fmt, ...);
+void g_process_message(const gchar *fmt, ...) G_GNUC_PRINTF(1, 2);
 
 void g_process_set_mode(GProcessMode mode);
 GProcessMode g_process_get_mode(void);

--- a/lib/logproto/tests/test-text-server.c
+++ b/lib/logproto/tests/test-text-server.c
@@ -360,7 +360,7 @@ accumulator_assert_that_lines_are_starting_with_sequence_number(LogProtoTextServ
 {
   assert_true((msg[0] - '0') == accumulate_seq,
               "accumulate_line: Message doesn't start with sequence number, msg=%.*s, seq=%d",
-              msg_len, msg, accumulate_seq);
+              (int)msg_len, msg, accumulate_seq);
   assert_gint(consumed_len, -1, "Initial invocation of the accumulator expects -1 as consumed_len");
   accumulate_seq++;
   return LPT_CONSUME_LINE | LPT_EXTRACTED;

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -99,7 +99,7 @@ void
 cr_assert_msg_field_equals(LogMessage *msg, const gchar *field_name, const gchar *expected_value,
                            gssize expected_value_len)
 {
-  const gboolean result = assert_msg_field_equals_non_fatal(msg, field_name, expected_value, expected_value_len, "");
+  const gboolean result = assert_msg_field_equals_non_fatal(msg, field_name, expected_value, expected_value_len, NULL);
   cr_assert(result, "Message field assert");
 }
 

--- a/libtest/stopwatch.h
+++ b/libtest/stopwatch.h
@@ -30,6 +30,7 @@
 
 void start_stopwatch(void);
 guint64 stop_stopwatch_and_get_result(void);
-void stop_stopwatch_and_display_result(gint iterations, const gchar *message_template, ...);
+void stop_stopwatch_and_display_result(gint iterations, const gchar *message_template,
+                                       ...) G_GNUC_PRINTF(2, 3);
 
 #endif

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -36,7 +36,7 @@ GString *current_testcase_description = NULL;
 const gchar *current_testcase_function = NULL;
 gchar *current_testcase_file = NULL;
 
-static void
+static void G_GNUC_PRINTF(1, 0) G_GNUC_PRINTF(3, 4)
 print_failure(const gchar *custom_template, va_list custom_args, const gchar *assertion_failure_template, ...)
 {
   testutils_global_success = FALSE;
@@ -127,7 +127,7 @@ assert_gint64_non_fatal(gint64 actual, gint64 expected, const gchar *error_messa
     return TRUE;
 
   va_start(args, error_message);
-  print_failure(error_message, args, "actual=%lld, expected=%lld", actual, expected);
+  print_failure(error_message, args, "actual=%"G_GINT64_FORMAT", expected=%"G_GINT64_FORMAT, actual, expected);
   va_end(args);
 
   return FALSE;
@@ -142,7 +142,7 @@ assert_guint64_non_fatal(guint64 actual, guint64 expected, const gchar *error_me
     return TRUE;
 
   va_start(args, error_message);
-  print_failure(error_message, args, "actual=%llu, expected=%llu", actual, expected);
+  print_failure(error_message, args, "actual=%"G_GUINT64_FORMAT", expected=%"G_GUINT64_FORMAT, actual, expected);
   va_end(args);
 
   return FALSE;
@@ -166,7 +166,7 @@ assert_gdouble_non_fatal(gdouble actual, gdouble expected, const gchar *error_me
   return FALSE;
 }
 
-static gboolean
+static gboolean G_GNUC_PRINTF(5, 0)
 assert_nstring_non_fatal_va(const gchar *actual, gint actual_len, const gchar *expected, gint expected_len,
                             const gchar *error_message, va_list args)
 {
@@ -211,7 +211,7 @@ assert_nstring_non_fatal(const gchar *actual, gint actual_len, const gchar *expe
 }
 
 
-static gboolean
+static gboolean G_GNUC_PRINTF(5, 0)
 compare_arrays_trivially(void *actual, guint32 actual_length,
                          void *expected, guint32 expected_length,
                          const gchar *error_message_template, va_list error_message_args)
@@ -333,13 +333,13 @@ assert_gboolean_non_fatal(gboolean actual, gboolean expected, const gchar *error
   return FALSE;
 }
 
-gboolean
+gboolean G_GNUC_PRINTF(2, 0)
 assert_null_non_fatal_va(const void *pointer, const gchar *error_message, va_list args)
 {
   if (pointer == NULL)
     return TRUE;
 
-  print_failure(error_message, args, "Pointer expected to be NULL; pointer=%llx", (guint64)pointer);
+  print_failure(error_message, args, "Pointer expected to be NULL; pointer=%p", pointer);
 
   return FALSE;
 }
@@ -356,7 +356,7 @@ assert_null_non_fatal(const void *pointer, const gchar *error_message, ...)
   return success;
 }
 
-gboolean
+gboolean G_GNUC_PRINTF(2, 0)
 assert_not_null_non_fatal_va(void *pointer, const gchar *error_message, va_list args)
 {
   if (pointer != NULL)
@@ -434,7 +434,7 @@ assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error
     return TRUE;
 
   va_start(args, error_message);
-  print_failure(error_message, args, "actual=%x, expected=%x", actual, expected);
+  print_failure(error_message, args, "actual=%p, expected=%p", actual, expected);
   va_end(args);
 
   return FALSE;

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -47,33 +47,41 @@
 #define ASSERTION_ERROR(message) "%s:%d/%s\n  #       %s", \
                                  basename(__FILE__), __LINE__, __FUNCTION__, ((message) ? (message) : "")
 
-gboolean assert_grabbed_messages_contain_non_fatal(const gchar *pattern, const gchar *error_message, ...);
+gboolean assert_grabbed_messages_contain_non_fatal(const gchar *pattern, const gchar *error_message,
+                                                   ...) G_GNUC_PRINTF(2, 3);
 
 #define assert_grabbed_messages_contain(pattern, error_message, ...) (assert_grabbed_messages_contain_non_fatal(pattern, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
 
 gchar **fill_string_array(gint number_of_elements, ...);
 
-gboolean assert_guint16_non_fatal(guint16 actual, guint16 expected, const gchar *error_message, ...);
-gboolean assert_gint64_non_fatal(gint64 actual, gint64 expected, const gchar *error_message, ...);
-gboolean assert_guint64_non_fatal(guint64 actual, guint64 expected, const gchar *error_message, ...);
-gboolean assert_gdouble_non_fatal(gdouble actual, gdouble expected, const gchar *error_message, ...);
+gboolean assert_guint16_non_fatal(guint16 actual, guint16 expected, const gchar *error_message,
+                                  ...) G_GNUC_PRINTF(3, 4);
+gboolean assert_gint64_non_fatal(gint64 actual, gint64 expected, const gchar *error_message,
+                                 ...) G_GNUC_PRINTF(3, 4);
+gboolean assert_guint64_non_fatal(guint64 actual, guint64 expected, const gchar *error_message,
+                                  ...) G_GNUC_PRINTF(3, 4);
+gboolean assert_gdouble_non_fatal(gdouble actual, gdouble expected, const gchar *error_message,
+                                  ...) G_GNUC_PRINTF(3, 4);
 gboolean assert_nstring_non_fatal(const gchar *actual, gint actual_len, const gchar *expected, gint expected_len,
-                                  const gchar *error_message, ...);
+                                  const gchar *error_message, ...) G_GNUC_PRINTF(5, 6);
 gboolean assert_guint32_array_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected,
-                                        guint32 expected_length, const gchar *error_message, ...);
+                                        guint32 expected_length, const gchar *error_message, ...) G_GNUC_PRINTF(5, 6);
 gboolean assert_string_array_non_fatal(gchar **actual, guint32 actual_length, gchar **expected, guint32 expected_length,
-                                       const gchar *error_message, ...);
-gboolean assert_gboolean_non_fatal(gboolean actual, gboolean expected, const gchar *error_message, ...);
-gboolean assert_null_non_fatal(const void *pointer, const gchar *error_message, ...);
-gboolean assert_not_null_non_fatal(void *pointer, const gchar *error_message, ...);
-gboolean assert_no_error_non_fatal(GError *error, const gchar *error_message, ...);
+                                       const gchar *error_message, ...) G_GNUC_PRINTF(5, 6);
+gboolean assert_gboolean_non_fatal(gboolean actual, gboolean expected, const gchar *error_message,
+                                   ...) G_GNUC_PRINTF(3, 4);
+gboolean assert_null_non_fatal(const void *pointer, const gchar *error_message, ...) G_GNUC_PRINTF(2, 3);
+gboolean assert_not_null_non_fatal(void *pointer, const gchar *error_message, ...) G_GNUC_PRINTF(2, 3);
+gboolean assert_no_error_non_fatal(GError *error, const gchar *error_message, ...) G_GNUC_PRINTF(2, 3);
 gboolean assert_guint32_set_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected,
-                                      guint32 expected_length, const gchar *error_message, ...);
-gboolean assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error_message, ...);
+                                      guint32 expected_length, const gchar *error_message, ...) G_GNUC_PRINTF(5, 6);
+gboolean assert_gpointer_non_fatal(gpointer actual, gpointer expected, const gchar *error_message,
+                                   ...) G_GNUC_PRINTF(3, 4);
 gboolean assert_msg_field_equals_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *expected_value,
-                                           gssize expected_value_len, const gchar *error_message, ...);
-gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *error_message, ...);
-gboolean expect_not_reached(const gchar *error_message, ...);
+                                           gssize expected_value_len, const gchar *error_message, ...) G_GNUC_PRINTF(5, 6);
+gboolean assert_msg_field_unset_non_fatal(LogMessage *msg, const gchar *field_name, const gchar *error_message,
+                                          ...) G_GNUC_PRINTF(3, 4);
+gboolean expect_not_reached(const gchar *error_message, ...) G_GNUC_PRINTF(1, 2);
 
 #define assert_guint16(actual, expected, error_message, ...) (assert_guint16_non_fatal(actual, expected, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
 

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -80,7 +80,7 @@ _execute(const gchar *testcase, Checks checks, const gchar *user_data)
 static gboolean
 _execute_find_text_in_log(const gchar *pattern)
 {
-  return assert_grabbed_messages_contain_non_fatal(pattern, "mismatch", NULL);
+  return assert_grabbed_messages_contain_non_fatal(pattern, "mismatch");
 }
 
 static void

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -119,7 +119,7 @@ _pdb_state_stack_pop(PDBStateStack *self)
   return self->stack[self->top];
 }
 
-static void
+static void G_GNUC_PRINTF(3, 4)
 pdb_loader_set_error(PDBLoader *state, GError **error, const gchar *format, ...)
 {
   gchar *error_text;

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1184,7 +1184,6 @@ usage(void)
     {
       fprintf(stderr, "    %-12s %s\n", modes[mode].mode, modes[mode].description);
     }
-  exit(1);
 }
 
 int
@@ -1199,6 +1198,7 @@ main(int argc, char *argv[])
   if (!mode_string)
     {
       usage();
+      return 1;
     }
 
   ctx = NULL;
@@ -1218,6 +1218,7 @@ main(int argc, char *argv[])
     {
       fprintf(stderr, "Unknown command\n");
       usage();
+      return 1;
     }
 
   setlocale(LC_ALL, "");

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -235,7 +235,6 @@ usage(void)
     {
       fprintf(stderr, "    %-12s %s\n", modes[mode].mode, modes[mode].description);
     }
-  exit(1);
 }
 
 void
@@ -256,6 +255,7 @@ main(int argc, char *argv[])
   if (!mode_string)
     {
       usage();
+      return 1;
     }
 
   ctx = NULL;
@@ -277,6 +277,7 @@ main(int argc, char *argv[])
     {
       fprintf(stderr, "Unknown command\n");
       usage();
+      return 1;
     }
 
   if (!g_option_context_parse(ctx, &argc, &argv, &error))

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -360,7 +360,7 @@ testcase_diskbuffer_restart_corrupted(void)
       assert_gint(stat(filename, &file_stat), 0,
                   "New disk-queue file does not exists!!");
       assert_gint(S_ISREG(file_stat.st_mode), TRUE,
-                  "New disk-queue file expected to be a regular file!! st_mode value=",
+                  "New disk-queue file expected to be a regular file!! st_mode value=%04o",
                   (file_stat.st_mode & S_IFMT));
       stat(filename_corrupted_dq, &file_stat);
       assert_gint(S_ISREG(file_stat.st_mode), TRUE,

--- a/modules/geoip2/maxminddb-helper.c
+++ b/modules/geoip2/maxminddb-helper.c
@@ -296,7 +296,7 @@ dump_geodata_into_msg_array(LogMessage *msg, MMDB_entry_data_list_s *entry_data_
   return entry_data_list;
 }
 
-static void
+static void G_GNUC_PRINTF(3, 4)
 dump_geodata_into_msg_data(LogMessage *msg, GArray *path, gchar *fmt, ...)
 {
   GString *value = scratch_buffers_alloc();


### PR DESCRIPTION
This PR fixes #1961.

-Wmissing-format-attribute is the alias for -Wsuggest-attribute=format.
This attribute can be added to any function, which has a format string in its arguments, and possibly additional variable arguments, intended to match with the format string.
When 'format' attribute is added, the compiler checks, whether the format string is valid, and the variable arguments match the format.
After enabling this flag, several functions were shown to be candidates for the format attribute.
As clang and gcc has different syntactic, I made macros for every module, which was affected, with different syntactic for the mentioned compilers.
I wanted to make only one macro, but I did not find the mutual source file for it.
After marking each candidate functions with 'format' attribute, the compiler found some calls, where the format string and the arguments were not compatible. I fixed these instances.

-Wsuggest-attribute=noreturn suggests the compiler, that the code will not return from the function call.
I found, that clang and gcc had the same syntactic, so macro was not needed here.
After enabling this warning flag, I found some instances, where the attribute could be added to a function.
I checked the functions, added the 'noreturn' attribute and the warnings disappeared.

I do not suggest turning on -Wformat=2 make flag, as it throws warnings for such cases, where the format string is built run-time, and the compiler is not able to check those cases with -Wmissing-format-attribute. So the warnings caused by -Wformat=2 cannot be eliminated.

I tested the PR with Travis and it passed, but I found, that with clang, the extra warnings flags are not enabled, so I tested this scenario manually, by configuring with --enable-extra-warnings and building with clang. I found the build output to be as expected, the new warnings (caused by turning on the make flags) were cleared with the code modification.