### PR TITLE
Added elasticsearch-http() destination

### DIFF
--- a/scl/elasticsearch/elastic-http.conf
+++ b/scl/elasticsearch/elastic-http.conf
@@ -1,0 +1,48 @@
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@requires http
+
+block destination elasticsearch-http(
+  url()
+  index()
+  type()
+  custom_id("")
+  workers(4)
+  batch_lines(100)
+  timeout(10)
+  template("$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})")
+  headers("Content-Type: application/x-ndjson")
+  body_suffix("\n")
+  ...)
+{
+  http(
+  url(`url`)
+  headers(`headers`)
+  workers(`workers`)
+  batch_lines(`batch_lines`)
+  timeout(`timeout`)
+  body_suffix(`body_suffix`)
+  body("$(format-json --scope none --omit-empty-values index._index=`index` index._type=`type` index._id=`custom_id`)\n`template`")
+  `__VARARGS__`
+  );
+};


### PR DESCRIPTION
This destination is based on the native http destination of syslog-ng
and uses elasticsearch bulk api (https://www.elastic.co/guide/en/elasticsearch/reference/6.5/docs-bulk.html)

Example:
destination d_elasticsearch_http {
    elasticsearch-http(index("my_index")
 type("my_type")
 url("http://my_elastic_server:9200/_bulk"));
};

Signed-off-by: Zoltan Pallagi <pzoleex@gmail.com>