### PR TITLE
simpler names for WORKER_INSERT_RESULT_T in language bindings

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -309,7 +309,7 @@ _perform_flush(LogThreadedDestWorker *self)
                 evt_tag_int("worker_index", self->worker_index),
                 evt_tag_int("batch_size", self->batch_size));
 
-      worker_insert_result_t result = log_threaded_dest_worker_flush(self);
+      LogThreadedResult result = log_threaded_dest_worker_flush(self);
       _process_result(self, result);
     }
 
@@ -323,7 +323,7 @@ static void
 _perform_inserts(LogThreadedDestWorker *self)
 {
   LogMessage *msg;
-  worker_insert_result_t result;
+  LogThreadedResult result;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
   if (self->batch_size == 0)
@@ -651,7 +651,7 @@ _worker_thread(gpointer arg)
   _schedule_restart(self);
   iv_main();
 
-  worker_insert_result_t result = log_threaded_dest_worker_flush(self);
+  LogThreadedResult result = log_threaded_dest_worker_flush(self);
   _process_result(self, result);
   log_queue_rewind_backlog_all(self->queue);
 
@@ -768,13 +768,13 @@ _compat_disconnect(LogThreadedDestWorker *self)
     self->owner->worker.disconnect(self->owner);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _compat_insert(LogThreadedDestWorker *self, LogMessage *msg)
 {
   return self->owner->worker.insert(self->owner, msg);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _compat_flush(LogThreadedDestWorker *self)
 {
   if (self->owner->worker.flush)

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -37,13 +37,13 @@
 
 typedef enum
 {
-  WORKER_INSERT_RESULT_DROP,
-  WORKER_INSERT_RESULT_ERROR,
-  WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT,
-  WORKER_INSERT_RESULT_SUCCESS,
-  WORKER_INSERT_RESULT_QUEUED,
-  WORKER_INSERT_RESULT_NOT_CONNECTED,
-  WORKER_INSERT_RESULT_MAX
+  LTR_DROP,
+  LTR_ERROR,
+  LTR_EXPLICIT_ACK_MGMT,
+  LTR_SUCCESS,
+  LTR_QUEUED,
+  LTR_NOT_CONNECTED,
+  LTR_MAX
 } LogThreadedResult;
 
 typedef struct _LogThreadedDestDriver LogThreadedDestDriver;
@@ -179,7 +179,7 @@ log_threaded_dest_worker_insert(LogThreadedDestWorker *self, LogMessage *msg)
 static inline LogThreadedResult
 log_threaded_dest_worker_flush(LogThreadedDestWorker *self)
 {
-  LogThreadedResult result = WORKER_INSERT_RESULT_SUCCESS;
+  LogThreadedResult result = LTR_SUCCESS;
 
   if (self->flush)
     result = self->flush(self);

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -162,7 +162,7 @@ _insert_single_message_success(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_processed)
@@ -187,7 +187,7 @@ _insert_single_message_drop(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  return WORKER_INSERT_RESULT_DROP;
+  return LTR_DROP;
 }
 
 Test(logthrdestdrv, message_drops_are_accounted_in_the_drop_counter_and_are_reported_properly)
@@ -213,8 +213,8 @@ _insert_single_message_connection_failure(LogThreadedDestDriver *s, LogMessage *
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   if (self->insert_counter++ < 10)
-    return WORKER_INSERT_RESULT_NOT_CONNECTED;
-  return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_NOT_CONNECTED;
+  return LTR_SUCCESS;
 }
 
 Test(logthrdestdrv, connection_failure_is_considered_an_error_and_retried_indefinitely)
@@ -241,7 +241,7 @@ _insert_single_message_error_until_drop(LogThreadedDestDriver *s, LogMessage *ms
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
-  return WORKER_INSERT_RESULT_ERROR;
+  return LTR_ERROR;
 }
 
 Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_drops)
@@ -270,8 +270,8 @@ _insert_single_message_error_until_successful(LogThreadedDestDriver *s, LogMessa
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   if (self->insert_counter++ < 4)
-    return WORKER_INSERT_RESULT_ERROR;
-  return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_ERROR;
+  return LTR_SUCCESS;
 }
 
 Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_accepts)
@@ -301,10 +301,10 @@ _insert_batched_message_success(LogThreadedDestDriver *s, LogMessage *msg)
 
   self->insert_counter++;
   if (self->super.worker.instance.batch_size < s->batch_lines)
-    return WORKER_INSERT_RESULT_QUEUED;
+    return LTR_QUEUED;
 
   self->flush_size += self->super.worker.instance.batch_size;
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 static LogThreadedResult
@@ -314,7 +314,7 @@ _flush_batched_message_success(LogThreadedDestDriver *s)
 
   self->flush_counter++;
   self->flush_size += self->super.worker.instance.batch_size;
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
@@ -344,10 +344,10 @@ _insert_batched_message_drop(LogThreadedDestDriver *s, LogMessage *msg)
 
   self->insert_counter++;
   if (self->super.worker.instance.batch_size < s->batch_lines)
-    return WORKER_INSERT_RESULT_QUEUED;
+    return LTR_QUEUED;
 
   self->flush_size += self->super.worker.instance.batch_size;
-  return WORKER_INSERT_RESULT_DROP;
+  return LTR_DROP;
 }
 
 static LogThreadedResult
@@ -357,7 +357,7 @@ _flush_batched_message_drop(LogThreadedDestDriver *s)
 
   self->flush_counter++;
   self->flush_size += self->super.worker.instance.batch_size;
-  return WORKER_INSERT_RESULT_DROP;
+  return LTR_DROP;
 }
 
 Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
@@ -399,11 +399,11 @@ _insert_batched_message_error_drop(LogThreadedDestDriver *s, LogMessage *msg)
 
   self->insert_counter++;
   if (self->super.worker.instance.batch_size < s->batch_lines)
-    return WORKER_INSERT_RESULT_QUEUED;
+    return LTR_QUEUED;
 
   self->flush_size += self->super.worker.instance.batch_size;
   _expect_batch_size_remains_the_same_across_retries(self);
-  return WORKER_INSERT_RESULT_ERROR;
+  return LTR_ERROR;
 }
 
 static LogThreadedResult
@@ -415,9 +415,9 @@ _flush_batched_message_error_drop(LogThreadedDestDriver *s)
   _expect_batch_size_remains_the_same_across_retries(self);
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.worker.instance.batch_size == 0)
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
 
-  return WORKER_INSERT_RESULT_ERROR;
+  return LTR_ERROR;
 }
 
 Test(logthrdestdrv,
@@ -457,9 +457,9 @@ static inline LogThreadedResult
 _inject_error_a_few_times(TestThreadedDestDriver *self)
 {
   if (self->super.worker.instance.retries_counter >= FAILING_ATTEMPTS_DROP)
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
   else
-    return WORKER_INSERT_RESULT_ERROR;
+    return LTR_ERROR;
 }
 
 static LogThreadedResult
@@ -469,7 +469,7 @@ _insert_batched_message_error_success(LogThreadedDestDriver *s, LogMessage *msg)
 
   self->insert_counter++;
   if (self->super.worker.instance.batch_size < s->batch_lines)
-    return WORKER_INSERT_RESULT_QUEUED;
+    return LTR_QUEUED;
 
   self->flush_size += self->super.worker.instance.batch_size;
   _expect_batch_size_remains_the_same_across_retries(self);
@@ -486,7 +486,7 @@ _flush_batched_message_error_success(LogThreadedDestDriver *s)
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.worker.instance.batch_size == 0)
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
 
   return _inject_error_a_few_times(self);
 }
@@ -530,10 +530,10 @@ _inject_not_connected_a_few_times(TestThreadedDestDriver *self)
   if (self->failure_counter++ >= FAILING_ATTEMPTS_NOTCONN)
     {
       self->failure_counter = 0;
-      return WORKER_INSERT_RESULT_SUCCESS;
+      return LTR_SUCCESS;
     }
   else
-    return WORKER_INSERT_RESULT_NOT_CONNECTED;
+    return LTR_NOT_CONNECTED;
 }
 
 static LogThreadedResult
@@ -543,7 +543,7 @@ _insert_batched_message_not_connected(LogThreadedDestDriver *s, LogMessage *msg)
 
   self->insert_counter++;
   if (self->super.worker.instance.batch_size < s->batch_lines)
-    return WORKER_INSERT_RESULT_QUEUED;
+    return LTR_QUEUED;
 
   self->flush_size += self->super.worker.instance.batch_size;
   _expect_batch_size_remains_the_same_across_retries(self);
@@ -560,7 +560,7 @@ _flush_batched_message_not_connected(LogThreadedDestDriver *s)
 
   /* see the note in logthrdestdrv.c:_perform_flush() */
   if (self->super.worker.instance.batch_size == 0)
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
 
   return _inject_not_connected_a_few_times(self);
 }
@@ -734,11 +734,11 @@ _insert_explicit_acks_message_success(LogThreadedDestDriver *s, LogMessage *msg)
 
   self->insert_counter++;
   if (self->super.worker.instance.batch_size < s->batch_lines)
-    return WORKER_INSERT_RESULT_QUEUED;
+    return LTR_QUEUED;
 
   self->flush_size += 1;
   log_threaded_dest_worker_ack_messages(&s->worker.instance, 1);
-  return WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT;
+  return LTR_EXPLICIT_ACK_MGMT;
 }
 
 static LogThreadedResult
@@ -748,7 +748,7 @@ _flush_explicit_acks_message_success(LogThreadedDestDriver *s)
 
   self->flush_size += 1;
   log_threaded_dest_worker_ack_messages(&s->worker.instance, 1);
-  return WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT;
+  return LTR_EXPLICIT_ACK_MGMT;
 }
 
 Test(logthrdestdrv, test_explicit_ack_accept)

--- a/lib/tests/test_logthrdestdrv.c
+++ b/lib/tests/test_logthrdestdrv.c
@@ -156,7 +156,7 @@ _teardown_dd(void)
   log_pipe_unref(&dd->super.super.super.super);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single_message_success(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -181,7 +181,7 @@ Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_proce
             "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.shared_seq_num);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single_message_drop(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -207,7 +207,7 @@ Test(logthrdestdrv, message_drops_are_accounted_in_the_drop_counter_and_are_repo
   assert_grabbed_log_contains("dropped while sending");
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single_message_connection_failure(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -235,7 +235,7 @@ Test(logthrdestdrv, connection_failure_is_considered_an_error_and_retried_indefi
   assert_grabbed_log_contains("Server disconnected");
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single_message_error_until_drop(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -264,7 +264,7 @@ Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_drops)
   assert_grabbed_log_contains("Multiple failures while sending");
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single_message_error_until_successful(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -294,7 +294,7 @@ Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_accept
   assert_grabbed_log_contains("Error occurred while");
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batched_message_success(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -307,7 +307,7 @@ _insert_batched_message_success(LogThreadedDestDriver *s, LogMessage *msg)
   return WORKER_INSERT_RESULT_SUCCESS;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_batched_message_success(LogThreadedDestDriver *s)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -337,7 +337,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
             "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batched_message_drop(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -350,7 +350,7 @@ _insert_batched_message_drop(LogThreadedDestDriver *s, LogMessage *msg)
   return WORKER_INSERT_RESULT_DROP;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_batched_message_drop(LogThreadedDestDriver *s)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -392,7 +392,7 @@ _expect_batch_size_remains_the_same_across_retries(TestThreadedDestDriver *self)
     self->prev_flush_size = self->super.worker.instance.batch_size;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batched_message_error_drop(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -406,7 +406,7 @@ _insert_batched_message_error_drop(LogThreadedDestDriver *s, LogMessage *msg)
   return WORKER_INSERT_RESULT_ERROR;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_batched_message_error_drop(LogThreadedDestDriver *s)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -453,7 +453,7 @@ Test(logthrdestdrv,
 
 #define FAILING_ATTEMPTS_DROP 2
 
-static inline worker_insert_result_t
+static inline LogThreadedResult
 _inject_error_a_few_times(TestThreadedDestDriver *self)
 {
   if (self->super.worker.instance.retries_counter >= FAILING_ATTEMPTS_DROP)
@@ -462,7 +462,7 @@ _inject_error_a_few_times(TestThreadedDestDriver *self)
     return WORKER_INSERT_RESULT_ERROR;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batched_message_error_success(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -476,7 +476,7 @@ _insert_batched_message_error_success(LogThreadedDestDriver *s, LogMessage *msg)
   return _inject_error_a_few_times(self);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_batched_message_error_success(LogThreadedDestDriver *s)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -524,7 +524,7 @@ Test(logthrdestdrv,
 
 #define FAILING_ATTEMPTS_NOTCONN 20
 
-static inline worker_insert_result_t
+static inline LogThreadedResult
 _inject_not_connected_a_few_times(TestThreadedDestDriver *self)
 {
   if (self->failure_counter++ >= FAILING_ATTEMPTS_NOTCONN)
@@ -536,7 +536,7 @@ _inject_not_connected_a_few_times(TestThreadedDestDriver *self)
     return WORKER_INSERT_RESULT_NOT_CONNECTED;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batched_message_not_connected(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -550,7 +550,7 @@ _insert_batched_message_not_connected(LogThreadedDestDriver *s, LogMessage *msg)
   return _inject_not_connected_a_few_times(self);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_batched_message_not_connected(LogThreadedDestDriver *s)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -727,7 +727,7 @@ Test(logthrdestdrv, test_connect_failure_kicks_in_suspend_retry_logic_which_keep
 }
 
 /* we batch 5 messages but then flush them only one-by-one */
-static worker_insert_result_t
+static LogThreadedResult
 _insert_explicit_acks_message_success(LogThreadedDestDriver *s, LogMessage *msg)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
@@ -741,7 +741,7 @@ _insert_explicit_acks_message_success(LogThreadedDestDriver *s, LogMessage *msg)
   return WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_explicit_acks_message_success(LogThreadedDestDriver *s)
 {
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -602,12 +602,12 @@ afamqp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   AMQPDestDriver *self = (AMQPDestDriver *)s;
 
   if (!afamqp_dd_connect(self, TRUE))
-    return WORKER_INSERT_RESULT_NOT_CONNECTED;
+    return LTR_NOT_CONNECTED;
 
   if (!afamqp_worker_publish (self, msg))
-    return WORKER_INSERT_RESULT_ERROR;
+    return LTR_ERROR;
 
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 static void

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -596,7 +596,7 @@ afamqp_worker_publish(AMQPDestDriver *self, LogMessage *msg)
   return success;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 afamqp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)s;

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -360,7 +360,7 @@ _vp_process_value(const gchar *name, const gchar *prefix, TypeHint type,
   return FALSE;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -368,7 +368,7 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   gboolean drop_silently = self->template_options.on_error & ON_ERROR_SILENT;
 
   if (!_connect(self, TRUE))
-    return WORKER_INSERT_RESULT_NOT_CONNECTED;
+    return LTR_NOT_CONNECTED;
 
   bson_reinit(self->bson);
 
@@ -390,7 +390,7 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
                                         LTZ_SEND, &self->template_options),
                     evt_tag_str("driver", self->super.super.super.id));
         }
-      return WORKER_INSERT_RESULT_DROP;
+      return LTR_DROP;
     }
 
   msg_debug("Outgoing message to MongoDB destination",
@@ -409,7 +409,7 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
                     evt_tag_int("time_reopen", self->super.time_reopen),
                     evt_tag_str("reason", error.message),
                     evt_tag_str("driver", self->super.super.super.id));
-          return WORKER_INSERT_RESULT_NOT_CONNECTED;
+          return LTR_NOT_CONNECTED;
         }
       else
         {
@@ -417,11 +417,11 @@ _worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
                     evt_tag_int("time_reopen", self->super.time_reopen),
                     evt_tag_str("reason", error.message),
                     evt_tag_str("driver", self->super.super.super.id));
-          return WORKER_INSERT_RESULT_ERROR;
+          return LTR_ERROR;
         }
     }
 
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 gboolean

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -495,7 +495,7 @@ afsmtp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
     {
       msg_debug("Mark messages are dropped by SMTP destination",
                 evt_tag_str("driver", self->super.super.super.id));
-      return WORKER_INSERT_RESULT_SUCCESS;
+      return LTR_SUCCESS;
     }
 
   session = __build_session(self, msg);
@@ -509,12 +509,12 @@ afsmtp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   if (!success)
     {
       if (!message_sent)
-        return WORKER_INSERT_RESULT_NOT_CONNECTED;
+        return LTR_NOT_CONNECTED;
       else
-        return WORKER_INSERT_RESULT_ERROR;
+        return LTR_ERROR;
     }
 
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 static void

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -482,7 +482,7 @@ __send_message(AFSMTPDriver *self, smtp_session_t session)
   return success;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 afsmtp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AFSMTPDriver *self = (AFSMTPDriver *)s;

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -867,7 +867,7 @@ afsql_dd_handle_insert_row_error_depending_on_connection_availability(AFSqlDestD
 
   if (dbi_conn_ping(self->dbi_ctx) == 1)
     {
-      return WORKER_INSERT_RESULT_ERROR;
+      return LTR_ERROR;
     }
 
   if (afsql_dd_is_transaction_handling_enabled(self))
@@ -889,7 +889,7 @@ afsql_dd_handle_insert_row_error_depending_on_connection_availability(AFSqlDestD
             evt_tag_str("database", self->database),
             evt_tag_str("error", dbi_error));
 
-  return WORKER_INSERT_RESULT_ERROR;
+  return LTR_ERROR;
 }
 
 static LogThreadedResult
@@ -898,15 +898,15 @@ afsql_dd_flush(LogThreadedDestDriver *s)
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
 
   if (!afsql_dd_is_transaction_handling_enabled(self))
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
 
   if (!afsql_dd_commit_transaction(self))
     {
       /* Assuming that in case of error, the queue is rewound by afsql_dd_commit_transaction() */
       afsql_dd_rollback_transaction(self);
-      return WORKER_INSERT_RESULT_ERROR;
+      return LTR_ERROR;
     }
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 static gboolean
@@ -933,7 +933,7 @@ afsql_dd_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
   GString *table = NULL;
-  LogThreadedResult retval = WORKER_INSERT_RESULT_ERROR;
+  LogThreadedResult retval = LTR_ERROR;
 
   table = afsql_dd_ensure_accessible_database_table(self, msg);
   if (!table)
@@ -949,8 +949,8 @@ afsql_dd_insert(LogThreadedDestDriver *s, LogMessage *msg)
     }
 
   retval = afsql_dd_is_transaction_handling_enabled(self)
-           ? WORKER_INSERT_RESULT_QUEUED
-           : WORKER_INSERT_RESULT_SUCCESS;
+           ? LTR_QUEUED
+           : LTR_SUCCESS;
 
 error:
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -860,7 +860,7 @@ afsql_dd_should_commit_transaction(const AFSqlDestDriver *self)
   return afsql_dd_is_transaction_handling_enabled(self);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 afsql_dd_handle_insert_row_error_depending_on_connection_availability(AFSqlDestDriver *self)
 {
   const gchar *dbi_error, *error_message;
@@ -892,7 +892,7 @@ afsql_dd_handle_insert_row_error_depending_on_connection_availability(AFSqlDestD
   return WORKER_INSERT_RESULT_ERROR;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 afsql_dd_flush(LogThreadedDestDriver *s)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
@@ -928,12 +928,12 @@ afsql_dd_run_insert_query(AFSqlDestDriver *self, GString *table, LogMessage *msg
  * Returns: FALSE to indicate that the connection should be closed and
  * this destination suspended for time_reopen() time.
  **/
-static worker_insert_result_t
+static LogThreadedResult
 afsql_dd_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
   GString *table = NULL;
-  worker_insert_result_t retval = WORKER_INSERT_RESULT_ERROR;
+  LogThreadedResult retval = WORKER_INSERT_RESULT_ERROR;
 
   table = afsql_dd_ensure_accessible_database_table(self, msg);
   if (!table)

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -324,12 +324,12 @@ afstomp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   STOMPDestDriver *self = (STOMPDestDriver *)s;
 
   if (!afstomp_dd_connect(self, TRUE))
-    return WORKER_INSERT_RESULT_NOT_CONNECTED;
+    return LTR_NOT_CONNECTED;
 
   if (!afstomp_worker_publish (self, msg))
-    return WORKER_INSERT_RESULT_ERROR;
+    return LTR_ERROR;
 
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 static void

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -318,7 +318,7 @@ afstomp_worker_publish(STOMPDestDriver *self, LogMessage *msg)
   return success;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 afstomp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   STOMPDestDriver *self = (STOMPDestDriver *)s;

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -212,11 +212,11 @@ _add_message_to_batch(HTTPDestinationWorker *self, LogMessage *msg)
     }
 }
 
-worker_insert_result_t
+LogThreadedResult
 map_http_status_to_worker_status(HTTPDestinationWorker *self, const gchar *url, glong http_code)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
-  worker_insert_result_t retval = WORKER_INSERT_RESULT_ERROR;
+  LogThreadedResult retval = WORKER_INSERT_RESULT_ERROR;
 
   switch (http_code/100)
     {
@@ -289,7 +289,7 @@ _finish_request_body(HTTPDestinationWorker *self)
     g_string_append_len(self->request_body, owner->body_suffix->str, owner->body_suffix->len);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _flush_on_target(HTTPDestinationWorker *self, HTTPLoadBalancerTarget *target)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
@@ -351,13 +351,13 @@ _flush_on_target(HTTPDestinationWorker *self, HTTPLoadBalancerTarget *target)
  *   1) we reach batch_size,
  *   2) the message queue becomes empty
  */
-static worker_insert_result_t
+static LogThreadedResult
 _flush(LogThreadedDestWorker *s)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) s->owner;
   HTTPLoadBalancerTarget *target, *alt_target = NULL;
-  worker_insert_result_t retval = WORKER_INSERT_RESULT_NOT_CONNECTED;
+  LogThreadedResult retval = WORKER_INSERT_RESULT_NOT_CONNECTED;
   gint retry_attempts = owner->load_balancer->num_targets;
 
   if (self->super.batch_size == 0)
@@ -412,7 +412,7 @@ _should_initiate_flush(HTTPDestinationWorker *self)
 
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batched(LogThreadedDestWorker *s, LogMessage *msg)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
@@ -429,7 +429,7 @@ _insert_batched(LogThreadedDestWorker *s, LogMessage *msg)
   return WORKER_INSERT_RESULT_QUEUED;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single(LogThreadedDestWorker *s, LogMessage *msg)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;

--- a/modules/http/http-worker.h
+++ b/modules/http/http-worker.h
@@ -41,7 +41,7 @@ typedef struct _HTTPDestinationWorker
   struct curl_slist *request_headers;
 } HTTPDestinationWorker;
 
-worker_insert_result_t map_http_status_to_worker_status(HTTPDestinationWorker *self, const gchar *url, glong http_code);
+LogThreadedResult map_http_status_to_worker_status(HTTPDestinationWorker *self, const gchar *url, glong http_code);
 LogThreadedDestWorker *http_dw_new(LogThreadedDestDriver *owner, gint worker_index);
 
 #endif

--- a/modules/http/tests/test_http.c
+++ b/modules/http/tests/test_http.c
@@ -37,10 +37,10 @@ Test(http, test_error_codes)
   HTTPDestinationWorker *worker = (HTTPDestinationWorker *) http_dw_new(&driver->super, 0);
   const gchar *url = "http://dummy.url";
 
-  cr_assert_eq(map_http_status_to_worker_status(worker, url, 200), WORKER_INSERT_RESULT_SUCCESS);
-  cr_assert_eq(map_http_status_to_worker_status(worker, url, 301), WORKER_INSERT_RESULT_ERROR);
-  cr_assert_eq(map_http_status_to_worker_status(worker, url, 404), WORKER_INSERT_RESULT_DROP);
-  cr_assert_eq(map_http_status_to_worker_status(worker, url, 500), WORKER_INSERT_RESULT_ERROR);
+  cr_assert_eq(map_http_status_to_worker_status(worker, url, 200), LTR_SUCCESS);
+  cr_assert_eq(map_http_status_to_worker_status(worker, url, 301), LTR_ERROR);
+  cr_assert_eq(map_http_status_to_worker_status(worker, url, 404), LTR_DROP);
+  cr_assert_eq(map_http_status_to_worker_status(worker, url, 500), LTR_ERROR);
 
   log_threaded_dest_worker_free(&worker->super);
   log_pipe_unref((LogPipe *)driver);

--- a/modules/java-modules/dummy/src/main/java/org/syslog_ng/DummyTextDestination.java
+++ b/modules/java-modules/dummy/src/main/java/org/syslog_ng/DummyTextDestination.java
@@ -36,7 +36,7 @@ public class DummyTextDestination extends TextLogDestination {
 
   public int flush() {
     InternalMessageSender.debug("Flush");
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return SUCCESS;
   }
 
   public boolean init() {
@@ -65,7 +65,7 @@ public class DummyTextDestination extends TextLogDestination {
 
   public int send(String arg0) {
     InternalMessageSender.debug("Incoming message: " + arg0);
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return SUCCESS;
   }
 
   public String getNameByUniqOptions() {

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -92,22 +92,22 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	private int send_batch(ESIndex index) {
 		if (client.send(index))
-			return WORKER_INSERT_RESULT_QUEUED;
+			return QUEUED;
 		else
-			return WORKER_INSERT_RESULT_ERROR;
+			return ERROR;
 	}
 
 	private int send_single(ESIndex index) {
 		if (client.send(index))
-			return WORKER_INSERT_RESULT_SUCCESS;
+			return SUCCESS;
 		else
-			return WORKER_INSERT_RESULT_ERROR;
+			return ERROR;
 	}
 
 	@Override
 	protected int send(LogMessage msg) {
 		if (!client.isOpened()) {
-			return WORKER_INSERT_RESULT_NOT_CONNECTED;
+			return NOT_CONNECTED;
 		}
 
                 ESIndex index = createIndexRequest(msg);
@@ -139,8 +139,8 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 	@Override
 	public int flush() {
 		if (client.flush())
-			return WORKER_INSERT_RESULT_SUCCESS;
+			return SUCCESS;
 		else
-			return WORKER_INSERT_RESULT_ERROR;
+			return ERROR;
 	}
 }

--- a/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic/src/main/java/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
@@ -101,12 +101,12 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 	protected int send(LogMessage msg) {
 		if (!client.isOpened()) {
 			close();
-			return WORKER_INSERT_RESULT_SUCCESS;
+			return SUCCESS;
 		}
 		if (msgProcessor.send(createIndexRequest(msg)))
-			return WORKER_INSERT_RESULT_SUCCESS;
+			return SUCCESS;
 		else
-			return WORKER_INSERT_RESULT_ERROR;
+			return ERROR;
 	}
 
 	@Override

--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -243,7 +243,7 @@ public class HdfsDestination extends StructuredLogDestination {
         if (hdfsfile == null) {
             // Unable to open file
             closeAll(true);
-            return WORKER_INSERT_RESULT_ERROR;
+            return ERROR;
         }
 
         try {
@@ -259,14 +259,14 @@ public class HdfsDestination extends StructuredLogDestination {
         } catch (IOException e) {
             printStackTrace(e);
             closeAll(false);
-            return WORKER_INSERT_RESULT_ERROR;
+            return ERROR;
         } finally {
           lock.unlock();
         }
 
 
         isOpened = true;
-        return WORKER_INSERT_RESULT_SUCCESS;
+        return SUCCESS;
     }
 
     private HdfsFile getHdfsFile(String resolvedFileName) {
@@ -342,7 +342,7 @@ public class HdfsDestination extends StructuredLogDestination {
          * that data has been flushed to persistent store on the datanode)
          */
 
-        int retval = WORKER_INSERT_RESULT_SUCCESS;
+        int retval = SUCCESS;
 
         logger.debug("Flushing hdfs");
         lock.lock();
@@ -353,7 +353,7 @@ public class HdfsDestination extends StructuredLogDestination {
                 hdfsfile.flush();
             } catch (IOException e) {
                 logger.debug(String.format("Flush failed on file %s, reason: %s", entry.getKey(), e.getMessage()));
-                retval = WORKER_INSERT_RESULT_ERROR;
+                retval = ERROR;
             }
         }
         } finally {

--- a/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
+++ b/modules/java-modules/http/src/main/java/org/syslog_ng/http/HTTPDestination.java
@@ -95,19 +95,19 @@ public class HTTPDestination extends StructuredLogDestination {
                 osw.close();
             } catch (IOException e) {
                 logger.error("error in writing message.");
-                return WORKER_INSERT_RESULT_ERROR;
+                return ERROR;
             }
             responseCode = connection.getResponseCode();
             if (isHTTPResponseError(responseCode)) {
                 logger.error("HTTP response code error: " + responseCode);
-                return WORKER_INSERT_RESULT_ERROR;
+                return ERROR;
             }
         } catch (IOException | SecurityException | IllegalStateException e) {
             logger.debug("error in writing message." +
                     (responseCode != 0 ? "Response code is " + responseCode : ""));
-            return WORKER_INSERT_RESULT_ERROR;
+            return ERROR;
         }
-        return WORKER_INSERT_RESULT_SUCCESS;
+        return SUCCESS;
     }
 
     private static boolean isHTTPResponseError(int responseCode) {
@@ -116,7 +116,7 @@ public class HTTPDestination extends StructuredLogDestination {
 
     @Override
     public int flush() {
-        return WORKER_INSERT_RESULT_SUCCESS;
+        return SUCCESS;
     }
 
     @Override

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
@@ -74,9 +74,9 @@ public class KafkaDestination extends StructuredLogDestination {
       result = sendAsynchronously(producerRecord);
 
     if (result)
-        return WORKER_INSERT_RESULT_SUCCESS;
+        return SUCCESS;
     else
-        return WORKER_INSERT_RESULT_ERROR;
+        return ERROR;
   }
 
   private boolean sendSynchronously(ProducerRecord<String, String> producerRecord) {

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -206,7 +206,7 @@ java_dd_close(LogThreadedDestDriver *s)
     }
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 java_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;
@@ -219,7 +219,7 @@ java_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   return java_dd_send_to_object(self, msg);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 java_worker_flush(LogThreadedDestDriver *d)
 {
   JavaDestDriver *self = (JavaDestDriver *)d;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -174,12 +174,12 @@ gint
 java_dd_send_to_object(JavaDestDriver *self, LogMessage *msg)
 {
   gint result = java_destination_proxy_send(self->proxy, msg);
-  if (result < 0 || result >= WORKER_INSERT_RESULT_MAX)
+  if (result < 0 || result >= LTR_MAX)
     {
       msg_error("java_destination: worker insert result out of range. Retrying message later",
                 log_pipe_location_tag((LogPipe *)self),
                 evt_tag_int("result", result));
-      return WORKER_INSERT_RESULT_ERROR;
+      return LTR_ERROR;
     }
 
   return result;
@@ -213,7 +213,7 @@ java_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 
   if (!java_dd_open(s))
     {
-      return WORKER_INSERT_RESULT_NOT_CONNECTED;
+      return LTR_NOT_CONNECTED;
     }
 
   return java_dd_send_to_object(self, msg);

--- a/modules/java/src/main/java/org/syslog_ng/DummyStructuredDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/DummyStructuredDestination.java
@@ -37,7 +37,7 @@ public class DummyStructuredDestination extends StructuredLogDestination {
 
   public int flush() {
     System.out.println("Flush");
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return SUCCESS;
   }
 
   public boolean init() {
@@ -64,7 +64,7 @@ public class DummyStructuredDestination extends StructuredLogDestination {
 
   public int send(LogMessage arg0) {
     arg0.release();
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return SUCCESS;
   }
 
   @Override

--- a/modules/java/src/main/java/org/syslog_ng/DummyTextDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/DummyTextDestination.java
@@ -37,7 +37,7 @@ public class DummyTextDestination extends TextLogDestination {
 
   public int flush() {
     InternalMessageSender.debug("Flush");
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return SUCCESS;
   }
 
   public boolean init() {
@@ -66,7 +66,7 @@ public class DummyTextDestination extends TextLogDestination {
 
   public int send(String arg0) {
     InternalMessageSender.debug("Incoming message: " + arg0);
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return SUCCESS;
   }
 
   @Override

--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -26,12 +26,11 @@ package org.syslog_ng;
 
 public abstract class LogDestination extends LogPipe {
 
-	protected static final int WORKER_INSERT_RESULT_DROP = 0;
-	protected static final int WORKER_INSERT_RESULT_ERROR = 1;
-	protected static final int WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT = 2;
-	protected static final int WORKER_INSERT_RESULT_SUCCESS = 3;
-	protected static final int WORKER_INSERT_RESULT_QUEUED = 4;
-	protected static final int WORKER_INSERT_RESULT_NOT_CONNECTED = 5;
+	protected static final int DROP = 0;
+	protected static final int ERROR = 1;
+	protected static final int SUCCESS = 3;
+	protected static final int QUEUED = 4;
+	protected static final int NOT_CONNECTED = 5;
 
 	public LogDestination(long pipeHandle) {
 		super(pipeHandle);
@@ -82,7 +81,7 @@ public abstract class LogDestination extends LogPipe {
 	private native int setBatchTimeout(long ptr, long timeout);
 
 	protected int flush() {
-		return WORKER_INSERT_RESULT_SUCCESS;
+		return SUCCESS;
 	}
 
 	public boolean openProxy() {
@@ -120,7 +119,7 @@ public abstract class LogDestination extends LogPipe {
 		}
 		catch (Exception e) {
 			sendExceptionMessage(e);
-			return WORKER_INSERT_RESULT_ERROR;
+			return ERROR;
 		}
 	}
 

--- a/modules/java/src/main/java/org/syslog_ng/StructuredLogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/StructuredLogDestination.java
@@ -36,7 +36,7 @@ public abstract class StructuredLogDestination extends LogDestination {
 		}
 		catch (Exception e) {
 			sendExceptionMessage(e);
-			return WORKER_INSERT_RESULT_DROP;
+			return DROP;
 		}
 		finally {
 			msg.release();

--- a/modules/java/src/main/java/org/syslog_ng/TextLogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/TextLogDestination.java
@@ -36,7 +36,7 @@ public abstract class TextLogDestination extends LogDestination {
 		}
 		catch (Exception e) {
 			sendExceptionMessage(e);
-			return WORKER_INSERT_RESULT_DROP;
+			return DROP;
 		}
 	}
 }

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -187,7 +187,7 @@ _py_invoke_close(PythonDestDriver *self)
   _dd_py_invoke_void_method_by_name(self, "close");
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _as_int(PyObject *obj)
 {
   int result = pyobject_as_int(obj);
@@ -210,13 +210,13 @@ _as_int(PyObject *obj)
   return result;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _as_bool(PyObject *obj)
 {
   return PyObject_IsTrue(obj) ? WORKER_INSERT_RESULT_SUCCESS : WORKER_INSERT_RESULT_ERROR;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 pyobject_to_worker_insert_result(PyObject *obj)
 {
   if (PyBool_Check(obj))
@@ -225,7 +225,7 @@ pyobject_to_worker_insert_result(PyObject *obj)
     return _as_int(obj);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _py_invoke_flush(PythonDestDriver *self)
 {
   if (!self->py.flush)
@@ -235,12 +235,12 @@ _py_invoke_flush(PythonDestDriver *self)
   if (!ret)
     return WORKER_INSERT_RESULT_ERROR;
 
-  worker_insert_result_t result = pyobject_to_worker_insert_result(ret);
+  LogThreadedResult result = pyobject_to_worker_insert_result(ret);
   Py_XDECREF(ret);
   return result;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _py_invoke_send(PythonDestDriver *self, PyObject *dict)
 {
   PyObject *ret;
@@ -249,7 +249,7 @@ _py_invoke_send(PythonDestDriver *self, PyObject *dict)
   if (!ret)
     return WORKER_INSERT_RESULT_ERROR;
 
-  worker_insert_result_t result = pyobject_to_worker_insert_result(ret);
+  LogThreadedResult result = pyobject_to_worker_insert_result(ret);
   Py_XDECREF(ret);
   return result;
 }
@@ -404,11 +404,11 @@ _py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_ob
 }
 
 
-static worker_insert_result_t
+static LogThreadedResult
 python_dd_insert(LogThreadedDestDriver *d, LogMessage *msg)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  worker_insert_result_t result = WORKER_INSERT_RESULT_ERROR;
+  LogThreadedResult result = WORKER_INSERT_RESULT_ERROR;
   PyObject *msg_object;
   PyGILState_STATE gstate;
 
@@ -446,14 +446,14 @@ python_dd_open(PythonDestDriver *self)
   PyGILState_Release(gstate);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 python_dd_flush(LogThreadedDestDriver *s)
 {
   PythonDestDriver *self = (PythonDestDriver *)s;
   PyGILState_STATE gstate;
 
   gstate = PyGILState_Ensure();
-  worker_insert_result_t result = _py_invoke_flush(self);
+  LogThreadedResult result = _py_invoke_flush(self);
   PyGILState_Release(gstate);
   return result;
 };

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -273,7 +273,7 @@ _py_clear(PyObject *self)
 }
 
 #define _inject_worker_insert_result(self, value) \
-  _inject_const(self, #value, value)
+  _inject_const(self, #value, WORKER_INSERT_RESULT_ ## value)
 
 static void
 _inject_const(PythonDestDriver *self, const gchar *field_name, gint value)
@@ -286,13 +286,12 @@ _inject_const(PythonDestDriver *self, const gchar *field_name, gint value)
 static void
 _inject_worker_insert_result_consts(PythonDestDriver *self)
 {
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_DROP);
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_ERROR);
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT);
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_SUCCESS);
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_QUEUED);
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_NOT_CONNECTED);
-  _inject_worker_insert_result(self, WORKER_INSERT_RESULT_MAX);
+  _inject_worker_insert_result(self, DROP);
+  _inject_worker_insert_result(self, ERROR);
+  _inject_worker_insert_result(self, SUCCESS);
+  _inject_worker_insert_result(self, QUEUED);
+  _inject_worker_insert_result(self, NOT_CONNECTED);
+  _inject_worker_insert_result(self, MAX);
 };
 
 static gboolean

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -235,15 +235,15 @@ redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   int argc = 2;
 
   if (!redis_dd_connect(self))
-    return WORKER_INSERT_RESULT_NOT_CONNECTED;
+    return LTR_NOT_CONNECTED;
 
   if (self->c->err)
-    return WORKER_INSERT_RESULT_ERROR;
+    return LTR_ERROR;
 
   if (!check_connection_to_redis(self))
     {
       msg_error("REDIS: worker failed to connect");
-      return WORKER_INSERT_RESULT_NOT_CONNECTED;
+      return LTR_NOT_CONNECTED;
     }
 
   log_template_format(self->key, msg, &self->template_options, LTZ_SEND,
@@ -287,7 +287,7 @@ redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
                 evt_tag_str("param2", self->param2_str->str),
                 evt_tag_str("error", self->c->errstr),
                 evt_tag_int("time_reopen", self->super.time_reopen));
-      return WORKER_INSERT_RESULT_ERROR;
+      return LTR_ERROR;
     }
 
   msg_debug("REDIS command sent",
@@ -298,7 +298,7 @@ redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
             evt_tag_str("param2", self->param2_str->str));
   freeReplyObject(reply);
 
-  return WORKER_INSERT_RESULT_SUCCESS;
+  return LTR_SUCCESS;
 }
 
 static void

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -225,7 +225,7 @@ redis_dd_disconnect(LogThreadedDestDriver *s)
  * Worker thread
  */
 
-static worker_insert_result_t
+static LogThreadedResult
 redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   RedisDriver *self = (RedisDriver *)s;

--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -309,7 +309,7 @@ riemann_worker_insert_one(RiemannDestWorker *self, LogMessage *msg)
   return success;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 riemann_worker_flush(LogThreadedDestWorker *s)
 {
   RiemannDestWorker *self = (RiemannDestWorker *) s;
@@ -347,7 +347,7 @@ riemann_worker_flush(LogThreadedDestWorker *s)
     return WORKER_INSERT_RESULT_SUCCESS;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_single(RiemannDestWorker *self, LogMessage *msg)
 {
   RiemannDestDriver *owner = (RiemannDestDriver *) self->super.owner;
@@ -367,7 +367,7 @@ _insert_single(RiemannDestWorker *self, LogMessage *msg)
   return log_threaded_dest_worker_flush(&self->super);
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 _insert_batch(RiemannDestWorker *self, LogMessage *msg)
 {
   RiemannDestDriver *owner = (RiemannDestDriver *) self->super.owner;
@@ -391,7 +391,7 @@ _insert_batch(RiemannDestWorker *self, LogMessage *msg)
   return WORKER_INSERT_RESULT_QUEUED;
 }
 
-static worker_insert_result_t
+static LogThreadedResult
 riemann_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
 {
   RiemannDestWorker *self = (RiemannDestWorker *) s;

--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -318,7 +318,7 @@ riemann_worker_flush(LogThreadedDestWorker *s)
   int r;
 
   if (self->event.n == 0)
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
 
   message = riemann_message_new();
 
@@ -342,9 +342,9 @@ riemann_worker_flush(LogThreadedDestWorker *s)
   self->event.list = (riemann_event_t **) malloc(sizeof (riemann_event_t *) *
                                                  MAX(1, owner->super.batch_lines));
   if (r != 0)
-    return WORKER_INSERT_RESULT_ERROR;
+    return LTR_ERROR;
   else
-    return WORKER_INSERT_RESULT_SUCCESS;
+    return LTR_SUCCESS;
 }
 
 static LogThreadedResult
@@ -361,7 +361,7 @@ _insert_single(RiemannDestWorker *self, LogMessage *msg)
                 log_pipe_location_tag(&owner->super.super.super.super),
                 evt_tag_str("driver", owner->super.super.super.id));
 
-      return WORKER_INSERT_RESULT_DROP;
+      return LTR_DROP;
     }
 
   return log_threaded_dest_worker_flush(&self->super);
@@ -388,7 +388,7 @@ _insert_batch(RiemannDestWorker *self, LogMessage *msg)
        */
     }
 
-  return WORKER_INSERT_RESULT_QUEUED;
+  return LTR_QUEUED;
 }
 
 static LogThreadedResult


### PR DESCRIPTION
I got a valuable comment from @pzoleex that the recently introduced constant names in java and python destinations could be more user friendly.

In an attempt to do so, I did a little renaming on them. Also, the python example is updated.

I also removed the `WORKER_INSERT_RESULT_EXPLICIT_ACK_MGMT`, that could not be used by the bindings this time of writing.

Please review this with in mind that we conclude here, that would be published in the documentation.