### PR TITLE
contrib: fix default config file location (systemd)

### DIFF
--- a/contrib/systemd/syslog-ng@default
+++ b/contrib/systemd/syslog-ng@default
@@ -1,4 +1,4 @@
-CONFIG_FILE=/etc/syslog-ng.conf
+CONFIG_FILE=/etc/syslog-ng/syslog-ng.conf
 PERSIST_FILE=/var/lib/syslog-ng/syslog-ng.persist
 CONTROL_FILE=/var/run/syslog-ng.ctl
 PID_FILE=/var/run/syslog-ng.pid


### PR DESCRIPTION
syslog-ng has multiple configuration files (syslog-ng.conf, scl.conf,
patterndb.d), so they are usually installed under the /etc/syslog-ng
directory.

Signed-off-by: Janos SZIGETVARI
Signed-off-by: László Várady