### PR TITLE
internal source + trace level causes message storm

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -369,12 +369,12 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   LogSource *self = (LogSource *) s;
   gint i;
 
+  msg_set_context(msg);
+
   msg_trace(">>>>>> Source side message processing begin",
             evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
-
-  msg_set_context(msg);
 
   if (!self->options->keep_timestamp)
     msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
@@ -414,8 +414,6 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   stats_counter_set(self->last_message_seen, msg->timestamps[LM_TS_RECVD].tv_sec);
   log_pipe_forward_msg(s, msg, path_options);
 
-  msg_set_context(NULL);
-
   if (accurate_nanosleep && self->threaded && self->window_full_sleep_nsec > 0 && !log_source_free_to_send(self))
     {
       struct timespec ts;
@@ -429,6 +427,8 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
             evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
             log_pipe_location_tag(s),
             evt_tag_printf("msg", "%p", msg));
+
+  msg_set_context(NULL);
 
 }
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -58,12 +58,11 @@ _flow_control_window_size_adjust(LogSource *self, guint32 window_size_increment,
   gboolean suspended;
   gsize old_window_size = window_size_counter_add(&self->window_size, window_size_increment, &suspended);
 
-  msg_trace("Window size adjustment",
-            evt_tag_int("old_window_size", old_window_size),
-            evt_tag_int("window_size_increment", window_size_increment),
-            evt_tag_str("suspended_before_increment", suspended ? "TRUE" : "FALSE"),
-            evt_tag_str("last_ack_type_is_suspended", last_ack_type_is_suspended ? "TRUE" : "FALSE"));
-
+  msg_diagnostics("Window size adjustment",
+                  evt_tag_int("old_window_size", old_window_size),
+                  evt_tag_int("window_size_increment", window_size_increment),
+                  evt_tag_str("suspended_before_increment", suspended ? "TRUE" : "FALSE"),
+                  evt_tag_str("last_ack_type_is_suspended", last_ack_type_is_suspended ? "TRUE" : "FALSE"));
 
   gboolean need_to_resume_counter = !last_ack_type_is_suspended && suspended;
   if (need_to_resume_counter)
@@ -371,10 +370,10 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
 
   msg_set_context(msg);
 
-  msg_trace(">>>>>> Source side message processing begin",
-            evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
-            log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+  msg_diagnostics(">>>>>> Source side message processing begin",
+                  evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
+                  log_pipe_location_tag(s),
+                  evt_tag_printf("msg", "%p", msg));
 
   if (!self->options->keep_timestamp)
     msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
@@ -423,10 +422,10 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
       ts.tv_nsec = self->window_full_sleep_nsec;
       nanosleep(&ts, NULL);
     }
-  msg_trace("<<<<<< Source side message processing finish",
-            evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
-            log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+  msg_diagnostics("<<<<<< Source side message processing finish",
+                  evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
+                  log_pipe_location_tag(s),
+                  evt_tag_printf("msg", "%p", msg));
 
   msg_set_context(NULL);
 

--- a/lib/messages.c
+++ b/lib/messages.c
@@ -197,6 +197,18 @@ msg_event_suppress_recursions_and_send(EVTREC *e)
   msg_event_send_with_suppression(e, msg_limit_internal_message);
 }
 
+void
+msg_event_print_event_to_stderr(EVTREC *e)
+{
+  gchar *msg;
+
+  msg = evt_format(e);
+  msg_send_formatted_message_to_stderr(msg);
+  free(msg);
+  msg_event_free(e);
+
+}
+
 EVTREC *
 msg_event_create(gint prio, const gchar *desc, EVTTAG *tag1, ...)
 {
@@ -322,4 +334,3 @@ msg_add_option_group(GOptionContext *ctx)
   g_option_group_add_entries(group, msg_option_entries);
   g_option_context_add_group(ctx, group);
 }
-

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -43,6 +43,7 @@ EVTREC *msg_event_create_from_desc(gint prio, const char *desc);
 void msg_event_free(EVTREC *e);
 void msg_event_send(EVTREC *e);
 void msg_event_suppress_recursions_and_send(EVTREC *e);
+void msg_event_print_event_to_stderr(EVTREC *e);
 
 
 void msg_set_post_func(MsgPostFunc func);
@@ -103,6 +104,13 @@ void msg_add_option_group(GOptionContext *ctx);
   do {                    \
     if (G_UNLIKELY(trace_flag))                     \
       msg_event_suppress_recursions_and_send(                               \
+            msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
+  } while (0)
+
+#define msg_diagnostics(desc, tags...)              \
+  do {                    \
+    if (G_UNLIKELY(trace_flag))                     \
+      msg_event_print_event_to_stderr(              \
             msg_event_create(EVT_PRI_DEBUG, desc, ##tags, NULL ));          \
   } while (0)
 


### PR DESCRIPTION
Problem: when internal source is enabled and trace level set, infinite message is generated in an exponential manner.

There are two independent root cause for this, both of these need to be addressed.

1)
There is a loop detection that was not working, because the order msg_set_context and the triggering messages were swapped. With that change, the `Source side message processing begin` messages are suppressed.

With that `internal() messages are looping back, preventing loop by ...` messages occur, so the detection kicks in, avoiding the infinite loop, but still causing minor inconvenience.

2)
There is a message about window size adjustment, that also triggers a message each time a message arrives into the internal queue. However, the loop detection does not work on this, and should not, the window size change is completely valid event in this case.

For now I just deleted the msg_trace, but this is probably suboptimal solution.

-----

I was thinking that maybe trace level messages could be written to stderr unconditionally. To my undrestanding, that would also stop the infinite generation of messages, because the trace messages are not put back into the internal queue. 