### PR TITLE
Fix threaded source/destination crash when reverting configuration

### DIFF
--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -235,7 +235,7 @@ _register_sync_call_action(GQueue *q, void (*func)(gpointer user_data), gpointer
 }
 
 void
-_consume_action(SyncCallAction *action, gpointer dummy)
+_consume_action(SyncCallAction *action)
 {
   action->func(action->user_data);
   g_free(action);
@@ -244,8 +244,11 @@ _consume_action(SyncCallAction *action, gpointer dummy)
 static void
 _invoke_sync_call_actions(void)
 {
-  g_queue_foreach(&sync_call_actions, (GFunc)_consume_action, NULL);
-  g_queue_clear(&sync_call_actions);
+  while (!g_queue_is_empty(&sync_call_actions))
+    {
+      SyncCallAction *action = g_queue_pop_head(&sync_call_actions);
+      _consume_action(action);
+    }
 }
 
 /*

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -220,6 +220,14 @@ main_loop_was_last_reload_successful(MainLoop *self)
 }
 
 static void
+main_loop_reload_config_finished(MainLoop *self)
+{
+  app_config_changed();
+  self->new_config = NULL;
+  self->old_config = NULL;
+}
+
+static void
 main_loop_reload_config_revert(gpointer user_data)
 {
   MainLoop *self = (MainLoop *) user_data;
@@ -240,10 +248,7 @@ main_loop_reload_config_revert(gpointer user_data)
   cfg_free(self->new_config);
   self->current_configuration = self->old_config;
 
-  app_config_changed();
-
-  self->new_config = NULL;
-  self->old_config = NULL;
+  main_loop_reload_config_finished(self);
 }
 
 /* called to apply the new configuration once all I/O worker threads have finished */
@@ -287,10 +292,7 @@ main_loop_reload_config_apply(gpointer user_data)
     }
 
   /* this is already running with the new config in place */
-  app_config_changed();
-
-  self->new_config = NULL;
-  self->old_config = NULL;
+  main_loop_reload_config_finished(self);
 }
 
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -272,24 +272,21 @@ main_loop_reload_config_apply(gpointer user_data)
   cfg_persist_config_move(self->old_config, self->new_config);
 
   self->last_config_reload_successful = cfg_init(self->new_config);
-  if (self->last_config_reload_successful)
-    {
-      msg_verbose("New configuration initialized");
-      persist_config_free(self->new_config->persist);
-      self->new_config->persist = NULL;
-      cfg_free(self->old_config);
-      self->current_configuration = self->new_config;
-      service_management_clear_status();
-      msg_notice("Configuration reload request received, reloading configuration");
-
-    }
-  else
+  if (!self->last_config_reload_successful)
     {
       msg_error("Error initializing new configuration, reverting to old config");
       service_management_publish_status("Error initializing new configuration, using the old config");
       main_loop_worker_sync_call(main_loop_reload_config_revert, self);
       return;
     }
+
+  msg_verbose("New configuration initialized");
+  persist_config_free(self->new_config->persist);
+  self->new_config->persist = NULL;
+  cfg_free(self->old_config);
+  self->current_configuration = self->new_config;
+  service_management_clear_status();
+  msg_notice("Configuration reload request received, reloading configuration");
 
   /* this is already running with the new config in place */
   main_loop_reload_config_finished(self);


### PR DESCRIPTION
If a new configuration turns out to be invalid (I mean init()-time validation) during reload, the old one has to be restored.

In such case, the new configuration is in a half-initialized state, so it needs to be deinitialized. This must include a step called `main_loop_worker_sync_call()`, where worker threads are requested and waited to be stopped.