### PR TITLE
Fix frequent disconnects of syslog() with TLS

### DIFF
--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -97,7 +97,7 @@ log_proto_framed_server_fetch_data(LogProtoFramedServer *self, gboolean *may_rea
     {
       if (errno != EAGAIN)
         {
-          msg_error("Error reading RFC5428 style framed data",
+          msg_error("Error reading RFC6587 style framed data",
                     evt_tag_int("fd", self->super.transport->fd),
                     evt_tag_error("error"));
           return LPS_ERROR;

--- a/lib/logproto/tests/test-framed-server.c
+++ b/lib/logproto/tests/test-framed-server.c
@@ -80,7 +80,7 @@ test_log_proto_framed_server_io_error(void)
               LTM_EOF),
             get_inited_proto_server_options());
   assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC5428 style framed data");
+  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC6587 style framed data");
   log_proto_server_free(proto);
 }
 
@@ -192,7 +192,7 @@ test_log_proto_framed_server_multi_read(void)
             get_inited_proto_server_options());
   assert_proto_server_fetch(proto, "foobar\n", -1);
   /* with multi-read, we get the injected failure at the 2nd fetch */
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC5428 style framed data");
+  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC6587 style framed data");
   log_proto_server_free(proto);
 
   /* NOTE: LPBS_NOMREAD is not implemented for framed protocol */

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -655,10 +655,9 @@ afinet_dd_new_udp6(gchar *host, GlobalConfig *cfg)
 static LogWriter *
 afinet_dd_syslog_construct_writer(AFSocketDestDriver *s)
 {
-  AFInetDestDriver *self G_GNUC_UNUSED = (AFInetDestDriver *) s;
-  LogWriter *writer;
+  AFInetDestDriver *self = (AFInetDestDriver *) s;
+  LogWriter *writer = afsocket_dd_construct_writer_method(s);
 
-  writer = afsocket_dd_construct_writer_method(s);
   log_writer_set_flags(writer, log_writer_get_flags(writer) | LW_SYSLOG_PROTOCOL);
   return writer;
 }

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -206,14 +206,9 @@ afinet_dd_set_failback_successful_probes_required(LogDriver *s, gint successful_
   afinet_dd_failover_set_successful_probes_required(self->failover, successful_probes_required);
 }
 
-static LogWriter *
-afinet_dd_construct_writer(AFSocketDestDriver *s)
+static void
+_disable_connection_closure_on_input(LogWriter *writer)
 {
-  AFInetDestDriver *self G_GNUC_UNUSED = (AFInetDestDriver *) s;
-  LogWriter *writer;
-  TransportMapperInet *transport_mapper_inet G_GNUC_UNUSED = ((TransportMapperInet *) (self->super.transport_mapper));
-
-  writer = afsocket_dd_construct_writer_method(s);
   /* SSL is duplex, so we can certainly expect input from the server, which
    * would cause the LogWriter to close this connection.  In a better world
    * LW_DETECT_EOF would be implemented by the LogProto class and would
@@ -221,8 +216,19 @@ afinet_dd_construct_writer(AFSocketDestDriver *s)
    * (and possibly for all eternity :)
    */
 
+  log_writer_set_flags(writer, log_writer_get_flags(writer) & ~LW_DETECT_EOF);
+}
+
+static LogWriter *
+afinet_dd_construct_writer(AFSocketDestDriver *s)
+{
+  AFInetDestDriver *self = (AFInetDestDriver *) s;
+  TransportMapperInet *transport_mapper_inet = ((TransportMapperInet *) (self->super.transport_mapper));
+
+  LogWriter *writer = afsocket_dd_construct_writer_method(s);
+
   if (((self->super.transport_mapper->sock_type == SOCK_STREAM) && transport_mapper_inet->tls_context))
-    log_writer_set_flags(writer, log_writer_get_flags(writer) & ~LW_DETECT_EOF);
+    _disable_connection_closure_on_input(writer);
 
   return writer;
 }

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -656,7 +656,12 @@ static LogWriter *
 afinet_dd_syslog_construct_writer(AFSocketDestDriver *s)
 {
   AFInetDestDriver *self = (AFInetDestDriver *) s;
+  TransportMapperInet *transport_mapper_inet = ((TransportMapperInet *) (self->super.transport_mapper));
+
   LogWriter *writer = afsocket_dd_construct_writer_method(s);
+
+  if (((self->super.transport_mapper->sock_type == SOCK_STREAM) && transport_mapper_inet->tls_context))
+    _disable_connection_closure_on_input(writer);
 
   log_writer_set_flags(writer, log_writer_get_flags(writer) | LW_SYSLOG_PROTOCOL);
   return writer;


### PR DESCRIPTION
`LW_DETECT_EOF` closes the connection when input is received from a destination socket.
This is only acceptable for one-way protocols. TLS is duplex, so it has to be disabled both in TLS-based streaming and RFC 6587-framed protocols.

I've also fixed an incorrect RFC reference in logproto.
RFC 5428 is about SNMP, I think RFC 6587 is what we've actually implemented (`syslog()`).

https://tools.ietf.org/html/rfc5428
https://tools.ietf.org/html/rfc6587

Fixes #2328