### PR TITLE
simplify libtest queue utils

### DIFF
--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -41,22 +41,15 @@ test_ack(LogMessage *msg, AckType ack_type)
 void
 feed_some_messages(LogQueue *q, int n)
 {
-  MsgFormatOptions format_options;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   LogMessage *msg;
   gint i;
 
-  format_options.format_handler = NULL;
   path_options.ack_needed = q->use_backlog;
   path_options.flow_control_requested = TRUE;
   for (i = 0; i < n; i++)
     {
-      gchar *msg_str =
-        g_strdup_printf("<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép ID :%08d",i);
-      GSockAddr *test_addr = g_sockaddr_inet_new("10.10.10.10", 1010);
-      msg = log_msg_new(msg_str, strlen(msg_str), test_addr, &format_options);
-      g_sockaddr_unref(test_addr);
-      g_free(msg_str);
+      msg = log_msg_new_empty();
 
       log_msg_add_ack(msg, &path_options);
       msg->ack_func = test_ack;

--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -75,20 +75,3 @@ send_some_messages(LogQueue *q, gint n)
     }
 }
 
-void
-app_rewind_some_messages(LogQueue *q, guint n)
-{
-  log_queue_rewind_backlog(q,n);
-}
-
-void
-app_ack_some_messages(LogQueue *q, guint n)
-{
-  log_queue_ack_backlog(q, n);
-}
-
-void
-rewind_messages(LogQueue *q)
-{
-  log_queue_rewind_backlog_all(q);
-}

--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -39,12 +39,14 @@ test_ack(LogMessage *msg, AckType ack_type)
 }
 
 void
-feed_some_messages(LogQueue *q, int n, MsgFormatOptions *po)
+feed_some_messages(LogQueue *q, int n)
 {
+  MsgFormatOptions format_options;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   LogMessage *msg;
   gint i;
 
+  format_options.format_handler = NULL;
   path_options.ack_needed = q->use_backlog;
   path_options.flow_control_requested = TRUE;
   for (i = 0; i < n; i++)
@@ -52,7 +54,7 @@ feed_some_messages(LogQueue *q, int n, MsgFormatOptions *po)
       gchar *msg_str =
         g_strdup_printf("<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép ID :%08d",i);
       GSockAddr *test_addr = g_sockaddr_inet_new("10.10.10.10", 1010);
-      msg = log_msg_new(msg_str, strlen(msg_str), test_addr, po);
+      msg = log_msg_new(msg_str, strlen(msg_str), test_addr, &format_options);
       g_sockaddr_unref(test_addr);
       g_free(msg_str);
 

--- a/libtest/queue_utils_lib.h
+++ b/libtest/queue_utils_lib.h
@@ -32,7 +32,7 @@ extern int acked_messages;
 extern int fed_messages;
 
 void test_ack(LogMessage *msg, AckType ack_type);
-void feed_some_messages(LogQueue *q, int n, MsgFormatOptions *po);
+void feed_some_messages(LogQueue *q, int n);
 
 void send_some_messages(LogQueue *q, gint n);
 

--- a/libtest/queue_utils_lib.h
+++ b/libtest/queue_utils_lib.h
@@ -36,10 +36,4 @@ void feed_some_messages(LogQueue *q, int n);
 
 void send_some_messages(LogQueue *q, gint n);
 
-void app_rewind_some_messages(LogQueue *q, guint n);
-
-void app_ack_some_messages(LogQueue *q, guint n);
-
-void rewind_messages(LogQueue *q);
-
 #endif

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,5 +1,5 @@
 DISKQ_TEST_C_FLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/diskq
-DISKQ_TEST_LD_FLAGS = $(TEST_LDFLAGS) ${PREOPEN_SYSLOGFORMAT} -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la
+DISKQ_TEST_LD_FLAGS = $(TEST_LDFLAGS) -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la
 DISKQ_TEST_LD_ADD = $(TEST_LDADD)
 
 modules_diskq_tests_TESTS = \

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -74,7 +74,7 @@ testcase_zero_diskbuf_and_normal_acks(void)
   fed_messages = 0;
   acked_messages = 0;
   for (i = 0; i < 10; i++)
-    feed_some_messages(q, 10, &parse_options);
+    feed_some_messages(q, 10);
 
   send_some_messages(q, fed_messages);
   app_ack_some_messages(q, fed_messages);
@@ -109,7 +109,7 @@ testcase_zero_diskbuf_alternating_send_acks(void)
   acked_messages = 0;
   for (i = 0; i < 10; i++)
     {
-      feed_some_messages(q, 10, &parse_options);
+      feed_some_messages(q, 10);
       send_some_messages(q, 10);
       app_ack_some_messages(q, 10);
     }
@@ -151,7 +151,7 @@ testcase_ack_and_rewind_messages(void)
 
   fed_messages = 0;
   acked_messages = 0;
-  feed_some_messages(q, 1000, &parse_options);
+  feed_some_messages(q, 1000);
   assert_gint(stats_counter_get(q->queued_messages), 1000, "queued messages: %d", __LINE__);
 
   for(i = 0; i < 10; i++)
@@ -351,7 +351,7 @@ testcase_diskbuffer_restart_corrupted(void)
 
       log_queue_disk_load_queue(q, filename);
       fed_messages = 0;
-      feed_some_messages(q, 100, &parse_options);
+      feed_some_messages(q, 100);
       assert_gint(fed_messages, 100, "Failed to push all messages to the disk-queue!\n");
 
       LogQueueDisk *disk_queue = (LogQueueDisk *)q;
@@ -434,7 +434,7 @@ assert_general_message_flow(LogQueue *q, gssize one_msg_size)
   assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: line: %d", __LINE__);
   assert_gint(stats_counter_get(q->memory_usage), 0, "memory_usage: line: %d", __LINE__);
 
-  feed_some_messages(q, 10, &parse_options);
+  feed_some_messages(q, 10);
   assert_gint(stats_counter_get(q->queued_messages), 10, "queued messages: line: %d", __LINE__);
   assert_gint(stats_counter_get(q->memory_usage), one_msg_size*10, "memory_usage: line: %d", __LINE__);
 
@@ -467,7 +467,7 @@ testcase_diskq_prepare(DiskQueueOptions *options, diskq_tester_parameters_t *par
 static void
 assert_first_message_reliable(LogQueue *q, diskq_tester_parameters_t *parameters)
 {
-  feed_some_messages(q, 1, &parse_options);
+  feed_some_messages(q, 1);
   assert_gint(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
   /* For reliable queue we have qout = 0, so messages go to the overflow area.
      But qreliable pushes 3 elements per message: msg, options, position */
@@ -479,7 +479,7 @@ static void
 assert_first_message_non_reliable(LogQueue *q, diskq_tester_parameters_t *parameters)
 {
   LogQueueDiskNonReliable *queue = (LogQueueDiskNonReliable *)q;
-  feed_some_messages(q, 1, &parse_options);
+  feed_some_messages(q, 1);
   assert_gint(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
   assert_gint(queue->qoverflow->length, 0, "one message on overflow area: line: %d", __LINE__);
 }
@@ -488,7 +488,7 @@ static void
 assert_second_message_reliable(LogQueue *q, diskq_tester_parameters_t *parameters, gssize one_msg_size)
 {
   LogQueueDiskReliable *queue = (LogQueueDiskReliable *)q;
-  feed_some_messages(q, 1, &parse_options);
+  feed_some_messages(q, 1);
   assert_gint(stats_counter_get(q->queued_messages), 2, "queued messages: line: %d", __LINE__);
   assert_gint(stats_counter_get(q->memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
 
@@ -499,7 +499,7 @@ assert_second_message_reliable(LogQueue *q, diskq_tester_parameters_t *parameter
 static void
 assert_second_message_non_reliable(LogQueue *q, diskq_tester_parameters_t *parameters, gssize one_msg_size)
 {
-  feed_some_messages(q, 1, &parse_options);
+  feed_some_messages(q, 1);
   assert_gint(stats_counter_get(q->queued_messages), 2, "queued messages: line: %d", __LINE__);
   assert_gint(stats_counter_get(q->memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
 

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -74,7 +74,7 @@ testcase_zero_diskbuf_and_normal_acks(void)
     feed_some_messages(q, 10);
 
   send_some_messages(q, fed_messages);
-  app_ack_some_messages(q, fed_messages);
+  log_queue_ack_backlog(q, fed_messages);
   assert_gint(fed_messages, acked_messages,
               "%s: did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d\n", __FUNCTION__, fed_messages,
               acked_messages);
@@ -108,7 +108,7 @@ testcase_zero_diskbuf_alternating_send_acks(void)
     {
       feed_some_messages(q, 10);
       send_some_messages(q, 10);
-      app_ack_some_messages(q, 10);
+      log_queue_ack_backlog(q, 10);
     }
 
   assert_gint(fed_messages, acked_messages,
@@ -155,17 +155,17 @@ testcase_ack_and_rewind_messages(void)
     {
       send_some_messages(q,1);
       assert_gint(stats_counter_get(q->queued_messages), 999, "queued messages wrong number %d", __LINE__);
-      app_rewind_some_messages(q,1);
+      log_queue_rewind_backlog(q,1);
       assert_gint(stats_counter_get(q->queued_messages), 1000, "queued messages wrong number: %d", __LINE__);
     }
   send_some_messages(q,1000);
   assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
-  app_ack_some_messages(q,500);
-  app_rewind_some_messages(q,500);
+  log_queue_ack_backlog(q,500);
+  log_queue_rewind_backlog(q,500);
   assert_gint(stats_counter_get(q->queued_messages), 500, "queued messages: %d", __LINE__);
   send_some_messages(q,500);
   assert_gint(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
-  app_ack_some_messages(q,500);
+  log_queue_ack_backlog(q,500);
   log_queue_unref(q);
   unlink(filename->str);
   g_string_free(filename,TRUE);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -592,5 +592,8 @@ main(void)
   testcase_zero_diskbuf_and_normal_acks();
   testcase_diskbuffer_restart_corrupted();
 
+  cfg_free(configuration);
+  app_shutdown();
+
   return 0;
 }

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -78,7 +78,7 @@ test_diskq_become_full(gboolean reliable)
   stats_unlock();
   unlink(DISKQ_FILENAME);
   log_queue_disk_load_queue(q, DISKQ_FILENAME);
-  feed_some_messages(q, 1000, &parse_options);
+  feed_some_messages(q, 1000);
 
   assert_gint(atomic_gssize_racy_get(&q->dropped_messages->value), 1000, "Bad dropped message number (reliable: %s)",
               reliable ? "TRUE" : "FALSE");

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -96,7 +96,12 @@ main(void)
   configuration = cfg_new_snippet();
   cfg_load_module(configuration, "disk-buffer");
   msg_set_post_func(msg_post_function);
+
   test_diskq_become_full(TRUE);
   test_diskq_become_full(FALSE);
+
+  cfg_free(configuration);
+  app_shutdown();
+
   return 0;
 }

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -38,8 +38,6 @@
 
 #define DISKQ_FILENAME "test_become_full.qf"
 
-MsgFormatOptions parse_options;
-
 
 static void msg_post_function(LogMessage *msg)
 {
@@ -96,12 +94,8 @@ main(void)
   tzset();
 
   configuration = cfg_new_snippet();
-  cfg_load_module(configuration, "syslogformat");
   cfg_load_module(configuration, "disk-buffer");
-  cfg_load_module(configuration, "builtin-serializer");
   msg_set_post_func(msg_post_function);
-  msg_format_options_defaults(&parse_options);
-  msg_format_options_init(&parse_options, configuration);
   test_diskq_become_full(TRUE);
   test_diskq_become_full(FALSE);
   return 0;

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -212,7 +212,7 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
   cr_assert_eq(stats_counter_get(q->memory_usage), 101*size_when_single_msg);
 
   send_some_messages(q, fed_messages);
-  app_ack_some_messages(q, fed_messages);
+  log_queue_ack_backlog(q, fed_messages);
 
   cr_assert_eq(fed_messages, acked_messages,
                "did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d",
@@ -235,7 +235,7 @@ Test(logqueue, test_zero_diskbuf_alternating_send_acks)
     {
       feed_some_messages(q, 10);
       send_some_messages(q, 10);
-      app_ack_some_messages(q, 10);
+      log_queue_ack_backlog(q, 10);
     }
 
   cr_assert_eq(fed_messages, acked_messages,

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -171,7 +171,7 @@ setup(void)
   app_startup();
   setenv("TZ", "MET-1METDST", TRUE);
   tzset();
-  init_and_load_syslogformat_module();
+  configuration = cfg_new_snippet();
   configuration->stats_options.level = 1;
   cr_assert(cfg_init(configuration), "cfg_init failed!");
 }
@@ -179,7 +179,7 @@ setup(void)
 void
 teardown(void)
 {
-  deinit_syslogformat_module();
+  cfg_free(configuration);
   app_shutdown();
 }
 

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -205,13 +205,13 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
 
   fed_messages = 0;
   acked_messages = 0;
-  feed_some_messages(q, 1, &parse_options);
+  feed_some_messages(q, 1);
   cr_assert_eq(stats_counter_get(q->queued_messages), 1);
   cr_assert_neq(stats_counter_get(q->memory_usage), 0);
   gint size_when_single_msg = stats_counter_get(q->memory_usage);
 
   for (i = 0; i < 10; i++)
-    feed_some_messages(q, 10, &parse_options);
+    feed_some_messages(q, 10);
 
   cr_assert_eq(stats_counter_get(q->queued_messages), 101);
   cr_assert_eq(stats_counter_get(q->memory_usage), 101*size_when_single_msg);
@@ -238,7 +238,7 @@ Test(logqueue, test_zero_diskbuf_alternating_send_acks)
   acked_messages = 0;
   for (i = 0; i < 10; i++)
     {
-      feed_some_messages(q, 10, &parse_options);
+      feed_some_messages(q, 10);
       send_some_messages(q, 10);
       app_ack_some_messages(q, 10);
     }
@@ -297,10 +297,10 @@ Test(logqueue, log_queue_fifo_rewind_all_and_memory_usage)
   stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
 
-  feed_some_messages(q, 1, &parse_options);
+  feed_some_messages(q, 1);
   gint size_when_single_msg = stats_counter_get(q->memory_usage);
 
-  feed_some_messages(q, 9, &parse_options);
+  feed_some_messages(q, 9);
   cr_assert_eq(stats_counter_get(q->memory_usage), 10*size_when_single_msg);
 
   send_some_messages(q, 10);

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -52,13 +52,10 @@ static gpointer
 _threaded_feed(gpointer args)
 {
   LogQueue *q = args;
-  char *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép";
-  gint msg_len = strlen(msg_str);
   gint i;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   LogMessage *msg, *tmpl;
   GTimeVal start, end;
-  GSockAddr *sa;
   glong diff;
 
   iv_init();
@@ -66,9 +63,7 @@ _threaded_feed(gpointer args)
   /* emulate main loop for LogQueue */
   main_loop_worker_thread_start(NULL);
 
-  sa = g_sockaddr_inet_new("10.10.10.10", 1010);
-  tmpl = log_msg_new(msg_str, msg_len, sa, &parse_options);
-  g_sockaddr_unref(sa);
+  tmpl = log_msg_new_empty();
 
   g_get_current_time(&start);
   for (i = 0; i < MESSAGES_PER_FEEDER; i++)


### PR DESCRIPTION
While I checked the disk queue related tests, I had some time to kill so I thought this changes improve the code.
Now the queue util based functions do not depend on `syslogformat` module.