### PR TITLE
Fix config revert (threaded destinations)

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -1003,6 +1003,8 @@ log_threaded_dest_driver_init_method(LogPipe *s)
   if (!log_dest_driver_init_method(&self->super.super.super))
     return FALSE;
 
+  self->under_termination = FALSE;
+
   if (cfg && self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 


### PR DESCRIPTION
After an invalid configuration is reverted, the `under_termination` flag of the previous driver remained `TRUE`. This results in an inoperable state.