### PR TITLE
add persist-tool to file list

### DIFF
--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -327,6 +327,7 @@ fi
 %{_bindir}/pdbtool
 %{_bindir}/dqtool
 %{_bindir}/update-patterndb
+%{_bindir}/persist-tool
 %{_libdir}/lib%{name}-*.so.*
 %{_libdir}/libevtlog-*.so.*
 %{_libdir}/libsecret-storage.so.*


### PR DESCRIPTION
rpm-packaging: add persist-tool to file list

Update syslog-ng.spec by adding persist-tool to file list.
Fixes https://github.com/balabit/syslog-ng/issues/2560
I just learned from @fekete-robert that I can send a PR without using git :)

Signed-off-by: Peter Czanik <peter@czanik.hu>