### PR TITLE
xml/geoip2: make prefix optional

### DIFF
--- a/lib/scanner/xml-scanner/tests/test_xml_scanner.c
+++ b/lib/scanner/xml-scanner/tests/test_xml_scanner.c
@@ -165,7 +165,7 @@ Test(xml_scanner, test_strip_whitespaces)
      .expected.test_push_function = _test_strip,
                .expected.expected_pairs = (NameValuePair [])
     {
-      {".tag", "part1part2"},
+      {"tag", "part1part2"},
     }
   });
 

--- a/lib/scanner/xml-scanner/xml-scanner.c
+++ b/lib/scanner/xml-scanner/xml-scanner.c
@@ -185,6 +185,8 @@ before_last_dot(GString *str)
 {
   const gchar *s = str->str;
   gchar *pos = strrchr(s, '.');
+  if (!pos)
+    return 0;
   return (pos-s);
 }
 
@@ -197,7 +199,9 @@ _clear_current_element_from_key(XMLScanner *self)
 static void
 _add_current_element_to_key(XMLScanner *self, const gchar *element_name)
 {
-  g_string_append_c(self->key, '.');
+  if (self->key->len > 0)
+    g_string_append_c(self->key, '.');
+
   g_string_append(self->key, element_name);
 }
 

--- a/modules/geoip2/geoip-parser.c
+++ b/modules/geoip2/geoip-parser.c
@@ -151,7 +151,8 @@ maxminddb_parser_free(LogPipe *s)
 static void
 remove_trailing_dot(gchar *str)
 {
-  g_assert(strlen(str));
+  if (!strlen(str))
+    return;
   if (str[strlen(str)-1] == '.')
     str[strlen(str)-1] = 0;
 }

--- a/modules/geoip2/tests/test_geoip_parser.c
+++ b/modules/geoip2/tests/test_geoip_parser.c
@@ -94,9 +94,12 @@ test_geoip_parser_basics(void)
 
   geoip_parser_set_prefix(geoip_parser, ".prefix.");
   msg = parse_geoip_into_log_message("217.20.130.99");
-
   assert_log_message_value(msg, log_msg_get_value_handle(".prefix.country.iso_code"), "HU");
+  log_msg_unref(msg);
 
+  geoip_parser_set_prefix(geoip_parser, "");
+  msg = parse_geoip_into_log_message("217.20.130.99");
+  assert_log_message_value(msg, log_msg_get_value_handle(".country.iso_code"), "HU");
   log_msg_unref(msg);
 }
 

--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -156,10 +156,8 @@ ParameterizedTest(ValidXMLTestCase *test_cases, xmlparser, valid_inputs)
   log_msg_unref(msg);
 }
 
-Test(xml_parser, test_drop_invalid)
+Test(xmlparser, test_drop_invalid)
 {
-  setup();
-
   LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions) {});
 
   LogMessage *msg = log_msg_new_empty();
@@ -175,8 +173,6 @@ Test(xml_parser, test_drop_invalid)
   log_pipe_deinit((LogPipe *)xml_parser);
   log_pipe_unref((LogPipe *)xml_parser);
   log_msg_unref(msg);
-
-  teardown();
 }
 
 typedef struct
@@ -263,10 +259,8 @@ ParameterizedTest(SingleExcludeTagTestCase *test_cases, xmlparser, single_exclud
   g_list_free(exclude_tags);
 }
 
-Test(xml_parser, test_multiple_exclude_tags)
+Test(xmlparser, test_multiple_exclude_tags)
 {
-  setup();
-
   GList *exclude_tags = NULL;
   exclude_tags = g_list_append(exclude_tags, "tag1");
   exclude_tags = g_list_append(exclude_tags, "tag2");
@@ -299,14 +293,10 @@ Test(xml_parser, test_multiple_exclude_tags)
   log_msg_unref(msg);
 
   g_list_free(exclude_tags);
-
-  teardown();
 }
 
-Test(xml_parser, test_strip_whitespaces)
+Test(xmlparser, test_strip_whitespaces)
 {
-  setup();
-
   LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions)
   {
     .strip_whitespaces = TRUE
@@ -326,8 +316,6 @@ Test(xml_parser, test_strip_whitespaces)
   log_pipe_deinit((LogPipe *)xml_parser);
   log_pipe_unref((LogPipe *)xml_parser);
   log_msg_unref(msg);
-
-  teardown();
 }
 
 typedef struct

--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -47,6 +47,7 @@ typedef struct
   gboolean forward_invalid;
   gboolean strip_whitespaces;
   GList *exclude_tags;
+  const gchar *prefix;
 } XMLParserTestOptions;
 
 static LogParser *
@@ -58,7 +59,8 @@ _construct_xml_parser(XMLParserTestOptions options)
     xml_scanner_options_set_strip_whitespaces(xml_parser_get_scanner_options(xml_parser), options.strip_whitespaces);
   if (options.exclude_tags)
     xml_scanner_options_set_and_compile_exclude_tags(xml_parser_get_scanner_options(xml_parser), options.exclude_tags);
-
+  if (options.prefix)
+    xml_parser_set_prefix(xml_parser, options.prefix);
 
   LogPipe *cloned = xml_parser_clone(&xml_parser->super);
   log_pipe_init(cloned);
@@ -326,4 +328,48 @@ Test(xml_parser, test_strip_whitespaces)
   log_msg_unref(msg);
 
   teardown();
+}
+
+typedef struct
+{
+  const gchar *input;
+  const gchar *prefix;
+  const gchar *key;
+  const gchar *value;
+} PrefixTestCase;
+
+ParameterizedTestParameters(xmlparser, test_prefix)
+{
+  static PrefixTestCase test_cases[] =
+  {
+    {"<tag>default_prefix</tag>", NULL, ".xml.tag", "default_prefix"},
+    {"<tag>foo</tag>", "", "tag", "foo"},
+    {"<tag>foobar</tag>", ".xmlparser", ".xmlparser.tag", "foobar"},
+    {"<tag>baz</tag>", ".meta.", ".meta.tag", "baz"},
+    {"<top><t1>asd</t1><t2>jkl</t2></top>", "", "top.t2", "jkl"},
+    {"<top><t1>1</t1><t2><t3>3</t3></t2></top>", "", "top.t2.t3", "3"},
+    {"<top><t1>1</t1><t2><t3>3</t3></t2><misc>value</misc></top>", "", "top.misc", "value"},
+  };
+  return cr_make_param_array(PrefixTestCase, test_cases, sizeof(test_cases)/sizeof(test_cases[0]));
+}
+
+ParameterizedTest(PrefixTestCase *test_cases, xmlparser, test_prefix)
+{
+  LogParser *xml_parser = _construct_xml_parser((XMLParserTestOptions)
+  {
+    .prefix = test_cases->prefix
+  });
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value(msg, LM_V_MESSAGE, test_cases->input, -1);
+
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  log_parser_process_message(xml_parser, &msg, &path_options);
+
+  const gchar *value = log_msg_get_value_by_name(msg, test_cases->key, NULL);
+  cr_assert_str_eq(value, test_cases->value);
+
+  log_pipe_deinit((LogPipe *)xml_parser);
+  log_pipe_unref((LogPipe *)xml_parser);
+  log_msg_unref(msg);
 }

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -34,7 +34,8 @@ xml_parser_get_scanner_options(LogParser *p)
 static void
 remove_trailing_dot(gchar *str)
 {
-  g_assert(strlen(str));
+  if (!strlen(str))
+    return;
   if (str[strlen(str)-1] == '.')
     str[strlen(str)-1] = 0;
 }


### PR DESCRIPTION
Until now, prefix for these parsers were mandatory: it was either the default prefix, or a user-defined.
After this PR, it is possible to set an empty prefix for geoip2 and xml parsers.
```
xml(prefix(""));
geoip2(prefix(""));
```
The resulting nv-pairs would be created without a prefix:
```
name1 = value1
name2 = value2
```