### PR TITLE
app-parser, pseudofile: fix crash with grammar error

### DIFF
--- a/modules/appmodel/appmodel-grammar.ym
+++ b/modules/appmodel/appmodel-grammar.ym
@@ -70,12 +70,12 @@ application_definition
         : KW_APPLICATION string '[' string ']'
           {
 	    last_application = application_new($2, $4);
-            free($2);
-            free($4);
           }
 	  '{' application_options '}'
 	  {
 	    $$ = last_application;
+            free($2);
+            free($4);
           }
         ;
 

--- a/modules/pseudofile/pseudofile-grammar.ym
+++ b/modules/pseudofile/pseudofile-grammar.ym
@@ -63,10 +63,10 @@ start
         ;
 
 dest_pseudofile
-	: KW_PSEUDOFILE 
-          '(' string						{ last_driver = pseudofile_dd_new($3, configuration); free($3); }
+	: KW_PSEUDOFILE
+          '(' string						{ last_driver = pseudofile_dd_new($3, configuration); }
 	  pseudofile_opts
-	  ')'							{ $$ = last_driver; }
+	  ')'							{ $$ = last_driver; free($3); }
 	;
 
 pseudofile_opts


### PR DESCRIPTION
See the following example.

```
@version: 3.20
application a[my-apparser] {
    rewrite { set("b" value("b") };
};

log {
  parser { app-parser(topic(my-apparser)); };
};
```

In this case, the error happens in the `application_options` in the
grammar file (`KW_REWRITE` is not allowed), after we freed `$2` and
`$4`. However, in case of grammar error, lexer frees these tokens
too, hence double free.

As a resolution, the `free` calls are moved to the end of the grammar file.
This way only grammar will free these tokens.

-----

Similarly, with pseudofile:
```
@version: 3.20

log {
  destination { pseudofile("/tmp/foo" disk-buffer(a) ); };
};
```
causes crash. 