### PR TITLE
Include json-c in the dist tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
       - libmaxminddb-dev
       - libxml2-utils
       - astyle
+      - doxygen
 install:
       - pip install --user -r requirements.txt
       - pip list

--- a/configure.ac
+++ b/configure.ac
@@ -1147,6 +1147,13 @@ dnl ***************************************************************************
 
 enable_json="no"
 
+JSON_INTERNAL_SOURCE_EXISTS="test -f $srcdir/lib/jsonc/json.h"
+
+if $JSON_INTERNAL_SOURCE_EXISTS; then
+  AC_CONFIG_SUBDIRS([lib/jsonc])
+  JSON_SUBDIRS="lib/jsonc"
+fi
+
 if test "x$with_jsonc" = "xsystem" -o "x$with_jsonc" = "xauto"; then
    enable_json="yes"
    PKG_CHECK_EXISTS(json-c, json_module_name="json-c",
@@ -1158,17 +1165,16 @@ if test "x$with_jsonc" = "xsystem" -o "x$with_jsonc" = "xauto"; then
 fi
 if test "x$with_jsonc" = "xinternal" -o "x$with_jsonc" = "xauto"; then
   AC_MSG_CHECKING(for JSON)
-  if test -f "$srcdir/lib/jsonc/json.h"; then
-      AC_CONFIG_SUBDIRS([lib/jsonc])
+  if $JSON_INTERNAL_SOURCE_EXISTS; then
       JSON_LIBS="\$(top_builddir)/lib/jsonc/libjson-c.la"
       JSON_DEPENDENCY="$JSON_LIBS"
       JSON_CFLAGS="-I\$(top_srcdir)/lib/jsonc -I\$(top_builddir)/lib/jsonc"
-      JSON_SUBDIRS="lib/jsonc"
       enable_json="yes"
       with_jsonc="internal"
   else
       AC_MSG_WARN([Internal jsonc sources not found in lib/jsonc])
       enable_json="no"
+      with_jsonc="no"
   fi
   AC_MSG_RESULT($enable_json)
 fi
@@ -1774,7 +1780,7 @@ AM_CONDITIONAL(ENABLE_GEOIP, [test "$enable_geoip" = "yes"])
 AM_CONDITIONAL(ENABLE_GEOIP2, [test "$enable_geoip2" = "yes"])
 AM_CONDITIONAL(ENABLE_REDIS, [test "$enable_redis" = "yes"])
 AM_CONDITIONAL(IVYKIS_INTERNAL, [test "x$with_ivykis" = "xinternal"])
-AM_CONDITIONAL(JSON_INTERNAL, [test "x$JSON_SUBDIRS" != "x"])
+AM_CONDITIONAL(JSON_INTERNAL, [test "x$with_jsonc" = "xinternal"])
 AM_CONDITIONAL(LIBMONGO_INTERNAL, [test "x$LIBMONGO_SUBDIRS" != "x"])
 AM_CONDITIONAL(LIBRABBITMQ_INTERNAL, [test "x$with_librabbitmq_client" = "xinternal"])
 AM_CONDITIONAL(ENABLE_RIEMANN, [test "$enable_riemann" != "no"])

--- a/dbld/images/helpers/packages.manifest
+++ b/dbld/images/helpers/packages.manifest
@@ -161,6 +161,7 @@ dh-exec                         [debian, ubuntu]
 dh-systemd                      [debian, ubuntu]
 dpkg-dev                        [debian, ubuntu]
 fakeroot                        [centos, debian, ubuntu]
+doxygen                         [centos, debian, ubuntu]
 rpm-build                       [centos]
 cyrus-sasl-devel                [centos-7]
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,4 @@
-DIST_SUBDIRS				+= @IVYKIS_SUBDIRS@
+DIST_SUBDIRS				+= @IVYKIS_SUBDIRS@ @JSON_SUBDIRS@
 
 include lib/eventlog/src/Makefile.am
 include lib/eventlog/tests/Makefile.am


### PR DESCRIPTION
Note:
`json-c` has a dist hook, where `doxygen` is used unconditionally:

https://github.com/json-c/json-c/blob/3e81b4abe359c8128bb2b4127f4e8c8c057fb004/Makefile.am#L8-L11

This means `doxygen` has to be installed in order to generate the tarball.

Questions:
- I don't think it is acceptable to depend on `doxygen`. Shouldn't we try to contribute and make it conditional in `json-c`?

Fixes #1204