### PR TITLE
pytest_framework: timeout parameter for wait_until_true

### DIFF
--- a/tests/pytest_framework/src/common/blocking.py
+++ b/tests/pytest_framework/src/common/blocking.py
@@ -23,13 +23,15 @@
 
 import time
 
-MONITORING_TIME = 10  # 10 sec
+DEFAULT_TIMEOUT = 10  # 10 sec
 POLL_FREQ = 0.001  # 1 millisecond
 
-
 def wait_until_true(func, *args):
+    return wait_until_true_custom(func, args)
+
+def wait_until_true_custom(func, args=(), timeout=DEFAULT_TIMEOUT):
     # Python 2 compatibility note: time.monotonic() is missing
-    t_end = time.time() + MONITORING_TIME
+    t_end = time.time() + timeout
     while time.time() <= t_end:
         result = func(*args)
         if result:
@@ -37,7 +39,9 @@ def wait_until_true(func, *args):
         time.sleep(POLL_FREQ)
     return False
 
-
 def wait_until_false(func, *args):
-    negate = lambda func, *args: not func(*args)
-    return wait_until_true(negate, func, *args)
+    return wait_until_false_custom(func, args)
+
+def wait_until_false_custom(func, args=(), timeout=DEFAULT_TIMEOUT):
+    negate = lambda func, args: not func(*args)
+    return wait_until_true_custom(negate, (func, args), timeout=timeout)

--- a/tests/pytest_framework/src/common/tests/test_blocking.py
+++ b/tests/pytest_framework/src/common/tests/test_blocking.py
@@ -21,11 +21,8 @@
 #
 #############################################################################
 
-from src.common.blocking import wait_until_true, wait_until_false
+from src.common.blocking import wait_until_true_custom, wait_until_false_custom
 from src.common import blocking
-
-blocking.MONITORING_TIME = 0.1
-
 
 def inner_function_return_true():
     return True
@@ -40,20 +37,20 @@ def inner_function_add_numbers():
 
 
 def test_wait_until_true_inner_function_returns_true():
-    assert wait_until_true(inner_function_return_true)
+    assert wait_until_true_custom(inner_function_return_true, timeout=0.1)
 
 
-def test_wait_until_true_inner_function_returns_false():
-    assert wait_until_true(inner_function_return_false) is False
+def test_wait_until_true_custom_inner_function_returns_false():
+    assert wait_until_true_custom(inner_function_return_false, timeout=0.1) is False
 
 
 def test_wait_until_false_inner_function_returns_true():
-    assert wait_until_false(inner_function_return_true) is False
+    assert wait_until_false_custom(inner_function_return_true, timeout=0.1) is False
 
 
 def test_wait_until_false_inner_function_returns_false():
-    assert wait_until_false(inner_function_return_false)
+    assert wait_until_false_custom(inner_function_return_false, timeout=0.1)
 
 
-def test_wait_until_true_returns_with_result():
-    assert wait_until_true(inner_function_add_numbers) == 5
+def test_wait_until_true_custom_returns_with_result():
+    assert wait_until_true_custom(inner_function_add_numbers, timeout=0.1) == 5

--- a/tests/pytest_framework/src/message_reader/message_reader.py
+++ b/tests/pytest_framework/src/message_reader/message_reader.py
@@ -21,7 +21,8 @@
 #
 #############################################################################
 
-from src.common.blocking import wait_until_true
+from src.common.blocking import wait_until_true_custom
+from src.common.blocking import DEFAULT_TIMEOUT
 
 
 class MessageReader(object):
@@ -47,8 +48,8 @@ class MessageReader(object):
             return len(self.__parser.msg_list)
         return counter
 
-    def pop_messages(self, counter):
-        assert wait_until_true(self.__buffer_and_parse, counter) is True
+    def pop_messages(self, counter, timeout=DEFAULT_TIMEOUT):
+        assert wait_until_true_custom(self.__buffer_and_parse, args=(counter,), timeout=timeout) is True
         counter = self.__map_counter(counter)
         required_number_of_messages = self.__parser.msg_list[0:counter]
         self.__parser.msg_list = self.__parser.msg_list[
@@ -57,7 +58,7 @@ class MessageReader(object):
         return required_number_of_messages
 
     def peek_messages(self, counter):
-        assert wait_until_true(self.__buffer_and_parse, counter) is True
+        assert wait_until_true_custom(self.__buffer_and_parse, args=(counter,)) is True
         counter = self.__map_counter(counter)
         required_number_of_messages = self.__parser.msg_list[0:counter]
         return required_number_of_messages

--- a/tests/pytest_framework/src/message_reader/tests/test_message_reader.py
+++ b/tests/pytest_framework/src/message_reader/tests/test_message_reader.py
@@ -26,8 +26,6 @@ from src.message_reader.message_reader import MessageReader
 from src.message_reader.single_line_parser import SingleLineParser
 from src.common import blocking
 
-blocking.MONITORING_TIME = 0.1
-
 
 @pytest.mark.parametrize(
     "input_message_counter, requested_message_counter, expected_result",
@@ -105,7 +103,7 @@ def test_pop_messages(tc_unittest, input_message, requested_message_counter, pop
 
     if requested_message_counter > input_message.count("\n"):
         with pytest.raises(AssertionError):
-            message_reader.pop_messages(requested_message_counter)
+            message_reader.pop_messages(requested_message_counter, timeout=0.1)
     else:
         assert message_reader.pop_messages(requested_message_counter) == popped_message
         assert message_reader._MessageReader__parser.msg_list == remaining_message


### PR DESCRIPTION
Prior this patch, pytest_framework did not support specifying timeout
as parameter for `wait_until_true`. Instead, a global variable was
responsible for the timeout. The default timeout (10s) was good for
the functional tests, but not for the unit tests, which executed
properly but unnecessarily long. For unit tests this global variable
was changed to 0.1s, which is too small for the functional
tests. Consequently, unit tests and functional tests cannot not be
executed together.

This patch adds timeout parameter for `wait_until_true`, and set the
proper timeout locally for unit tests. Hence unit tests and e2e test
can be executed together.

For example:
```
python3 -m pytest --installdir ../root/ tests/pytest_framework/src tests/pytest_framework/functional_tests
```

The way of parameterization (arguments as tuple) was motivated from
the way `threading.Thread` works.
One inconvenient thing worth mentioning: in python - single element
tuples need explicit comma ... `(1) == 1`. One needs to use `(1,)`.