### PR TITLE
improvements in example-msg-generator

### DIFF
--- a/modules/examples/sources/msg-generator/msg-generator-grammar.ym
+++ b/modules/examples/sources/msg-generator/msg-generator-grammar.ym
@@ -58,6 +58,7 @@ MsgGeneratorSourceOptions *last_msg_generator_source_options;
 
 %token KW_MSG_GENERATOR
 %token KW_FREQ
+%token KW_NUM
 %token KW_TEMPLATE
 
 %type <ptr> source_msg_generator
@@ -91,6 +92,10 @@ source_msg_generator_option
   | KW_FREQ '(' positive_integer ')'
     {
       msg_generator_source_options_set_freq(last_msg_generator_source_options, $3);
+    }
+  | KW_NUM '(' nonnegative_integer ')'
+    {
+      msg_generator_source_options_set_num(last_msg_generator_source_options, $3);
     }
   | KW_TEMPLATE '(' template_content ')'
     {

--- a/modules/examples/sources/msg-generator/msg-generator-parser.c
+++ b/modules/examples/sources/msg-generator/msg-generator-parser.c
@@ -33,6 +33,7 @@ static CfgLexerKeyword msg_generator_keywords[] =
 {
   { "example_msg_generator", KW_MSG_GENERATOR },
   { "freq", KW_FREQ },
+  { "num", KW_NUM },
   { "template", KW_TEMPLATE },
   { NULL }
 };

--- a/modules/examples/sources/msg-generator/msg-generator-source-options.h
+++ b/modules/examples/sources/msg-generator/msg-generator-source-options.h
@@ -31,6 +31,7 @@ typedef struct
 {
   LogSourceOptions super;
   guint freq;
+  gint max_num;
   LogTemplate *template;
 } MsgGeneratorSourceOptions;
 
@@ -58,6 +59,12 @@ static inline void
 msg_generator_source_options_set_freq(MsgGeneratorSourceOptions *self, gdouble freq)
 {
   self->freq = (guint) (freq * 1000);
+}
+
+static inline void
+msg_generator_source_options_set_num(MsgGeneratorSourceOptions *self, gint max_num)
+{
+  self->max_num = max_num;
 }
 
 static inline void

--- a/modules/examples/sources/msg-generator/msg-generator-source.c
+++ b/modules/examples/sources/msg-generator/msg-generator-source.c
@@ -36,6 +36,7 @@ struct MsgGeneratorSource
   LogSource super;
   MsgGeneratorSourceOptions *options;
   struct iv_timer timer;
+  gint num;
 };
 
 static void
@@ -120,7 +121,18 @@ _timer_expired(void *cookie)
 
   _send_generated_message(self);
 
-  _start_timer(self);
+  if (self->options->max_num > 0)
+    {
+      self->num++;
+      if (self->num < self->options->max_num)
+        {
+          _start_timer(self);
+        }
+    }
+  else
+    {
+      _start_timer(self);
+    }
 }
 
 gboolean

--- a/modules/examples/sources/msg-generator/msg-generator-source.c
+++ b/modules/examples/sources/msg-generator/msg-generator-source.c
@@ -55,6 +55,15 @@ _start_timer(MsgGeneratorSource *self)
   iv_timer_register(&self->timer);
 }
 
+static void
+_start_timer_immediately(MsgGeneratorSource *self)
+{
+  iv_validate_now();
+  self->timer.expires = iv_now;
+
+  iv_timer_register(&self->timer);
+}
+
 static gboolean
 _init(LogPipe *s)
 {
@@ -62,7 +71,7 @@ _init(LogPipe *s)
   if (!log_source_init(s))
     return FALSE;
 
-  _start_timer(self);
+  _start_timer_immediately(self);
 
   return TRUE;
 }


### PR DESCRIPTION
In this patch I added two changes to `example-msg-generator`. With these changes, `example-msg-generator` can be used for testing purposes easier.

- First message is sent immediately: we do not need to wait `freq`. With this, the tests can speed up.
- With the new `num` option, users can limit how many messages should be generated. Zero means infinite messages (this is the default). Positive integer means the maximum number of messages.

Example:
```
source { example-msg-generator(freq(1) num(5)); };
```