### PR TITLE
LogReader refactor + performance improvements

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -505,7 +505,6 @@ log_reader_init(LogPipe *s)
       return FALSE;
     }
 
-  poll_events_set_callback(self->poll_events, log_reader_io_handle_in, self);
 
   log_reader_update_watches(self);
   iv_event_register(&self->schedule_wakeup);
@@ -609,6 +608,7 @@ log_reader_reopen(LogReader *self, LogProtoServer *proto, PollEvents *poll_event
 {
   gpointer args[] = { self, proto, poll_events };
 
+  poll_events_set_callback(self->poll_events, log_reader_io_handle_in, self);
   main_loop_call((MainLoopTaskFunc) log_reader_reopen_deferred, args, TRUE);
 
   if (!main_loop_is_main_thread())

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -64,84 +64,132 @@ struct _LogReader
   struct iv_timer idle_timer;
 };
 
+static void log_reader_io_handle_in(gpointer s);
 static gboolean log_reader_fetch_log(LogReader *self);
-
-static void log_reader_stop_watches(LogReader *self);
-static void log_reader_stop_idle_timer(LogReader *self);
-static void log_reader_idle_timeout(void *cookie);
-
 static void log_reader_update_watches(LogReader *self);
 
-static void log_reader_wakeup(LogSource *s);
+/*****************************************************************************
+ * LogReader setters
+ *****************************************************************************/
+
+
+void
+log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr)
+{
+  LogReader *self = (LogReader *) s;
+
+  g_sockaddr_unref(self->peer_addr);
+  self->peer_addr = g_sockaddr_ref(peer_addr);
+}
+
+void
+log_reader_set_immediate_check(LogReader *s)
+{
+  LogReader *self = (LogReader *) s;
+
+  self->immediate_check = TRUE;
+}
+
+void
+log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options,
+                       const gchar *stats_id, const gchar *stats_instance)
+{
+  LogReader *self = (LogReader *) s;
+
+  /* log_reader_reopen() needs to be called prior to set_options.  This is
+   * an ugly hack, but at least it is more explicitly than what used to be
+   * here, which silently ignored if self->proto was NULL.
+   */
+
+  g_assert(self->proto != NULL);
+  gboolean pos_tracked = log_proto_server_is_position_tracked(self->proto);
+
+  log_source_set_options(&self->super, &options->super, stats_id, stats_instance,
+                         (options->flags & LR_THREADED), pos_tracked, control->expr_node);
+
+  log_pipe_unref(self->control);
+  log_pipe_ref(control);
+  self->control = control;
+
+  self->options = options;
+  log_proto_server_set_options(self->proto, &self->options->proto_options.super);
+  log_proto_server_set_ack_tracker(self->proto, self->super.ack_tracker);
+}
+
+/****************************************************************************
+ * Watches: the poll_events instance and the idle timer
+ ***************************************************************************/
 
 static void
-log_reader_apply_proto_and_poll_events(LogReader *self, LogProtoServer *proto, PollEvents *poll_events)
+log_reader_idle_timeout(void *cookie)
 {
-  if (self->proto)
-    log_proto_server_free(self->proto);
+  LogReader *self = (LogReader *) cookie;
+
+  g_assert(!self->io_job.working);
+  msg_notice("Source timeout has elapsed, closing connection",
+             evt_tag_int("fd", log_proto_server_get_fd(self->proto)));
+
+  log_pipe_notify(self->control, NC_CLOSE, self);
+}
+
+static void
+log_reader_stop_idle_timer(LogReader *self)
+{
+  if (iv_timer_registered(&self->idle_timer))
+    iv_timer_unregister(&self->idle_timer);
+}
+
+static void
+log_reader_start_watches(LogReader *self)
+{
+  g_assert(!self->watches_running);
   if (self->poll_events)
-    poll_events_free(self->poll_events);
-
-  self->proto = proto;
-
-  if (self->proto)
-    log_proto_server_set_wakeup_cb(self->proto, (LogProtoServerWakeupFunc) log_reader_wakeup, self);
-
-  self->poll_events = poll_events;
+    poll_events_start_watches(self->poll_events);
+  self->watches_running = TRUE;
 }
 
 static void
-_last_msg_sent(gpointer s)
+log_reader_stop_watches(LogReader *self)
 {
-  LogReader *self = (LogReader *) s;
-  log_pipe_notify(self->control, NC_LAST_MSG_SENT, self);
+  g_assert(self->watches_running);
+  if (self->poll_events)
+    poll_events_stop_watches(self->poll_events);
+  log_reader_stop_idle_timer(self);
+
+  self->watches_running = FALSE;
 }
 
 static void
-log_reader_work_perform(void *s, GIOCondition cond)
+log_reader_disable_watches(LogReader *self)
 {
-  LogReader *self = (LogReader *) s;
+  g_assert(self->watches_running);
+  if (self->poll_events)
+    poll_events_suspend_watches(self->poll_events);
+  log_reader_stop_idle_timer(self);
+}
 
-  self->notify_code = log_reader_fetch_log(self);
+/****************************************************************************
+ * Suspend/wakeup
+ ****************************************************************************/
+
+static void
+log_reader_suspend_until_awoken(LogReader *self)
+{
+  self->immediate_check = FALSE;
+  log_reader_disable_watches(self);
+  self->suspended = TRUE;
 }
 
 static void
-log_reader_work_finished(void *s)
+log_reader_force_check_in_next_poll(LogReader *self)
 {
-  LogReader *self = (LogReader *) s;
+  self->immediate_check = FALSE;
+  log_reader_disable_watches(self);
+  self->suspended = FALSE;
 
-  if (self->pending_proto_present)
+  if (!iv_task_registered(&self->restart_task))
     {
-      /* pending proto is only set in the main thread, so no need to
-       * lock it before coming here. After we're syncing with the
-       * log_writer_reopen() call, quite possibly coming from a
-       * non-main thread. */
-
-      g_static_mutex_lock(&self->pending_proto_lock);
-
-      log_reader_apply_proto_and_poll_events(self, self->pending_proto, self->pending_poll_events);
-      self->pending_proto = NULL;
-      self->pending_poll_events = NULL;
-      self->pending_proto_present = FALSE;
-
-      g_cond_signal(self->pending_proto_cond);
-      g_static_mutex_unlock(&self->pending_proto_lock);
-    }
-
-  if (self->notify_code)
-    {
-      gint notify_code = self->notify_code;
-
-      self->notify_code = 0;
-      log_pipe_notify(self->control, notify_code, self);
-    }
-  if (self->super.super.flags & PIF_INITIALIZED)
-    {
-      /* reenable polling the source assuming that we're still in
-       * business (e.g. the reader hasn't been uninitialized) */
-
-      log_proto_server_reset_error(self->proto);
-      log_reader_update_watches(self);
+      iv_task_register(&self->restart_task);
     }
 }
 
@@ -183,103 +231,77 @@ log_reader_wakeup(LogSource *s)
     iv_event_post(&self->schedule_wakeup);
 }
 
-static void
-log_reader_window_empty(LogSource *s)
-{
-  LogReader *self = (LogReader *) s;
-  if (self->super.super.flags & PIF_INITIALIZED)
-    iv_event_post(&self->last_msg_sent_event);
-}
+/****************************************************************************
+ * Open/close/reopen
+ ***************************************************************************/
 
 static void
-log_reader_disable_watches(LogReader *self)
+log_reader_apply_proto_and_poll_events(LogReader *self, LogProtoServer *proto, PollEvents *poll_events)
 {
-  g_assert(self->watches_running);
+  if (self->proto)
+    log_proto_server_free(self->proto);
   if (self->poll_events)
-    poll_events_suspend_watches(self->poll_events);
-  log_reader_stop_idle_timer(self);
+    poll_events_free(self->poll_events);
+
+  self->proto = proto;
+
+  if (self->proto)
+    log_proto_server_set_wakeup_cb(self->proto, (LogProtoServerWakeupFunc) log_reader_wakeup, self);
+
+  self->poll_events = poll_events;
 }
 
-static void
-log_reader_io_handle_in(gpointer s)
-{
-  LogReader *self = (LogReader *) s;
 
-  log_reader_disable_watches(self);
-  if ((self->options->flags & LR_THREADED))
+/* run in the main thread in reaction to a log_reader_reopen to change
+ * the source LogProtoServer instance. It needs to be ran in the main
+ * thread as it reregisters the watches associated with the main
+ * thread. */
+void
+log_reader_close_proto_deferred(gpointer s)
+{
+  gpointer *args = (gpointer *) s;
+  LogReader *self = args[0];
+  LogProtoServer *proto = args[1];
+  PollEvents *poll_events = args[2];
+
+  if (self->io_job.working)
     {
-      main_loop_io_worker_job_submit(&self->io_job, G_IO_IN);
+      self->pending_proto = proto;
+      self->pending_poll_events = poll_events;
+      self->pending_proto_present = TRUE;
+      return;
     }
-  else
+
+  log_reader_stop_watches(self);
+  log_reader_apply_proto_and_poll_events(self, proto, poll_events);
+  log_reader_start_watches(self);
+  log_reader_update_watches(self);
+}
+
+void
+log_reader_close_proto(LogReader *self)
+{
+  log_reader_reopen(self, NULL, NULL);
+}
+
+void
+log_reader_reopen(LogReader *self, LogProtoServer *proto, PollEvents *poll_events)
+{
+  gpointer args[] = { self, proto, poll_events };
+
+  if (poll_events)
+    poll_events_set_callback(poll_events, log_reader_io_handle_in, self);
+  main_loop_call((MainLoopTaskFunc) log_reader_close_proto_deferred, args, TRUE);
+
+  if (!main_loop_is_main_thread())
     {
-      /* Checking main_loop_io_worker_job_quit() helps to speed up the
-       * reload process.  If reload/shutdown is requested we shouldn't do
-       * anything here, outstanding messages will be processed by the new
-       * configuration.
-       *
-       * Our current understanding is that it doesn't prevent race
-       * conditions of any kind.
-       */
-      if (!main_loop_worker_job_quit())
+      g_static_mutex_lock(&self->pending_proto_lock);
+      while (self->pending_proto_present)
         {
-          log_reader_work_perform(s, G_IO_IN);
-          log_reader_work_finished(s);
+          g_cond_wait(self->pending_proto_cond, g_static_mutex_get_mutex(&self->pending_proto_lock));
         }
+      g_static_mutex_unlock(&self->pending_proto_lock);
     }
-}
-
-static void
-log_reader_init_watches(LogReader *self)
-{
-  IV_TASK_INIT(&self->restart_task);
-  self->restart_task.cookie = self;
-  self->restart_task.handler = log_reader_io_handle_in;
-
-  IV_EVENT_INIT(&self->schedule_wakeup);
-  self->schedule_wakeup.cookie = self;
-  self->schedule_wakeup.handler = log_reader_wakeup_triggered;
-
-  IV_EVENT_INIT(&self->last_msg_sent_event);
-  self->last_msg_sent_event.cookie = self;
-  self->last_msg_sent_event.handler = _last_msg_sent;
-
-  IV_TIMER_INIT(&self->idle_timer);
-  self->idle_timer.cookie = self;
-  self->idle_timer.handler = log_reader_idle_timeout;
-
-  main_loop_io_worker_job_init(&self->io_job);
-  self->io_job.user_data = self;
-  self->io_job.work = (void (*)(void *, GIOCondition)) log_reader_work_perform;
-  self->io_job.completion = (void (*)(void *)) log_reader_work_finished;
-  self->io_job.engage = (void (*)(void *)) log_pipe_ref;
-  self->io_job.release = (void (*)(void *)) log_pipe_unref;
-}
-
-static void
-log_reader_stop_watches(LogReader *self)
-{
-  g_assert(self->watches_running);
-  if (self->poll_events)
-    poll_events_stop_watches(self->poll_events);
-  log_reader_stop_idle_timer(self);
-
-  self->watches_running = FALSE;
-}
-
-static void
-log_reader_stop_idle_timer(LogReader *self)
-{
-  if (iv_timer_registered(&self->idle_timer))
-    iv_timer_unregister(&self->idle_timer);
-}
-
-static void
-log_reader_start_watches(LogReader *self)
-{
-  g_assert(!self->watches_running);
-  if (self->poll_events)
-    poll_events_start_watches(self->poll_events);
-  self->watches_running = TRUE;
 }
 
 static gboolean
@@ -288,26 +310,9 @@ log_reader_is_opened(LogReader *self)
   return self->proto && self->poll_events;
 }
 
-static void
-log_reader_suspend_until_awoken(LogReader *self)
-{
-  self->immediate_check = FALSE;
-  log_reader_disable_watches(self);
-  self->suspended = TRUE;
-}
-
-static void
-log_reader_force_check_in_next_poll(LogReader *self)
-{
-  self->immediate_check = FALSE;
-  log_reader_disable_watches(self);
-  self->suspended = FALSE;
-
-  if (!iv_task_registered(&self->restart_task))
-    {
-      iv_task_register(&self->restart_task);
-    }
-}
+/*****************************************************************************
+ * Set watches state so we are polling the event(s) that comes next.
+ *****************************************************************************/
 
 static void
 log_reader_update_watches(LogReader *self)
@@ -364,6 +369,77 @@ log_reader_update_watches(LogReader *self)
       break;
     }
 }
+
+static void
+_last_msg_sent(gpointer s)
+{
+  LogReader *self = (LogReader *) s;
+  log_pipe_notify(self->control, NC_LAST_MSG_SENT, self);
+}
+
+static void
+log_reader_window_empty(LogSource *s)
+{
+  LogReader *self = (LogReader *) s;
+  if (self->super.super.flags & PIF_INITIALIZED)
+    iv_event_post(&self->last_msg_sent_event);
+}
+
+/*****************************************************************************
+ * Glue into MainLoopIOWorker
+ *****************************************************************************/
+
+static void
+log_reader_work_perform(void *s, GIOCondition cond)
+{
+  LogReader *self = (LogReader *) s;
+
+  self->notify_code = log_reader_fetch_log(self);
+}
+
+static void
+log_reader_work_finished(void *s)
+{
+  LogReader *self = (LogReader *) s;
+
+  if (self->pending_proto_present)
+    {
+      /* pending proto is only set in the main thread, so no need to
+       * lock it before coming here. After we're syncing with the
+       * log_writer_reopen() call, quite possibly coming from a
+       * non-main thread. */
+
+      g_static_mutex_lock(&self->pending_proto_lock);
+
+      log_reader_apply_proto_and_poll_events(self, self->pending_proto, self->pending_poll_events);
+      self->pending_proto = NULL;
+      self->pending_poll_events = NULL;
+      self->pending_proto_present = FALSE;
+
+      g_cond_signal(self->pending_proto_cond);
+      g_static_mutex_unlock(&self->pending_proto_lock);
+    }
+
+  if (self->notify_code)
+    {
+      gint notify_code = self->notify_code;
+
+      self->notify_code = 0;
+      log_pipe_notify(self->control, notify_code, self);
+    }
+  if (self->super.super.flags & PIF_INITIALIZED)
+    {
+      /* reenable polling the source assuming that we're still in
+       * business (e.g. the reader hasn't been uninitialized) */
+
+      log_proto_server_reset_error(self->proto);
+      log_reader_update_watches(self);
+    }
+}
+
+/*****************************************************************************
+ * Input processing, the main function of LogReader
+ *****************************************************************************/
 
 static void
 _add_aux_nvpair(const gchar *name, const gchar *value, gsize value_len, gpointer user_data)
@@ -491,6 +567,38 @@ log_reader_fetch_log(LogReader *self)
   return 0;
 }
 
+static void
+log_reader_io_handle_in(gpointer s)
+{
+  LogReader *self = (LogReader *) s;
+
+  log_reader_disable_watches(self);
+  if ((self->options->flags & LR_THREADED))
+    {
+      main_loop_io_worker_job_submit(&self->io_job, G_IO_IN);
+    }
+  else
+    {
+      /* Checking main_loop_io_worker_job_quit() helps to speed up the
+       * reload process.  If reload/shutdown is requested we shouldn't do
+       * anything here, outstanding messages will be processed by the new
+       * configuration.
+       *
+       * Our current understanding is that it doesn't prevent race
+       * conditions of any kind.
+       */
+      if (!main_loop_worker_job_quit())
+        {
+          log_reader_work_perform(s, G_IO_IN);
+          log_reader_work_finished(s);
+        }
+    }
+}
+
+/*****************************************************************************
+ * LogReader->LogPipe interface implementation
+ *****************************************************************************/
+
 static gboolean
 log_reader_init(LogPipe *s)
 {
@@ -538,6 +646,34 @@ log_reader_deinit(LogPipe *s)
   return TRUE;
 }
 
+
+static void
+log_reader_init_watches(LogReader *self)
+{
+  IV_TASK_INIT(&self->restart_task);
+  self->restart_task.cookie = self;
+  self->restart_task.handler = log_reader_io_handle_in;
+
+  IV_EVENT_INIT(&self->schedule_wakeup);
+  self->schedule_wakeup.cookie = self;
+  self->schedule_wakeup.handler = log_reader_wakeup_triggered;
+
+  IV_EVENT_INIT(&self->last_msg_sent_event);
+  self->last_msg_sent_event.cookie = self;
+  self->last_msg_sent_event.handler = _last_msg_sent;
+
+  IV_TIMER_INIT(&self->idle_timer);
+  self->idle_timer.cookie = self;
+  self->idle_timer.handler = log_reader_idle_timeout;
+
+  main_loop_io_worker_job_init(&self->io_job);
+  self->io_job.user_data = self;
+  self->io_job.work = (void (*)(void *, GIOCondition)) log_reader_work_perform;
+  self->io_job.completion = (void (*)(void *)) log_reader_work_finished;
+  self->io_job.engage = (void (*)(void *)) log_pipe_ref;
+  self->io_job.release = (void (*)(void *)) log_pipe_unref;
+}
+
 static void
 log_reader_free(LogPipe *s)
 {
@@ -558,105 +694,6 @@ log_reader_free(LogPipe *s)
   log_source_free(s);
 }
 
-void
-log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options,
-                       const gchar *stats_id, const gchar *stats_instance)
-{
-  LogReader *self = (LogReader *) s;
-
-  /* log_reader_reopen() needs to be called prior to set_options.  This is
-   * an ugly hack, but at least it is more explicitly than what used to be
-   * here, which silently ignored if self->proto was NULL.
-   */
-
-  g_assert(self->proto != NULL);
-  gboolean pos_tracked = log_proto_server_is_position_tracked(self->proto);
-
-  log_source_set_options(&self->super, &options->super, stats_id, stats_instance,
-                         (options->flags & LR_THREADED), pos_tracked, control->expr_node);
-
-  log_pipe_unref(self->control);
-  log_pipe_ref(control);
-  self->control = control;
-
-  self->options = options;
-  log_proto_server_set_options(self->proto, &self->options->proto_options.super);
-  log_proto_server_set_ack_tracker(self->proto, self->super.ack_tracker);
-}
-
-/* run in the main thread in reaction to a log_reader_reopen to change
- * the source LogProtoServer instance. It needs to be ran in the main
- * thread as it reregisters the watches associated with the main
- * thread. */
-void
-log_reader_reopen_deferred(gpointer s)
-{
-  gpointer *args = (gpointer *) s;
-  LogReader *self = args[0];
-  LogProtoServer *proto = args[1];
-  PollEvents *poll_events = args[2];
-
-  if (self->io_job.working)
-    {
-      self->pending_proto = proto;
-      self->pending_poll_events = poll_events;
-      self->pending_proto_present = TRUE;
-      return;
-    }
-
-  log_reader_stop_watches(self);
-  log_reader_apply_proto_and_poll_events(self, proto, poll_events);
-  log_reader_start_watches(self);
-  log_reader_update_watches(self);
-}
-
-void
-log_reader_reopen(LogReader *self, LogProtoServer *proto, PollEvents *poll_events)
-{
-  gpointer args[] = { self, proto, poll_events };
-
-  if (self->poll_events)
-    poll_events_set_callback(self->poll_events, log_reader_io_handle_in, self);
-  main_loop_call((MainLoopTaskFunc) log_reader_reopen_deferred, args, TRUE);
-
-  if (!main_loop_is_main_thread())
-    {
-      g_static_mutex_lock(&self->pending_proto_lock);
-      while (self->pending_proto_present)
-        {
-          g_cond_wait(self->pending_proto_cond, g_static_mutex_get_mutex(&self->pending_proto_lock));
-        }
-      g_static_mutex_unlock(&self->pending_proto_lock);
-    }
-}
-
-void
-log_reader_close_proto(LogReader *self)
-{
-  log_reader_reopen(self, NULL, NULL);
-}
-
-static void
-log_reader_idle_timeout(void *cookie)
-{
-  LogReader *self = (LogReader *) cookie;
-
-  g_assert(!self->io_job.working);
-  msg_notice("Source timeout has elapsed, closing connection",
-             evt_tag_int("fd", log_proto_server_get_fd(self->proto)));
-
-  log_pipe_notify(self->control, NC_CLOSE, self);
-}
-
-void
-log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr)
-{
-  LogReader *self = (LogReader *) s;
-
-  g_sockaddr_unref(self->peer_addr);
-  self->peer_addr = g_sockaddr_ref(peer_addr);
-}
-
 LogReader *
 log_reader_new(GlobalConfig *cfg)
 {
@@ -675,13 +712,9 @@ log_reader_new(GlobalConfig *cfg)
   return self;
 }
 
-void
-log_reader_set_immediate_check(LogReader *s)
-{
-  LogReader *self = (LogReader *) s;
-
-  self->immediate_check = TRUE;
-}
+/****************************************************************************
+ * LogReaderOptions defaults/init/destroy
+ ***************************************************************************/
 
 void
 log_reader_options_defaults(LogReaderOptions *options)

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -254,8 +254,6 @@ log_reader_stop_watches(LogReader *self)
     {
       poll_events_stop_watches(self->poll_events);
 
-      if (iv_task_registered(&self->restart_task))
-        iv_task_unregister(&self->restart_task);
       self->watches_running = FALSE;
     }
 }
@@ -522,6 +520,9 @@ log_reader_deinit(LogPipe *s)
 
   iv_event_unregister(&self->schedule_wakeup);
   iv_event_unregister(&self->last_msg_sent_event);
+  if (iv_task_registered(&self->restart_task))
+    iv_task_unregister(&self->restart_task);
+
   log_reader_stop_watches(self);
   log_reader_stop_idle_timer(self);
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -146,6 +146,7 @@ log_reader_start_watches(LogReader *self)
   if (self->poll_events)
     poll_events_start_watches(self->poll_events);
   self->watches_running = TRUE;
+  log_reader_update_watches(self);
 }
 
 static void
@@ -275,7 +276,6 @@ log_reader_close_proto_deferred(gpointer s)
   log_reader_stop_watches(self);
   log_reader_apply_proto_and_poll_events(self, proto, poll_events);
   log_reader_start_watches(self);
-  log_reader_update_watches(self);
 }
 
 void
@@ -627,7 +627,6 @@ log_reader_init(LogPipe *s)
   iv_event_register(&self->last_msg_sent_event);
 
   log_reader_start_watches(self);
-  log_reader_update_watches(self);
 
   return TRUE;
 }

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -55,7 +55,7 @@ void log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *op
 void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filename);
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_immediate_check(LogReader *s);
-void log_reader_reopen(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
+void log_reader_open(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
 void log_reader_close_proto(LogReader *s);
 LogReader *log_reader_new(GlobalConfig *cfg);
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -147,7 +147,7 @@ _setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gbo
   FileReader *self = (FileReader *) s;
 
   self->reader = log_reader_new(log_pipe_get_config(s));
-  log_reader_reopen(self->reader, proto, poll_events);
+  log_reader_open(self->reader, proto, poll_events);
   log_reader_set_options(self->reader,
                          s,
                          &self->options->reader_options,

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -235,8 +235,7 @@ afprogram_sd_init(LogPipe *s)
       proto = log_proto_text_server_new(transport, &self->reader_options.proto_options.super);
 
       self->reader = log_reader_new(s->cfg);
-      log_reader_reopen(self->reader, proto,
-                        poll_fd_events_new(fd));
+      log_reader_open(self->reader, proto, poll_fd_events_new(fd));
       log_reader_set_options(self->reader,
                              s,
                              &self->reader_options,

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -102,7 +102,7 @@ afsocket_sc_init(LogPipe *s)
         }
 
       self->reader = log_reader_new(s->cfg);
-      log_reader_reopen(self->reader, proto, poll_fd_events_new(self->sock));
+      log_reader_open(self->reader, proto, poll_fd_events_new(self->sock));
       log_reader_set_peer_addr(self->reader, self->peer_addr);
     }
   log_reader_set_options(self->reader, &self->super,

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -185,8 +185,8 @@ afstreams_sd_init(LogPipe *s)
         }
       g_fd_set_nonblock(fd, TRUE);
       self->reader = log_reader_new(cfg);
-      log_reader_reopen(self->reader, log_proto_dgram_server_new(log_transport_streams_new(fd),
-                                                                 &self->reader_options.proto_options.super), poll_fd_events_new(fd));
+      log_reader_open(self->reader, log_proto_dgram_server_new(log_transport_streams_new(fd),
+                                                               &self->reader_options.proto_options.super), poll_fd_events_new(fd));
       log_reader_set_options(self->reader,
                              s,
                              &self->reader_options,

--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -121,9 +121,9 @@ _openbsd_sd_init(LogPipe *s)
     }
 
   self->reader = log_reader_new(cfg);
-  log_reader_reopen(self->reader, log_proto_dgram_server_new(log_transport_stream_socket_new(syslog_fd),
-                                                             &self->reader_options.proto_options.super),
-                    poll_fd_events_new(syslog_fd));
+  log_reader_open(self->reader, log_proto_dgram_server_new(log_transport_stream_socket_new(syslog_fd),
+                                                           &self->reader_options.proto_options.super),
+                  poll_fd_events_new(syslog_fd));
 
   log_reader_set_options(self->reader,
                          s,


### PR DESCRIPTION
This branch eliminates a lot of system calls on the LogReader input handling path, thereby increasing performance, especially if the per-wakeup overheads cannot be amortized over a lot of messages (e.g. it does not help much in case we are running with log-fetch-limit(1000) and sufficient window, but it does if we go to sleep every 10 messages).

The performance change is basically that we don't call  `iv_unregister_fd()` at every input callback, rather we'll only set the interesting poll mask to zero. This removes a number of epoll_ctl/setsockopt calls, whose overhead can be quite visible.

On the other hand this branch also contains a quite significant refactor of the LogReader, by clearing up various internal layers. These changes are:

* "watches": are the set of events that we need wrt. the input protocols (poll_events and idle_timeout)
  - we can start/stop/disable watches
  - init starts, deinit stops watches
  - at every input processing we disable watches (in contrast to stopping them).

* I've removed the log_reader_reopen() concept, as we are not using that anymore, this has become log_reader_open(), and this allowed me to remove complexity

* I've reordered a functions to make it more amangeable, related concepts are moved to the same place, with a "comment flag" on top to indicate what each is. Otherwise I was jumping back and forth in the source code a lot.

Most of these changes were doing in a pair programming session with @gaborznagy 
