### PR TITLE
afamqp: add support for external authentication

### DIFF
--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -55,6 +55,7 @@
 %token KW_VHOST
 %token KW_ROUTING_KEY
 %token KW_BODY
+%token KW_AUTH_METHOD
 %token KW_PASSWORD
 %token KW_USERNAME
 %token KW_MAX_CHANNEL
@@ -90,6 +91,7 @@ afamqp_option
 	| KW_ROUTING_KEY '(' string ')'           { afamqp_dd_set_routing_key(last_driver, $3); free($3); }
 	| KW_BODY '(' string ')'                  { afamqp_dd_set_body(last_driver, $3); free($3); }
 	| KW_PERSISTENT '(' yesno ')'             { afamqp_dd_set_persistent(last_driver, $3); }
+	| KW_AUTH_METHOD '(' string ')'           { CHECK_ERROR(afamqp_dd_set_auth_method(last_driver, $3), @3, "unknown auth-method() argument"); free($3); }
 	| KW_USERNAME '(' string ')'              { afamqp_dd_set_user(last_driver, $3); free($3); }
 	| KW_PASSWORD '(' string ')'              { afamqp_dd_set_password(last_driver, $3); free($3); }
 	| KW_MAX_CHANNEL '(' positive_integer ')' { afamqp_dd_set_max_channel(last_driver, $3); }

--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -40,6 +40,7 @@ static CfgLexerKeyword afamqp_keywords[] =
   { "exchange_type",    KW_EXCHANGE_TYPE },
   { "routing_key",    KW_ROUTING_KEY },
   { "persistent",   KW_PERSISTENT },
+  { "auth_method",  KW_AUTH_METHOD },
   { "username",     KW_USERNAME },
   { "password",     KW_PASSWORD },
   { "max_channel",     KW_MAX_CHANNEL },

--- a/modules/afamqp/afamqp.h
+++ b/modules/afamqp/afamqp.h
@@ -39,6 +39,7 @@ void afamqp_dd_set_vhost(LogDriver *d, const gchar *vhost);
 void afamqp_dd_set_routing_key(LogDriver *d, const gchar *routing_key);
 void afamqp_dd_set_body(LogDriver *d, const gchar *body);
 void afamqp_dd_set_persistent(LogDriver *d, gboolean persistent);
+gboolean afamqp_dd_set_auth_method(LogDriver *d, const gchar *auth_method);
 void afamqp_dd_set_user(LogDriver *d, const gchar *user);
 void afamqp_dd_set_password(LogDriver *d, const gchar *password);
 void afamqp_dd_set_max_channel(LogDriver *d, gint max_channel);


### PR DESCRIPTION
AMQP has support for an 'external' authentication scheme which uses some out-of-band method for authenticating the user. For instance, the user may be identified from the Distinguished Name or Common Name in their client certificate. The method by which the user is identified when using external authentication depends on the server configuration.

Add a new 'auth-method' parameter to the amqp destination configuration which may be set to 'plain' or 'external'. When this parameter is omitted or set to 'plain', the existing behaviour is unchanged. When set to 'external' then external authentication is enabled and the username, if supplied, will be used as the identity, although this is generally not needed and may be omitted.