### PR TITLE
Make include-path more discoverable

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -613,6 +613,10 @@ cfg_lexer_include_file(CfgLexer *self, const gchar *filename_)
   struct stat st;
   gchar *filename;
 
+  msg_debug("Processing @include statement",
+            evt_tag_str("filename", filename_),
+            evt_tag_str("include-path", _get_include_path(self)));
+
   if (self->include_depth >= MAX_INCLUDE_DEPTH - 1)
     {
       msg_error("Include file depth is too deep, increase MAX_INCLUDE_DEPTH and recompile",

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -148,6 +148,7 @@ version(void)
 
   printf("Module-Directory: %s\n", get_installation_path_for(SYSLOG_NG_PATH_MODULEDIR));
   printf("Module-Path: %s\n", resolvedConfigurablePaths.initial_module_path);
+  printf("Include-Path: %s\n", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
   printf("Available-Modules: ");
   plugin_list_modules(stdout, FALSE);
 


### PR DESCRIPTION
I received feedback that the support for include-path was not intuitive at all, and while going into this I've discovered, that it's:

* not documented
* none of the log messages contain anything on it

So I've decided to rectify the situation on the code side, this patch adds a debug message and an additional line to --version output, so both add the include-path.

Also @fekete-robert it would be great if we could document this in https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.18/administration-guide/15
