### PR TITLE
Add support for Graylog GELF over TLS and UDP

### DIFF
--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -25,10 +25,23 @@
 
 template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
-block destination graylog2(host("127.0.0.1") port(12201) template("$(format-gelf)") ...) {
+block destination graylog2(host("127.0.0.1") port(12201) transport(tcp) template("$(format-gelf)") ...) {
 	network("`host`"
                 port(`port`)
-		transport(tcp)
+		transport(`transport`)
 		template("`template`")
 		`__VARARGS__`);
+};
+
+block destination graylog2-tls(host("127.0.0.1") port(12201) ca-dir("/etc/ssl/certs") peer-verify("required-trusted") template("$(format-gelf)") ...) {
+    network(
+        "`host`"
+        port(`port`)
+        transport(tls)
+        tls (
+            ca-dir("`ca-dir`")
+            peer-verify("`peer-verify`")
+        )
+        template("`template`")
+        `__VARARGS__`);
 };


### PR DESCRIPTION
Graylog GELF supports both UDP and TCP+TLS. There is no reason you can't default to TCP but add support for using the plugin while changing the transport to UDP. Also added a block for TLS.