### PR TITLE
light: example-msg-generator support

### DIFF
--- a/tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -35,7 +35,7 @@ def test_manipulating_config_between_reload(tc):
     syslog_ng.start(config)
 
     # update positional value of file source
-    file_source.options["file_name"] = "updated_input.log"
+    file_source.set_path("updated_input.log")
 
     # add new option to file source
     file_source.options["log_iw_size"] = "100"

--- a/tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py
+++ b/tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_generator_source(tc):
+    config = tc.new_config()
+
+    generator_source = config.create_example_msg_generator(num=1)
+    file_destination = config.create_file_destination(file_name="output.log", template="'$MSG\n'")
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng = tc.new_syslog_ng()
+    syslog_ng.start(config)
+    log = file_destination.read_log()
+    assert log == generator_source.DEFAULT_MESSAGE + "\n"

--- a/tests/python_functional/src/message_reader/single_line_parser.py
+++ b/tests/python_functional/src/message_reader/single_line_parser.py
@@ -27,8 +27,12 @@ class SingleLineParser(object):
         self.__logger = logger_factory.create_logger("SingleLineParser")
         self.msg_list = []
         self.__parse_rule = "\n"
+        self.current_chunk = ""
 
     def parse_buffer(self, content_buffer):
-        for line in list(content_buffer.splitlines(True)):
+        full_content = self.current_chunk + content_buffer
+        for line in list(full_content.splitlines(True)):
             if line.endswith(self.__parse_rule):
                 self.msg_list.append(line)
+            else:
+                self.current_chunk = line

--- a/tests/python_functional/src/message_reader/tests/test_single_line_parser.py
+++ b/tests/python_functional/src/message_reader/tests/test_single_line_parser.py
@@ -50,3 +50,9 @@ def test_single_line_parser_parsing_multiple_times(tc_unittest):
 """
     single_line_parser.parse_buffer(content_buffer=input_buffer2)
     assert single_line_parser.msg_list == ["test message 1\n", "test message 2\n"]
+
+def test_single_line_parser_chunks(tc_unittest):
+    single_line_parser = SingleLineParser(tc_unittest.get_fake_logger_factory())
+    single_line_parser.parse_buffer(content_buffer="first")
+    single_line_parser.parse_buffer(content_buffer="second\n")
+    assert single_line_parser.msg_list == ["firstsecond\n"]

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -57,23 +57,18 @@ class ConfigRenderer(object):
             self.__syslog_ng_config_content += "    {}({});\n".format(option_name, option_value)
         self.__syslog_ng_config_content += globals_options_footer
 
-    def __render_positional_options(self, driver_options, positional_options):
-        for option_name, option_value in driver_options.items():
-            if option_name in positional_options:
-                if str(self.__working_dir) not in str(option_value):
-                    driver_options[option_name] = Path(self.__working_dir, option_value)
-                option_value = str(driver_options[option_name])
-                self.__syslog_ng_config_content += "        {}\n".format(option_value)
+    def __render_positional_options(self, positional_parameters):
+        for parameter in positional_parameters:
+            self.__syslog_ng_config_content += "        {}\n".format(str(parameter))
 
-    def __render_driver_options(self, driver_options, positional_options):
+    def __render_driver_options(self, driver_options):
         for option_name, option_value in driver_options.items():
-            if option_name not in positional_options:
-                if isinstance(option_value, dict):
-                    self.__syslog_ng_config_content += "        {}(\n".format(option_name)
-                    self.__render_driver_options(driver_options=option_value, positional_options=positional_options)
-                    self.__syslog_ng_config_content += "        )\n"
-                else:
-                    self.__syslog_ng_config_content += "        {}({})\n".format(option_name, option_value)
+            if isinstance(option_value, dict):
+                self.__syslog_ng_config_content += "        {}(\n".format(option_name)
+                self.__render_driver_options(option_value)
+                self.__syslog_ng_config_content += "        )\n"
+            else:
+                self.__syslog_ng_config_content += "        {}({})\n".format(option_name, option_value)
 
     def __render_statement_groups(self):
         for statement_group in self.__syslog_ng_config["statement_groups"]:
@@ -87,8 +82,8 @@ class ConfigRenderer(object):
                 self.__syslog_ng_config_content += "    {} (\n".format(statement.driver_name)
 
                 # driver options
-                self.__render_positional_options(statement.options, statement.positional_option_name)
-                self.__render_driver_options(statement.options, statement.positional_option_name)
+                self.__render_positional_options(statement.positional_parameters)
+                self.__render_driver_options(statement.options)
 
                 # driver footer
                 self.__syslog_ng_config_content += "    );\n"

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -28,11 +28,14 @@ from src.message_reader.single_line_parser import SingleLineParser
 class DestinationDriver(object):
     group_type = "destination"
 
-    def __init__(self, logger_factory, IOClass):
+    def __init__(self, logger_factory, IOClass, positional_parameters=[], options={}):
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("DestinationDriver")
         self.__IOClass = IOClass
         self.__reader = None
+        self.positional_parameters = positional_parameters
+        self.options = options
+
 
     def dd_read_logs(self, path, counter):
         if not self.__reader:

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -27,15 +27,13 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 
 
 class FileDestination(DestinationDriver):
-    def __init__(self, logger_factory, working_dir, file_name, **kwargs):
-        super(FileDestination, self).__init__(logger_factory, FileIO)
-        self.options = kwargs
+    def __init__(self, logger_factory, working_dir, file_name, **options):
         self.driver_name = "file"
-        self.positional_option_name = "file_name"
-        self.options[self.positional_option_name] = Path(working_dir, file_name)
+        self.path = Path(working_dir, file_name)
+        super(FileDestination, self).__init__(logger_factory, FileIO, [self.path], options)
 
     def get_path(self):
-        return Path(self.options[self.positional_option_name])
+        return self.path
 
     def read_log(self):
         return self.dd_read_logs(self.get_path(), counter=1)[0]

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -27,12 +27,12 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 
 
 class FileDestination(DestinationDriver):
-    def __init__(self, logger_factory, working_dir, **kwargs):
+    def __init__(self, logger_factory, working_dir, file_name, **kwargs):
         super(FileDestination, self).__init__(logger_factory, FileIO)
         self.options = kwargs
         self.driver_name = "file"
         self.positional_option_name = "file_name"
-        self.__construct_file_path(working_dir)
+        self.options[self.positional_option_name] = Path(working_dir, file_name)
 
     def get_path(self):
         return Path(self.options[self.positional_option_name])
@@ -42,10 +42,3 @@ class FileDestination(DestinationDriver):
 
     def read_logs(self, counter):
         return self.dd_read_logs(self.get_path(), counter=counter)
-
-    def __construct_file_path(self, working_dir):
-        if self.positional_option_name in self.options.keys():
-            given_positional_option_value = self.options[self.positional_option_name]
-            self.options[self.positional_option_name] = Path(
-                working_dir, given_positional_option_value
-            )

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -29,22 +29,10 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 class FileDestination(DestinationDriver):
     def __init__(self, logger_factory, working_dir, **kwargs):
         super(FileDestination, self).__init__(logger_factory, FileIO)
-        self.__options = kwargs
-        self.__driver_name = "file"
-        self.__positional_option = "file_name"
+        self.options = kwargs
+        self.driver_name = "file"
+        self.positional_option_name = "file_name"
         self.__construct_file_path(working_dir)
-
-    @property
-    def driver_name(self):
-        return self.__driver_name
-
-    @property
-    def positional_option_name(self):
-        return self.__positional_option
-
-    @property
-    def options(self):
-        return self.__options
 
     def get_path(self):
         return Path(self.options[self.positional_option_name])

--- a/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
@@ -29,4 +29,4 @@ class Filter(object):
         self.__logger_factory = logger_factory
         self.options = kwargs
         self.driver_name = ""
-        self.positional_option_name = ""
+        self.positional_parameters = []

--- a/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
@@ -27,17 +27,6 @@ class Filter(object):
 
     def __init__(self, logger_factory, **kwargs):
         self.__logger_factory = logger_factory
-        self.__options = kwargs
-        self.__driver_name = ""
-
-    @property
-    def driver_name(self):
-        return self.__driver_name
-
-    @property
-    def options(self):
-        return self.__options
-
-    @property
-    def positional_option_name(self):
-        return ""
+        self.options = kwargs
+        self.driver_name = ""
+        self.positional_option_name = ""

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -27,16 +27,17 @@ from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 
 
 class FileSource(SourceDriver):
-    def __init__(self, logger_factory, working_dir, file_name, **kwargs):
-        super(FileSource, self).__init__(logger_factory, FileIO)
-        self.options = kwargs
+    def __init__(self, logger_factory, working_dir, file_name, **options):
+        self.working_dir = working_dir
         self.driver_name = "file"
         self.path = Path(working_dir, file_name)
-        self.positional_option_name = "file_name"
-        self.options[self.positional_option_name] = self.path
+        super(FileSource, self).__init__(logger_factory, FileIO, [self.path], options)
 
     def get_path(self):
         return self.path
+
+    def set_path(self, pathname):
+        self.path = Path(self.working_dir, pathname)
 
     def write_log(self, formatted_log, counter=1):
         self.sd_write_log(self.get_path(), formatted_log, counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -27,22 +27,15 @@ from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 
 
 class FileSource(SourceDriver):
-    def __init__(self, logger_factory, working_dir, **kwargs):
+    def __init__(self, logger_factory, working_dir, file_name, **kwargs):
         super(FileSource, self).__init__(logger_factory, FileIO)
         self.options = kwargs
         self.driver_name = "file"
         self.positional_option_name = "file_name"
-        self.__construct_file_path(working_dir)
+        self.options[self.positional_option_name] = Path(working_dir, file_name)
 
     def get_path(self):
         return Path(self.options[self.positional_option_name])
 
     def write_log(self, formatted_log, counter=1):
         self.sd_write_log(self.get_path(), formatted_log, counter=counter)
-
-    def __construct_file_path(self, working_dir):
-        if self.positional_option_name in self.options.keys():
-            given_positional_option_value = self.options[self.positional_option_name]
-            self.options[self.positional_option_name] = Path(
-                working_dir, given_positional_option_value
-            )

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -31,11 +31,12 @@ class FileSource(SourceDriver):
         super(FileSource, self).__init__(logger_factory, FileIO)
         self.options = kwargs
         self.driver_name = "file"
+        self.path = Path(working_dir, file_name)
         self.positional_option_name = "file_name"
-        self.options[self.positional_option_name] = Path(working_dir, file_name)
+        self.options[self.positional_option_name] = self.path
 
     def get_path(self):
-        return Path(self.options[self.positional_option_name])
+        return self.path
 
     def write_log(self, formatted_log, counter=1):
         self.sd_write_log(self.get_path(), formatted_log, counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -29,22 +29,10 @@ from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 class FileSource(SourceDriver):
     def __init__(self, logger_factory, working_dir, **kwargs):
         super(FileSource, self).__init__(logger_factory, FileIO)
-        self.__options = kwargs
-        self.__driver_name = "file"
-        self.__positional_option = "file_name"
+        self.options = kwargs
+        self.driver_name = "file"
+        self.positional_option_name = "file_name"
         self.__construct_file_path(working_dir)
-
-    @property
-    def driver_name(self):
-        return self.__driver_name
-
-    @property
-    def positional_option_name(self):
-        return self.__positional_option
-
-    @property
-    def options(self):
-        return self.__options
 
     def get_path(self):
         return Path(self.options[self.positional_option_name])

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
@@ -25,11 +25,13 @@
 class SourceDriver(object):
     group_type = "source"
 
-    def __init__(self, logger_factory, IOClass):
+    def __init__(self, logger_factory, IOClass, positional_parameters=[], options={}):
         self.__logger_factory = logger_factory
         self.__logger = logger_factory.create_logger("SourceDriver")
         self.__IOClass = IOClass
         self.__writer = None
+        self.positional_parameters = positional_parameters
+        self.options = options
 
     def __construct_writer(self, path):
         if not self.__writer:

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -25,6 +25,7 @@ from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.renderer import ConfigRenderer
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
 from src.syslog_ng_config.statements.sources.file_source import FileSource
+from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
 from src.syslog_ng_config.statement_group import StatementGroup
 from src.common.operations import cast_to_list
@@ -108,3 +109,10 @@ class SyslogNgConfig(object):
     def create_inner_logpath(self, statements=None, flags=None):
         inner_logpath = self.__create_logpath_with_conversion(statements, flags)
         return inner_logpath
+
+    def create_example_msg_generator(self, **options):
+        generator_source = SourceDriver(self.__logger_factory, None)
+        generator_source.driver_name = "example_msg_generator"
+        generator_source.DEFAULT_MESSAGE = "-- Generated message. --"
+        generator_source.options = options
+        return generator_source


### PR DESCRIPTION
This patchset adds initial support for `example-msg-generator` in the light test framework.

For now, only template can be specified. In a followup patch, I plan to support specific message list that is emitted by the generator.

I needed to do a small refactor on the code: prior this patch positional parameters were mandatory in drivers, that I needed to eliminate. 

The patchset contains a minor fix in the `SingleLineParser` code in the test framework.