### PR TITLE
syslog-ng@default: use pid file location on control socket

### DIFF
--- a/contrib/systemd/syslog-ng@default
+++ b/contrib/systemd/syslog-ng@default
@@ -1,5 +1,5 @@
 CONFIG_FILE=/etc/syslog-ng.conf
 PERSIST_FILE=/var/lib/syslog-ng/syslog-ng.persist
-CONTROL_FILE=/var/lib/syslog-ng/syslog-ng.ctl
+CONTROL_FILE=/var/run/syslog-ng.ctl
 PID_FILE=/var/run/syslog-ng.pid
 OTHER_OPTIONS="--enable-core"


### PR DESCRIPTION
When the pid file location was changed via `--with-pidfile-dir=` control socket was still pointing to `/var/lib/syslog-ng` even if they are using same path definition.