### PR TITLE
persist-tool: remove criterion as dependency

### DIFF
--- a/persist-tool/Makefile.am
+++ b/persist-tool/Makefile.am
@@ -11,11 +11,12 @@ persist_tool_persist_tool_SOURCES	=	\
 	persist-tool/generate.c \
 	persist-tool/generate.h \
 	persist-tool/persist-tool.c \
-	persist-tool/persist-tool.h 
+	persist-tool/persist-tool.h
 
 persist_tool_persist_tool_LDADD	= \
-  $(TEST_LDADD) \
-	@GLIB_LIBS@ \
-	@BASE_LIBS@
+	$(MODULE_DEPS_LIBS) \
+	$(TOOL_DEPS_LIBS)
 
 EXTRA_DIST += persist-tool/CMakeLists.txt
+
+persist_tool_persist_tool_DEPENDENCIES	= lib/libsyslog-ng.la


### PR DESCRIPTION
`persist-tool` was linked to `TEST_LDADD`, which contains `criterion`. This caused problem during deb package generation on debian jessie: the dpkg-buildpackage framework picked criterion as deb package dependency automatically. As a consequence, the resulting deb package could not be installed due to missing criterion package.

Replacing `TEST_LDADD` with the usual dependencies solves the problem.
