### PR TITLE
Docbook: Search for docbook.xsl in configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ before_script:
       --enable-manpages
       --enable-force-gnu99
       --with-python=2
-      --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
       $EXTRA_WARN
       $DISABLE_MONGODB
       "

--- a/configure.ac
+++ b/configure.ac
@@ -333,6 +333,7 @@ AC_ARG_WITH(docbook,
             AC_HELP_STRING([--with-docbook=FILE],
                            [compiling manpages using docbook in the specified path, if not set online version will be used from http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl]),
             [ XSL_STYLESHEET=$with_docbook ],
+            [ XSL_STYLESHEET=`find /usr/share/{xml,sgml} -path '*/manpages/docbook.xsl'` ],
             [ XSL_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl ]
             )
 

--- a/dbld/rules
+++ b/dbld/rules
@@ -20,7 +20,7 @@ RELEASE_DIR=$(DBLD_DIR)/release
 VERSION=$(shell cat VERSION)
 TARBALL=$(BUILD_DIR)/syslog-ng-$(VERSION).tar.gz
 MODE=snapshot
-CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl $(CONFIGURE_ADD)
+CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install $(CONFIGURE_ADD)
 
 -include dbld/rules.conf
 

--- a/dbld/tarball
+++ b/dbld/tarball
@@ -12,7 +12,7 @@ SYSLOGNG_TARBALL=${SYSLOGNG_DIR}.tar.gz
 rm -rf /build/dist-build
 mkdir /build/dist-build
 cd /build/dist-build
-/source/configure --enable-manpages --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
+/source/configure --enable-manpages
 make dist
 mv ${SYSLOGNG_TARBALL} /build
 


### PR DESCRIPTION
- with the hardcoded docbook-path syslog-ng can not find docbook.xsl on
CentOS systems and `make install` will fail
- on this systems docbook.xsl has different installation dir

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>

With this change `configure` can use always the proper docbook.xsl path.

To reproduce the fail, run:
```
$ dbld/rules bootstrap-centos-7 ; export DEFAULT_IMAGE=centos-7 ; dbld/rules make-install
```

docbook.xsl path in supported DBLD images
```
$ declare -a images=("balabit/syslog-ng-debian-buster" "balabit/syslog-ng-debian-stretch" "balabit/syslog-ng-debian-jessie" "balabit/syslog-ng-centos-6" "balabit/syslog-ng-centos-7" "balabit/syslog-ng-ubuntu-trusty" "balabit/syslog-ng-ubuntu-xenial" "balabit/syslog-ng-ubuntu-cosmic" "balabit/syslog-ng-ubuntu-bionic") ; for image in ${images[@]}; do echo $image ; docker run $image find / | grep '/docbook\.xsl' | grep man ; done
balabit/syslog-ng-debian-buster
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
balabit/syslog-ng-debian-stretch
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
balabit/syslog-ng-debian-jessie
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
balabit/syslog-ng-centos-6
/usr/share/sgml/docbook/xsl-stylesheets-1.75.2/manpages/docbook.xsl
balabit/syslog-ng-centos-7
/usr/share/sgml/docbook/xsl-stylesheets-1.78.1/manpages/docbook.xsl
balabit/syslog-ng-ubuntu-trusty
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
balabit/syslog-ng-ubuntu-xenial
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
balabit/syslog-ng-ubuntu-cosmic
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
balabit/syslog-ng-ubuntu-bionic
/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl
```