### PR TITLE
Own grammar support in generator plugin

### DIFF
--- a/lib/block-ref-parser.c
+++ b/lib/block-ref-parser.c
@@ -44,6 +44,7 @@ CfgParser block_ref_parser =
   .context = LL_CONTEXT_BLOCK_REF,
   .keywords = block_ref_keywords,
   .parse = (gint (*)(CfgLexer *, gpointer *, gpointer arg)) block_ref_parse,
+  .cleanup = (void (*)(gpointer))cfg_args_unref
 };
 
 CFG_PARSER_IMPLEMENT_LEXER_BINDING(block_ref_, CfgArgs **)

--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -35,7 +35,7 @@ cfg_block_generator_format_name_method(CfgBlockGenerator *self, gchar *buf, gsiz
 }
 
 gboolean
-cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, gpointer args, GString *result,
                              const gchar *reference)
 {
   gchar block_name[1024];

--- a/lib/cfg-block-generator.h
+++ b/lib/cfg-block-generator.h
@@ -26,7 +26,6 @@
 #define CFG_BLOCK_GENERATOR_H_INCLUDED 1
 
 #include "syslog-ng.h"
-#include "cfg-args.h"
 
 /**
  * CfgBlockGenerator:
@@ -46,7 +45,7 @@ struct _CfgBlockGenerator
   gchar *name;
   gboolean suppress_backticks;
   const gchar *(*format_name)(CfgBlockGenerator *self, gchar *buf, gsize buf_len);
-  gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+  gboolean (*generate)(CfgBlockGenerator *self, GlobalConfig *cfg, gpointer args, GString *result,
                        const gchar *reference);
   void (*free_fn)(CfgBlockGenerator *self);
 };
@@ -57,7 +56,7 @@ cfg_block_generator_format_name(CfgBlockGenerator *self, gchar *buf, gsize buf_l
   return self->format_name(self, buf, buf_len);
 }
 
-gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+gboolean cfg_block_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, gpointer args, GString *result,
                                       const gchar *reference);
 void cfg_block_generator_init_instance(CfgBlockGenerator *self, gint context, const gchar *name);
 void cfg_block_generator_free_instance(CfgBlockGenerator *self);

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -149,25 +149,26 @@ _validate_args(CfgArgs *self, CfgArgs *defs, const gchar *reference)
  * for the lexer.
  */
 gboolean
-cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result, const gchar *reference)
+cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, gpointer args, GString *result, const gchar *reference)
 {
   CfgBlock *self = (CfgBlock *) s;
   gchar *value;
   gsize length;
   GError *error = NULL;
   gchar buf[256];
+  CfgArgs *cfgargs = (CfgArgs *)args;
 
-  if (!_validate_args(args, self->arg_defs, reference))
+  if (!_validate_args(cfgargs, self->arg_defs, reference))
     return FALSE;
 
   if (cfg_args_is_accepting_varargs(self->arg_defs))
     {
-      gchar *formatted_varargs = cfg_args_format_varargs(args, self->arg_defs);
-      cfg_args_set(args, "__VARARGS__", formatted_varargs);
+      gchar *formatted_varargs = cfg_args_format_varargs(cfgargs, self->arg_defs);
+      cfg_args_set(cfgargs, "__VARARGS__", formatted_varargs);
       g_free(formatted_varargs);
     }
 
-  value = cfg_lexer_subst_args_in_input(cfg->globals, self->arg_defs, args, self->content, -1, &length, &error);
+  value = cfg_lexer_subst_args_in_input(cfg->globals, self->arg_defs, cfgargs, self->content, -1, &length, &error);
   if (!value)
     {
       msg_warning("Syntax error while resolving backtick references in block",

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -911,6 +911,8 @@ cfg_lexer_parse_and_run_block_generator(CfgLexer *self, Plugin *p, YYSTYPE *yylv
   CfgParser *gen_parser = p->parser;
   if (gen_parser && !cfg_parser_parse(gen_parser, self, (gpointer *) &args, NULL))
     {
+      cfg_parser_cleanup(gen_parser, args);
+
       level->lloc.first_line = saved_line;
       level->lloc.first_column = saved_column;
       free(yylval->cptr);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -929,7 +929,7 @@ cfg_lexer_parse_and_run_block_generator(CfgLexer *self, Plugin *p, YYSTYPE *yylv
                                          cfg_lexer_format_location(self, &level->lloc, buf, sizeof(buf)));
 
   free(yylval->cptr);
-  cfg_args_unref((CfgArgs *)args);
+  cfg_parser_cleanup(gen_parser, args);
 
   if (!success)
     {

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -766,7 +766,7 @@ _is_generator_plugin(Plugin *p)
 }
 
 static Plugin *
-cfg_lexer_find_generator(CfgLexer *self, GlobalConfig *cfg, gint context, const gchar *name)
+cfg_lexer_find_generator_plugin(CfgLexer *self, GlobalConfig *cfg, gint context, const gchar *name)
 {
   Plugin *p;
 
@@ -1028,7 +1028,7 @@ cfg_lexer_preprocess(CfgLexer *self, gint tok, YYSTYPE *yylval, YYLTYPE *yylloc)
 
   if (tok == LL_IDENTIFIER &&
       self->cfg &&
-      (p = cfg_lexer_find_generator(self, self->cfg, cfg_lexer_get_context_type(self), yylval->cptr)))
+      (p = cfg_lexer_find_generator_plugin(self, self->cfg, cfg_lexer_get_context_type(self), yylval->cptr)))
     {
       if (!cfg_lexer_parse_and_run_block_generator(self, p, yylval))
         return CLPR_ERROR;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -753,6 +753,7 @@ cfg_lexer_register_generator_plugin(PluginContext *context, CfgBlockGenerator *g
   plugin->super.name = g_strdup(gen->name);
   plugin->super.free_fn = _generator_plugin_free;
   plugin->super.construct = _generator_plugin_construct;
+  plugin->super.parser = &block_ref_parser;
   plugin->gen = gen;
 
   plugin_register(context, &plugin->super, 1);
@@ -907,7 +908,8 @@ cfg_lexer_parse_and_run_block_generator(CfgLexer *self, Plugin *p, YYSTYPE *yylv
 
   gint saved_line = level->lloc.first_line;
   gint saved_column = level->lloc.first_column;
-  if (!cfg_parser_parse(&block_ref_parser, self, (gpointer *) &args, NULL))
+  CfgParser *gen_parser = p->parser;
+  if (gen_parser && !cfg_parser_parse(gen_parser, self, (gpointer *) &args, NULL))
     {
       level->lloc.first_line = saved_line;
       level->lloc.first_column = saved_column;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -898,7 +898,7 @@ cfg_lexer_append_preprocessed_output(CfgLexer *self, const gchar *token_text)
 static gboolean
 cfg_lexer_parse_and_run_block_generator(CfgLexer *self, Plugin *p, YYSTYPE *yylval)
 {
-  CfgArgs *args;
+  gpointer *args;
   CfgIncludeLevel *level = &self->include_stack[self->include_depth];
   CfgBlockGenerator *gen = plugin_construct(p);
   gboolean success = TRUE;
@@ -927,7 +927,7 @@ cfg_lexer_parse_and_run_block_generator(CfgLexer *self, Plugin *p, YYSTYPE *yylv
                                          cfg_lexer_format_location(self, &level->lloc, buf, sizeof(buf)));
 
   free(yylval->cptr);
-  cfg_args_unref(args);
+  cfg_args_unref((CfgArgs *)args);
 
   if (!success)
     {

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -74,7 +74,6 @@ plugin_candidate_free(PluginCandidate *self)
 gpointer
 plugin_construct(Plugin *self)
 {
-  g_assert(self->parser == NULL);
   if (self->construct)
     {
       return self->construct(self);

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -456,7 +456,7 @@ include \"foo.conf\";\n");
 }
 
 static gboolean
-_fake_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *result,
+_fake_generator_generate(CfgBlockGenerator *self, GlobalConfig *cfg, gpointer args, GString *result,
                          const gchar *reference)
 {
   g_string_append(result, "fake_generator_content");

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -212,12 +212,13 @@ _parse_arguments(AppParserGenerator *self, CfgArgs *args, const gchar *reference
 }
 
 static gboolean
-_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result, const gchar *reference)
+_generate(CfgBlockGenerator *s, GlobalConfig *cfg, gpointer args, GString *result, const gchar *reference)
 {
   AppParserGenerator *self = (AppParserGenerator *) s;
   AppModelContext *appmodel = appmodel_get_context(cfg);
+  CfgArgs *cfgargs = (CfgArgs *)args;
 
-  if (!_parse_arguments(self, args, reference))
+  if (!_parse_arguments(self, cfgargs, reference))
     return FALSE;
 
   self->block = result;

--- a/modules/appmodel/appmodel-plugin.c
+++ b/modules/appmodel/appmodel-plugin.c
@@ -24,6 +24,7 @@
 #include "cfg-parser.h"
 #include "appmodel-parser.h"
 #include "app-parser-generator.h"
+#include "block-ref-parser.h"
 #include "plugin.h"
 #include "plugin-types.h"
 
@@ -45,7 +46,8 @@ static Plugin appmodel_plugins[] =
   {
     .type = LL_CONTEXT_PARSER | LL_CONTEXT_FLAG_GENERATOR,
     .name = "app-parser",
-    .construct = app_parser_construct
+    .construct = app_parser_construct,
+    .parser = &block_ref_parser
   }
 };
 

--- a/modules/confgen/confgen-plugin.c
+++ b/modules/confgen/confgen-plugin.c
@@ -67,19 +67,20 @@ _read_program_output(FILE *out, GString *result)
 }
 
 gboolean
-confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, CfgArgs *args, GString *result, const gchar *reference)
+confgen_exec_generate(CfgBlockGenerator *s, GlobalConfig *cfg, gpointer args, GString *result, const gchar *reference)
 {
   ConfgenExec *self = (ConfgenExec *) s;
   FILE *out;
   gchar buf[256];
   gint res;
+  CfgArgs *cfgargs = (CfgArgs *)args;
 
   g_snprintf(buf, sizeof(buf), "%s confgen %s", cfg_lexer_lookup_context_name_by_type(self->super.context),
              self->super.name);
 
-  cfg_args_foreach(args, confgen_set_args_as_env, NULL);
+  cfg_args_foreach(cfgargs, confgen_set_args_as_env, NULL);
   out = popen(self->exec, "r");
-  cfg_args_foreach(args, confgen_unset_args_from_env, NULL);
+  cfg_args_foreach(cfgargs, confgen_unset_args_from_env, NULL);
 
   if (!out)
     {

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -350,29 +350,30 @@ system_generate_app_parser(GlobalConfig *cfg, GString *sysblock, CfgArgs *args)
 }
 
 static gboolean
-system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, CfgArgs *args, GString *sysblock,
+system_source_generate(CfgBlockGenerator *self, GlobalConfig *cfg, gpointer args, GString *sysblock,
                        const gchar *reference)
 {
   gboolean result = FALSE;
+  CfgArgs *cfgargs = (CfgArgs *)args;
 
   /* NOTE: we used to have an exclude-kmsg() option that was removed, still
    * we need to ignore it */
 
-  if (args)
-    cfg_args_remove(args, "exclude-kmsg");
+  if (cfgargs)
+    cfg_args_remove(cfgargs, "exclude-kmsg");
 
   g_string_append(sysblock,
                   "channel {\n"
                   "    source {\n");
 
-  if (!system_generate_system_transports(sysblock, args))
+  if (!system_generate_system_transports(sysblock, cfgargs))
     {
       goto exit;
     }
 
   g_string_append(sysblock, "    }; # source\n");
 
-  system_generate_app_parser(cfg, sysblock, args);
+  system_generate_app_parser(cfg, sysblock, cfgargs);
 
   g_string_append(sysblock, "}; # channel\n");
   result = TRUE;

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -23,6 +23,7 @@
 
 #include "cfg.h"
 #include "cfg-block-generator.h"
+#include "block-ref-parser.h"
 #include "messages.h"
 #include "plugin.h"
 #include "plugin-types.h"
@@ -403,7 +404,8 @@ Plugin system_plugins[] =
   {
     .type = LL_CONTEXT_SOURCE | LL_CONTEXT_FLAG_GENERATOR,
     .name = "system",
-    .construct = system_source_construct
+    .construct = system_source_construct,
+    .parser = &block_ref_parser
   }
 };
 


### PR DESCRIPTION
This is just an internal refactor, no user visible change.

The `generator` plugins could have parameters such as `system-source( foo(bar) )`. Every `generator` plugin had one grammar/parser that could handle any kind of key-value pair. (such as `foo(bar)`).

This has a few limitation:
* user has to create his own parsing logic inside a c logic, instead of a grammar; which could lead into nice error messages.
* the current grammar/parser is more limited than the grammar that user could provide

This PR brings two change:
* generator plugin could have its own grammar
* it is required from the generator's parser to support `cleanup` function, which should clean after itself (same as for other plugins).