### PR TITLE
pytest_framework: support for implicit groups in config.create_logpath

### DIFF
--- a/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -51,7 +51,7 @@ def test_manipulating_config_between_reload(tc):
     destination_group.update_group_with_statement(file_destination2)
 
     # update first logpath group with new source group
-    logpath.add_source_group(source_group2)
+    logpath.add_group(source_group2)
 
     syslog_ng.reload(config)
 

--- a/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -46,7 +46,7 @@ def test_manipulating_config_between_reload(tc):
 
     # create new file destination and update first destination group
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group.update_group_with_statement(file_destination2)
+    destination_group.append(file_destination2)
 
     # update first logpath group with new source group
     logpath.add_group(source_group2)
@@ -57,7 +57,7 @@ def test_manipulating_config_between_reload(tc):
     file_source.options.pop("log_iw_size")
 
     # remove file destination from destination group
-    destination_group.remove_statement(file_destination2)
+    destination_group.remove(file_destination2)
 
     # remove second source group from logpath
     logpath.logpath.remove(source_group2)

--- a/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -26,10 +26,10 @@ def test_manipulating_config_between_reload(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     file_destination = config.create_file_destination(file_name="output.log")
-    destination_group = config.create_destination_group(file_destination)
+    destination_group = config.create_statement_group(file_destination)
 
     logpath = config.create_logpath(statements=[source_group, destination_group])
 
@@ -44,7 +44,7 @@ def test_manipulating_config_between_reload(tc):
 
     # create new file source and add to separate source group
     file_source2 = config.create_file_source(file_name="input2.log")
-    source_group2 = config.create_source_group(file_source2)
+    source_group2 = config.create_statement_group(file_source2)
 
     # create new file destination and update first destination group
     file_destination2 = config.create_file_destination(file_name="output2.log")

--- a/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/pytest_framework/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -26,12 +26,10 @@ def test_manipulating_config_between_reload(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     file_destination = config.create_file_destination(file_name="output.log")
     destination_group = config.create_statement_group(file_destination)
 
-    logpath = config.create_logpath(statements=[source_group, destination_group])
+    logpath = config.create_logpath(statements=[file_source, destination_group])
 
     syslog_ng = tc.new_syslog_ng()
     syslog_ng.start(config)

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_catch_all.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_catch_all.py
@@ -42,17 +42,12 @@ def test_flags_catch_all(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group = config.create_statement_group(file_destination1)
+    catch_all_destination = config.create_file_destination(file_name="output2.log")
 
-    file_destination2 = config.create_file_destination(file_name="output2.log")
-    catch_all_destination = config.create_statement_group(file_destination2)
+    inner_logpath = config.create_inner_logpath(statements=[file_destination1])
 
-    inner_logpath = config.create_inner_logpath(statements=[destination_group])
-
-    config.create_logpath(statements=[source_group, inner_logpath])
+    config.create_logpath(statements=[file_source, inner_logpath])
     config.create_logpath(statements=[catch_all_destination], flags="catch-all")
 
     bsd_message = write_dummy_message(tc, file_source)
@@ -66,7 +61,7 @@ def test_flags_catch_all(tc):
     # message should arrived into destination1
     assert tc.format_as_bsd(expected_bsd_message) in dest1_logs
 
-    dest2_logs = file_destination2.read_log()
+    dest2_logs = catch_all_destination.read_log()
     # message should arrived into destination2
     # there is a flags(catch-all)
     assert tc.format_as_bsd(expected_bsd_message) in dest2_logs

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_catch_all.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_catch_all.py
@@ -42,13 +42,13 @@ def test_flags_catch_all(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group = config.create_destination_group(file_destination1)
+    destination_group = config.create_statement_group(file_destination1)
 
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    catch_all_destination = config.create_destination_group(file_destination2)
+    catch_all_destination = config.create_statement_group(file_destination2)
 
     inner_logpath = config.create_inner_logpath(statements=[destination_group])
 

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_catch_all.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_catch_all.py
@@ -42,10 +42,10 @@ def test_flags_catch_all(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    file_destination1 = config.create_file_destination(file_name="output1.log")
-    catch_all_destination = config.create_file_destination(file_name="output2.log")
+    file_destination = config.create_file_destination(file_name="output.log")
+    catch_all_destination = config.create_file_destination(file_name="catchall_output.log")
 
-    inner_logpath = config.create_inner_logpath(statements=[file_destination1])
+    inner_logpath = config.create_inner_logpath(statements=[file_destination])
 
     config.create_logpath(statements=[file_source, inner_logpath])
     config.create_logpath(statements=[catch_all_destination], flags="catch-all")
@@ -57,11 +57,11 @@ def test_flags_catch_all(tc):
     syslog_ng = tc.new_syslog_ng()
     syslog_ng.start(config)
 
-    dest1_logs = file_destination1.read_log()
+    destination_logs = file_destination.read_log()
     # message should arrived into destination1
-    assert tc.format_as_bsd(expected_bsd_message) in dest1_logs
+    assert tc.format_as_bsd(expected_bsd_message) in destination_logs
 
-    dest2_logs = catch_all_destination.read_log()
-    # message should arrived into destination2
+    catch_all_destination_logs = catch_all_destination.read_log()
+    # message should arrived into catch_all_destination
     # there is a flags(catch-all)
-    assert tc.format_as_bsd(expected_bsd_message) in dest2_logs
+    assert tc.format_as_bsd(expected_bsd_message) in catch_all_destination_logs

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_fallback.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_fallback.py
@@ -45,16 +45,16 @@ def test_flags_fallback(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_filter_group(host_filter)
+    filter_group1 = config.create_statement_group(host_filter)
 
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_destination_group(file_destination1)
+    destination_group1 = config.create_statement_group(file_destination1)
 
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_destination_group(file_destination2)
+    destination_group2 = config.create_statement_group(file_destination2)
 
     inner_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1])
 

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_fallback.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_fallback.py
@@ -45,22 +45,14 @@ def test_flags_fallback(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_statement_group(host_filter)
-
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_statement_group(file_destination1)
-
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_statement_group(file_destination2)
 
-    inner_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1])
+    inner_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1])
+    inner_logpath2 = config.create_inner_logpath(statements=[file_destination2], flags="fallback")
 
-    inner_logpath2 = config.create_inner_logpath(statements=[destination_group2], flags="fallback")
-
-    config.create_logpath(statements=[source_group, inner_logpath1, inner_logpath2])
+    config.create_logpath(statements=[file_source, inner_logpath1, inner_logpath2])
 
     bsd_message1 = write_message_with_fields(tc, file_source, hostname="host-A", message="message from host-A")
     bsd_message2 = write_message_with_fields(tc, file_source, hostname="host-B", message="message from host-B")

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_final.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_final.py
@@ -45,16 +45,16 @@ def test_flags_final(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_filter_group(host_filter)
+    filter_group1 = config.create_statement_group(host_filter)
 
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_destination_group(file_destination1)
+    destination_group1 = config.create_statement_group(file_destination1)
 
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_destination_group(file_destination2)
+    destination_group2 = config.create_statement_group(file_destination2)
 
     inner_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1], flags="final")
 

--- a/tests/pytest_framework/functional_tests/logpath/test_flags_final.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_flags_final.py
@@ -45,22 +45,14 @@ def test_flags_final(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_statement_group(host_filter)
-
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_statement_group(file_destination1)
-
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_statement_group(file_destination2)
 
-    inner_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1], flags="final")
+    inner_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1], flags="final")
+    inner_logpath2 = config.create_inner_logpath(statements=[file_destination2])
 
-    inner_logpath2 = config.create_inner_logpath(statements=[destination_group2])
-
-    config.create_logpath(statements=[source_group, inner_logpath1, inner_logpath2])
+    config.create_logpath(statements=[file_source, inner_logpath1, inner_logpath2])
 
     bsd_message1 = write_message_with_fields(tc, file_source, hostname="host-A", message="message from host-A")
     bsd_message2 = write_message_with_fields(tc, file_source, hostname="host-B", message="message from host-B")

--- a/tests/pytest_framework/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -49,25 +49,25 @@ def test_multiple_embedded_logpaths(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_filter_group(host_filter)
+    filter_group1 = config.create_statement_group(host_filter)
 
     program_filter = config.create_filter(program="'app-A'")
-    filter_group2 = config.create_filter_group(program_filter)
+    filter_group2 = config.create_statement_group(program_filter)
 
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_destination_group(file_destination1)
+    destination_group1 = config.create_statement_group(file_destination1)
 
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_destination_group(file_destination2)
+    destination_group2 = config.create_statement_group(file_destination2)
 
     file_destination3 = config.create_file_destination(file_name="output3.log")
-    destination_group3 = config.create_destination_group(file_destination3)
+    destination_group3 = config.create_statement_group(file_destination3)
 
     file_destination4 = config.create_file_destination(file_name="output4.log")
-    destination_group4 = config.create_destination_group(file_destination4)
+    destination_group4 = config.create_statement_group(file_destination4)
 
     second_level_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1])
 

--- a/tests/pytest_framework/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -49,36 +49,23 @@ def test_multiple_embedded_logpaths(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_statement_group(host_filter)
-
     program_filter = config.create_filter(program="'app-A'")
-    filter_group2 = config.create_statement_group(program_filter)
-
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_statement_group(file_destination1)
-
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_statement_group(file_destination2)
-
     file_destination3 = config.create_file_destination(file_name="output3.log")
-    destination_group3 = config.create_statement_group(file_destination3)
-
     file_destination4 = config.create_file_destination(file_name="output4.log")
-    destination_group4 = config.create_statement_group(file_destination4)
 
-    second_level_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1])
+    second_level_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1])
 
-    second_level_logpath2 = config.create_inner_logpath(statements=[filter_group2, destination_group2])
+    second_level_logpath2 = config.create_inner_logpath(statements=[program_filter, file_destination2])
 
-    second_level_logpath3 = config.create_inner_logpath(statements=[destination_group3])
+    second_level_logpath3 = config.create_inner_logpath(statements=[file_destination3])
 
     config.create_logpath(
-        statements=[source_group, second_level_logpath1, second_level_logpath2, second_level_logpath3]
+        statements=[file_source, second_level_logpath1, second_level_logpath2, second_level_logpath3]
     )
-    config.create_logpath(statements=[destination_group4])
+    config.create_logpath(statements=[file_destination4])
 
     bsd_message1 = write_message_with_fields(
         tc, file_source, hostname="host-A", program="app-A", message="message from host-A and app-A"

--- a/tests/pytest_framework/functional_tests/logpath/test_multiple_flags.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_multiple_flags.py
@@ -49,36 +49,21 @@ def test_multiple_flags(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_statement_group(host_filter)
-
     program_filter = config.create_filter(program="'app-A'")
-    filter_group2 = config.create_statement_group(program_filter)
-
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_statement_group(file_destination1)
-
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_statement_group(file_destination2)
-
     file_destination3 = config.create_file_destination(file_name="output3.log")
-    destination_group3 = config.create_statement_group(file_destination3)
-
     file_destination4 = config.create_file_destination(file_name="output4.log")
-    destination_group4 = config.create_statement_group(file_destination4)
 
-    second_level_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1], flags="final")
-
-    second_level_logpath2 = config.create_inner_logpath(statements=[filter_group2, destination_group2])
-
-    second_level_logpath3 = config.create_inner_logpath(statements=[destination_group3], flags="fallback")
+    second_level_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1], flags="final")
+    second_level_logpath2 = config.create_inner_logpath(statements=[program_filter, file_destination2])
+    second_level_logpath3 = config.create_inner_logpath(statements=[file_destination3], flags="fallback")
 
     config.create_logpath(
-        statements=[source_group, second_level_logpath1, second_level_logpath2, second_level_logpath3]
+        statements=[file_source, second_level_logpath1, second_level_logpath2, second_level_logpath3]
     )
-    config.create_logpath(statements=[destination_group4], flags="catch-all")
+    config.create_logpath(statements=[file_destination4], flags="catch-all")
 
     bsd_message1 = write_message_with_fields(
         tc, file_source, hostname="host-A", program="app-A", message="message from host-A and app-A"

--- a/tests/pytest_framework/functional_tests/logpath/test_multiple_flags.py
+++ b/tests/pytest_framework/functional_tests/logpath/test_multiple_flags.py
@@ -49,25 +49,25 @@ def test_multiple_flags(tc):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     host_filter = config.create_filter(host="'host-A'")
-    filter_group1 = config.create_filter_group(host_filter)
+    filter_group1 = config.create_statement_group(host_filter)
 
     program_filter = config.create_filter(program="'app-A'")
-    filter_group2 = config.create_filter_group(program_filter)
+    filter_group2 = config.create_statement_group(program_filter)
 
     file_destination1 = config.create_file_destination(file_name="output1.log")
-    destination_group1 = config.create_destination_group(file_destination1)
+    destination_group1 = config.create_statement_group(file_destination1)
 
     file_destination2 = config.create_file_destination(file_name="output2.log")
-    destination_group2 = config.create_destination_group(file_destination2)
+    destination_group2 = config.create_statement_group(file_destination2)
 
     file_destination3 = config.create_file_destination(file_name="output3.log")
-    destination_group3 = config.create_destination_group(file_destination3)
+    destination_group3 = config.create_statement_group(file_destination3)
 
     file_destination4 = config.create_file_destination(file_name="output4.log")
-    destination_group4 = config.create_destination_group(file_destination4)
+    destination_group4 = config.create_statement_group(file_destination4)
 
     second_level_logpath1 = config.create_inner_logpath(statements=[filter_group1, destination_group1], flags="final")
 

--- a/tests/pytest_framework/functional_tests/source_drivers/file_source/test_acceptance.py
+++ b/tests/pytest_framework/functional_tests/source_drivers/file_source/test_acceptance.py
@@ -26,12 +26,9 @@ def test_acceptance(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_statement_group(file_source)
-
     file_destination = config.create_file_destination(file_name="output.log")
-    destination_group = config.create_statement_group(file_destination)
 
-    config.create_logpath(statements=[source_group, destination_group])
+    config.create_logpath(statements=[file_source, file_destination])
 
     log_message = tc.new_log_message()
     bsd_log = tc.format_as_bsd(log_message)

--- a/tests/pytest_framework/functional_tests/source_drivers/file_source/test_acceptance.py
+++ b/tests/pytest_framework/functional_tests/source_drivers/file_source/test_acceptance.py
@@ -26,10 +26,10 @@ def test_acceptance(tc):
     config = tc.new_config()
 
     file_source = config.create_file_source(file_name="input.log")
-    source_group = config.create_source_group(file_source)
+    source_group = config.create_statement_group(file_source)
 
     file_destination = config.create_file_destination(file_name="output.log")
-    destination_group = config.create_destination_group(file_destination)
+    destination_group = config.create_statement_group(file_destination)
 
     config.create_logpath(statements=[source_group, destination_group])
 

--- a/tests/pytest_framework/src/syslog_ng_config/renderer.py
+++ b/tests/pytest_framework/src/syslog_ng_config/renderer.py
@@ -77,7 +77,7 @@ class ConfigRenderer(object):
                 statement_group.group_type, statement_group.group_id
             )
 
-            for statement in statement_group.statements:
+            for statement in statement_group:
                 # driver header
                 self.__syslog_ng_config_content += "    {} (\n".format(statement.driver_name)
 

--- a/tests/pytest_framework/src/syslog_ng_config/statement_group.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statement_group.py
@@ -25,13 +25,11 @@ import functools
 from src.common.random_id import get_unique_id
 from src.common.operations import cast_to_list
 
-class StatementGroup(object):
+class StatementGroup(list):
     def __init__(self, statements):
+        super(StatementGroup, self).__init__(cast_to_list(statements))
         self.__group_type = self.__calculate_group_type(cast_to_list(statements))
         self.__group_id = "%s_%s" % (self.__group_type, get_unique_id())
-        self.__statements = []
-        if statements:
-            self.update_group_with_statements(cast_to_list(statements))
 
     @staticmethod
     def __calculate_group_type(statements):
@@ -51,17 +49,3 @@ class StatementGroup(object):
     @property
     def group_id(self):
         return self.__group_id
-
-    @property
-    def statements(self):
-        return self.__statements
-
-    def remove_statement(self, statement):
-        self.statements.remove(statement)
-
-    def update_group_with_statement(self, statement):
-        self.statements.append(statement)
-
-    def update_group_with_statements(self, statements):
-        for statement in statements:
-            self.update_group_with_statement(statement)

--- a/tests/pytest_framework/src/syslog_ng_config/statement_group.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statement_group.py
@@ -21,14 +21,28 @@
 #
 #############################################################################
 
+import functools
 from src.common.random_id import get_unique_id
-
+from src.common.operations import cast_to_list
 
 class StatementGroup(object):
-    def __init__(self, group_type):
-        self.__group_type = group_type
-        self.__group_id = "%s_%s" % (group_type, get_unique_id())
+    def __init__(self, statements):
+        self.__group_type = self.__calculate_group_type(cast_to_list(statements))
+        self.__group_id = "%s_%s" % (self.__group_type, get_unique_id())
         self.__statements = []
+        if statements:
+            self.update_group_with_statements(cast_to_list(statements))
+
+    @staticmethod
+    def __calculate_group_type(statements):
+        def check_consistency(stmt1, stmt2):
+            type1 = stmt1.group_type
+            type2 = stmt2.group_type
+            if type1 != type2:
+                raise TypeError("Conflict in statement types: {} and {}".format(type1, type2))
+            return stmt2
+
+        return functools.reduce(check_consistency, statements).group_type
 
     @property
     def group_type(self):

--- a/tests/pytest_framework/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -26,6 +26,8 @@ from src.message_reader.single_line_parser import SingleLineParser
 
 
 class DestinationDriver(object):
+    group_type = "destination"
+
     def __init__(self, logger_factory, IOClass):
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("DestinationDriver")

--- a/tests/pytest_framework/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/filters/filter.py
@@ -23,6 +23,8 @@
 
 
 class Filter(object):
+    group_type = "filter"
+
     def __init__(self, logger_factory, **kwargs):
         self.__logger_factory = logger_factory
         self.__options = kwargs

--- a/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
@@ -75,4 +75,5 @@ class LogPath(object):
         self.flags.append(flag)
 
     def add_flags(self, flags):
-        list(map(self.add_flag, flags))
+        for flag in flags:
+            self.add_flag(flag)

--- a/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/logpath/logpath.py
@@ -40,36 +40,12 @@ class LogPath(object):
     def flags(self):
         return self.__flags
 
-    def add_source_group(self, source_group):
-        self.update_logpath_with_group(source_group)
-
-    def add_source_groups(self, source_groups):
-        self.update_logpath_with_groups(source_groups)
-
-    def add_destination_group(self, destination_group):
-        self.update_logpath_with_group(destination_group)
-
-    def add_destination_groups(self, destination_groups):
-        self.update_logpath_with_groups(destination_groups)
-
-    def add_filter_group(self, filter_group):
-        self.update_logpath_with_group(filter_group)
-
-    def add_filter_groups(self, filter_groups):
-        self.update_logpath_with_groups(filter_groups)
-
-    def add_logpath_group(self, logpath_group):
-        self.update_logpath_with_group(logpath_group)
-
-    def add_logpath_groups(self, logpath_groups):
-        self.update_logpath_with_groups(logpath_groups)
-
-    def update_logpath_with_group(self, group):
+    def add_group(self, group):
         self.logpath.append(group)
 
-    def update_logpath_with_groups(self, groups):
+    def add_groups(self, groups):
         for group in groups:
-            self.update_logpath_with_group(group)
+            self.add_group(group)
 
     def add_flag(self, flag):
         self.flags.append(flag)

--- a/tests/pytest_framework/src/syslog_ng_config/statements/sources/source_driver.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/sources/source_driver.py
@@ -23,6 +23,8 @@
 
 
 class SourceDriver(object):
+    group_type = "source"
+
     def __init__(self, logger_factory, IOClass):
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("SourceDriver")

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -56,8 +56,7 @@ class SyslogNgConfig(object):
 
     @staticmethod
     def __create_statement_group(group_type, statements):
-        statement_group = StatementGroup(group_type)
-        statement_group.update_group_with_statements(cast_to_list(statements))
+        statement_group = StatementGroup(statements)
         return statement_group
 
     @staticmethod

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -64,7 +64,7 @@ class SyslogNgConfig(object):
     def __create_logpath_group(statements=None, flags=None):
         logpath = LogPath()
         if statements:
-            logpath.update_logpath_with_groups(cast_to_list(statements))
+            logpath.add_groups(cast_to_list(statements))
         if flags:
             logpath.add_flags(cast_to_list(flags))
         return logpath

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -55,11 +55,6 @@ class SyslogNgConfig(object):
         FileIO(self.__logger_factory, self.__config_path).rewrite(rendered_config)
 
     @staticmethod
-    def __create_statement_group(group_type, statements):
-        statement_group = StatementGroup(statements)
-        return statement_group
-
-    @staticmethod
     def __create_logpath_group(statements=None, flags=None):
         logpath = LogPath()
         if statements:
@@ -80,20 +75,10 @@ class SyslogNgConfig(object):
     def create_filter(self, **kwargs):
         return Filter(self.__logger_factory, **kwargs)
 
-    def create_source_group(self, drivers):
-        source_group = self.__create_statement_group("source", drivers)
-        self.__syslog_ng_config["statement_groups"].append(source_group)
-        return source_group
-
-    def create_destination_group(self, drivers):
-        destination_group = self.__create_statement_group("destination", drivers)
-        self.__syslog_ng_config["statement_groups"].append(destination_group)
-        return destination_group
-
-    def create_filter_group(self, filters):
-        filter_group = self.__create_statement_group("filter", filters)
-        self.__syslog_ng_config["statement_groups"].append(filter_group)
-        return filter_group
+    def create_statement_group(self, statements):
+        statement_group = StatementGroup(statements)
+        self.__syslog_ng_config["statement_groups"].append(statement_group)
+        return statement_group
 
     def create_logpath(self, statements=None, flags=None):
         logpath = self.__create_logpath_group(statements, flags)

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -54,11 +54,22 @@ class SyslogNgConfig(object):
         )
         FileIO(self.__logger_factory, self.__config_path).rewrite(rendered_config)
 
+    def __maybe_convert_to_statement_group(self, item):
+        if isinstance(item, StatementGroup) or isinstance(item, LogPath):
+            return item
+        else:
+            return self.create_statement_group(item)
+
+    def __create_logpath(self, items, flags):
+        return self.__create_logpath_group(
+            map(self.__maybe_convert_to_statement_group, cast_to_list(items)),
+            flags)
+
     @staticmethod
     def __create_logpath_group(statements=None, flags=None):
         logpath = LogPath()
         if statements:
-            logpath.add_groups(cast_to_list(statements))
+            logpath.add_groups(statements)
         if flags:
             logpath.add_flags(cast_to_list(flags))
         return logpath
@@ -81,10 +92,10 @@ class SyslogNgConfig(object):
         return statement_group
 
     def create_logpath(self, statements=None, flags=None):
-        logpath = self.__create_logpath_group(statements, flags)
+        logpath = self.__create_logpath(statements, flags)
         self.__syslog_ng_config["logpath_groups"].append(logpath)
         return logpath
 
     def create_inner_logpath(self, statements=None, flags=None):
-        inner_logpath = self.__create_logpath_group(statements, flags)
+        inner_logpath = self.__create_logpath(statements, flags)
         return inner_logpath

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -54,15 +54,15 @@ class SyslogNgConfig(object):
         )
         FileIO(self.__logger_factory, self.__config_path).rewrite(rendered_config)
 
-    def __maybe_convert_to_statement_group(self, item):
-        if isinstance(item, StatementGroup) or isinstance(item, LogPath):
+    def create_statement_group_if_needed(self, item):
+        if isinstance(item, (StatementGroup, LogPath)):
             return item
         else:
             return self.create_statement_group(item)
 
-    def __create_logpath(self, items, flags):
+    def __create_logpath_with_conversion(self, items, flags):
         return self.__create_logpath_group(
-            map(self.__maybe_convert_to_statement_group, cast_to_list(items)),
+            map(self.create_statement_group_if_needed, cast_to_list(items)),
             flags)
 
     @staticmethod
@@ -92,10 +92,10 @@ class SyslogNgConfig(object):
         return statement_group
 
     def create_logpath(self, statements=None, flags=None):
-        logpath = self.__create_logpath(statements, flags)
+        logpath = self.__create_logpath_with_conversion(statements, flags)
         self.__syslog_ng_config["logpath_groups"].append(logpath)
         return logpath
 
     def create_inner_logpath(self, statements=None, flags=None):
-        inner_logpath = self.__create_logpath(statements, flags)
+        inner_logpath = self.__create_logpath_with_conversion(statements, flags)
         return inner_logpath


### PR DESCRIPTION
There is a little repetitive process in test writing in pytest framework: each driver (for example `FileSource`) must be encapsulated into a `StatementGroup` (for example `source`), prior constructing `LogPath`. If the group is not needed otherwise (one does not want to have multiple drivers in the same group, or update group on the fly), the explicit construction of the intermediate `StatementGroup` is unnecessary.

This patchset features logpath creation without explicitely creating these statement groups.

Note to developers:
 I like the idea of having the same api for the group/non-group based construction in `config.create_logpath`, which means the function should branch somehow on the parameter type, that's why I think the `isinstance` part in the last patch is reasonable. At least I don't have any clue how can I eliminate it from clean code point of view for now :(. If you feel using `isinstance` too offensive, I can offer to create a `def create_logpath(statements=[], groups=[])` separation and delegate the classification problem to the users. But I think the current api looks neat form user perspective.