### PR TITLE
elasticsearch2: Added deprecation warning

### DIFF
--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -51,6 +51,7 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	@Override
 	protected boolean init() {
+		logger.warn("Using elasticsearch2() destination is deprecated please use elasticsearch-http() instead. The java-based elasticsearch2() works as before but it may be removed in the future");
 		boolean result = false;
 		try {
 			options.init();


### PR DESCRIPTION
After https://github.com/balabit/syslog-ng/pull/2509 was merged, the elasticsearch-http() destination should be the recommended destination to forward logs to elasticsearch.