### PR TITLE
loggen: paramter handling

### DIFF
--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -449,15 +449,23 @@ main(int argc, char *argv[])
   /* debug option defined by --debug command line option */
   set_debug_level(debug);
 
-  if (argc < 3)
+  if (argc>=3)
     {
-      ERROR("please specify target and port at least\n");
-      g_ptr_array_free(plugin_array,TRUE);
-      return 1;
+      global_plugin_option.target = g_strdup(argv[1]);
+      global_plugin_option.port = g_strdup(argv[2]);
+    }
+  else if (argc>=2)
+    {
+      global_plugin_option.target = g_strdup(argv[1]);
+      global_plugin_option.port = NULL;
+    }
+  else
+    {
+      global_plugin_option.target = NULL;
+      global_plugin_option.port = NULL;
+      DEBUG("no port and address specified");
     }
 
-  global_plugin_option.target = g_strdup(argv[1]);
-  global_plugin_option.port = g_strdup(argv[2]);
   DEBUG("target=%s port=%s\n",global_plugin_option.target,global_plugin_option.port);
 
   if (global_plugin_option.message_length > MAX_MESSAGE_LENGTH)

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -133,6 +133,20 @@ start(PluginOption *option)
       return;
     }
 
+  if (unix_socket_x)
+    {
+      if (!option->target)
+        {
+          ERROR("in case of unix domain socket please specify target parameter\n");
+          return;
+        }
+    }
+  else if (!option->target || !option->port)
+    {
+      ERROR("in case of TCP or UDP socket please specify target and port parameters\n");
+      return;
+    }
+
   DEBUG("plugin (%d,%d,%d,%d)start\n",
         option->message_length,
         option->interval,

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -127,6 +127,12 @@ start(PluginOption *option)
       return;
     }
 
+  if (!option->target || !option->port)
+    {
+      ERROR("please specify target and port parameters\n");
+      return;
+    }
+
   DEBUG("plugin (%d,%d,%d,%d)start\n",
         option->message_length,
         option->interval,
@@ -243,6 +249,7 @@ idle_thread_func(gpointer user_data)
 {
   PluginOption *option = ((ThreadData *)user_data)->option;
   int thread_index = ((ThreadData *)user_data)->index;
+
   int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
 
   SSL *ssl = open_ssl_connection(sock_fd);
@@ -296,6 +303,7 @@ active_thread_func(gpointer user_data)
   PluginOption *option = thread_context->option;
 
   char *message = g_malloc0(MAX_MESSAGE_LENGTH+1);
+
   int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
 
   SSL *ssl = open_ssl_connection(sock_fd);


### PR DESCRIPTION
Move the parameter count check into plugins.
This allow us to run plugin options which
doesn't need target and port port parameters.
Fixes #2239

Signed-off-by: norberttakacs <norbert.takacs@balabit.com>