### PR TITLE
Force C99 with GNU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ before_script:
       --disable-sql
       --enable-pacct
       --enable-manpages
+      --enable-force-gnu99
       --with-python=2
       --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
       $EXTRA_WARN

--- a/cmake/Modules/ExternalIVYKIS.cmake
+++ b/cmake/Modules/ExternalIVYKIS.cmake
@@ -28,19 +28,19 @@ if (EXISTS ${PROJECT_SOURCE_DIR}/lib/ivykis/src/include/iv.h.in)
 
     ExternalProject_Add(
         ${LIB_NAME}
-        PREFIX            ${CMAKE_CURRENT_BINARY_DIR}
-        INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}
+        PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/
+        INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/
         SOURCE_DIR        ${PROJECT_SOURCE_DIR}/lib/ivykis/
         DOWNLOAD_COMMAND  echo
         BUILD_COMMAND     make
         INSTALL_COMMAND   make install
-        CONFIGURE_COMMAND autoreconf -i ${PROJECT_SOURCE_DIR}/lib/ivykis && ${PROJECT_SOURCE_DIR}/lib/ivykis/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}
+        CONFIGURE_COMMAND autoreconf -i ${PROJECT_SOURCE_DIR}/lib/ivykis && ${PROJECT_SOURCE_DIR}/lib/ivykis/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/
     )
 
     set(${LIB_NAME}_INTERNAL TRUE)
-    set(${LIB_NAME}_INTERNAL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include" CACHE STRING "${LIB_NAME} include path")
-    set(${LIB_NAME}_INTERNAL_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/lib/libivykis${CMAKE_SHARED_LIBRARY_SUFFIX}" CACHE STRING "${LIB_NAME} library path")
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/ DESTINATION lib USE_SOURCE_PERMISSIONS FILES_MATCHING PATTERN "libivykis${CMAKE_SHARED_LIBRARY_SUFFIX}*")
+    set(${LIB_NAME}_INTERNAL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/include" CACHE STRING "${LIB_NAME} include path")
+    set(${LIB_NAME}_INTERNAL_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/lib/libivykis${CMAKE_SHARED_LIBRARY_SUFFIX}" CACHE STRING "${LIB_NAME} library path")
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/lib/ DESTINATION lib USE_SOURCE_PERMISSIONS FILES_MATCHING PATTERN "libivykis${CMAKE_SHARED_LIBRARY_SUFFIX}*")
 
 else()
   set(${LIB_NAME}_INTERNAL FALSE)

--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,9 @@ AC_ARG_ENABLE(forced_server_mode,
 AC_ARG_ENABLE(debug,
               [  --enable-debug      Enable debugging code.],, enable_debug="no")
 
+AC_ARG_ENABLE(force_gnu99,
+              [  --enable-force-gnu99      Enforce C99 with gnu extensions.],, force_gnu99="no")
+
 AC_ARG_ENABLE(extra-warnings,
               [  --enable-extra-warnings      Enable extra compiler warnings (recommended).],, enable_extra_warnings="no")
 
@@ -480,7 +483,6 @@ dnl ***************************************************************************
 dnl Set up CFLAGS
 
 
-
 dnl The rest of CFLAGS. We produce
 dnl -g/-O2/-pg/-fprofile-arcs/-ftest-coverage combinations, the rest is
 dnl supplied by Makefile.am
@@ -506,6 +508,12 @@ else
         enable_extra_warnings="no"
 fi
 CFLAGS_ADD="${CFLAGS_ADD} -pthread"
+
+dnl The current supported standard is C99 with gnu extensions
+
+if test "x$force_gnu99" = "xyes"; then
+	CFLAGS_ADD="${CFLAGS_ADD} -std=gnu99"
+fi
 
 dnl We are checking for the postive warning flag, as gcc handles the
 dnl -Wno-XXX version oddly, so if no other warnings are present, it is not

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -295,9 +295,13 @@ set(CORE_INCLUDE_DIRS
 add_library(syslog-ng SHARED ${LIB_SOURCES})
 
 target_include_directories(syslog-ng
-  SYSTEM PUBLIC
+  PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+target_include_directories(syslog-ng
+  SYSTEM PUBLIC
     ${CORE_INCLUDE_DIRS}
 )
 

--- a/lib/value-pairs/internals.h
+++ b/lib/value-pairs/internals.h
@@ -28,7 +28,6 @@
 #include "syslog-ng.h"
 #include "atomic.h"
 
-typedef struct _ValuePairs ValuePairs;
 struct _ValuePairs
 {
   GAtomicCounter ref_cnt;


### PR DESCRIPTION
Enables a switch to force GNU99 as the current used C standard is C99.
In case of CMake the GNU99 was already enabled, but warnings were excluded with `-isystem` style include.