### PR TITLE
version from git describe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,7 @@ include(add_tests)
 set(MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/tests/valgrind/unit-test-leak.supp")
 set(MEMORYCHECK_COMMAND_OPTIONS "--num-callers=30 --sim-hints=no-nptl-pthread-stackcache --gen-suppressions=all --leak-check=full --freelist-vol=200000000 --freelist-big-blocks=10000000 --malloc-fill=55 --free-fill=AA")
 
-file(STRINGS "${PROJECT_SOURCE_DIR}/VERSION" VERSION_FROM_FILE)
-set(SYSLOG_NG_VERSION "${VERSION_FROM_FILE}")
+execute_process(COMMAND ${PROJECT_SOURCE_DIR}/scripts/version.sh SET OUTPUT_VARIABLE SYSLOG_NG_VERSION)
 set(SYSLOG_NG_COMBINED_VERSION ${SYSLOG_NG_VERSION})
 set(SYSLOG_NG_SOURCE_REVISION ${SYSLOG_NG_VERSION})
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ dnl BINARY_BRANCH      - the value is added to all source/binary packages
 dnl SOURCE_REVISION    - Revision of the source-tree, will added to the version string
 dnl
 
-AC_INIT([syslog-ng], m4_esyscmd([tr -d '\n' < VERSION]))
+AC_INIT([syslog-ng], m4_esyscmd_s([scripts/version.sh]))
 AC_CONFIG_SRCDIR([syslog-ng/main.c])
 AC_CONFIG_MACRO_DIR([m4])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/dbld/deb
+++ b/dbld/deb
@@ -3,7 +3,7 @@
 set -e
 
 cd /source
-VERSION=`cat VERSION`
+VERSION=`scripts/version.sh`
 GITREF=`git describe`
 cd /build
 

--- a/dbld/generate-debian-directory
+++ b/dbld/generate-debian-directory
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MODE=$1
-VERSION=`cat /source/VERSION`
+VERSION=`/source/scripts/version.sh`
 
 cp -r /source/packaging/debian .
 if [ $MODE = "snapshot" ]; then

--- a/dbld/generate-rpm-specfile
+++ b/dbld/generate-rpm-specfile
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MODE=$1
-VERSION=`cat /source/VERSION`
+VERSION=`/source/scripts/version.sh`
 
 cp /source/packaging/rhel/* .
 

--- a/dbld/pkg-tarball
+++ b/dbld/pkg-tarball
@@ -2,7 +2,7 @@
 
 cd /source
 
-VERSION=`cat /source/VERSION`
+VERSION=`/source/scripts/version.sh`
 MODE=$1
 SYSLOGNG_DIR=syslog-ng-${VERSION}
 SYSLOGNG_TARBALL=${SYSLOGNG_DIR}.tar.gz

--- a/dbld/rpm
+++ b/dbld/rpm
@@ -3,7 +3,7 @@
 set -e
 
 cd /source
-VERSION=`cat VERSION`
+VERSION=`scripts/version.sh`
 RPMBUILD=${HOME}/rpmbuild
 RPMBUILD_SOURCES=$RPMBUILD/SOURCES
 

--- a/dbld/rules
+++ b/dbld/rules
@@ -17,7 +17,7 @@ ROOT_DIR=$(shell pwd)
 DBLD_DIR=$(ROOT_DIR)/dbld
 BUILD_DIR=$(DBLD_DIR)/build
 RELEASE_DIR=$(DBLD_DIR)/release
-VERSION=$(shell cat VERSION)
+VERSION=$(shell scripts/version.sh)
 TARBALL=$(BUILD_DIR)/syslog-ng-$(VERSION).tar.gz
 MODE=snapshot
 CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl $(CONFIGURE_ADD)

--- a/dbld/tarball
+++ b/dbld/tarball
@@ -3,7 +3,7 @@
 set -e
 
 cd /source
-VERSION=`cat VERSION`
+VERSION=`scripts/version.sh`
 SYSLOGNG_DIR=syslog-ng-${VERSION}
 SYSLOGNG_TARBALL=${SYSLOGNG_DIR}.tar.gz
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST	+= scripts/update-patterndb.in \
 	scripts/get-libjvm-path.sh	\
 	scripts/make-and-check.sh	\
 	scripts/rm-extra-msg-sentinel.sh	\
+	scripts/version.sh	\
 	scripts/style-checker.sh
 
 install-exec-local:

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -24,5 +24,11 @@
 
 BASEDIR=$(dirname "$0")
 
-cat $BASEDIR/../VERSION
+cd $BASEDIR/../
+
+if [ -d .git ]; then
+  git describe --tags --dirty --abbrev=7 | sed 's/^syslog-ng-//'
+else
+  cat VERSION
+fi
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#############################################################################
+# Copyright (c) 2019 Balabit
+# Copyright (c) 2018 Kokan <kokaipeter@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+BASEDIR=$(dirname "$0")
+
+cat $BASEDIR/../VERSION
+

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -27,7 +27,7 @@ BASEDIR=$(dirname "$0")
 cd $BASEDIR/../
 
 if [ -d .git ]; then
-  git describe --tags --dirty --abbrev=7 | sed 's/^syslog-ng-//' | tr '-' '.'
+  git describe --tags --dirty --abbrev=7 | sed 's/^syslog-ng-//' | tr '-' '.' | tr -d '\n'
 else
   cat VERSION
 fi

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -27,7 +27,7 @@ BASEDIR=$(dirname "$0")
 cd $BASEDIR/../
 
 if [ -d .git ]; then
-  git describe --tags --dirty --abbrev=7 | sed 's/^syslog-ng-//'
+  git describe --tags --dirty --abbrev=7 | sed 's/^syslog-ng-//' | tr '-' '.'
 else
   cat VERSION
 fi


### PR DESCRIPTION
The `git describe` is capable to get a much nicer cheap version.

A few things left to do:
- [x] test dbld/rules tarball
- [x] fix dbld/rules deb (some strange error occurs)
- [x] test dbld/rules rpm (at least not worse then the current)
- [x] cmake
- [x] enforce different versioning
