### PR TITLE
pytest_framework: eliminating __registered_instances, exposing SyslogNgCtl to user api

### DIFF
--- a/tests/pytest_framework/conftest.py
+++ b/tests/pytest_framework/conftest.py
@@ -21,7 +21,7 @@
 #
 #############################################################################
 
-import pytest
+import pytest, subprocess
 from pathlib2 import Path
 from datetime import datetime
 from src.setup.testcase import SetupTestCase
@@ -56,7 +56,7 @@ def reports(request):
     return request.config.getoption("--reports")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def installdir(request):
     return request.config.getoption("--installdir")
 
@@ -96,3 +96,9 @@ def tc(request):
 @pytest.fixture
 def tc_unittest(request):
     return SetupUnitTestcase(request, get_current_date)
+
+@pytest.fixture(scope="session")
+def version(request, installdir):
+    binary_path = str(Path(installdir, "sbin", "syslog-ng"))
+    version_output = subprocess.check_output([binary_path, "--version"]).decode()
+    return version_output.splitlines()[1].split()[2]

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -86,8 +86,10 @@ class SetupTestCase(object):
     def new_syslog_ng_ctl(self, syslog_ng):
         return SyslogNgCtl(self.__logger_factory, syslog_ng.instance_paths)
 
-    def new_config(self):
-        return SyslogNgConfig(self.__logger_factory, self.__testcase_parameters.get_working_dir())
+    def new_config(self, version=None):
+        if not version:
+            version = self.__testcase_context.getfixturevalue("version")
+        return SyslogNgConfig(self.__logger_factory, self.__testcase_parameters.get_working_dir(), version)
 
     @staticmethod
     def format_as_bsd(log_message):

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -27,7 +27,6 @@ from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
 from src.logger.logger_factory import LoggerFactory
 from src.syslog_ng_config.syslog_ng_config import SyslogNgConfig
 from src.syslog_ng.syslog_ng import SyslogNg
-from src.syslog_ng.syslog_ng_cli import SyslogNgCli
 from src.message_builder.bsd_format import BSDFormat
 from src.message_builder.log_message import LogMessage
 
@@ -79,8 +78,7 @@ class SetupTestCase(object):
         instance_paths = SyslogNgPaths(self.__testcase_context, self.__testcase_parameters).set_syslog_ng_paths(
             instance_name
         )
-        syslog_ng_cli = SyslogNgCli(self.__logger_factory, instance_paths, self.__testcase_parameters)
-        syslog_ng = SyslogNg(syslog_ng_cli)
+        syslog_ng = SyslogNg(self.__logger_factory, instance_paths, self.__testcase_parameters)
         self.__teardown_actions.append(syslog_ng.stop)
         return syslog_ng
 

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -26,6 +26,7 @@ from src.setup.testcase_parameters import TestcaseParameters
 from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
 from src.logger.logger_factory import LoggerFactory
 from src.syslog_ng_config.syslog_ng_config import SyslogNgConfig
+from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
 from src.syslog_ng.syslog_ng import SyslogNg
 from src.message_builder.bsd_format import BSDFormat
 from src.message_builder.log_message import LogMessage
@@ -81,6 +82,9 @@ class SetupTestCase(object):
         syslog_ng = SyslogNg(self.__logger_factory, instance_paths, self.__testcase_parameters)
         self.__teardown_actions.append(syslog_ng.stop)
         return syslog_ng
+
+    def new_syslog_ng_ctl(self, syslog_ng):
+        return SyslogNgCtl(self.__logger_factory, syslog_ng.instance_paths)
 
     def new_config(self):
         return SyslogNgConfig(self.__logger_factory, self.__testcase_parameters.get_working_dir())

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -89,7 +89,7 @@ class SetupTestCase(object):
         self.__instances.update({instance_name: {}})
         self.__instances[instance_name]["syslog-ng"] = syslog_ng
         self.__instances[instance_name]["config"] = SyslogNgConfig(
-            self.__logger_factory, instance_paths, syslog_ng.get_version()
+            self.__logger_factory, instance_paths
         )
 
     def new_config(self, instance_name="server"):

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -42,7 +42,6 @@ class SetupTestCase(object):
             report_file=self.__testcase_parameters.get_report_file(), loglevel=self.__testcase_parameters.get_loglevel()
         )
         self.__logger = self.__logger_factory.create_logger("Setup", use_console_handler=True, use_file_handler=True)
-        self.__instances = {}
 
         self.__teardown_actions = []
         testcase_context.addfinalizer(self.__teardown)
@@ -76,26 +75,17 @@ class SetupTestCase(object):
                     )
                     self.__logger.error(str(failed_report.longrepr))
 
-    def __is_instance_registered(self, instance_name):
-        return instance_name in self.__instances.keys()
-
-    def __register_instance(self, instance_name):
+    def new_syslog_ng(self, instance_name="server"):
         instance_paths = SyslogNgPaths(self.__testcase_context, self.__testcase_parameters).set_syslog_ng_paths(
             instance_name
         )
         syslog_ng_cli = SyslogNgCli(self.__logger_factory, instance_paths, self.__testcase_parameters)
         syslog_ng = SyslogNg(syslog_ng_cli)
         self.__teardown_actions.append(syslog_ng.stop)
-        self.__instances.update({instance_name: {}})
-        self.__instances[instance_name]["syslog-ng"] = syslog_ng
+        return syslog_ng
 
     def new_config(self):
         return SyslogNgConfig(self.__logger_factory, self.__testcase_parameters.get_working_dir())
-
-    def new_syslog_ng(self, instance_name="server"):
-        if not self.__is_instance_registered(instance_name):
-            self.__register_instance(instance_name)
-        return self.__instances[instance_name]["syslog-ng"]
 
     @staticmethod
     def format_as_bsd(log_message):

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -89,7 +89,7 @@ class SetupTestCase(object):
         self.__instances.update({instance_name: {}})
         self.__instances[instance_name]["syslog-ng"] = syslog_ng
         self.__instances[instance_name]["config"] = SyslogNgConfig(
-            self.__logger_factory, instance_paths
+            self.__logger_factory, instance_paths.get_working_dir()
         )
 
     def new_config(self, instance_name="server"):

--- a/tests/pytest_framework/src/setup/testcase.py
+++ b/tests/pytest_framework/src/setup/testcase.py
@@ -88,14 +88,9 @@ class SetupTestCase(object):
         self.__teardown_actions.append(syslog_ng.stop)
         self.__instances.update({instance_name: {}})
         self.__instances[instance_name]["syslog-ng"] = syslog_ng
-        self.__instances[instance_name]["config"] = SyslogNgConfig(
-            self.__logger_factory, instance_paths.get_working_dir()
-        )
 
-    def new_config(self, instance_name="server"):
-        if not self.__is_instance_registered(instance_name):
-            self.__register_instance(instance_name)
-        return self.__instances[instance_name]["config"]
+    def new_config(self):
+        return SyslogNgConfig(self.__logger_factory, self.__testcase_parameters.get_working_dir())
 
     def new_syslog_ng(self, instance_name="server"):
         if not self.__is_instance_registered(instance_name):

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng.py
@@ -25,6 +25,7 @@ from src.syslog_ng.syslog_ng_cli import SyslogNgCli
 
 class SyslogNg(object):
     def __init__(self, logger_factory, instance_paths, testcase_parameters):
+        self.instance_paths = instance_paths
         self.__syslog_ng_cli = SyslogNgCli(logger_factory, instance_paths, testcase_parameters)
 
     def start(self, config):

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng.py
@@ -21,10 +21,11 @@
 #
 #############################################################################
 
+from src.syslog_ng.syslog_ng_cli import SyslogNgCli
 
 class SyslogNg(object):
-    def __init__(self, syslog_ng_cli):
-        self.__syslog_ng_cli = syslog_ng_cli
+    def __init__(self, logger_factory, instance_paths, testcase_parameters):
+        self.__syslog_ng_cli = SyslogNgCli(logger_factory, instance_paths, testcase_parameters)
 
     def start(self, config):
         self.__syslog_ng_cli.start(config)

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -89,6 +89,7 @@ class SyslogNgCli(object):
     # Process commands
     def start(self, config):
         self.__logger.info("Beginning of syslog-ng start")
+        config.set_version(self.get_version())
         config.write_config_content()
 
         self.__syntax_check()
@@ -98,6 +99,7 @@ class SyslogNgCli(object):
 
     def reload(self, config):
         self.__logger.info("Beginning of syslog-ng reload")
+        config.set_version(self.get_version())
         config.write_config_content()
 
         # effective reload

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -89,7 +89,6 @@ class SyslogNgCli(object):
     # Process commands
     def start(self, config):
         self.__logger.info("Beginning of syslog-ng start")
-        config.set_version(self.get_version())
         config.write_content(self.__instance_paths.get_config_path())
 
         self.__syntax_check()
@@ -99,7 +98,6 @@ class SyslogNgCli(object):
 
     def reload(self, config):
         self.__logger.info("Beginning of syslog-ng reload")
-        config.set_version(self.get_version())
         config.write_content(self.__instance_paths.get_config_path())
 
         # effective reload

--- a/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/pytest_framework/src/syslog_ng/syslog_ng_cli.py
@@ -90,7 +90,7 @@ class SyslogNgCli(object):
     def start(self, config):
         self.__logger.info("Beginning of syslog-ng start")
         config.set_version(self.get_version())
-        config.write_config_content()
+        config.write_content(self.__instance_paths.get_config_path())
 
         self.__syntax_check()
         self.__start_syslog_ng()
@@ -100,7 +100,7 @@ class SyslogNgCli(object):
     def reload(self, config):
         self.__logger.info("Beginning of syslog-ng reload")
         config.set_version(self.get_version())
-        config.write_config_content()
+        config.write_content(self.__instance_paths.get_config_path())
 
         # effective reload
         self.__syslog_ng_ctl.reload()

--- a/tests/pytest_framework/src/syslog_ng_config/renderer.py
+++ b/tests/pytest_framework/src/syslog_ng_config/renderer.py
@@ -25,9 +25,9 @@ from pathlib2 import Path
 
 
 class ConfigRenderer(object):
-    def __init__(self, syslog_ng_config, instance_paths):
+    def __init__(self, syslog_ng_config, working_dir):
         self.__syslog_ng_config = syslog_ng_config
-        self.__instance_paths = instance_paths
+        self.__working_dir = working_dir
         self.__syslog_ng_config_content = ""
         self.__render()
 
@@ -60,8 +60,8 @@ class ConfigRenderer(object):
     def __render_positional_options(self, driver_options, positional_options):
         for option_name, option_value in driver_options.items():
             if option_name in positional_options:
-                if str(self.__instance_paths.get_working_dir()) not in str(option_value):
-                    driver_options[option_name] = Path(self.__instance_paths.get_working_dir(), option_value)
+                if str(self.__working_dir) not in str(option_value):
+                    driver_options[option_name] = Path(self.__working_dir, option_value)
                 option_value = str(driver_options[option_name])
                 self.__syslog_ng_config_content += "        {}\n".format(option_value)
 

--- a/tests/pytest_framework/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -27,12 +27,12 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 
 
 class FileDestination(DestinationDriver):
-    def __init__(self, logger_factory, instance_paths, **kwargs):
+    def __init__(self, logger_factory, working_dir, **kwargs):
         super(FileDestination, self).__init__(logger_factory, FileIO)
         self.__options = kwargs
         self.__driver_name = "file"
         self.__positional_option = "file_name"
-        self.__construct_file_path(instance_paths)
+        self.__construct_file_path(working_dir)
 
     @property
     def driver_name(self):
@@ -55,9 +55,9 @@ class FileDestination(DestinationDriver):
     def read_logs(self, counter):
         return self.dd_read_logs(self.get_path(), counter=counter)
 
-    def __construct_file_path(self, instance_paths):
+    def __construct_file_path(self, working_dir):
         if self.positional_option_name in self.options.keys():
             given_positional_option_value = self.options[self.positional_option_name]
             self.options[self.positional_option_name] = Path(
-                instance_paths.get_working_dir(), given_positional_option_value
+                working_dir, given_positional_option_value
             )

--- a/tests/pytest_framework/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/pytest_framework/src/syslog_ng_config/statements/sources/file_source.py
@@ -27,12 +27,12 @@ from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 
 
 class FileSource(SourceDriver):
-    def __init__(self, logger_factory, instance_paths, **kwargs):
+    def __init__(self, logger_factory, working_dir, **kwargs):
         super(FileSource, self).__init__(logger_factory, FileIO)
         self.__options = kwargs
         self.__driver_name = "file"
         self.__positional_option = "file_name"
-        self.__construct_file_path(instance_paths)
+        self.__construct_file_path(working_dir)
 
     @property
     def driver_name(self):
@@ -52,9 +52,9 @@ class FileSource(SourceDriver):
     def write_log(self, formatted_log, counter=1):
         self.sd_write_log(self.get_path(), formatted_log, counter=counter)
 
-    def __construct_file_path(self, instance_paths):
+    def __construct_file_path(self, working_dir):
         if self.positional_option_name in self.options.keys():
             given_positional_option_value = self.options[self.positional_option_name]
             self.options[self.positional_option_name] = Path(
-                instance_paths.get_working_dir(), given_positional_option_value
+                working_dir, given_positional_option_value
             )

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -32,11 +32,12 @@ from src.syslog_ng_config.statements.filters.filter import Filter
 
 
 class SyslogNgConfig(object):
-    def __init__(self, logger_factory, working_dir):
+    def __init__(self, logger_factory, working_dir, version):
         self.__working_dir = working_dir
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("SyslogNgConfig")
         self.__syslog_ng_config = {
+            "version": version,
             "global_options": {},
             "statement_groups": [],
             "logpath_groups": [],

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -32,9 +32,8 @@ from src.syslog_ng_config.statements.filters.filter import Filter
 
 
 class SyslogNgConfig(object):
-    def __init__(self, logger_factory, instance_paths):
-        self.__instance_paths = instance_paths
-        self.__config_path = instance_paths.get_config_path()
+    def __init__(self, logger_factory, working_dir):
+        self.__working_dir = working_dir
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("SyslogNgConfig")
         self.__syslog_ng_config = {
@@ -46,15 +45,15 @@ class SyslogNgConfig(object):
     def set_version(self, version):
         self.__syslog_ng_config["version"]=version
 
-    def write_config_content(self):
-        rendered_config = ConfigRenderer(self.__syslog_ng_config, self.__instance_paths).get_rendered_config()
+    def write_content(self, config_path):
+        rendered_config = ConfigRenderer(self.__syslog_ng_config, self.__working_dir).get_rendered_config()
         self.__logger.info(
             "Used config \
         \n->Content:[{}]".format(
                 rendered_config
             )
         )
-        FileIO(self.__logger_factory, self.__config_path).rewrite(rendered_config)
+        FileIO(self.__logger_factory, config_path).rewrite(rendered_config)
 
     def create_statement_group_if_needed(self, item):
         if isinstance(item, (StatementGroup, LogPath)):
@@ -80,10 +79,10 @@ class SyslogNgConfig(object):
         self.__syslog_ng_config["global_options"].update(kwargs)
 
     def create_file_source(self, **kwargs):
-        return FileSource(self.__logger_factory, self.__instance_paths, **kwargs)
+        return FileSource(self.__logger_factory, self.__working_dir, **kwargs)
 
     def create_file_destination(self, **kwargs):
-        return FileDestination(self.__logger_factory, self.__instance_paths, **kwargs)
+        return FileDestination(self.__logger_factory, self.__working_dir, **kwargs)
 
     def create_filter(self, **kwargs):
         return Filter(self.__logger_factory, **kwargs)

--- a/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/pytest_framework/src/syslog_ng_config/syslog_ng_config.py
@@ -32,17 +32,19 @@ from src.syslog_ng_config.statements.filters.filter import Filter
 
 
 class SyslogNgConfig(object):
-    def __init__(self, logger_factory, instance_paths, syslog_ng_version):
+    def __init__(self, logger_factory, instance_paths):
         self.__instance_paths = instance_paths
         self.__config_path = instance_paths.get_config_path()
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("SyslogNgConfig")
         self.__syslog_ng_config = {
-            "version": syslog_ng_version,
             "global_options": {},
             "statement_groups": [],
             "logpath_groups": [],
         }
+
+    def set_version(self, version):
+        self.__syslog_ng_config["version"]=version
 
     def write_config_content(self):
         rendered_config = ConfigRenderer(self.__syslog_ng_config, self.__instance_paths).get_rendered_config()


### PR DESCRIPTION
This patchset starts off by making `SyslogNgConfig` independently deployable from `SyslogNg`.

Until now, they depended on a common `SyslogNgPaths` instance, so these two needed to be created at the same time. Thats why the `__registered_instances` database was introduced originally, so that either one is created, the other one is created too, and cached in case it will be queried later. This had the benefit that users do not need to know about the hidden dependency, they could just create a new config, then a syslog_ng instance, without explicitely linking the two together.

After looking into the nature of the dependency, it turned out `SyslogNgConfig` needed only the current `working_directory` from `SyslogNgPaths`, which could be also queried from the testcase parameters. It also needed the path of the configuration that would be used when the config is written, and also a syslog_ng version. I removed these dependencies, and made `SyslogNg` to inject them, only when needed. I believe this removal makes sense: for now the Driver creation in SyslogNgConfig does not depend on the version, and I don't think it will in the future, as the framework version is tied to the syslog_ng source version, as sharing the common repository. I was thinking we could even fill it from `gitroot/VERSION`, but now I remained with the original concept, we ask it from the installed syslog_ng.
Removing config_path also seems reasonable, `SyslogNgConfig` should just have a textual representation, and could be written to anywhere at will without losing any of its merits.

As a result, `SyslogNgConfig` and `SyslogNg` is created independently, which aligns well with that shown in the user api.

So the question remained: how can I expose `SyslogNgCtl` after eliminating `__registered_instances`. To resolve that I promoted SyslogNg to know about instance paths too. Until now `SyslogNg` was nothing more than the public interface of `SyslogNgCli`. So they share the same construction dependency. So I could move `SyslogNgCli` creation into `SyslogNg`, and make the common dependencies into the constructor.

After the change, I will think about `SyslogNg` that carries around knowledge about the whole syslog_ng deployment, which is `SyslogNgPaths` for now. With `SyslogNgPaths` exposed through `SyslogNg`, I could construct a `SyslogNgCtl` from `SyslogNg`: `syslog_ng_ctl = SyslogNgCtl(syslog_ng)`. This makes sense, because a `SyslogNgCtl` does not stand on its own, it depends on the deployed syslog_ng (for example through control socket path). This expression makes this connection explicit.