### PR TITLE
python, java destination add already introduced retry

### DIFF
--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -31,6 +31,7 @@ public abstract class LogDestination extends LogPipe {
 	protected static final int SUCCESS = 3;
 	protected static final int QUEUED = 4;
 	protected static final int NOT_CONNECTED = 5;
+	protected static final int RETRY = 6;
 
 	public LogDestination(long pipeHandle) {
 		super(pipeHandle);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -291,6 +291,7 @@ _inject_worker_insert_result_consts(PythonDestDriver *self)
   _inject_worker_insert_result(self, SUCCESS);
   _inject_worker_insert_result(self, QUEUED);
   _inject_worker_insert_result(self, NOT_CONNECTED);
+  _inject_worker_insert_result(self, RETRY);
   _inject_worker_insert_result(self, MAX);
 };
 

--- a/modules/python/sngexample.py
+++ b/modules/python/sngexample.py
@@ -56,7 +56,8 @@ class LogDestination(object):
             (same as boolean False)
         self.DROP: message cannot be sent, it should be dropped immediately.
         self.QUEUED: message is not sent immediately, it will be sent with the flush method.
-        self.NOT_CONNECTED: message is put back to the queue, open method will be called until success."""
+        self.NOT_CONNECTED: message is put back to the queue, open method will be called until success.
+        self.RETRY: message is put back to the queue, try to send again until 3 times, then fallback to self.NOT_CONNECTED."""
 
         pass
 
@@ -73,7 +74,8 @@ class LogDestination(object):
         self.ERROR: batch sending was unsuccessful. (same as boolean False)
         self.DROP: batch cannot be sent, the messages should be dropped immediately.
         self.NOT_CONNECTED: the messages in the batch is put back to the queue,
-            open method will be called until success."""
+            open method will be called until success.
+        self.RETRY: message is put back to the queue, try to send again until 3 times, then fallback to self.NOT_CONNECTED."""
 
         pass
 


### PR DESCRIPTION
A new possible value added to python, java (as the C lib already has it): `RETRY`.