### PR TITLE
value-pairs: add an --omit-empty-values option

### DIFF
--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -393,6 +393,8 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
   ValuePairs *vp;
   GOptionContext *ctx;
 
+  vp = value_pairs_new();
+
   GOptionEntry vp_options[] =
   {
     {
@@ -440,6 +442,10 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
       NULL, NULL
     },
     {
+      "omit-empty-values", 0, 0, G_OPTION_ARG_NONE, &vp->omit_empty_values,
+      NULL, NULL
+    },
+    {
       G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_pair_or_key,
       NULL, NULL
     },
@@ -449,7 +455,6 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
   gpointer user_data_args[4];
   gboolean success;
 
-  vp = value_pairs_new();
   user_data_args[0] = cfg;
   user_data_args[1] = vp;
   user_data_args[2] = NULL;

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -64,17 +64,6 @@ typedef struct
   GArray *values;
 } VPResults;
 
-struct _ValuePairs
-{
-  GAtomicCounter ref_cnt;
-  GPtrArray *builtins;
-  GPtrArray *patterns;
-  GPtrArray *vpairs;
-  GPtrArray *transforms;
-
-  /* guint32 as CfgFlagHandler only supports 32 bit integers */
-  guint32 scopes;
-};
 
 typedef enum
 {
@@ -264,6 +253,8 @@ vp_pairs_foreach(gpointer data, gpointer user_data)
                              template_options,
                              time_zone_mode, seq_num, NULL, sb);
 
+  if (vp->omit_empty_values && sb->len == 0)
+    return;
   vp_results_insert(results, vp_transform_apply(vp, vpc->name), vpc->template->type_hint, sb);
 }
 
@@ -278,6 +269,9 @@ vp_msg_nvpairs_foreach(NVHandle handle, gchar *name,
   guint j;
   gboolean inc;
   GString *sb;
+
+  if (vp->omit_empty_values && value_len == 0)
+    return FALSE;
 
   inc = (name[0] == '.' && (vp->scopes & VPS_DOT_NV_PAIRS)) ||
   (name[0] != '.' && (vp->scopes & VPS_NV_PAIRS)) ||

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -30,8 +30,22 @@
 #include "value-pairs/transforms.h"
 #include "type-hinting.h"
 #include "template/templates.h"
+#include "atomic.h"
 
 typedef struct _ValuePairs ValuePairs;
+struct _ValuePairs
+{
+  GAtomicCounter ref_cnt;
+  GPtrArray *builtins;
+  GPtrArray *patterns;
+  GPtrArray *vpairs;
+  GPtrArray *transforms;
+
+  gboolean omit_empty_values;
+
+  /* guint32 as CfgFlagHandler only supports 32 bit integers */
+  guint32 scopes;
+};
 
 typedef gboolean
 (*VPForeachFunc) (const gchar *name, TypeHint type, const gchar *value,

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -127,6 +127,7 @@ create_sample_message(void)
   log_msg_set_value_by_name(msg, "escaping2", "\xc3", -1);
   log_msg_set_value_by_name(msg, "null", "binary\0stuff", 12);
   log_msg_set_value_by_name(msg, "comma_value", "value,with,a,comma", -1);
+  log_msg_set_value_by_name(msg, "empty_value", "", -1);
 
   return msg;
 }

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -116,6 +116,17 @@ Test(format_json, test_format_json_rekey)
                          "{\"_msg\":{\"text\":\"dotted\"}}");
 }
 
+Test(format_json, test_format_json_omit_empty_values)
+{
+  assert_template_format("$(format-json --omit-empty-values msg.set=value msg.unset='')",
+                         "{\"msg\":{\"set\":\"value\"}}");
+
+  assert_template_format("$(format-json --omit-empty-values msg.set=value --key empty_value)",
+                         "{\"msg\":{\"set\":\"value\"}}");
+  assert_template_format("$(format-json msg.set=value --key empty_value)",
+                         "{\"msg\":{\"set\":\"value\"},\"empty_value\":\"\"}");
+}
+
 Test(format_json, test_format_json_with_type_hints)
 {
   assert_template_format("$(format-json i32=int32(1234))",


### PR DESCRIPTION
This new option will allow a template function to skip name-value pairs
that are empty. This used to be the default behavior until unset() was
introduced, since which time we only omit unset name-value pairs.

For example, ElasticSearch needs a transaction description as a JSON
before each record, that can be generated like this:

$(format-json --omit-empty-values index._type=`type` index._index=`index` index._id=`custom_id`)

If $(format-json) would include index._id as an empty string, that would
invalidate the JSON in the eyes of ElasticSearch.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>