### PR TITLE
[WIP] Add some new pytest features

### DIFF
--- a/tests/pytest_framework/conftest.py
+++ b/tests/pytest_framework/conftest.py
@@ -29,7 +29,7 @@ from src.setup.unit_testcase import SetupUnitTestcase
 
 
 def pytest_addoption(parser):
-    parser.addoption("--runslow", action="store_true", help="Also run @slow tests.")
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
     parser.addoption(
         "--loglevel",
         action="store",
@@ -65,9 +65,13 @@ def loglevel(request):
     return request.config.getoption("--loglevel")
 
 
-@pytest.fixture
-def runslow(request):
-    return request.config.getoption("--runslow")
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 
 def get_relative_report_dir():

--- a/tests/pytest_framework/functional_tests/profiling/test_with_valgrind.py
+++ b/tests/pytest_framework/functional_tests/profiling/test_with_valgrind.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2018 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+import pytest
+
+
+def process_valgrind_log(valgrind_log_path):
+    with open(valgrind_log_path, "r") as valgrind_log:
+        valgrind_content = valgrind_log.read()
+        assert "Invalid read" not in valgrind_content
+        assert "Invalid write" not in valgrind_content
+
+
+@pytest.mark.slow
+def test_with_valgrind(tc):
+    config = tc.new_config()
+
+    file_source = config.create_file_source(file_name="input.log")
+    source_group = config.create_source_group(file_source)
+
+    file_destination = config.create_file_destination(file_name="output.log")
+    destination_group = config.create_destination_group(file_destination)
+
+    config.create_logpath(sources=source_group, destinations=destination_group)
+
+    bsd_message = tc.create_dummy_bsd_message()
+    bsd_log = tc.format_as_bsd(bsd_message)
+
+    syslog_ng = tc.new_syslog_ng()
+    syslog_ng.start(config, external_tool="valgrind")
+
+    for __counter in range(1, 5):
+        syslog_ng.reload(config)
+        file_source.write_log(bsd_log, counter=100)
+        syslog_ng.reload(config)
+
+    syslog_ng.stop()
+
+    valgrind_log_path = syslog_ng.get_instance_paths().get_valgrind_log_path()
+    process_valgrind_log(valgrind_log_path)

--- a/tests/pytest_framework/src/executors/process_executor.py
+++ b/tests/pytest_framework/src/executors/process_executor.py
@@ -43,3 +43,8 @@ class ProcessExecutor(object):
         )
         self.__logger.info("Process started with pid [{}]".format(self.process.pid))
         return self.process
+
+    def stop(self, signal):
+        self.process.send_signal(signal)
+        exit_code = self.process.process.wait(timeout=2)
+        return exit_code

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng.py
@@ -27,12 +27,13 @@ from src.syslog_ng.syslog_ng_cli import SyslogNgCli
 
 class SyslogNg(object):
     def __init__(self, logger_factory, instance_paths, syslog_ng_ctl):
+        self.instance_paths = instance_paths
         self.__syslog_ng_cli = SyslogNgCli(
             logger_factory, instance_paths, ConsoleLogReader(logger_factory, instance_paths), syslog_ng_ctl
         )
 
-    def start(self, config):
-        self.__syslog_ng_cli.start(config)
+    def start(self, config, external_tool=None):
+        self.__syslog_ng_cli.start(config, external_tool)
 
     def stop(self, unexpected_messages=None):
         self.__syslog_ng_cli.stop(unexpected_messages)
@@ -40,9 +41,12 @@ class SyslogNg(object):
     def reload(self, config):
         self.__syslog_ng_cli.reload(config)
 
-    def restart(self, config):
-        self.__syslog_ng_cli.start(config)
+    def restart(self, config, external_tool=None):
+        self.__syslog_ng_cli.start(config, external_tool)
         self.__syslog_ng_cli.stop()
 
     def get_version(self):
         return self.__syslog_ng_cli.get_version()
+
+    def get_instance_paths(self):
+        return self.instance_paths

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng.py
@@ -35,8 +35,8 @@ class SyslogNg(object):
     def start(self, config, external_tool=None):
         self.__syslog_ng_cli.start(config, external_tool)
 
-    def stop(self, unexpected_messages=None):
-        self.__syslog_ng_cli.stop(unexpected_messages)
+    def stop(self, unexpected_messages=None, signal=None):
+        self.__syslog_ng_cli.stop(unexpected_messages, signal)
 
     def reload(self, config):
         self.__syslog_ng_cli.reload(config)

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -94,12 +94,15 @@ class SyslogNgCli(object):
             raise Exception("Reload message not arrived")
         self.__logger.info("End of syslog-ng reload")
 
-    def stop(self, unexpected_messages=None):
+    def stop(self, unexpected_messages=None, signal=None):
         self.__logger.info("Beginning of syslog-ng stop")
         if self.__process and not self.__core_file_exist:
 
             # effective stop
-            result = self.__syslog_ng_ctl.stop()
+            if signal:
+                result = self.__syslog_ng_executor.stop_process_with_signal(signal)
+            else:
+                result = self.__syslog_ng_ctl.stop()
 
             # wait for stop and check stop result
             if result["exit_code"] != 0:

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -53,7 +53,7 @@ class SyslogNgCli(object):
         )
 
     # Process commands
-    def start(self, config):
+    def start(self, config, external_tool):
         self.__logger.info("Beginning of syslog-ng start")
         config.write_config_content()
 
@@ -64,7 +64,10 @@ class SyslogNgCli(object):
             raise Exception("syslog-ng can not started")
 
         # effective start
-        self.__process = self.__syslog_ng_executor.run_process()
+        if external_tool:
+            self.__process = self.__syslog_ng_executor.run_process_behind(external_tool=external_tool)
+        else:
+            self.__process = self.__syslog_ng_executor.run_process()
 
         # wait for start and check start result
         if not self.__syslog_ng_ctl.wait_for_control_socket_alive():

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
@@ -45,6 +45,22 @@ class SyslogNgExecutor(object):
             stderr_path=self.__instance_paths.get_stderr_path_with_postfix(postfix=command_short_name),
         )
 
+    def get_backtrace_from_core(self, core_file):
+        gdb_command_args = [
+            "gdb",
+            "-ex",
+            "bt full",
+            "--batch",
+            self.__instance_paths.get_syslog_ng_bin(),
+            "--core",
+            core_file,
+        ]
+        return self.__command_executor.run(
+            command=gdb_command_args,
+            stdout_path=self.__instance_paths.get_stdout_path_with_postfix(postfix="gdb_core"),
+            stderr_path=self.__instance_paths.get_stderr_path_with_postfix(postfix="gdb_core"),
+        )
+
     def __construct_syslog_ng_process(
         self,
         stderr=True,

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
@@ -63,6 +63,9 @@ class SyslogNgExecutor(object):
             stderr_path=self.__instance_paths.get_stderr_path(),
         )
 
+    def stop_process_with_signal(self, signal):
+        return self.__process_executor.stop(signal)
+
     def run_process_behind(self, external_tool):
         return self.__process_executor.start(
             command=self.__construct_syslog_ng_process_behind_external_tool(external_tool),

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_paths.py
@@ -50,6 +50,9 @@ class SyslogNgPaths(object):
                 "control_socket_path": Path(relative_working_dir, "syslog_ng_{}.ctl".format(instance_name)),
                 "stderr": Path(working_dir, "syslog_ng_{}_stderr".format(instance_name)),
                 "stdout": Path(working_dir, "syslog_ng_{}_stdout".format(instance_name)),
+                "valgrind": Path(working_dir, "valgrind.log"),
+                "perf": Path(working_dir, "perf.log"),
+                "strace": Path(working_dir, "strace.log"),
             },
             "binary_file_paths": {
                 "syslog_ng_binary": Path(install_dir, "sbin", "syslog-ng"),
@@ -96,3 +99,12 @@ class SyslogNgPaths(object):
 
     def get_syslog_ng_ctl_bin(self):
         return self.__syslog_ng_paths["binary_file_paths"]["syslog_ng_ctl"]
+
+    def get_strace_log_path(self):
+        return self.__syslog_ng_paths["file_paths"]["strace"]
+
+    def get_perf_log_path(self):
+        return self.__syslog_ng_paths["file_paths"]["perf"]
+
+    def get_valgrind_log_path(self):
+        return self.__syslog_ng_paths["file_paths"]["valgrind"]

--- a/tests/pytest_framework/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/pytest_framework/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -38,6 +38,9 @@ def test_syslog_ng_paths(tc_unittest):
         "control_socket_path",
         "stderr",
         "stdout",
+        "valgrind",
+        "perf",
+        "strace",
     }
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["binary_file_paths"])) == {
         "syslog_ng_binary",

--- a/tests/pytest_framework/src/syslog_ng_config/renderer.py
+++ b/tests/pytest_framework/src/syslog_ng_config/renderer.py
@@ -41,6 +41,8 @@ class ConfigRenderer(object):
             self.__render_version()
         if self.__syslog_ng_config["sources"]:
             self.__render_statements(root_statement="sources", statement_name="source")
+        if self.__syslog_ng_config["filters"]:
+            self.__render_statements(root_statement="filters", statement_name="filter")
         if self.__syslog_ng_config["destinations"]:
             self.__render_statements(root_statement="destinations", statement_name="destination")
         if self.__syslog_ng_config["logpaths"]:
@@ -87,6 +89,8 @@ class ConfigRenderer(object):
             self.__syslog_ng_config_content += "\nlog {\n"
             for src_driver in self.__syslog_ng_config["logpaths"][logpath]["sources"]:
                 self.__syslog_ng_config_content += "    source({});\n".format(src_driver)
+            for filter in self.__syslog_ng_config["logpaths"][logpath]["filters"]:
+                self.__syslog_ng_config_content += "    filter({});\n".format(filter)
             for dst_driver in self.__syslog_ng_config["logpaths"][logpath]["destinations"]:
                 self.__syslog_ng_config_content += "    destination({});\n".format(dst_driver)
             for flags in self.__syslog_ng_config["logpaths"][logpath]["flags"]:

--- a/tests/pytest_framework/src/syslog_ng_config/renderer.py
+++ b/tests/pytest_framework/src/syslog_ng_config/renderer.py
@@ -46,7 +46,7 @@ class ConfigRenderer(object):
         if self.__syslog_ng_config["destinations"]:
             self.__render_statements(root_statement="destinations", statement_name="destination")
         if self.__syslog_ng_config["logpaths"]:
-            self.__render_logpath()
+            self.__render_logpath(self.__syslog_ng_config["logpaths"])
 
     def __render_version(self):
         self.__syslog_ng_config_content += "@version: {}\n".format(self.__syslog_ng_config["version"])
@@ -84,15 +84,20 @@ class ConfigRenderer(object):
             # statement footer
             self.__syslog_ng_config_content += "};\n"
 
-    def __render_logpath(self):
-        for logpath in self.__syslog_ng_config["logpaths"]:
+    def __render_logpath(self, logpath_node):
+        for logpath_id in logpath_node:
+
             self.__syslog_ng_config_content += "\nlog {\n"
-            for src_driver in self.__syslog_ng_config["logpaths"][logpath]["sources"]:
+            for src_driver in logpath_node[logpath_id]["sources"]:
                 self.__syslog_ng_config_content += "    source({});\n".format(src_driver)
-            for filter in self.__syslog_ng_config["logpaths"][logpath]["filters"]:
+            for filter in logpath_node[logpath_id]["filters"]:
                 self.__syslog_ng_config_content += "    filter({});\n".format(filter)
-            for dst_driver in self.__syslog_ng_config["logpaths"][logpath]["destinations"]:
+            for dst_driver in logpath_node[logpath_id]["destinations"]:
                 self.__syslog_ng_config_content += "    destination({});\n".format(dst_driver)
-            for flags in self.__syslog_ng_config["logpaths"][logpath]["flags"]:
+
+            if len(logpath_node[logpath_id]["logpaths"]) > 0:
+                self.__render_logpath(logpath_node=logpath_node[logpath_id]["logpaths"])
+
+            for flags in logpath_node[logpath_id]["flags"]:
                 self.__syslog_ng_config_content += "    flags({});\n".format(flags)
             self.__syslog_ng_config_content += "};\n"

--- a/tests/pytest_framework/src/syslog_ng_config/renderer.py
+++ b/tests/pytest_framework/src/syslog_ng_config/renderer.py
@@ -89,4 +89,6 @@ class ConfigRenderer(object):
                 self.__syslog_ng_config_content += "    source({});\n".format(src_driver)
             for dst_driver in self.__syslog_ng_config["logpaths"][logpath]["destinations"]:
                 self.__syslog_ng_config_content += "    destination({});\n".format(dst_driver)
+            for flags in self.__syslog_ng_config["logpaths"][logpath]["flags"]:
+                self.__syslog_ng_config_content += "    flags({});\n".format(flags)
             self.__syslog_ng_config_content += "};\n"

--- a/tests/pytest_framework/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -35,11 +35,12 @@ class DestinationDriver(object):
     def dd_read_logs(self, path, counter):
         if path not in self.__native_driver_io_collection.keys():
             native_driver_io = self.__native_driver_io_ref(self.__logger_factory, path)
-            self.__native_driver_io_collection.update({path: native_driver_io})
             native_driver_io.wait_for_creation()
             message_reader = MessageReader(
                 self.__logger_factory, native_driver_io.read, SingleLineParser(self.__logger_factory)
             )
+            self.__native_driver_io_collection.update({path: message_reader})
+        message_reader = self.__native_driver_io_collection[path]
         messages = message_reader.pop_messages(counter)
         self.__logger.print_io_content(path, messages, "Content has been read from")
         return messages

--- a/tests/pytest_framework/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/filters/filter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2018 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+from src.common.random_id import RandomId
+
+
+class Filter:
+    def __init__(self, logger_factory, instance_paths, **kwargs):
+        self.options = kwargs
+
+        self.driver_id = "driverid_%s" % RandomId(use_static_seed=False).get_unique_id()
+        self.__driver_content = {"driver_name": "", "positional_option": "", "driver_options": self.options}
+        self.__driver_node = {self.driver_id: self.__driver_content}
+
+    def get_driver_node(self):
+        return self.__driver_node

--- a/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
@@ -27,7 +27,9 @@ from src.common.random_id import RandomId
 class LogPath(object):
     def __init__(self):
         self.logpath_id = "logpath_%s" % RandomId(use_static_seed=False).get_unique_id()
-        self.full_logpath_node = {self.logpath_id: {"sources": [], "filters": [], "destinations": [], "flags": []}}
+        self.full_logpath_node = {
+            self.logpath_id: {"sources": [], "filters": [], "destinations": [], "logpaths": {}, "flags": []}
+        }
         self.logpath_node = self.full_logpath_node[self.logpath_id]
 
     def add_source_groups(self, source_groups):
@@ -41,6 +43,10 @@ class LogPath(object):
     def add_destination_groups(self, destination_groups):
         target_node = self.logpath_node["destinations"]
         self.update_logpath_node(target_node, destination_groups)
+
+    def add_logpaths(self, logpaths):
+        target_node = self.logpath_node["logpaths"]
+        target_node.update(logpaths.full_logpath_node)
 
     def add_flags(self, flags):
         target_node = self.logpath_node["flags"]

--- a/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
@@ -27,7 +27,7 @@ from src.common.random_id import RandomId
 class LogPath(object):
     def __init__(self):
         self.logpath_id = "logpath_%s" % RandomId(use_static_seed=False).get_unique_id()
-        self.full_logpath_node = {self.logpath_id: {"sources": [], "destinations": []}}
+        self.full_logpath_node = {self.logpath_id: {"sources": [], "destinations": [], "flags": []}}
         self.logpath_node = self.full_logpath_node[self.logpath_id]
 
     def add_source_groups(self, source_groups):
@@ -37,6 +37,10 @@ class LogPath(object):
     def add_destination_groups(self, destination_groups):
         target_node = self.logpath_node["destinations"]
         self.update_logpath_node(target_node, destination_groups)
+
+    def add_flags(self, flags):
+        target_node = self.logpath_node["flags"]
+        target_node.append(flags)
 
     @staticmethod
     def update_logpath_node(target_node, config_groups):

--- a/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
@@ -27,12 +27,16 @@ from src.common.random_id import RandomId
 class LogPath(object):
     def __init__(self):
         self.logpath_id = "logpath_%s" % RandomId(use_static_seed=False).get_unique_id()
-        self.full_logpath_node = {self.logpath_id: {"sources": [], "destinations": [], "flags": []}}
+        self.full_logpath_node = {self.logpath_id: {"sources": [], "filters": [], "destinations": [], "flags": []}}
         self.logpath_node = self.full_logpath_node[self.logpath_id]
 
     def add_source_groups(self, source_groups):
         target_node = self.logpath_node["sources"]
         self.update_logpath_node(target_node, source_groups)
+
+    def add_filter_groups(self, filter_groups):
+        target_node = self.logpath_node["filters"]
+        self.update_logpath_node(target_node, filter_groups)
 
     def add_destination_groups(self, destination_groups):
         target_node = self.logpath_node["destinations"]

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -65,9 +65,13 @@ class SyslogNgConfig(object):
         self.__syslog_ng_config["destinations"].update(config_group.full_group_node)
         return config_group
 
-    def create_logpath(self, sources, destinations):
+    def create_logpath(self, sources=None, destinations=None, flags=None):
         logpath = LogPath()
-        logpath.add_source_groups(sources)
-        logpath.add_destination_groups(destinations)
+        if sources:
+            logpath.add_source_groups(sources)
+        if destinations:
+            logpath.add_destination_groups(destinations)
+        if flags:
+            logpath.add_flags(flags)
         self.__syslog_ng_config["logpaths"].update(logpath.full_logpath_node)
         return logpath

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -81,7 +81,7 @@ class SyslogNgConfig(object):
         self.__syslog_ng_config["filters"].update(config_group.full_group_node)
         return config_group
 
-    def create_logpath(self, sources=None, filters=None, destinations=None, flags=None):
+    def create_logpath(self, sources=None, filters=None, destinations=None, logpaths=None, flags=None):
         logpath = LogPath()
         if sources:
             logpath.add_source_groups(sources)
@@ -89,7 +89,23 @@ class SyslogNgConfig(object):
             logpath.add_filter_groups(filters)
         if destinations:
             logpath.add_destination_groups(destinations)
+        if logpaths:
+            logpath.add_logpaths(logpaths)
         if flags:
             logpath.add_flags(flags)
         self.__syslog_ng_config["logpaths"].update(logpath.full_logpath_node)
+        return logpath
+
+    def create_inner_logpath(self, sources=None, filters=None, destinations=None, logpaths=None, flags=None):
+        logpath = LogPath()
+        if sources:
+            logpath.add_source_groups(sources)
+        if filters:
+            logpath.add_filter_groups(filters)
+        if destinations:
+            logpath.add_destination_groups(destinations)
+        if logpaths:
+            logpath.add_logpaths(logpaths)
+        if flags:
+            logpath.add_flags(flags)
         return logpath


### PR DESCRIPTION
This PR allows to do the followings in pytest fw:

syslog-ng config related
- Support log { flags(...)} from config
- Support filters {...} from config
- Support embedded log statements in config

syslog-ng cli related
- if syslog-ng crashed and core file was generated detect and save core files with backtrace
- Allow to stop syslog-ng with signal
- Support to run syslog-ng behind external tools: strace, perf, valgrind

some bugfixes
- bugfix: Save message_reader between readings
- bugfix: Fix running tests with marked 'slow'
