### PR TITLE
pytest_framework: faster failure detection for semantically invalid configs

### DIFF
--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -25,7 +25,7 @@ from pathlib2 import Path
 from src.syslog_ng.syslog_ng_executor import SyslogNgExecutor
 from src.syslog_ng.console_log_reader import ConsoleLogReader
 from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
-from src.common.blocking import wait_until_true
+from src.common.blocking import wait_until_true, wait_until_false
 
 class SyslogNgCli(object):
     def __init__(self, logger_factory, instance_paths, testcase_parameters):
@@ -121,9 +121,9 @@ class SyslogNgCli(object):
             # wait for stop and check stop result
             if result["exit_code"] != 0:
                 self.__error_handling()
-            if not self.__syslog_ng_ctl.wait_for_control_socket_stopped():
+            if not wait_until_false(self.__is_process_running):
                 self.__error_handling()
-                raise Exception("Control socket still alive")
+                raise Exception("syslog-ng did not stop")
             if not self.__console_log_reader.wait_for_stop_message():
                 self.__error_handling()
                 raise Exception("Stop message not arrived")

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -25,7 +25,7 @@ from pathlib2 import Path
 from src.syslog_ng.syslog_ng_executor import SyslogNgExecutor
 from src.syslog_ng.console_log_reader import ConsoleLogReader
 from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
-
+from src.common.blocking import wait_until_true
 
 class SyslogNgCli(object):
     def __init__(self, logger_factory, instance_paths, testcase_parameters):
@@ -60,9 +60,12 @@ class SyslogNgCli(object):
             self.__logger.error(result["stderr"])
             raise Exception("syslog-ng can not started")
 
+    def __wait_for_control_socket_alive(self):
+        return wait_until_true(self.__syslog_ng_ctl.is_control_socket_alive)
+
     def __wait_for_start(self):
         # wait for start and check start result
-        if not self.__syslog_ng_ctl.wait_for_control_socket_alive():
+        if not self.__wait_for_control_socket_alive():
             self.__error_handling()
             raise Exception("Control socket not alive")
         if not self.__console_log_reader.wait_for_start_message():
@@ -94,7 +97,7 @@ class SyslogNgCli(object):
         self.__syslog_ng_ctl.reload()
 
         # wait for reload and check reload result
-        if not self.__syslog_ng_ctl.wait_for_control_socket_alive():
+        if not self.__wait_for_control_socket_alive():
             self.__error_handling()
             raise Exception("Control socket not alive")
         if not self.__console_log_reader.wait_for_reload_message():

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -60,8 +60,15 @@ class SyslogNgCli(object):
             self.__logger.error(result["stderr"])
             raise Exception("syslog-ng can not started")
 
+    def __is_process_running(self):
+        return self.__process.poll() == None
+
     def __wait_for_control_socket_alive(self):
-        return wait_until_true(self.__syslog_ng_ctl.is_control_socket_alive)
+        def is_alive(s):
+            if not s.__is_process_running():
+                raise Exception("syslog-ng could not start")
+            return s.__syslog_ng_ctl.is_control_socket_alive()
+        return wait_until_true(is_alive, self)
 
     def __wait_for_start(self):
         # wait for start and check start result

--- a/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl.py
+++ b/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl.py
@@ -39,3 +39,6 @@ class SyslogNgCtl(object):
 
     def wait_for_control_socket_stopped(self):
         return self.__syslog_ng_ctl_cli.wait_for_control_socket_stopped()
+
+    def is_control_socket_alive(self):
+        return self.__syslog_ng_ctl_cli.is_control_socket_alive()

--- a/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl.py
+++ b/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl.py
@@ -34,11 +34,5 @@ class SyslogNgCtl(object):
     def stop(self):
         return self.__syslog_ng_ctl_cli.stop()
 
-    def wait_for_control_socket_alive(self):
-        return self.__syslog_ng_ctl_cli.wait_for_control_socket_alive()
-
-    def wait_for_control_socket_stopped(self):
-        return self.__syslog_ng_ctl_cli.wait_for_control_socket_stopped()
-
     def is_control_socket_alive(self):
         return self.__syslog_ng_ctl_cli.is_control_socket_alive()

--- a/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl_cli.py
+++ b/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl_cli.py
@@ -39,11 +39,11 @@ class SyslogNgCtlCli(object):
         ctl_stats_command = self.__syslog_ng_ctl_executor.construct_ctl_stats_command(reset=reset)
         return self.__syslog_ng_ctl_executor.run_command(command_short_name="stats", command=ctl_stats_command)
 
-    def __is_control_socket_alive(self):
+    def is_control_socket_alive(self):
         return self.stats(reset=False)["exit_code"] == 0
 
     def wait_for_control_socket_alive(self):
-        return wait_until_true(self.__is_control_socket_alive)
+        return wait_until_true(self.is_control_socket_alive)
 
     def wait_for_control_socket_stopped(self):
-        return wait_until_false(self.__is_control_socket_alive)
+        return wait_until_false(self.is_control_socket_alive)

--- a/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl_cli.py
+++ b/tests/pytest_framework/src/syslog_ng_ctl/syslog_ng_ctl_cli.py
@@ -41,9 +41,3 @@ class SyslogNgCtlCli(object):
 
     def is_control_socket_alive(self):
         return self.stats(reset=False)["exit_code"] == 0
-
-    def wait_for_control_socket_alive(self):
-        return wait_until_true(self.is_control_socket_alive)
-
-    def wait_for_control_socket_stopped(self):
-        return wait_until_false(self.is_control_socket_alive)


### PR DESCRIPTION
Prior this patchet, the syslog-ng start validation was the following: we relied on `syslog-ng -s` to detect if syslog-ng can be started. After that it waited for the control socket with a 10s timeout. However, when the configuration passes `syslog-ng -s`, the control socket may or may not be created, if there are other kind of errors in configuration that `syslog-ng -s` does not detect. That introduces a 10s delay for detecting failure in those cases.

For that sake, this patch checks if syslog-ng exited unexpectedly besides the control socket check.

This patch also eliminates the `class SyslogNgCtl` (or `/SyslogNgCtlCli`, depending on point of view).
Edit: We decided not to eliminate `SyslogNgCtl` here.