### PR TITLE
Fix timeutils warning

### DIFF
--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -38,7 +38,7 @@ wall_clock_time_unset(WallClockTime *self)
 gchar *
 wall_clock_time_strptime(WallClockTime *wct, const gchar *format, const gchar *input)
 {
-  return strptime_with_tz(input, format, &wct->tm, &wct->wct_gmtoff, &wct->wct_zone);
+  return strptime_with_tz(input, format, &wct->tm, &wct->wct_gmtoff, (const char **) &wct->wct_zone);
 }
 
 /* Determine (guess) the year for the month.


### PR DESCRIPTION
`Passing 'char **' to parameter of type 'const char **' discards qualifiers in nested pointer types.`

char** can not be converted to const char** implicitly.
This is one of my favorite "riddles" in C, I'm quoting the explanation from [21st Century C](http://shop.oreilly.com/product/0636920033677.do):

![image](https://user-images.githubusercontent.com/3130044/53976768-f2776c00-4107-11e9-93cf-4987aa42d047.png)
