### PR TITLE
WIP: set-level()

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1274,13 +1274,13 @@ msg_format_option
 	  {
 	    if (last_msg_format_options->default_pri == 0xFFFF)
 	      last_msg_format_options->default_pri = LOG_USER;
-	    last_msg_format_options->default_pri = (last_msg_format_options->default_pri & ~7) | $3;
+	    last_msg_format_options->default_pri = (last_msg_format_options->default_pri & ~LOG_PRIMASK) | $3;
           }
 	| KW_DEFAULT_FACILITY '(' facility_string ')'
 	  {
 	    if (last_msg_format_options->default_pri == 0xFFFF)
 	      last_msg_format_options->default_pri = LOG_NOTICE;
-	    last_msg_format_options->default_pri = (last_msg_format_options->default_pri & 7) | $3;
+	    last_msg_format_options->default_pri = (last_msg_format_options->default_pri & LOG_PRIMASK) | $3;
           }
         ;
 

--- a/lib/rewrite/CMakeLists.txt
+++ b/lib/rewrite/CMakeLists.txt
@@ -6,6 +6,7 @@ set(REWRITE_HEADERS
     rewrite/rewrite-expr-parser.h
     rewrite/rewrite-groupset.h
     rewrite/rewrite-unset.h
+    rewrite/rewrite-set-level.h
     PARENT_SCOPE
     )
 
@@ -17,6 +18,7 @@ set(REWRITE_SOURCES
     rewrite/rewrite-expr-parser.c
     rewrite/rewrite-groupset.c
     rewrite/rewrite-unset.c
+    rewrite/rewrite-set-level.c
     PARENT_SCOPE
     )
 

--- a/lib/rewrite/Makefile.am
+++ b/lib/rewrite/Makefile.am
@@ -8,8 +8,9 @@ rewriteinclude_HEADERS = 			\
 	lib/rewrite/rewrite-set.h		\
 	lib/rewrite/rewrite-unset.h		\
 	lib/rewrite/rewrite-subst.h		\
-	lib/rewrite/rewrite-expr-parser.h   \
-	lib/rewrite/rewrite-groupset.h
+	lib/rewrite/rewrite-expr-parser.h	\
+	lib/rewrite/rewrite-groupset.h		\
+	lib/rewrite/rewrite-set-level.h
 
 
 rewrite_sources = 				\
@@ -19,8 +20,9 @@ rewrite_sources = 				\
 	lib/rewrite/rewrite-unset.c		\
 	lib/rewrite/rewrite-subst.c		\
 	lib/rewrite/rewrite-expr-parser.c	\
-	lib/rewrite/rewrite-expr-grammar.y  \
-	lib/rewrite/rewrite-groupset.c
+	lib/rewrite/rewrite-expr-grammar.y	\
+	lib/rewrite/rewrite-groupset.c		\
+	lib/rewrite/rewrite-set-level.c
 
 BUILT_SOURCES += 				\
 	lib/rewrite/rewrite-expr-grammar.y	\

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -36,6 +36,7 @@
 #include "rewrite/rewrite-unset.h"
 #include "rewrite/rewrite-subst.h"
 #include "rewrite/rewrite-groupset.h"
+#include "rewrite/rewrite-set-level.h"
 #include "filter/filter-expr.h"
 #include "filter/filter-expr-parser.h"
 #include "cfg-grammar.h"
@@ -70,6 +71,7 @@ LogRewrite *last_rewrite;
 %token KW_SUBST
 %token KW_VALUE
 %token KW_VALUES
+%token KW_SET_LEVEL
 
 %%
 
@@ -134,6 +136,7 @@ rewrite_expr
         {
             last_rewrite = log_rewrite_groupunset_new(configuration);
         } rewrite_groupset_opts ')' { $$ = last_rewrite; }
+        | KW_SET_LEVEL '(' rewrite_template_content ')' { $$ = log_rewrite_set_level_new($3, configuration);  }
         | LL_IDENTIFIER
           {
             Plugin *p;

--- a/lib/rewrite/rewrite-expr-parser.c
+++ b/lib/rewrite/rewrite-expr-parser.c
@@ -36,6 +36,7 @@ static CfgLexerKeyword rewrite_expr_keywords[] =
   { "subst",              KW_SUBST },
   { "set_tag",            KW_SET_TAG },
   { "clear_tag",          KW_CLEAR_TAG },
+  { "set_level",          KW_SET_LEVEL },
 
   { "condition",          KW_CONDITION },
   { "groupset",           KW_GROUP_SET },

--- a/lib/rewrite/rewrite-set-level.c
+++ b/lib/rewrite/rewrite-set-level.c
@@ -25,6 +25,7 @@
 #include "rewrite-set-level.h"
 #include "template/templates.h"
 #include "syslog-names.h"
+#include "scratch-buffers.h"
 
 #include <stdlib.h>
 
@@ -82,7 +83,8 @@ _set_msg_level(LogMessage *msg, const guint16 level)
 static void
 log_rewrite_set_level_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
 {
-  GString *result = g_string_sized_new(64);
+  ScratchBuffersMarker marker;
+  GString *result = scratch_buffers_alloc_and_mark(&marker);
   LogRewriteSetLevel *self = (LogRewriteSetLevel *) s;
 
   log_msg_make_writable(pmsg, path_options);
@@ -99,7 +101,7 @@ log_rewrite_set_level_process(LogRewrite *s, LogMessage **pmsg, const LogPathOpt
   _set_msg_level(*pmsg, _convert_level(result));
 
 error:
-  g_string_free(result, TRUE);
+  scratch_buffers_reclaim_marked(marker);
 }
 
 static LogPipe *

--- a/lib/rewrite/rewrite-set-level.c
+++ b/lib/rewrite/rewrite-set-level.c
@@ -24,6 +24,7 @@
 
 #include "rewrite-set-level.h"
 #include "template/templates.h"
+#include "syslog-names.h"
 
 #include <stdlib.h>
 
@@ -53,9 +54,19 @@ _convert_level_as_number(GString *level_text)
 }
 
 static gint
+_convert_level_as_text(GString *level_text)
+{
+  return syslog_name_lookup_level_by_name(level_text->str);
+}
+
+static gint
 _convert_level(GString *level_text)
 {
   gint level = _convert_level_as_number(level_text);
+  if (level > 0)
+    return level;
+
+  level = _convert_level_as_text(level_text);
   if (level > 0)
     return level;
 

--- a/lib/rewrite/rewrite-set-level.c
+++ b/lib/rewrite/rewrite-set-level.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "rewrite-set-level.h"
+#include "template/templates.h"
+
+#include <stdlib.h>
+
+typedef struct _LogRewriteSetLevel LogRewriteSetLevel;
+
+struct _LogRewriteSetLevel
+{
+  LogRewrite super;
+  LogTemplate *level;
+};
+
+static gint
+_convert_level_as_number(GString *level_text)
+{
+  char *endptr;
+  long int level = strtol(level_text->str, &endptr, 10);
+  if (0 == endptr)
+    return -1;
+
+  if (endptr[0] != '\0')
+    return -1;
+
+  if (level > 7)
+    return -1;
+
+  return level;
+}
+
+static gint
+_convert_level(GString *level_text)
+{
+  gint level = _convert_level_as_number(level_text);
+  if (level > 0)
+    return level;
+
+  return -1;
+}
+
+static void
+_set_msg_level(LogMessage *msg, const guint16 level)
+{
+  msg->pri = (msg->pri & ~LOG_PRIMASK) | level;
+}
+
+static void
+log_rewrite_set_level_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  GString *result = g_string_sized_new(64);
+  LogRewriteSetLevel *self = (LogRewriteSetLevel *) s;
+
+  log_msg_make_writable(pmsg, path_options);
+
+  log_template_format(self->level, *pmsg, NULL, LTZ_LOCAL, 0, NULL, result);
+
+  const gint level = _convert_level(result);
+  if (level < 0)
+    {
+      msg_warning("Warning: invalid level to set", evt_tag_str("level", result->str), log_pipe_location_tag(&s->super));
+      goto error;
+    }
+
+  _set_msg_level(*pmsg, _convert_level(result));
+
+error:
+  g_string_free(result, TRUE);
+}
+
+static LogPipe *
+log_rewrite_set_level_clone(LogPipe *s)
+{
+  LogRewriteSetLevel *self = (LogRewriteSetLevel *) s;
+  LogRewriteSetLevel *cloned = (LogRewriteSetLevel *)log_rewrite_set_level_new(log_template_ref(self->level), s->cfg);
+
+  if (self->super.condition)
+    cloned->super.condition = filter_expr_ref(self->super.condition);
+
+  return &cloned->super.super;
+}
+
+void
+log_rewrite_set_level_free(LogPipe *s)
+{
+  LogRewriteSetLevel *self = (LogRewriteSetLevel *) s;
+  log_template_unref(self->level);
+  log_rewrite_free_method(s);
+}
+
+LogRewrite *
+log_rewrite_set_level_new(LogTemplate *level, GlobalConfig *cfg)
+{
+  LogRewriteSetLevel *self = g_new0(LogRewriteSetLevel, 1);
+
+  log_rewrite_init_instance(&self->super, cfg);
+  self->super.super.free_fn = log_rewrite_set_level_free;
+  self->super.super.clone = log_rewrite_set_level_clone;
+  self->super.process = log_rewrite_set_level_process;
+  self->level = level;
+  return &self->super;
+}

--- a/lib/rewrite/rewrite-set-level.h
+++ b/lib/rewrite/rewrite-set-level.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef REWRITE_SET_LEVEL_H_INCLUDED
+#define REWRITE_SET_LEVEL_H_INCLUDED
+
+#include "rewrite-expr.h"
+
+LogRewrite *log_rewrite_set_level_new(LogTemplate *level, GlobalConfig *cfg);
+
+#endif

--- a/lib/rewrite/tests/CMakeLists.txt
+++ b/lib/rewrite/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(LIBTEST CRITERION TARGET test_rewrite)
+add_unit_test(LIBTEST CRITERION TARGET test_set_level)

--- a/lib/rewrite/tests/Makefile.am
+++ b/lib/rewrite/tests/Makefile.am
@@ -1,14 +1,18 @@
 lib_rewrite_tests_TESTS = \
-    lib/rewrite/tests/test_rewrite
+    lib/rewrite/tests/test_rewrite \
+    lib/rewrite/tests/test_set_level
 
 EXTRA_DIST += lib/rewrite/tests/CMakeLists.txt
 
 check_PROGRAMS  +=  ${lib_rewrite_tests_TESTS}
 
 lib_rewrite_tests_test_rewrite_CFLAGS = $(TEST_CFLAGS)
-
 lib_rewrite_tests_test_rewrite_LDADD = $(TEST_LDADD)    \
     $(PREOPEN_SYSLOGFORMAT)
-
 lib_rewrite_tests_test_rewrite_SOURCES =    \
     lib/rewrite/tests/test_rewrite.c
+
+lib_rewrite_tests_test_set_level_CFLAGS = $(TEST_CFLAGS)
+lib_rewrite_tests_test_set_level_LDADD = $(TEST_LDADD)
+lib_rewrite_tests_test_set_level_SOURCES =    \
+    lib/rewrite/tests/test_set_level.c

--- a/lib/rewrite/tests/test_set_level.c
+++ b/lib/rewrite/tests/test_set_level.c
@@ -43,6 +43,24 @@ _create_template(const gchar *str)
   return template;
 }
 
+Test(set_level, text)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *msg = log_msg_new_empty();
+
+  LogRewrite *set_level = log_rewrite_set_level_new(_create_template("error"), cfg);
+
+  log_pipe_init(&set_level->super);
+  log_msg_ref(msg);
+  log_pipe_queue(&set_level->super, msg, &path_options);
+
+  cr_assert_eq(msg->pri & LOG_PRIMASK, 3);
+
+  log_msg_unref(msg);
+  log_pipe_deinit(&set_level->super);
+  log_pipe_unref(&set_level->super);
+}
+
 Test(set_level, numeric)
 {
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
@@ -67,6 +85,22 @@ Test(set_level, large_number)
   LogMessage *msg = log_msg_new_empty();
 
   LogRewrite *set_level = log_rewrite_set_level_new(_create_template("8"), cfg);
+
+  log_pipe_init(&set_level->super);
+  log_pipe_queue(&set_level->super, msg, &path_options);
+
+  assert_grabbed_log_contains("invalid level to set");
+
+  log_pipe_deinit(&set_level->super);
+  log_pipe_unref(&set_level->super);
+}
+
+Test(set_level, invalid)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *msg = log_msg_new_empty();
+
+  LogRewrite *set_level = log_rewrite_set_level_new(_create_template("random-text"), cfg);
 
   log_pipe_init(&set_level->super);
   log_pipe_queue(&set_level->super, msg, &path_options);

--- a/lib/rewrite/tests/test_set_level.c
+++ b/lib/rewrite/tests/test_set_level.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "apphook.h"
+#include "rewrite/rewrite-set-level.h"
+#include "logmsg/logmsg.h"
+#include "grab-logging.h"
+
+GlobalConfig *cfg = NULL;
+
+static LogTemplate *
+_create_template(const gchar *str)
+{
+  GError *error = NULL;
+  LogTemplate *template = log_template_new(cfg, NULL);
+  log_template_compile(template, str, &error);
+
+  cr_expect_null(error);
+
+  return template;
+}
+
+Test(set_level, numeric)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *msg = log_msg_new_empty();
+
+  LogRewrite *set_level = log_rewrite_set_level_new(_create_template("1"), cfg);
+
+  log_pipe_init(&set_level->super);
+  log_msg_ref(msg);
+  log_pipe_queue(&set_level->super, msg, &path_options);
+
+  cr_assert_eq(msg->pri & LOG_PRIMASK, 1);
+
+  log_msg_unref(msg);
+  log_pipe_deinit(&set_level->super);
+  log_pipe_unref(&set_level->super);
+}
+
+Test(set_level, large_number)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *msg = log_msg_new_empty();
+
+  LogRewrite *set_level = log_rewrite_set_level_new(_create_template("8"), cfg);
+
+  log_pipe_init(&set_level->super);
+  log_pipe_queue(&set_level->super, msg, &path_options);
+
+  assert_grabbed_log_contains("invalid level to set");
+
+  log_pipe_deinit(&set_level->super);
+  log_pipe_unref(&set_level->super);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  cfg = cfg_new_snippet();
+  start_grabbing_messages();
+}
+
+static void
+teardown(void)
+{
+  app_shutdown();
+  stop_grabbing_messages();
+  cfg_free(cfg);
+}
+
+TestSuite(set_level, .init = setup, .fini = teardown);
+
+

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -80,6 +80,7 @@ block parser cisco-triplet-parser(template() prefix()) {
             };
             rewrite { set("${`prefix`facility}-$1" value('`prefix`facility')); };
         };
+	rewrite { set-level("${`prefix`severity}"); };
     };
 };
 


### PR DESCRIPTION
```
rewrite {
  set-level("${.some_prefix.level}");
};
```
Accepts any template that must be resolved into either the level represented via numeric value or text.

Use this *rewrite* in the cisco parser.