### PR TITLE
value-pairs: move ValuePairs struct declaration to a private header

### DIFF
--- a/lib/value-pairs/CMakeLists.txt
+++ b/lib/value-pairs/CMakeLists.txt
@@ -2,6 +2,7 @@ set(VALUE_PAIRS_HEADERS
     value-pairs/value-pairs.h
     value-pairs/transforms.h
     value-pairs/cmdline.h
+    value-pairs/internals.h
     value-pairs/evttag.h
     PARENT_SCOPE)
 

--- a/lib/value-pairs/Makefile.am
+++ b/lib/value-pairs/Makefile.am
@@ -7,6 +7,7 @@ value_pairsinclude_HEADERS = \
 	lib/value-pairs/value-pairs.h		\
 	lib/value-pairs/transforms.h		\
 	lib/value-pairs/cmdline.h		\
+	lib/value-pairs/internals.h		\
 	lib/value-pairs/evttag.h
 
 value_pairs_sources = \

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -22,6 +22,7 @@
  *
  */
 #include "value-pairs/cmdline.h"
+#include "value-pairs/internals.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/lib/value-pairs/internals.h
+++ b/lib/value-pairs/internals.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2014 Balabit
+ * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef VALUE_PAIRS_INTERNALS_H_INCLUDED
+#define VALUE_PAIRS_INTERNALS_H_INCLUDED 1
+
+#include "syslog-ng.h"
+#include "atomic.h"
+
+typedef struct _ValuePairs ValuePairs;
+struct _ValuePairs
+{
+  GAtomicCounter ref_cnt;
+  GPtrArray *builtins;
+  GPtrArray *patterns;
+  GPtrArray *vpairs;
+  GPtrArray *transforms;
+
+  gboolean omit_empty_values;
+
+  /* guint32 as CfgFlagHandler only supports 32 bit integers */
+  guint32 scopes;
+};
+
+
+#endif

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -22,6 +22,7 @@
  *
  */
 
+#include "value-pairs/internals.h"
 #include "value-pairs/value-pairs.h"
 #include "logmsg/logmsg.h"
 #include "template/templates.h"

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -33,19 +33,6 @@
 #include "atomic.h"
 
 typedef struct _ValuePairs ValuePairs;
-struct _ValuePairs
-{
-  GAtomicCounter ref_cnt;
-  GPtrArray *builtins;
-  GPtrArray *patterns;
-  GPtrArray *vpairs;
-  GPtrArray *transforms;
-
-  gboolean omit_empty_values;
-
-  /* guint32 as CfgFlagHandler only supports 32 bit integers */
-  guint32 scopes;
-};
 
 typedef gboolean
 (*VPForeachFunc) (const gchar *name, TypeHint type, const gchar *value,


### PR DESCRIPTION
To make the ValuePairs struct opaque to users, move its definition to
a private header, so that cmdline.c can have access, but still the
rest of the codebase can't.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>