### PR TITLE
mainloop-worker-io: possible refcount leak during reload/shutdown

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -214,10 +214,8 @@ log_reader_io_process_input(gpointer s)
        */
       if (!main_loop_worker_job_quit())
         {
-          log_pipe_ref(s);
           log_reader_work_perform(s);
           log_reader_work_finished(s);
-          log_pipe_unref(s);
         }
     }
 }

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -197,9 +197,9 @@ log_reader_io_process_input(gpointer s)
   LogReader *self = (LogReader *) s;
 
   log_reader_stop_watches(self);
-  log_pipe_ref(&self->super.super);
   if ((self->options->flags & LR_THREADED))
     {
+      log_pipe_ref(&self->super.super);
       main_loop_io_worker_job_submit(&self->io_job);
     }
   else
@@ -214,6 +214,7 @@ log_reader_io_process_input(gpointer s)
        */
       if (!main_loop_worker_job_quit())
         {
+          log_pipe_ref(s);
           log_reader_work_perform(s);
           log_reader_work_finished(s);
           log_pipe_unref(s);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -199,7 +199,6 @@ log_reader_io_process_input(gpointer s)
   log_reader_stop_watches(self);
   if ((self->options->flags & LR_THREADED))
     {
-      log_pipe_ref(&self->super.super);
       main_loop_io_worker_job_submit(&self->io_job);
     }
   else
@@ -243,6 +242,7 @@ log_reader_init_watches(LogReader *self)
   self->io_job.user_data = self;
   self->io_job.work = (void (*)(void *)) log_reader_work_perform;
   self->io_job.completion = (void (*)(void *)) log_reader_work_finished;
+  self->io_job.engage = (void (*)(void *)) log_pipe_ref;
   self->io_job.release = (void (*)(void *)) log_pipe_unref;
 }
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -143,7 +143,6 @@ log_reader_work_finished(void *s)
       log_proto_server_reset_error(self->proto);
       log_reader_update_watches(self);
     }
-  log_pipe_unref(&self->super.super);
 }
 
 static void
@@ -217,6 +216,7 @@ log_reader_io_process_input(gpointer s)
         {
           log_reader_work_perform(s);
           log_reader_work_finished(s);
+          log_pipe_unref(s);
         }
     }
 }
@@ -244,6 +244,7 @@ log_reader_init_watches(LogReader *self)
   self->io_job.user_data = self;
   self->io_job.work = (void (*)(void *)) log_reader_work_perform;
   self->io_job.completion = (void (*)(void *)) log_reader_work_finished;
+  self->io_job.release = (void (*)(void *)) log_pipe_unref;
 }
 
 static void

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -262,10 +262,8 @@ log_writer_io_flush_output(gpointer s)
 
       if (!main_loop_worker_job_quit())
         {
-          log_pipe_ref(s);
           log_writer_work_perform(s);
           log_writer_work_finished(s);
-          log_pipe_unref(s);
         }
     }
 }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -246,7 +246,6 @@ log_writer_io_flush_output(gpointer s)
   log_writer_stop_watches(self);
   if ((self->options->options & LWO_THREADED))
     {
-      log_pipe_ref(&self->super);
       main_loop_io_worker_job_submit(&self->io_job);
     }
   else
@@ -1327,6 +1326,7 @@ log_writer_init_watches(LogWriter *self)
   self->io_job.user_data = self;
   self->io_job.work = (void (*)(void *)) log_writer_work_perform;
   self->io_job.completion = (void (*)(void *)) log_writer_work_finished;
+  self->io_job.engage = (void (*)(void *)) log_pipe_ref;
   self->io_job.release = (void (*)(void *)) log_pipe_unref;
 }
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -244,9 +244,9 @@ log_writer_io_flush_output(gpointer s)
   main_loop_assert_main_thread();
 
   log_writer_stop_watches(self);
-  log_pipe_ref(&self->super);
   if ((self->options->options & LWO_THREADED))
     {
+      log_pipe_ref(&self->super);
       main_loop_io_worker_job_submit(&self->io_job);
     }
   else
@@ -262,6 +262,7 @@ log_writer_io_flush_output(gpointer s)
 
       if (!main_loop_worker_job_quit())
         {
+          log_pipe_ref(s);
           log_writer_work_perform(s);
           log_writer_work_finished(s);
           log_pipe_unref(s);

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -61,6 +61,8 @@ _complete(MainLoopIOWorkerJob *self)
   self->working = FALSE;
   self->completion(self->user_data);
   main_loop_worker_job_complete();
+  if (self->release)
+    self->release(self->user_data);
 }
 
 void

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -39,17 +39,22 @@ _release(MainLoopIOWorkerJob *self)
     self->release(self->user_data);
 }
 
+static void
+_engage(MainLoopIOWorkerJob *self)
+{
+  if (self->engage)
+    self->engage(self->user_data);
+}
+
 /* NOTE: runs in the main thread */
 void
 main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self)
 {
   g_assert(self->working == FALSE);
   if (main_loop_workers_quit)
-    {
-      _release(self);
-      return;
-    }
+    return;
 
+  _engage(self);
   main_loop_worker_job_start();
   self->working = TRUE;
   iv_work_pool_submit_work(&main_loop_io_workers, &self->work_item);

--- a/lib/mainloop-io-worker.h
+++ b/lib/mainloop-io-worker.h
@@ -32,6 +32,7 @@ typedef struct _MainLoopIOWorkerJob
 {
   void (*work)(gpointer user_data);
   void (*completion)(gpointer user_data);
+  void (*release)(gpointer user_data);
   gpointer user_data;
   gboolean working:1;
   struct iv_work_item work_item;

--- a/lib/mainloop-io-worker.h
+++ b/lib/mainloop-io-worker.h
@@ -30,6 +30,7 @@
 
 typedef struct _MainLoopIOWorkerJob
 {
+  void (*engage)(gpointer user_data);
   void (*work)(gpointer user_data);
   void (*completion)(gpointer user_data);
   void (*release)(gpointer user_data);

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -546,7 +546,6 @@ _io_process_input(gpointer s)
   _stop_watches(self);
   if ((self->options->flags & JR_THREADED))
     {
-      log_pipe_ref(&self->super.super);
       main_loop_io_worker_job_submit(&self->io_job);
     }
   else
@@ -676,6 +675,7 @@ _init_watches(JournalReader *self)
   self->io_job.user_data = self;
   self->io_job.work = (void (*)(void *)) _work_perform;
   self->io_job.completion = (void (*)(void *)) _work_finished;
+  self->io_job.engage = (void (*)(void *)) log_pipe_ref;
   self->io_job.release = (void (*)(void *)) log_pipe_unref;
 }
 

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -544,15 +544,16 @@ _io_process_input(gpointer s)
   JournalReader *self = (JournalReader *) s;
 
   _stop_watches(self);
-  log_pipe_ref(&self->super.super);
   if ((self->options->flags & JR_THREADED))
     {
+      log_pipe_ref(&self->super.super);
       main_loop_io_worker_job_submit(&self->io_job);
     }
   else
     {
       if (!main_loop_worker_job_quit())
         {
+          log_pipe_ref(s);
           _work_perform(s);
           _work_finished(s);
           log_pipe_unref(s);

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -516,7 +516,6 @@ _work_finished(gpointer s)
     {
       _update_watches(self);
     }
-  log_pipe_unref(&self->super.super);
 }
 
 static void
@@ -556,6 +555,7 @@ _io_process_input(gpointer s)
         {
           _work_perform(s);
           _work_finished(s);
+          log_pipe_unref(s);
         }
     }
 }
@@ -677,6 +677,7 @@ _init_watches(JournalReader *self)
   self->io_job.user_data = self;
   self->io_job.work = (void (*)(void *)) _work_perform;
   self->io_job.completion = (void (*)(void *)) _work_finished;
+  self->io_job.release = (void (*)(void *)) log_pipe_unref;
 }
 
 JournalReader *

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -553,10 +553,8 @@ _io_process_input(gpointer s)
     {
       if (!main_loop_worker_job_quit())
         {
-          log_pipe_ref(s);
           _work_perform(s);
           _work_finished(s);
-          log_pipe_unref(s);
         }
     }
 }


### PR DESCRIPTION
When reload/shutdown is triggered, syslog-ng waits for the ongoing jobs to finish. Specially, a MainLoopIOWorkerJob early returns without scheduling the ivykis task. The problem with the current implementation is that api users call `log_pipe_unref` in the `completion` callback, that is not called in this case, because the ivykis task is not scheduled at all.

To mitigate that, users can specify a destroy function that will be used to `unref` the user_data before returning. Practically the ownership of user_data is given to (shared between the pipe and) MainLoopIOWorkerJob.

Reproduction steps:

Starting the config below with -Fv (verbose is mandatory, must not use -e)

```
@version: 3.18
@include "scl.conf"

options{
    time-reap(5);
};

destination d_java {
  java( ... );
};

log {
  source { internal(); };
  destination { file("/tmp/tmp.txt"); };
};

log {
  destination(d_java);
};
```
after reload one can see syslog-ng leaked an fd related to /tmp/tmp.txt (check output of lsof -p ...). Java destination is not necessary for the condition to trigger, but for some reason such unused destination increased the condition frequency dramatically.