### PR TITLE
pytest-framework: fix travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ addons:
       - libmaxminddb-dev
       - libxml2-utils
       - astyle
-install: pip install --user -r requirements.txt
+install:
+      - pip install --user -r requirements.txt
+      - pip list
 before_script:
   - echo 'Europe/Budapest' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mockito
 pathlib2
 psutil
 pytest
+six>=1.10.0


### PR DESCRIPTION
With version shipped travis we received:
```
make: *** [pytest-self-check] Error 1
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/.local/lib/python2.7/site-packages/pytest.py", line 14, in <module>
    from _pytest.fixtures import fillfixtures as _fillfuncargs
  File "/home/travis/.local/lib/python2.7/site-packages/_pytest/fixtures.py", line 1055, in <module>
    @fixture(scope="session")
  File "/home/travis/.local/lib/python2.7/site-packages/_pytest/fixtures.py", line 981, in __call__
    function = wrap_function_to_error_out_if_called_directly(function, self)
  File "/home/travis/.local/lib/python2.7/site-packages/_pytest/fixtures.py", line 953, in wrap_function_to_error_out_if_called_directly
    @six.wraps(function)
AttributeError: 'module' object has no attribute 'wraps'
make: *** [pytest-check] Error 1
```

Forcing six versions resolves the problem.