### PR TITLE
Fix a general source-related crash and enhance wildcard-file()'s bookmark handling

### DIFF
--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -35,6 +35,7 @@ struct _AckTracker
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, AckType ack_type);
   void (*free_fn)(AckTracker *self);
+  void (*disable_bookmark_saving)(AckTracker *self);
 };
 
 struct _AckRecord
@@ -70,6 +71,15 @@ static inline void
 ack_tracker_manage_msg_ack(AckTracker *self, LogMessage *msg, AckType ack_type)
 {
   self->manage_msg_ack(self, msg, ack_type);
+}
+
+static inline void
+ack_tracker_disable_bookmark_saving(AckTracker *self)
+{
+  if (self->disable_bookmark_saving)
+    {
+      self->disable_bookmark_saving(self);
+    }
 }
 
 #endif

--- a/lib/bookmark.h
+++ b/lib/bookmark.h
@@ -52,4 +52,13 @@ bookmark_init(Bookmark *self)
   self->destroy = NULL;
 }
 
+static inline void
+bookmark_save(Bookmark *self)
+{
+  if (self->save)
+    {
+      self->save(self);
+    }
+}
+
 #endif

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -170,7 +170,7 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
         if (ack_type != AT_ABORTED)
           {
             Bookmark *bookmark = &(last_in_range->bookmark);
-            bookmark->save(bookmark);
+            bookmark_save(bookmark);
           }
         _drop_range(self, ack_range_length);
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -39,7 +39,6 @@
 #define NC_FILE_EOF    5
 #define NC_REOPEN_REQUIRED 6
 #define NC_FILE_DELETED 7
-#define NC_LAST_MSG_SENT 8
 
 /* indicates that the LogPipe was initialized */
 #define PIF_INITIALIZED       0x0001

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -113,6 +113,12 @@ log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options
   log_proto_server_set_ack_tracker(self->proto, self->super.ack_tracker);
 }
 
+void
+log_reader_disable_bookmark_saving(LogReader *s)
+{
+  log_source_disable_bookmark_saving(&s->super);
+}
+
 /****************************************************************************
  * Watches: the poll_events instance and the idle timer
  ***************************************************************************/

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -55,6 +55,7 @@ void log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *op
 void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filename);
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_immediate_check(LogReader *s);
+void log_reader_disable_bookmark_saving(LogReader *s);
 void log_reader_open(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
 void log_reader_close_proto(LogReader *s);
 LogReader *log_reader_new(GlobalConfig *cfg);

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -140,6 +140,12 @@ log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_si
   _flow_control_rate_adjust(self);
 }
 
+void
+log_source_disable_bookmark_saving(LogSource *self)
+{
+  ack_tracker_disable_bookmark_saving(self->ack_tracker);
+}
+
 /**
  * log_source_msg_ack:
  *

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -44,14 +44,6 @@ log_source_wakeup(LogSource *self)
   msg_diagnostics("Source has been resumed", log_pipe_location_tag(&self->super));
 }
 
-void
-log_source_window_empty(LogSource *self)
-{
-  if (self->window_empty_cb)
-    self->window_empty_cb(self);
-  msg_diagnostics("LogSource window is empty");
-}
-
 static inline void
 _flow_control_window_size_adjust(LogSource *self, guint32 window_size_increment, gboolean last_ack_type_is_suspended)
 {
@@ -69,9 +61,6 @@ _flow_control_window_size_adjust(LogSource *self, guint32 window_size_increment,
     window_size_counter_resume(&self->window_size);
   if (old_window_size == 0 || need_to_resume_counter)
     log_source_wakeup(self);
-
-  if (old_window_size+window_size_increment == self->options->init_window_size)
-    log_source_window_empty(self);
 }
 
 static void

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -77,7 +77,6 @@ struct _LogSource
   AckTracker *ack_tracker;
 
   void (*wakeup)(LogSource *s);
-  void (*window_empty_cb)(LogSource *s);
 };
 
 static inline gboolean
@@ -107,7 +106,6 @@ void log_source_options_destroy(LogSourceOptions *options);
 void log_source_options_set_tags(LogSourceOptions *options, GList *tags);
 void log_source_free(LogPipe *s);
 void log_source_wakeup(LogSource *self);
-void log_source_window_empty(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -109,6 +109,7 @@ void log_source_wakeup(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);
+void log_source_disable_bookmark_saving(LogSource *self);
 
 void log_source_global_init(void);
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -321,6 +321,7 @@ file_reader_remove_persist_state(FileReader *self)
 void
 file_reader_stop_follow_file(FileReader *self)
 {
+  log_reader_disable_bookmark_saving(self->reader);
   log_reader_close_proto(self->reader);
 }
 

--- a/modules/affile/tests/test_wildcard_file_reader.c
+++ b/modules/affile/tests/test_wildcard_file_reader.c
@@ -121,6 +121,7 @@ _init(void)
 static void
 _teardown(void)
 {
+  log_pipe_deinit(&reader->super.super);
   log_pipe_unref(&reader->super.super);
   free(test_event);
   app_shutdown();
@@ -205,4 +206,3 @@ Test(test_wildcard_file_reader, status_finished_then_delete)
   cr_assert_eq(test_event->deleted_eof_called, TRUE);
   cr_assert_eq(test_event->finished_called, TRUE);
 }
-

--- a/modules/affile/wildcard-file-reader.c
+++ b/modules/affile/wildcard-file-reader.c
@@ -29,7 +29,6 @@ _init(LogPipe *s)
   WildcardFileReader *self = (WildcardFileReader *)s;
   self->file_state.deleted = FALSE;
   self->file_state.eof = FALSE;
-  self->file_state.last_msg_sent = TRUE;
   return file_reader_init_method(s);
 }
 
@@ -49,17 +48,7 @@ _queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   WildcardFileReader *self = (WildcardFileReader *)s;
   self->file_state.eof = FALSE;
-  self->file_state.last_msg_sent = FALSE;
   file_reader_queue_method(s, msg, path_options);
-}
-
-static void
-_deleted_file_finished(FileStateEvent *self, FileReader *reader)
-{
-  if (self && self->deleted_file_finished)
-    {
-      self->deleted_file_finished(reader, self->deleted_file_finished_user_data);
-    }
 }
 
 static void
@@ -85,16 +74,6 @@ static void
 _set_eof(WildcardFileReader *self)
 {
   self->file_state.eof = TRUE;
-  if (self->file_state.deleted)
-    {
-      _schedule_state_change_handling(self);
-    }
-}
-
-static void
-_set_last_msg_sent(WildcardFileReader *self)
-{
-  self->file_state.last_msg_sent = TRUE;
   if (self->file_state.deleted)
     {
       _schedule_state_change_handling(self);
@@ -137,25 +116,9 @@ _handle_file_state_event(gpointer s)
   msg_debug("File status changed",
             evt_tag_int("EOF", self->file_state.eof),
             evt_tag_int("DELETED", self->file_state.deleted),
-            evt_tag_int("LAST_MSG_SENT", self->file_state.last_msg_sent),
             evt_tag_str("Filename", self->super.filename->str));
   if (self->file_state.deleted && self->file_state.eof)
-    {
-      _deleted_file_eof(&self->file_state_event, &self->super);
-      if (self->file_state.last_msg_sent)
-        {
-          _deleted_file_finished(&self->file_state_event, &self->super);
-        }
-    }
-}
-
-void
-wildcard_file_reader_on_deleted_file_finished(WildcardFileReader *self,
-                                              FileStateEventCallback cb,
-                                              gpointer user_data)
-{
-  self->file_state_event.deleted_file_finished = cb;
-  self->file_state_event.deleted_file_finished_user_data = user_data;
+    _deleted_file_eof(&self->file_state_event, &self->super);
 }
 
 void

--- a/modules/affile/wildcard-file-reader.c
+++ b/modules/affile/wildcard-file-reader.c
@@ -124,9 +124,6 @@ _notify(LogPipe *s, gint notify_code, gpointer user_data)
     case NC_FILE_EOF:
       _set_eof(self);
       break;
-    case NC_LAST_MSG_SENT:
-      _set_last_msg_sent(self);
-      break;
     default:
       file_reader_notify_method(s, notify_code, user_data);
       break;

--- a/modules/affile/wildcard-file-reader.h
+++ b/modules/affile/wildcard-file-reader.h
@@ -33,8 +33,6 @@ typedef void (*FileStateEventCallback)(FileReader *file_reader, gpointer user_da
 
 typedef struct _FileStateEvent
 {
-  FileStateEventCallback deleted_file_finished;
-  gpointer deleted_file_finished_user_data;
   FileStateEventCallback deleted_file_eof;
   gpointer deleted_file_eof_user_data;
 } FileStateEvent;
@@ -43,7 +41,6 @@ typedef struct _FileState
 {
   gboolean deleted;
   gboolean eof;
-  gboolean last_msg_sent;
 } FileState;
 
 
@@ -60,8 +57,6 @@ wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options,
                          FileOpener *opener, LogSrcDriver *owner,
                          GlobalConfig *cfg);
 
-void wildcard_file_reader_on_deleted_file_finished(WildcardFileReader *self, FileStateEventCallback cb,
-                                                   gpointer user_data);
 void wildcard_file_reader_on_deleted_file_eof(WildcardFileReader *self, FileStateEventCallback cb, gpointer user_data);
 gboolean wildcard_file_reader_is_deleted(WildcardFileReader *self);
 


### PR DESCRIPTION
The `window_empty` functionality was used only by `wildcard-file()`, and had an ordering issue (between `iv_event` `unregister()` and `post()`) everywhere else, causing a crash or an infinite loop inside ivykis. 

In order to resolve the crash, `window_empty` and `NC_LAST_MSG_SENT` have been removed from `LogSource`/`LogReader` and something else has been added by @lbudai :
a `LogSource`/`AckTracker`-level functionality that makes it possible to disable bookmark handling when a file is deleted from the disk. Since bookmark information is invalidated after a file is removed, 
saving them is unnecessary.

This functionality allows us to merge 2 events inside wildcard file source (`deleted_file_finished()` can be merged into `deleted_file_eof()`):

`_remove_file_reader()` had to be delayed to a point where all acks have been received in order to avoid persist name collision with a new file with the same name/path.

Now that bookmark handling is disabled after the file is removed and EOF is reached, this delay is not necessary anymore.

Pending non-bookmarked acks still keep `LogReader` and `FileReader` "alive" (through `LogReader::control`), but that instance is deinited and not relevant for the source driver anymore.

Fixes #2457