### PR TITLE
Pytest: Added minor fixes to unittest

### DIFF
--- a/tests/pytest_framework/src/logger/logger.py
+++ b/tests/pytest_framework/src/logger/logger.py
@@ -29,11 +29,14 @@ from colorlog import ColoredFormatter
 class Logger(logging.Logger):
     def __init__(self, logger_name, report_file, loglevel, use_console_handler=True, use_file_handler=True):
         super(Logger, self).__init__(logger_name, loglevel)
-        self.handlers = []
         if use_console_handler:
             self.__set_console_handler()
         if use_file_handler:
             self.__set_file_handler(file_path=report_file)
+
+    def __del__(self):
+        for open_handler in self.handlers:
+            open_handler.close()
 
     def __set_file_handler(self, file_path=None):
         # FileHandler can work only with string representation of file_path

--- a/tests/pytest_framework/src/setup/unit_testcase.py
+++ b/tests/pytest_framework/src/setup/unit_testcase.py
@@ -35,9 +35,9 @@ class SetupUnitTestcase(object):
     def __init__(self, testcase_context, get_current_date):
         self.testcase_context = testcase_context
         self.__get_current_date = get_current_date
-        self.__registerd_dirs = []
-        self.__registerd_files = []
+        self.__registered_dirs = []
         self.__registered_files = []
+        self.__registered_fds = []
 
         self.testcase_context.addfinalizer(self.__teardown)
 
@@ -46,13 +46,13 @@ class SetupUnitTestcase(object):
         testcase_subdir = "{}_{}".format(self.__get_current_date(), testcase_name)
         temp_dir = Path("/tmp", testcase_subdir)
         temp_dir.mkdir()
-        self.__registerd_dirs.append(temp_dir)
+        self.__registered_dirs.append(temp_dir)
         return temp_dir
 
     def get_temp_file(self):
         temp_dir = self.get_temp_dir()
         temp_file_path = Path(temp_dir, RandomId(use_static_seed=False).get_unique_id())
-        self.__registerd_files.append(temp_file_path)
+        self.__registered_files.append(temp_file_path)
         return temp_file_path
 
     def get_fake_testcase_parameters(self):
@@ -79,22 +79,23 @@ class SetupUnitTestcase(object):
         input_file_path = self.get_temp_file()
         writeable_file = open_file(input_file_path, "a+")
         readable_file = open_file(input_file_path, "r")
-        self.__registered_files.append(writeable_file)
-        self.__registered_files.append(readable_file)
 
+        self.__registered_fds.append(writeable_file)
+        self.__registered_fds.append(readable_file)
         writeable_file.write(input_content)
         writeable_file.flush()
         return writeable_file, readable_file
 
     def __teardown(self):
-        for registered_file in self.__registered_files:
-            registered_file.close()
+        for registered_fd in self.__registered_fds:
+            registered_fd.close()
 
-        for temp_file in self.__registerd_files:
+        for temp_file in self.__registered_files:
             if temp_file.exists():
                 temp_file.unlink()
 
-        for temp_dir in self.__registerd_dirs:
+        for temp_dir in self.__registered_dirs:
             if temp_dir.exists():
                 temp_dir.rmdir()
+
         unstub()


### PR DESCRIPTION
- eliminate duplicated variables and typos
- fix multiple registering of temporary files
- remove closing of PosixPath type of files

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>