### PR TITLE
filter-re: ref/unref NVTable around regex eval

### DIFF
--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -49,14 +49,20 @@ static gboolean
 filter_re_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
 {
   FilterRE *self = (FilterRE *) s;
+  NVTable *payload;
   const gchar *value;
   LogMessage *msg = msgs[num_msg - 1];
   gssize len = 0;
+  gboolean rc;
 
+  payload = nv_table_ref(msg->payload);
   value = log_msg_get_value(msg, self->value_handle, &len);
-
   APPEND_ZERO(value, value, len);
-  return filter_re_eval_string(s, msg, self->value_handle, value, len);
+
+  rc = filter_re_eval_string(s, msg, self->value_handle, value, len);
+
+  nv_table_unref(payload);
+  return rc;
 }
 
 static void


### PR DESCRIPTION
The regex evaluation can change the message itself, by adding
values to its NVTable.
The change can result in reallocating the message's NVTable, if
there is insufficient space for the newly added value.
We do not want this to happen, because we are pointing to a value
of it.

When we reference the NVTable, if it needs more space, it will be
copied, instead of being moved. After we are done using it, we can
unref it, which will result in freeing it, if it was copied during
the evaluation, so memory will not be leaked.

Fixes #2470.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>