### PR TITLE
PytestPART3: SyslogNgCli updates

### DIFF
--- a/tests/pytest_framework/conftest.py
+++ b/tests/pytest_framework/conftest.py
@@ -30,6 +30,7 @@ from src.setup.unit_testcase import SetupUnitTestcase
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--run-with-valgrind", action="store_true", default=False, help="Run tests behind valgrind")
     parser.addoption(
         "--loglevel",
         action="store",
@@ -72,6 +73,11 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+@pytest.fixture
+def runwithvalgrind(request):
+    return request.config.getoption("--run-with-valgrind")
 
 
 def get_relative_report_dir():

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -27,7 +27,7 @@ from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
 from src.logger.logger_factory import LoggerFactory
 from src.syslog_ng_config.syslog_ng_config import SyslogNgConfig
 from src.syslog_ng.syslog_ng import SyslogNg
-from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
+from src.syslog_ng.syslog_ng_cli import SyslogNgCli
 from src.message_builder.bsd_format import BSDFormat
 from src.message_builder.log_message import LogMessage
 
@@ -83,11 +83,10 @@ class SetupTestCase(object):
         instance_paths = SyslogNgPaths(self.__testcase_context, self.__testcase_parameters).set_syslog_ng_paths(
             instance_name
         )
-        syslog_ng_ctl = SyslogNgCtl(self.__logger_factory, instance_paths)
-        syslog_ng = SyslogNg(self.__logger_factory, instance_paths, syslog_ng_ctl)
+        syslog_ng_cli = SyslogNgCli(self.__logger_factory, instance_paths)
+        syslog_ng = SyslogNg(syslog_ng_cli)
         self.__teardown_actions.append(syslog_ng.stop)
         self.__instances.update({instance_name: {}})
-        self.__instances[instance_name]["ctl"] = syslog_ng_ctl
         self.__instances[instance_name]["syslog-ng"] = syslog_ng
         self.__instances[instance_name]["config"] = SyslogNgConfig(
             self.__logger_factory, instance_paths, syslog_ng.get_version()
@@ -102,11 +101,6 @@ class SetupTestCase(object):
         if not self.__is_instance_registered(instance_name):
             self.__register_instance(instance_name)
         return self.__instances[instance_name]["syslog-ng"]
-
-    def new_syslog_ng_ctl(self, instance_name="server"):
-        if not self.__is_instance_registered(instance_name):
-            self.__register_instance(instance_name)
-        return self.__instances[instance_name]["ctl"]
 
     @staticmethod
     def format_as_bsd(log_message):

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -83,7 +83,7 @@ class SetupTestCase(object):
         instance_paths = SyslogNgPaths(self.__testcase_context, self.__testcase_parameters).set_syslog_ng_paths(
             instance_name
         )
-        syslog_ng_cli = SyslogNgCli(self.__logger_factory, instance_paths)
+        syslog_ng_cli = SyslogNgCli(self.__logger_factory, instance_paths, self.__testcase_parameters)
         syslog_ng = SyslogNg(syslog_ng_cli)
         self.__teardown_actions.append(syslog_ng.stop)
         self.__instances.update({instance_name: {}})

--- a/tests/pytest_framework/src/setup/testcase_parameters.py
+++ b/tests/pytest_framework/src/setup/testcase_parameters.py
@@ -52,6 +52,7 @@ class TestcaseParameters(object):
             },
             "testcase_name": testcase_name,
             "loglevel": testcase_context.getfixturevalue("loglevel"),
+            "valgrind_usage": testcase_context.getfixturevalue("runwithvalgrind"),
         }
 
     def get_working_dir(self):
@@ -71,3 +72,6 @@ class TestcaseParameters(object):
 
     def get_loglevel(self):
         return self.testcase_parameters["loglevel"]
+
+    def get_valgrind_usage(self):
+        return self.testcase_parameters["valgrind_usage"]

--- a/tests/pytest_framework/src/setup/tests/test_testcase_parameters.py
+++ b/tests/pytest_framework/src/setup/tests/test_testcase_parameters.py
@@ -27,7 +27,7 @@ from src.setup.testcase_parameters import TestcaseParameters
 
 def test_testcase_parameters(request):
     testcase_parameters = TestcaseParameters(request).testcase_parameters
-    assert set(list(testcase_parameters)) == {"testcase_name", "dirs", "file_paths", "loglevel"}
+    assert set(list(testcase_parameters)) == {"testcase_name", "dirs", "file_paths", "loglevel", "valgrind_usage"}
     assert set(list(testcase_parameters["dirs"])) == {"working_dir", "relative_working_dir"}
     assert set(list(testcase_parameters["file_paths"])) == {"report_file", "testcase_file"}
 

--- a/tests/pytest_framework/src/setup/unit_testcase.py
+++ b/tests/pytest_framework/src/setup/unit_testcase.py
@@ -59,6 +59,7 @@ class SetupUnitTestcase(object):
         when(self.testcase_context).getfixturevalue("installdir").thenReturn(self.get_temp_dir())
         when(self.testcase_context).getfixturevalue("reports").thenReturn(self.get_temp_dir())
         when(self.testcase_context).getfixturevalue("loglevel").thenReturn("info")
+        when(self.testcase_context).getfixturevalue("runwithvalgrind").thenReturn(False)
         return TestcaseParameters(self.testcase_context)
 
     def get_fake_logger_factory(self):

--- a/tests/pytest_framework/src/syslog_ng/console_log_reader.py
+++ b/tests/pytest_framework/src/syslog_ng/console_log_reader.py
@@ -74,3 +74,10 @@ class ConsoleLogReader(object):
     def dump_stderr(self, last_n_lines=10):
         console_log_messages = self.__message_reader.peek_messages(counter=0)
         self.__logger.info("".join(console_log_messages[-last_n_lines:]))
+
+    @staticmethod
+    def handle_valgrind_log(valgrind_log_path):
+        with open(valgrind_log_path, "r") as valgrind_log:
+            valgrind_content = valgrind_log.read()
+            assert "Invalid read" not in valgrind_content
+            assert "Invalid write" not in valgrind_content

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng.py
@@ -21,15 +21,10 @@
 #
 #############################################################################
 
-from src.syslog_ng.console_log_reader import ConsoleLogReader
-from src.syslog_ng.syslog_ng_cli import SyslogNgCli
-
 
 class SyslogNg(object):
-    def __init__(self, logger_factory, instance_paths, syslog_ng_ctl):
-        self.__syslog_ng_cli = SyslogNgCli(
-            logger_factory, instance_paths, ConsoleLogReader(logger_factory, instance_paths), syslog_ng_ctl
-        )
+    def __init__(self, syslog_ng_cli):
+        self.__syslog_ng_cli = syslog_ng_cli
 
     def start(self, config):
         self.__syslog_ng_cli.start(config)

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -23,15 +23,16 @@
 
 from pathlib2 import Path
 from src.syslog_ng.syslog_ng_executor import SyslogNgExecutor
-
+from src.syslog_ng.console_log_reader import ConsoleLogReader
+from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
 
 class SyslogNgCli(object):
-    def __init__(self, logger_factory, instance_paths, console_log_reader, syslog_ng_ctl):
+    def __init__(self, logger_factory, instance_paths):
         self.__instance_paths = instance_paths
-        self.__console_log_reader = console_log_reader
+        self.__console_log_reader = ConsoleLogReader(logger_factory, instance_paths)
         self.__logger = logger_factory.create_logger("SyslogNgCli")
         self.__syslog_ng_executor = SyslogNgExecutor(logger_factory, instance_paths)
-        self.__syslog_ng_ctl = syslog_ng_ctl
+        self.__syslog_ng_ctl = SyslogNgCtl(logger_factory, instance_paths)
         self.__process = None
 
     # Application commands

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
@@ -23,6 +23,7 @@
 
 from src.executors.command_executor import CommandExecutor
 from src.executors.process_executor import ProcessExecutor
+from src.common.random_id import RandomId
 
 
 class SyslogNgExecutor(object):
@@ -43,6 +44,23 @@ class SyslogNgExecutor(object):
             command=self.__construct_syslog_ng_command(command),
             stdout_path=self.__instance_paths.get_stdout_path_with_postfix(postfix=command_short_name),
             stderr_path=self.__instance_paths.get_stderr_path_with_postfix(postfix=command_short_name),
+        )
+
+    def get_backtrace_from_core(self, core_file):
+        gdb_command_args = [
+            "gdb",
+            "-ex",
+            "bt full",
+            "--batch",
+            self.__instance_paths.get_syslog_ng_bin(),
+            "--core",
+            core_file,
+        ]
+        core_postfix = "gdb_core_{}".format(RandomId(use_static_seed=False).get_unique_id())
+        return self.__command_executor.run(
+            command=gdb_command_args,
+            stdout_path=self.__instance_paths.get_stdout_path_with_postfix(postfix=core_postfix),
+            stderr_path=self.__instance_paths.get_stderr_path_with_postfix(postfix=core_postfix),
         )
 
     def __construct_syslog_ng_process(

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_executor.py
@@ -39,6 +39,27 @@ class SyslogNgExecutor(object):
             stderr_path=self.__instance_paths.get_stderr_path(),
         )
 
+    def run_process_with_valgrind(self):
+        valgrind_command_args = [
+            "valgrind",
+            "--show-leak-kinds=all",
+            "--track-origins=yes",
+            "--tool=memcheck",
+            "--leak-check=full",
+            "--keep-stacktraces=alloc-and-free",
+            "--read-var-info=yes",
+            "--error-limit=no",
+            "--num-callers=40",
+            "--verbose",
+            "--log-file={}".format(self.__instance_paths.get_valgrind_log_path()),
+        ]
+        full_command_args = valgrind_command_args + self.__construct_syslog_ng_process()
+        return self.__process_executor.start(
+            command=full_command_args,
+            stdout_path=self.__instance_paths.get_stdout_path(),
+            stderr_path=self.__instance_paths.get_stderr_path(),
+        )
+
     def run_command(self, command_short_name, command):
         return self.__command_executor.run(
             command=self.__construct_syslog_ng_command(command),

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_paths.py
@@ -22,6 +22,7 @@
 #############################################################################
 
 from pathlib2 import Path
+from src.common.random_id import RandomId
 
 
 class SyslogNgPaths(object):
@@ -50,6 +51,9 @@ class SyslogNgPaths(object):
                 "control_socket_path": Path(relative_working_dir, "syslog_ng_{}.ctl".format(instance_name)),
                 "stderr": Path(working_dir, "syslog_ng_{}_stderr".format(instance_name)),
                 "stdout": Path(working_dir, "syslog_ng_{}_stdout".format(instance_name)),
+                "valgrind": Path(
+                    working_dir, "valgrind_{}.log".format(RandomId(use_static_seed=False).get_unique_id())
+                ),
             },
             "binary_file_paths": {
                 "syslog_ng_binary": Path(install_dir, "sbin", "syslog-ng"),
@@ -96,3 +100,6 @@ class SyslogNgPaths(object):
 
     def get_syslog_ng_ctl_bin(self):
         return self.__syslog_ng_paths["binary_file_paths"]["syslog_ng_ctl"]
+
+    def get_valgrind_log_path(self):
+        return self.__syslog_ng_paths["file_paths"]["valgrind"]

--- a/tests/pytest_framework/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/pytest_framework/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -38,6 +38,7 @@ def test_syslog_ng_paths(tc_unittest):
         "control_socket_path",
         "stderr",
         "stdout",
+        "valgrind",
     }
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["binary_file_paths"])) == {
         "syslog_ng_binary",


### PR DESCRIPTION
This patch set extends SyslogNgCli with core file detection and with --run-with-valgrind fixture.
The --run-with-valgrind fixture enables to run syslog-ng in any functional test behind valgrind. 
In this case on syslog-ng stop in handle_valgrind_log() we can assert on any unexpected behaviour (invalid read).
