### PR TITLE
libtest: Adding stopwatch.h into libtest_HEADERS list

### DIFF
--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -39,6 +39,7 @@ libtestinclude_HEADERS		    =	\
 	libtest/msg_parse_lib.h		\
 	libtest/persist_lib.h		\
 	libtest/proto_lib.h		\
+	libtest/stopwatch.h		\
 	libtest/testutils.h
 
 pkgconfig_DATA			   +=	\


### PR DESCRIPTION
We need this to be able to include the header externally.