### PR TITLE
Fix old style include statement compatibility

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -79,7 +79,7 @@ yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *le
 
 
   p = buf;
-  while (*p == ' ' || *p == '\t')
+  while (*p != '\0' && (*p == ' ' || *p == '\t'))
     p++;
   if (strncmp(p, "include", 7) != 0)
     return TRUE;

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -75,10 +75,8 @@ static gboolean
 yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *len)
 {
   YYLTYPE *cur_lloc = &self->include_stack[self->include_depth].lloc;
-  const gchar *p;
 
-
-  p = buf;
+  gchar *p = buf;
   while (*p != '\0' && (*p == ' ' || *p == '\t'))
     p++;
   if (strncmp(p, "include", 7) != 0)
@@ -86,6 +84,11 @@ yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *le
   p += 7;
   if (*p != ' ' && *p != '\t')
     return TRUE;
+
+  p = strrchr(p, ';');
+  if (!p)
+    return TRUE;
+  *p = ' ';
 
   if (!cfg_is_config_version_older(configuration, VERSION_VALUE_3_20))
     {

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -77,8 +77,7 @@ yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *le
   YYLTYPE *cur_lloc = &self->include_stack[self->include_depth].lloc;
 
   gchar *p = buf;
-  while (*p != '\0' && (*p == ' ' || *p == '\t'))
-    p++;
+  p += strspn(p, " \t");
   if (strncmp(p, "include", 7) != 0)
     return TRUE;
   p += 7;


### PR DESCRIPTION
This PR
- fixes a buffer overrun
- completes the compatibility by removing the last semicolon
- refactors `patch_include_statement()` to use `strspn`

Please note that multiple statements within one line containing the old include statement won't work anymore (it worked before merging #2550), for example:

```
include "test.conf"; log {};
log {}; include "test.conf";
```

Or multiline include:
```
include
"test.conf"
;
```