### PR TITLE
pytest_framework: invalid state with read all messages

### DIFF
--- a/tests/pytest_framework/src/message_reader/message_reader.py
+++ b/tests/pytest_framework/src/message_reader/message_reader.py
@@ -41,7 +41,9 @@ class MessageReader(object):
             self.__read_eof = True
         if counter != self.__read_all_messages:
             return len(self.__parser.msg_list) >= counter
-        return self.__read_eof
+        retval = self.__read_eof
+        self.__read_eof = False
+        return retval
 
     def __map_counter(self, counter):
         if counter == self.__read_all_messages:

--- a/tests/pytest_framework/src/message_reader/message_reader.py
+++ b/tests/pytest_framework/src/message_reader/message_reader.py
@@ -32,19 +32,18 @@ class MessageReader(object):
 
         self.__read = read
         self.__parser = parser
-        self.__read_eof = False
 
     def __buffer_and_parse(self, counter):
         buffered_chunk = self.__read()
-        if buffered_chunk:
-            self.__parser.parse_buffer(buffered_chunk)
+        if counter == READ_ALL_MESSAGES:
+            if buffered_chunk:
+                self.__parser.parse_buffer(buffered_chunk)
+                return False
+            else:
+                return True # eof reached
         else:
-            self.__read_eof = True
-        if counter != READ_ALL_MESSAGES:
+            self.__parser.parse_buffer(buffered_chunk)
             return len(self.__parser.msg_list) >= counter
-        retval = self.__read_eof
-        self.__read_eof = False
-        return retval
 
     def __map_counter(self, counter):
         if counter == READ_ALL_MESSAGES:

--- a/tests/pytest_framework/src/message_reader/message_reader.py
+++ b/tests/pytest_framework/src/message_reader/message_reader.py
@@ -24,11 +24,12 @@
 from src.common.blocking import wait_until_true_custom
 from src.common.blocking import DEFAULT_TIMEOUT
 
+READ_ALL_MESSAGES = 0
 
 class MessageReader(object):
     def __init__(self, logger_factory, read, parser):
         self.__logger = logger_factory.create_logger("MessageReader")
-        self.__read_all_messages = 0
+
         self.__read = read
         self.__parser = parser
         self.__read_eof = False
@@ -39,14 +40,14 @@ class MessageReader(object):
             self.__parser.parse_buffer(buffered_chunk)
         else:
             self.__read_eof = True
-        if counter != self.__read_all_messages:
+        if counter != READ_ALL_MESSAGES:
             return len(self.__parser.msg_list) >= counter
         retval = self.__read_eof
         self.__read_eof = False
         return retval
 
     def __map_counter(self, counter):
-        if counter == self.__read_all_messages:
+        if counter == READ_ALL_MESSAGES:
             return len(self.__parser.msg_list)
         return counter
 

--- a/tests/pytest_framework/src/message_reader/tests/test_message_reader.py
+++ b/tests/pytest_framework/src/message_reader/tests/test_message_reader.py
@@ -22,10 +22,9 @@
 #
 #############################################################################
 import pytest
-from src.message_reader.message_reader import MessageReader
+from src.message_reader.message_reader import MessageReader, READ_ALL_MESSAGES
 from src.message_reader.single_line_parser import SingleLineParser
 from src.common import blocking
-
 
 @pytest.mark.parametrize(
     "input_message_counter, requested_message_counter, expected_result",
@@ -147,7 +146,7 @@ def test_writing_popping_in_sequence(tc_unittest):
     test_message = "test message 6\ntest message 7\ntest message 8\ntest message 9\n"
     writeable_file.write(test_message)
     writeable_file.flush()
-    assert message_reader.pop_messages(counter=0) == test_message.splitlines(True)
+    assert message_reader.pop_messages(counter=READ_ALL_MESSAGES) == test_message.splitlines(True)
 
     test_message = "test message 10\n"
     writeable_file.write(test_message)
@@ -175,5 +174,5 @@ def test_read_all_messages(tc_unittest):
     generator = read_generator()
     message_reader = MessageReader(tc_unittest.get_fake_logger_factory(), lambda : next(generator), single_line_parser)
 
-    assert len(message_reader.pop_messages(counter=0)) == 0
-    assert len(message_reader.pop_messages(counter=0)) == 2
+    assert len(message_reader.pop_messages(counter=READ_ALL_MESSAGES)) == 0
+    assert len(message_reader.pop_messages(counter=READ_ALL_MESSAGES)) == 2

--- a/tests/pytest_framework/src/message_reader/tests/test_message_reader.py
+++ b/tests/pytest_framework/src/message_reader/tests/test_message_reader.py
@@ -163,3 +163,17 @@ def test_peek_messages(tc_unittest):
 
     assert message_reader.peek_messages(counter=2) == test_message.splitlines(True)
     assert message_reader._MessageReader__parser.msg_list == test_message.splitlines(True)
+
+def test_read_all_messages(tc_unittest):
+    def read_generator():
+        yield "" # eof
+        yield "second\n"
+        yield "third\n"
+        yield "" # eof
+
+    single_line_parser = SingleLineParser(tc_unittest.get_fake_logger_factory())
+    generator = read_generator()
+    message_reader = MessageReader(tc_unittest.get_fake_logger_factory(), lambda : next(generator), single_line_parser)
+
+    assert len(message_reader.pop_messages(counter=0)) == 0
+    assert len(message_reader.pop_messages(counter=0)) == 2

--- a/tests/pytest_framework/src/syslog_ng/console_log_reader.py
+++ b/tests/pytest_framework/src/syslog_ng/console_log_reader.py
@@ -21,7 +21,7 @@
 #
 #############################################################################
 
-from src.message_reader.message_reader import MessageReader
+from src.message_reader.message_reader import MessageReader, READ_ALL_MESSAGES
 from src.driver_io.file.file_io import FileIO
 from src.message_reader.single_line_parser import SingleLineParser
 
@@ -52,7 +52,7 @@ class ConsoleLogReader(object):
         if not self.__stderr_io.wait_for_creation():
             raise Exception
 
-        console_log_messages = self.__message_reader.pop_messages(counter=0)
+        console_log_messages = self.__message_reader.pop_messages(counter=READ_ALL_MESSAGES)
         console_log_content = "".join(console_log_messages)
 
         result = []
@@ -62,7 +62,7 @@ class ConsoleLogReader(object):
 
     def check_for_unexpected_messages(self, unexpected_messages):
         unexpected_patterns = ["Plugin module not found"]
-        console_log_messages = self.__message_reader.peek_messages(counter=0)
+        console_log_messages = self.__message_reader.peek_messages(counter=READ_ALL_MESSAGES)
         if unexpected_messages is not None:
             unexpected_patterns.append(unexpected_messages)
         for unexpected_pattern in unexpected_patterns:
@@ -72,7 +72,7 @@ class ConsoleLogReader(object):
                     assert False
 
     def dump_stderr(self, last_n_lines=10):
-        console_log_messages = self.__message_reader.peek_messages(counter=0)
+        console_log_messages = self.__message_reader.peek_messages(counter=READ_ALL_MESSAGES)
         self.__logger.info("".join(console_log_messages[-last_n_lines:]))
 
     @staticmethod


### PR DESCRIPTION
Due to invalid state handling in MessageReader buffer and parsing, it was possible not to get all messages if the same reader is used second time.

To trigger, such a read method is needed that fetches data in blocks. In that sense, there is no triggerable bug in the current version of the framework, because the only supported read method is the file read, which reads until eof.

This patch eliminates the state itself, and covers the case with a unittest.