### PR TITLE
Fix app-parser() per reload memory leak

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -51,6 +51,7 @@ cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs
 void
 cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const gchar *name)
 {
+  self->ref_cnt = 1;
   self->context = context;
   self->name = g_strdup(name);
   self->format_name = cfg_block_generator_format_name_method;
@@ -63,10 +64,20 @@ cfg_block_generator_free_instance(CfgBlockGenerator *self)
   g_free(self->name);
 }
 
-void
-cfg_block_generator_free(CfgBlockGenerator *self)
+CfgBlockGenerator *
+cfg_block_generator_ref(CfgBlockGenerator *self)
 {
-  if (self->free_fn)
-    self->free_fn(self);
-  g_free(self);
+  self->ref_cnt++;
+  return self;
+}
+
+void
+cfg_block_generator_unref(CfgBlockGenerator *self)
+{
+  if (--self->ref_cnt == 0)
+    {
+      if (self->free_fn)
+        self->free_fn(self);
+      g_free(self);
+    }
 }

--- a/lib/cfg-block-generator.h
+++ b/lib/cfg-block-generator.h
@@ -41,6 +41,7 @@
 typedef struct _CfgBlockGenerator CfgBlockGenerator;
 struct _CfgBlockGenerator
 {
+  gint ref_cnt;
   gint context;
   gchar *name;
   gboolean suppress_backticks;
@@ -60,7 +61,8 @@ gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg
                                       const gchar *reference);
 void cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const gchar *name);
 void cfg_block_generator_free_instance(CfgBlockGenerator *self);
-void cfg_block_generator_free(CfgBlockGenerator *self);
+CfgBlockGenerator *cfg_block_generator_ref(CfgBlockGenerator *self);
+void cfg_block_generator_unref(CfgBlockGenerator *self);
 
 
 #endif

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -731,7 +731,7 @@ _generator_plugin_construct(Plugin *s)
 {
   GeneratorPlugin *self = (GeneratorPlugin *) s;
 
-  return self->gen;
+  return cfg_block_generator_ref(self->gen);
 }
 
 static void
@@ -1023,7 +1023,9 @@ cfg_lexer_preprocess(CfgLexer *self, gint tok, YYSTYPE *yylval, YYLTYPE *yylloc)
       self->cfg &&
       (gen = cfg_lexer_find_generator(self, self->cfg, cfg_lexer_get_context_type(self), yylval->cptr)))
     {
-      if (!cfg_lexer_parse_and_run_block_generator(self, gen, yylval))
+      gboolean success = cfg_lexer_parse_and_run_block_generator(self, gen, yylval);
+      cfg_block_generator_unref(gen);
+      if (!success)
         return CLPR_ERROR;
 
       return CLPR_LEX_AGAIN;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -739,7 +739,7 @@ _generator_plugin_free(Plugin *s)
 {
   GeneratorPlugin *self = (GeneratorPlugin *) s;
 
-  cfg_block_generator_free(self->gen);
+  cfg_block_generator_unref(self->gen);
   g_free((gchar *) self->super.name);
   g_free(s);
 }


### PR DESCRIPTION
The lexer didn't handle generators that were allocated dynamically for every invocation properly.

This patch adds reference counting for CfgBlockGenerators which makes the fix trivial. 

Note, this is not app-parser() related, this is a bug in the core, which app-parser() and potentially confgen triggers.