### PR TITLE
cfg-parser: printing error positions in case of parse failure

### DIFF
--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -334,7 +334,11 @@ report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const ch
         }
       else
         {
-          fprintf(stderr, "Included from %s:\n", from->name);
+          fprintf(stderr, "Included from %s:%d:%d-%d:%d:\n", from->name,
+                  from->lloc.first_line,
+                  from->lloc.first_column,
+                  from->lloc.last_line,
+                  from->lloc.last_column);
         }
       if (from->include_type == CFGI_FILE)
         {

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -323,10 +323,14 @@ report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const ch
     {
       if (from == level)
         {
-          fprintf(stderr, "Error parsing %s, %s in %s:\n",
+          fprintf(stderr, "Error parsing %s, %s in %s:%d:%d-%d:%d:\n",
                   what,
                   msg,
-                  yylloc->level->name);
+                  from->lloc.level->name,
+                  from->lloc.first_line,
+                  from->lloc.first_column,
+                  from->lloc.last_line,
+                  from->lloc.last_column);
         }
       else
         {


### PR DESCRIPTION
I would like to write a [flycheck](https://www.flycheck.org/en/latest/) module for syntax checking syslog-ng configuration. For that, I need to find the offending line along with the error message from the output of syslog-ng -s.

The current syntax check printout looks awesome and helps users visually detect the problem quickly. But to find the problem algorithmically it is a little challenging because the error position does not occur explicitely, only implicitely (for example: to find first line number, one needs to look for an arrow). 
```
Error parsing log statement, syntax error, unexpected KW_DESTINATION, expecting ';' in ../etc/tmp.conf:
1       @version: 3.18
2       
3       log {
4         source { stdin(flags(no-parse)); };
5         parser {}
6----->   destination { file(/dev/stdout template('$(list-nth $LEVEL_NUM "a,b,c,d")')); };
6----->   ^^^^^^^^^^^
7       };
```

This patch adds the positional parameters to the end of the error reporting line, so that a script could parse it more easily.

Example:
```
Error parsing log statement, syntax error, unexpected KW_DESTINATION, expecting ';' in ../etc/tmp.conf:6:3-6:14:
```