### PR TITLE
Remove duplicate log-fifo-size() keywords

### DIFF
--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -44,7 +44,6 @@ static CfgLexerKeyword afamqp_keywords[] =
   { "password",     KW_PASSWORD },
   { "max_channel",     KW_MAX_CHANNEL },
   { "frame_size",     KW_FRAME_SIZE },
-  { "log_fifo_size",    KW_LOG_FIFO_SIZE  },
   { "body",     KW_BODY },
   { "ca_file",        KW_CA_FILE },
   { "key_file",           KW_KEY_FILE },

--- a/modules/afsql/afsql-parser.c
+++ b/modules/afsql/afsql-parser.c
@@ -40,7 +40,6 @@ static CfgLexerKeyword afsql_keywords[] =
   { "columns",            KW_COLUMNS },
   { "indexes",            KW_INDEXES },
   { "values",             KW_VALUES },
-  { "log_fifo_size",      KW_LOG_FIFO_SIZE },
   { "frac_digits",        KW_FRAC_DIGITS },
   { "session_statements", KW_SESSION_STATEMENTS },
   { "host",               KW_HOST },

--- a/modules/afstomp/afstomp-parser.c
+++ b/modules/afstomp/afstomp-parser.c
@@ -39,7 +39,6 @@ static CfgLexerKeyword afstomp_keywords[] =
   { "ack",      KW_ACK },
   { "username",     KW_USERNAME },
   { "password",     KW_PASSWORD },
-  { "log_fifo_size",    KW_LOG_FIFO_SIZE  },
   { "body",     KW_BODY },
   { NULL }
 };


### PR DESCRIPTION
`log-fifo-size()` comes from the main grammar, from the
`dest_driver_option` and `threaded_dest_driver_option` nonterminal symbols.