### PR TITLE
collect-cov.sh: make coverage should work with lcov in bionic

### DIFF
--- a/tests/collect-cov.sh
+++ b/tests/collect-cov.sh
@@ -23,8 +23,10 @@
 
 set -e
 
-lcov --capture --directory `pwd` --compat-libtool --output-file coverage.info --rc geninfo_auto_base=1
+lcov --capture --directory `pwd` --compat-libtool --output-file coverage.info
 lcov --extract coverage.info "${top_srcdir}/*" --output-file coverage.info
 lcov --remove coverage.info "${top_srcdir}/modules/afmongodb/mongo-c-driver/*" --output-file coverage.info
 lcov --remove coverage.info "${top_srcdir}/modules/afamqp/rabbitmq-c/*" --output-file coverage.info
-genhtml coverage.info --output-directory coverage.html
+lcov --remove coverage.info "${top_srcdir}/lib/jsonc/*" --output-file coverage.info
+lcov --remove coverage.info "${top_srcdir}/lib/ivykis/*" --output-file coverage.info
+genhtml coverage.info --prefix "${top_srcdir}" --output-directory coverage.html


### PR DESCRIPTION
Our devshell image is bionic based so make sure our coverage targets
work with the version of lcov that is on bionic.

lcov seems to be changing configuration options quite frequently, but
I think it is enough to work in devshell.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>