### PR TITLE
fix include guard in systemd-journal

### DIFF
--- a/modules/systemd-journal/systemd-journal-parser.h
+++ b/modules/systemd-journal/systemd-journal-parser.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef AFPROG_PARSER_H_INCLUDED
-#define AFPROG_PARSER_H_INCLUDED
+#ifndef SYSTEMD_JOURNAL_PARSER_H_INCLUDED
+#define SYSTEMD_JOURNAL_PARSER_H_INCLUDED
 
 #include "cfg-parser.h"
 #include "driver.h"


### PR DESCRIPTION
replaced AFPROG_PARSER_H_INCLUDED by SYSTEMD_JOURNAL_PARSER_H_INCLUDED