### PR TITLE
Cmake clang sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,17 @@ endif()
 
 add_compile_options(${IMPORTANT_WARNINGS} ${ACCEPTABLE_WARNINGS} ${EXTRA_WARNINGS})
 
+# Sanatizer configuration
+set(SANITIZER "OFF" CACHE STRING "Enable clang sanitizer")
+
+set_property(CACHE SANITIZER PROPERTY STRINGS OFF address undefined)
+
+if (SANITIZER)
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O1 -fsanitize=${SANITIZER} -fno-omit-frame-pointer")
+endif()
+
+
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/syslog-ng-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/syslog-ng-config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -65,6 +65,7 @@ function (add_unit_test)
   endif()
 
   add_test (${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_TARGET})
+  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
 endfunction ()
 
 macro (add_test_subdirectory SUBDIR)

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -66,6 +66,7 @@ function (add_unit_test)
 
   add_test (${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_TARGET})
   set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
+  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR: LeakSanitizer")
 endfunction ()
 
 macro (add_test_subdirectory SUBDIR)


### PR DESCRIPTION
This make it possible to configure with a simple option (`sanitizer`) in case of cmake to use the clang address (or any other sanitizer).

https://clang.llvm.org/docs/AddressSanitizer.html

It is connected to the #2178 issue, which has a connected branch with memory issue fixes. I do rebase the current master from time to time, and since the last time (end of December) I got a lot more test failing, so I though I share a simple way to deploy it for others (and make my life easier not to switch, rebase branch).

This is cmake only, as I won't touch autotools before every unit tests passed.

What you actually need to set this up is: clang, cmake an example can be found on the original branch: https://github.com/Kokan/syslog-ng/blob/address-sanatize/.travis.yml#L157