### PR TITLE
java, elasticsearch2, explicit unsupport for named templates

### DIFF
--- a/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/options/TemplateOption.java
@@ -32,6 +32,8 @@ public class TemplateOption extends OptionDecorator {
 	private String strTemplate;
 	private long configHandle;
 
+	private native boolean isNamedTemplate(long configHandle, String template_name);
+
 	public TemplateOption(long configHandle, Option decoratedOption) {
 		super(decoratedOption);
 		this.configHandle = configHandle;
@@ -42,6 +44,9 @@ public class TemplateOption extends OptionDecorator {
 		decoratedOption.validate();
 		strTemplate = decoratedOption.getValue();
 		if (strTemplate != null) {
+			if (isNamedTemplate(configHandle, strTemplate))
+				throw new InvalidOptionException("Named templates not supported: '" + strTemplate + "'");
+
 			template = new LogTemplate(configHandle);
 			if(!template.compile(strTemplate)) {
 				throw new InvalidOptionException("Can't compile template: '" + strTemplate + "'");

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -79,7 +79,12 @@ java_dest_option
           	java_dd_set_class_name(last_driver, $3);
             free($3);
           }
-        | KW_TEMPLATE '(' string ')' { java_dd_set_template_string(last_driver, $3); free($3); }
+        | KW_TEMPLATE '(' string ')'
+          {
+            CHECK_ERROR(cfg_tree_lookup_template(&configuration->tree, $3) == NULL, @4,
+                        "named templates are not supported in java destination");
+            java_dd_set_template_string(last_driver, $3); free($3);
+          }
         | KW_OPTION '(' java_dest_custom_options ')'
         | threaded_dest_driver_option
         | { last_template_options = java_dd_get_template_options(last_driver); } template_option

--- a/modules/java/proxies/java-template-proxy.c
+++ b/modules/java/proxies/java-template-proxy.c
@@ -25,6 +25,19 @@
 
 #include "java-template-proxy.h"
 #include "messages.h"
+#include "cfg.h"
+#include "cfg-tree.h"
+
+JNIEXPORT jboolean JNICALL
+Java_org_syslog_1ng_options_TemplateOption_isNamedTemplate(JNIEnv *env, jobject obj, jlong cfg_handle,
+                                                           jstring template_name)
+{
+  GlobalConfig *cfg = (GlobalConfig *)cfg_handle;
+  const char *template_cstr = (*env)->GetStringUTFChars(env, template_name, NULL);
+  jboolean result = !!cfg_tree_lookup_template(&cfg->tree, template_cstr);
+  (*env)->ReleaseStringUTFChars(env, template_name, template_cstr);
+  return result;
+}
 
 
 JNIEXPORT jlong JNICALL


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/1870

As reported in #1870, elasticsearch destination does not support named templates. We concluded in that thread that there is no plan to support for it.

This patchset adds error detection in case someone tries to use named templates, so that the problem does not go undetected.

I added similar detection for java destination too. Interestingly, elasticsearch2 destination did not use the template grammar from java destination, so different implementation was needed there.

The motivation is that we would like to promote `@define` keyword instead of named templates.