### PR TITLE
python: internal() source exposed via syslogng.Logger

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -45,6 +45,8 @@ set(PYTHON_SOURCES
     python-logparser.c
     python-integerpointer.h
     python-integerpointer.c
+    python-logger.h
+    python-logger.c
     python-source.h
     python-source.c
     python-fetcher.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -48,6 +48,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-logtemplate-options.c\
 	modules/python/python-integerpointer.c    \
 	modules/python/python-integerpointer.h    \
+	modules/python/python-logger.c    \
+	modules/python/python-logger.h    \
 	modules/python/python-global-code-loader.h\
 	modules/python/python-global-code-loader.c\
 	modules/python/python-debugger.h	  \

--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-logger.h"
+
+#include "python-helpers.h"
+#include "messages.h"
+
+PyTypeObject py_logger_type;
+
+
+PyObject *
+py_msg_error(PyObject *obj, PyObject *args)
+{
+  char *message = NULL;
+  if (!PyArg_ParseTuple(args, "s", &message))
+    return NULL;
+
+  msg_error(message);
+  return Py_None;
+}
+
+PyObject *
+py_msg_warning(PyObject *obj, PyObject *args)
+{
+  char *message = NULL;
+  if (!PyArg_ParseTuple(args, "s", &message))
+    return NULL;
+
+  msg_warning(message);
+  return Py_None;
+}
+
+PyObject *
+py_msg_info(PyObject *obj, PyObject *args)
+{
+  char *message = NULL;
+  if (!PyArg_ParseTuple(args, "s", &message))
+    return NULL;
+
+  msg_info(message);
+  return Py_None;
+}
+
+PyObject *
+py_msg_debug(PyObject *obj, PyObject *args)
+{
+  if (!debug_flag)
+    return Py_None;
+
+  char *message = NULL;
+  if (!PyArg_ParseTuple(args, "s", &message))
+    return NULL;
+
+  msg_debug(message);
+  return Py_None;
+}
+
+PyObject *
+py_msg_trace(PyObject *obj, PyObject *args)
+{
+  if (!trace_flag)
+    return Py_None;
+
+  char *message = NULL;
+  if (!PyArg_ParseTuple(args, "s", &message))
+    return NULL;
+
+  msg_trace(message);
+  return Py_None;
+}
+
+
+
+static PyMethodDef py_logger_methods[] =
+{
+  { "error",   (PyCFunction)py_msg_error,   METH_VARARGS, "msg_error" },
+  { "warning", (PyCFunction)py_msg_warning, METH_VARARGS, "msg_warning" },
+  { "info",    (PyCFunction)py_msg_info,    METH_VARARGS, "msg_info" },
+  { "debug",   (PyCFunction)py_msg_debug,   METH_VARARGS, "msg_debug" },
+  { "trace",   (PyCFunction)py_msg_trace,   METH_VARARGS, "msg_trace" },
+
+  { NULL }
+};
+
+PyTypeObject py_logger_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_basicsize = sizeof(PyObject),
+  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_doc = "Those messages can be captured by internal() source.",
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_methods = py_logger_methods,
+  .tp_name = "Logger",
+  .tp_new = PyType_GenericNew,
+  0
+};
+
+void
+py_logger_init(void)
+{
+  PyType_Ready(&py_logger_type);
+  PyModule_AddObject(PyImport_AddModule("syslogng"), "Logger", (PyObject *) &py_logger_type);
+}

--- a/modules/python/python-logger.h
+++ b/modules/python/python-logger.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_LOGGER_H
+#define _SNG_PYTHON_LOGGER_H
+
+#include "python-module.h"
+
+
+void py_logger_init(void);
+
+#endif

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -29,6 +29,7 @@
 #include "python-logmsg.h"
 #include "python-logtemplate.h"
 #include "python-integerpointer.h"
+#include "python-logger.h"
 #include "python-source.h"
 #include "python-fetcher.h"
 #include "python-global-code-loader.h"
@@ -89,6 +90,7 @@ _py_init_interpreter(void)
       py_log_source_init();
       py_log_fetcher_init();
       py_global_code_loader_init();
+      py_logger_init();
       PyEval_SaveThread();
 
       interpreter_initialized = TRUE;


### PR DESCRIPTION
Introduces a logger that can send messages into the `internal()` source, which also respects the syslog-ng log level.


```python
import syslogng

logger = syslogng.Logger()

logger.error("plain text message")
logger.warning("plain text message")
logger.info("plain text message")
logger.debug("plain text message")
logger.trace("plain text message")
```

Question:
* Could syslogng utilize the built-in `logger` class by extending it (creating only a handler for internal source) ?
* Does the apsense of `evt_tag_*` formatting cause significant performance issue? Should it be solved ?

Fixes #1375