### PR TITLE
ProtoClient: provide process_in function to logwriter

### DIFF
--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -59,8 +59,15 @@ log_proto_client_init(LogProtoClient *self, LogTransport *transport, const LogPr
 }
 
 void
+log_proto_client_options_set_drop_input(LogProtoClientOptions *options, gboolean drop_input)
+{
+  options->drop_input = drop_input;
+}
+
+void
 log_proto_client_options_defaults(LogProtoClientOptions *options)
 {
+  options->drop_input = FALSE;
 }
 
 void

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -34,6 +34,7 @@ typedef struct _LogProtoClient LogProtoClient;
 
 typedef struct _LogProtoClientOptions
 {
+  gboolean drop_input;
 } LogProtoClientOptions;
 
 typedef union _LogProtoClientOptionsStorage
@@ -51,6 +52,8 @@ typedef struct
   LogProtoClientRewindCallback rewind_callback;
   gpointer user_data;
 } LogProtoClientFlowControlFuncs;
+
+void log_proto_client_options_set_drop_input(LogProtoClientOptions *options, gboolean drop_input);
 
 void log_proto_client_options_defaults(LogProtoClientOptions *options);
 void log_proto_client_options_init(LogProtoClientOptions *options, GlobalConfig *cfg);

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -64,6 +64,7 @@ struct _LogProtoClient
   /* FIXME: rename to something else */
   gboolean (*prepare)(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout);
   LogProtoStatus (*post)(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed);
+  LogProtoStatus (*process_in)(LogProtoClient *s);
   LogProtoStatus (*flush)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
   gboolean (*handshake_in_progess)(LogProtoClient *s);
@@ -130,6 +131,21 @@ static inline LogProtoStatus
 log_proto_client_flush(LogProtoClient *s)
 {
   if (s->flush)
+    return s->flush(s);
+  else
+    return LPS_SUCCESS;
+}
+
+static inline LogProtoStatus
+log_proto_client_process_in(LogProtoClient *s)
+{
+  if (s->process_in)
+    return s->process_in(s);
+  else if (s->flush)
+    /*
+     * In some clients, flush is used for input processing, but it should not be.
+     * Fix these clients, than remove the flush call here.
+     */
     return s->flush(s);
   else
     return LPS_SUCCESS;

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -192,7 +192,7 @@ log_reader_window_empty(LogSource *s)
 }
 
 static void
-log_reader_io_process_input(gpointer s)
+log_reader_io_handle_in(gpointer s)
 {
   LogReader *self = (LogReader *) s;
 
@@ -224,7 +224,7 @@ log_reader_init_watches(LogReader *self)
 {
   IV_TASK_INIT(&self->restart_task);
   self->restart_task.cookie = self;
-  self->restart_task.handler = log_reader_io_process_input;
+  self->restart_task.handler = log_reader_io_handle_in;
 
   IV_EVENT_INIT(&self->schedule_wakeup);
   self->schedule_wakeup.cookie = self;
@@ -504,7 +504,7 @@ log_reader_init(LogPipe *s)
       return FALSE;
     }
 
-  poll_events_set_callback(self->poll_events, log_reader_io_process_input, self);
+  poll_events_set_callback(self->poll_events, log_reader_io_handle_in, self);
 
   log_reader_update_watches(self);
   iv_event_register(&self->schedule_wakeup);

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -48,7 +48,7 @@ _engage(MainLoopIOWorkerJob *self)
 
 /* NOTE: runs in the main thread */
 void
-main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self)
+main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self, GIOCondition cond)
 {
   g_assert(self->working == FALSE);
   if (main_loop_workers_quit)
@@ -57,6 +57,7 @@ main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self)
   _engage(self);
   main_loop_worker_job_start();
   self->working = TRUE;
+  self->cond = cond;
   iv_work_pool_submit_work(&main_loop_io_workers, &self->work_item);
 }
 
@@ -65,7 +66,7 @@ main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self)
 static void
 _work(MainLoopIOWorkerJob *self)
 {
-  self->work(self->user_data);
+  self->work(self->user_data, self->cond);
   main_loop_worker_invoke_batch_callbacks();
   main_loop_worker_run_gc();
 }

--- a/lib/mainloop-io-worker.h
+++ b/lib/mainloop-io-worker.h
@@ -31,16 +31,17 @@
 typedef struct _MainLoopIOWorkerJob
 {
   void (*engage)(gpointer user_data);
-  void (*work)(gpointer user_data);
+  void (*work)(gpointer user_data, GIOCondition cond);
   void (*completion)(gpointer user_data);
   void (*release)(gpointer user_data);
   gpointer user_data;
   gboolean working:1;
+  GIOCondition cond;
   struct iv_work_item work_item;
 } MainLoopIOWorkerJob;
 
 void main_loop_io_worker_job_init(MainLoopIOWorkerJob *self);
-void main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self);
+void main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self, GIOCondition cond);
 
 void main_loop_io_worker_add_options(GOptionContext *ctx);
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -82,6 +82,14 @@ afsocket_dd_set_keep_alive(LogDriver *s, gboolean enable)
   self->connections_kept_alive_across_reloads = enable;
 }
 
+void
+afsocket_dd_set_close_on_input(LogDriver *s, gboolean close_on_input)
+{
+  AFSocketDestDriver *self = (AFSocketDestDriver *) s;
+
+  self->close_on_input = close_on_input;
+}
+
 static const gchar *_module_name = "afsocket_dd";
 
 static const gchar *
@@ -680,6 +688,7 @@ afsocket_dd_init_instance(AFSocketDestDriver *self,
   self->transport_mapper = transport_mapper;
   self->socket_options = socket_options;
   self->connections_kept_alive_across_reloads = TRUE;
+  self->close_on_input = TRUE;
   self->time_reopen = cfg->time_reopen;
   self->connection_initialized = FALSE;
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -468,7 +468,7 @@ afsocket_dd_construct_writer_method(AFSocketDestDriver *self)
   guint32 writer_flags = 0;
 
   writer_flags |= LW_FORMAT_PROTO;
-  if (self->transport_mapper->sock_type == SOCK_STREAM)
+  if (self->transport_mapper->sock_type == SOCK_STREAM && self->close_on_input)
     writer_flags |= LW_DETECT_EOF;
 
   return log_writer_new(writer_flags, self->super.super.super.cfg);

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -40,6 +40,7 @@ struct _AFSocketDestDriver
 
   gboolean
   connections_kept_alive_across_reloads:1;
+  gboolean close_on_input;
   gint fd;
   LogWriter *writer;
   LogWriterOptions writer_options;
@@ -80,6 +81,7 @@ afsocket_dd_get_dest_name(const AFSocketDestDriver *s)
 LogWriter *afsocket_dd_construct_writer_method(AFSocketDestDriver *self);
 gboolean afsocket_dd_setup_addresses_method(AFSocketDestDriver *self);
 void afsocket_dd_set_keep_alive(LogDriver *self, gint enable);
+void afsocket_dd_set_close_on_input(LogDriver *self, gboolean close_on_input);
 void afsocket_dd_init_instance(AFSocketDestDriver *self, SocketOptions *socket_options,
                                TransportMapper *transport_mapper, GlobalConfig *cfg);
 void afsocket_dd_reconnect(AFSocketDestDriver *self);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -654,7 +654,11 @@ dest_afinet_tcp_option
 
 dest_afsocket_option
         : KW_KEEP_ALIVE '(' yesno ')'        { afsocket_dd_set_keep_alive(last_driver, $3); }
-        | KW_CLOSE_ON_INPUT '(' yesno ')'        { afsocket_dd_set_close_on_input(last_driver, $3); }
+        | KW_CLOSE_ON_INPUT '(' yesno ')'
+          {
+            afsocket_dd_set_close_on_input(last_driver, $3);
+            log_proto_client_options_set_drop_input(last_proto_client_options, !$3);
+          }
         ;
 
 

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -154,6 +154,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 
 %token KW_KEEP_ALIVE
 %token KW_MAX_CONNECTIONS
+%token KW_CLOSE_ON_INPUT
 
 %token KW_LOCALIP
 %token KW_IP
@@ -653,6 +654,7 @@ dest_afinet_tcp_option
 
 dest_afsocket_option
         : KW_KEEP_ALIVE '(' yesno ')'        { afsocket_dd_set_keep_alive(last_driver, $3); }
+        | KW_CLOSE_ON_INPUT '(' yesno ')'        { afsocket_dd_set_close_on_input(last_driver, $3); }
         ;
 
 

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -84,6 +84,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "max_connections",    KW_MAX_CONNECTIONS },
   { "listen_backlog",     KW_LISTEN_BACKLOG },
   { "keep_alive",         KW_KEEP_ALIVE },
+  { "close_on_input",     KW_CLOSE_ON_INPUT },
   { "systemd_syslog",     KW_SYSTEMD_SYSLOG  },
   { "failover_servers",   KW_FAILOVER_SERVERS, KWS_OBSOLETE, "failover-servers has been deprecated, try failover() and use servers() option inside it." },
   { "failover",           KW_FAILOVER },


### PR DESCRIPTION
As discussed, it might be better to give clean `process_in()` function from `LogProtoClient` as currently `flush()` does both directions, which complicates the communication between `LogWriter` and `LogProtoClient`.

This cleanup would make it easier to do `ProtoClient` level I/O communications (handshake, result handling, etc...), and it would make cleaner code in `Proto` and `LogWriter` level.

I also implemented a use of this process_in() function. LogProtoTextClient can drop input, if it is set from the config by `close-on-input` option, in case of AFSocket based destinations.
This can help to continue the PR #1433.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>