### PR TITLE
[WIP] Throttle: Change throttling to limit batches sent, not log lines sent

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1192,7 +1192,7 @@ threaded_dest_driver_option
           log_threaded_dest_driver_set_max_retries(last_driver, $3);
         }
         | KW_BATCH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_lines(last_driver, $3); }
-        | KW_BATCH_TIMEOUT '(' positive_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
+        | KW_BATCH_TIMEOUT '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
         | dest_driver_option
         ;
 

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -254,7 +254,7 @@ log_dest_driver_acquire_queue_method(LogDestDriver *self, const gchar *persist_n
   if (!queue)
     {
       queue = log_queue_fifo_new(self->log_fifo_size < 0 ? cfg->log_fifo_size : self->log_fifo_size, persist_name);
-      log_queue_set_throttle(queue, self->throttle);
+      log_queue_set_throttle(queue, self->throttle, self->logs_per_throttle_bucket);
     }
   return queue;
 }
@@ -365,6 +365,7 @@ log_dest_driver_init_instance(LogDestDriver *self, GlobalConfig *cfg)
   self->release_queue = log_dest_driver_release_queue_method;
   self->log_fifo_size = -1;
   self->throttle = 0;
+  self->logs_per_throttle_bucket = 1;
 }
 
 void

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -167,6 +167,7 @@ struct _LogDestDriver
 
   gint log_fifo_size;
   gint throttle;
+  gint logs_per_throttle_bucket;
   StatsCounterItem *queued_global_messages;
 };
 

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -190,7 +190,8 @@ log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc para
            * rounded to zero when only a minimal interval passes between
            * poll iterations.
            */
-          self->throttle_buckets = MIN(self->throttle, self->throttle_buckets + new_buckets);
+          self->throttle_buckets = MIN(self->throttle, self->throttle_buckets + new_buckets)
+                                   * self->logs_per_throttle_bucket;
           self->last_throttle_check = now;
         }
       if (num_elements && self->throttle_buckets == 0)

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -44,6 +44,7 @@ struct _LogQueue
 
   gint throttle;
   gint throttle_buckets;
+  gint logs_per_throttle_bucket;
   GTimeVal last_throttle_check;
 
   gchar *persist_name;
@@ -187,10 +188,11 @@ log_queue_unref(LogQueue *self)
 }
 
 static inline void
-log_queue_set_throttle(LogQueue *self, gint throttle)
+log_queue_set_throttle(LogQueue *self, gint throttle, gint logs_per_throttle_bucket)
 {
   self->throttle = throttle;
-  self->throttle_buckets = throttle;
+  self->throttle_buckets = throttle * logs_per_throttle_bucket;
+  self->logs_per_throttle_bucket = logs_per_throttle_bucket;
 }
 
 static inline void

--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -39,6 +39,7 @@ log_threaded_dest_driver_set_batch_lines(LogDriver *s, gint batch_lines)
   LogThreadedDestDriver *self = (LogThreadedDestDriver *) s;
 
   self->batch_lines = batch_lines;
+  self->super.logs_per_throttle_bucket = batch_lines;
 }
 
 void

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -594,7 +594,7 @@ Test(logthrdestdrv,
 Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_called_more_often)
 {
   /* 3 messages per second, we need to set this explicitly on the queue as it has already been initialized */
-  log_queue_set_throttle(dd->super.worker.instance.queue, 3);
+  log_queue_set_throttle(dd->super.worker.instance.queue, 3, 1);
   dd->super.worker.insert = _insert_batched_message_success;
   dd->super.worker.flush = _flush_batched_message_success;
   dd->super.batch_lines = 5;

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -70,7 +70,7 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name)
     queue = log_queue_disk_reliable_new(&self->options, persist_name);
   else
     queue = log_queue_disk_non_reliable_new(&self->options, persist_name);
-  log_queue_set_throttle(queue, dd->throttle);
+  log_queue_set_throttle(queue, dd->throttle, dd->logs_per_throttle_bucket);
 
   qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
 


### PR DESCRIPTION
This PR intends to fix #2453.

The LogQueue's throttle_buckets variable counts how many logs can be popped from the queue, and its throttle variable is responsible for calculating the right amount of sleep, so we do not exceed the 
message / sec limit.
Currently these two variables are equal, so throttle limits for log lines sent, and not batches sent, which is okay, when we send 1 log line / batch, but if we batch several log lines to 1 batch it causes unexpected behavior.
In case of batching, the initial value of the LogQueue's throttle_buckets should be batch_lines * throttle,  so the LogQueue can grab enough log lines for the batch, but throttle should be intact, because the sleep is calculated from it.
However LogQueue should not know about batch_lines, but we can add an option to have a multiplicant relation between throttle and throttle buckets, so the unchanged throttle will cause the right amount of sleep, and the multiplied throttle_buckets will provide the right amount of log lines, which will be batched later in the Threaded Destination's _perform_insert() method.

For the reviewers:
1. Is it more logical for you as well, to limit the batches sent (e.g.: number of HTTP requests) / sec, instead of log lines sent / sec?
2. Is this the right way to provide enough log lines to the driver to batch?
3. Is `logs_per_throttle_bucket` name understandable?
4. Is it okay to set the LogDestDriver's `logs_per_throttle_bucket` attribute in `log_threaded_dest_driver_set_batch_lines()`?
5. How should we test this?