### PR TITLE
autotools: relaxing python dependency requirement 

### DIFF
--- a/Mk/lex-rules.am
+++ b/Mk/lex-rules.am
@@ -1,6 +1,10 @@
 %.y: %.ym $(syslog_ng_tools)/merge-grammar.py $(syslog_ng_tools)/cfg-grammar.y
+if HAVE_PYTHON_INTERPRETER
 	$(AM_V_at) $(mkinstalldirs) $(dir $@)
 	$(AM_V_GEN) $(PYTHON) $(syslog_ng_tools)/merge-grammar.py $< > $@
+else
+	$(error "Python interpreter is required to generate grammar files, but it was not detected during configure")
+endif
 
 .l.c:
 	$(AM_V_LEX)$(am__skiplex) $(SHELL) $(YLWRAP) $< $(LEX_OUTPUT_ROOT).c $*.c $(LEX_OUTPUT_ROOT).h $*.h -- $(LEXCOMPILE) | ($(EGREP) -v "(^updating|unchanged)" || true)

--- a/configure.ac
+++ b/configure.ac
@@ -391,9 +391,12 @@ if test "x$with_python" = "xauto"; then
 else
   AM_PATH_PYTHON([$with_python],,[:])
 fi
+
 if test "${PYTHON}" = ":"; then
-	AC_MSG_ERROR([Python interpreter is required])
+       AC_MSG_WARN([Python interpreter is missing.])
 fi
+
+AM_CONDITIONAL([HAVE_PYTHON_INTERPRETER], [test "$PYTHON" != :])
 
 dnl ***************************************************************************
 dnl Validate yacc

--- a/configure.ac
+++ b/configure.ac
@@ -387,9 +387,9 @@ AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
 LT_INIT([dlopen disable-static])
 if test "x$with_python" = "xauto"; then
-  AM_PATH_PYTHON()
+  AM_PATH_PYTHON(,,[:])
 else
-  AM_PATH_PYTHON([$with_python])
+  AM_PATH_PYTHON([$with_python],,[:])
 fi
 if test "${PYTHON}" = ":"; then
 	AC_MSG_ERROR([Python interpreter is required])


### PR DESCRIPTION
Python executable is not a hard dependency, unless someone needs to generate/update the grammar files. This patch delays the error reporting of the missing python executable until that. This makes possible to build syslog-ng from release tarball on a linux distribution without python (like archlinux).

Example execution in an archlinux container:

The warning:
```
checking for python2.0... no
configure: WARNING: Python interpreter is missing.
checking for C compiler vendor... gnu
```

The error:
```
[root@a3ad2aaeba81 build]# touch ../modules/redis/redis-grammar.ym
[root@a3ad2aaeba81 build]# make
Makefile:21760: *** "Python interpreter is required to generate grammar files, but it was not detected during configure".  Stop.
```

Without the touch, make executes successfully:
```
[root@a3ad2aaeba81 build]# make -j
make --no-print-directory all-recursive
  CC       lib/transport/lib_libsyslog_ng_la-logtransport.lo
  CC       lib/transport/lib_libsyslog_ng_la-transport-aux-data.lo
[...]
ar: `u' modifier ignored since `D' is the default (see `U')
  CCLD     modules/dbparser/pdbtool/pdbtool
ar: `u' modifier ignored since `D' is the default (see `U')
  CCLD     modules/examples/libexamples.la
[root@a3ad2aaeba81 build]# echo $?
0
```

Fixes: https://github.com/balabit/syslog-ng/issues/2463