### PR TITLE
graylog2: Add default value for PID

### DIFF
--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -23,7 +23,7 @@
 
 @requires json-plugin
 
-template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
+template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID:-0}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
 block destination graylog2(host("127.0.0.1") port(12201) template("$(format-gelf)") ...) {
 	network("`host`"


### PR DESCRIPTION
When you forward logs from a remote destination, there is no PID value. This results in a key without a value,

I.E.
```json
{
	"version": "1.1",
	"timestamp": 1553016201,
	"short_message": "message",
	"level": 0,
	"host": "host",
	"_program": "program",
	"_pid": ,
	"_facility": "facility",
	"_class": ""
}
```
Because there is no value for the key `_pid`, this json object is invalid, and thus rejected by the graylog server.