### PR TITLE
system-source: allow syslog-protocol on unix-dgram() sources

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -53,6 +53,7 @@ system_sysblock_add_unix_dgram_driver(GString *sysblock, const gchar *path,
     g_string_append_printf(sysblock, " perm(%s)", perms);
   if (recvbuf_size)
     g_string_append_printf(sysblock, " so_rcvbuf(%s)", recvbuf_size);
+  g_string_append(sysblock, " flags(syslog-protocol)");
   g_string_append(sysblock, ");\n");
 }
 


### PR DESCRIPTION
FreeBSD has started to use RFC5424 format between applications and syslogd
when using the syslog() API. Allow this use by enabling the syslog-protocol
flag.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>