### PR TITLE
test-stats-query: fix unit test

### DIFF
--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -34,6 +34,8 @@
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
 
+#include <string.h>
+
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 typedef struct _CounterHashContent
@@ -256,15 +258,6 @@ ParameterizedTestParameters(stats_query, test_stats_query_get_str_out)
     {"src.java.*.*", ""},
     {"src.ja*.*.*", ""},
     {"global.id.instance.name", "global.id.instance.name: 0\n"},
-    {
-      "*.aliased", ".aliased: 2\n"
-      "guba.frizbi.aliased: 2\n"
-      "guba.gumi.diszno.aliased: 2\n"
-      "guba.polo.aliased: 2\n"
-      "guba.aliased: 2\n"
-      "guba.gumi.disz.aliased: 2\n"
-      "guba.labda.aliased: 2\n"
-    },
   };
 
   return cr_make_param_array(QueryTestCase, test_cases, sizeof(test_cases) / sizeof(test_cases[0]));
@@ -277,6 +270,33 @@ ParameterizedTest(QueryTestCase *test_cases, stats_query, test_stats_query_get_s
   stats_query_get(test_cases->pattern, _test_format_str_get, (gpointer)result);
   cr_assert_str_eq(result->str, test_cases->expected,
                    "Pattern: '%s'; expected key and value: '%s';, got: '%s';", test_cases->pattern, test_cases->expected, result->str);
+
+  g_string_free(result, TRUE);
+}
+
+Test(stats_query, test_stats_query_get_str_out_with_multiple_matching_counters)
+{
+  const gchar *pattern = "*.aliased";
+
+  GString *result = g_string_new("");
+  stats_query_get(pattern, _test_format_str_get, (gpointer)result);
+
+  const gchar *expected_results[] =
+  {
+    ".aliased: 2\n",
+    "guba.frizbi.aliased: 2\n",
+    "guba.gumi.diszno.aliased: 2\n",
+    "guba.polo.aliased: 2\n",
+    "guba.aliased: 2\n",
+    "guba.gumi.disz.aliased: 2\n",
+    "guba.labda.aliased: 2\n"
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS(expected_results); ++i)
+    {
+      cr_assert_not_null(strstr(result->str, expected_results[i]),
+                         "Pattern: '%s'; expected key and value: '%s' in output: '%s';", pattern, expected_results[i], result->str);
+    }
 
   g_string_free(result, TRUE);
 }


### PR DESCRIPTION
This test bug was caught by our macOS Travis job.

The ordering of `stats_query_get()` is undefined, its implementation is based on a hash table.

In case of multiple matching counters, the test case had to be fixed by checking the existence of each counter in an unordered manner.