### PR TITLE
python: set_timestamp normalization

### DIFF
--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -23,10 +23,6 @@
 
 #include "compat-python.h"
 #include "python-helpers.h"
-#include "timeutils/misc.h"
-
-#include <datetime.h>
-
 
 void
 py_init_argv(void)
@@ -40,88 +36,6 @@ int_as_pyobject(gint num)
 {
   return PyInt_FromLong(num);
 };
-
-static PyObject *
-_datetime_timestamp(PyObject *py_datetime)
-{
-  PyObject *py_tzinfo = _py_get_attr_or_null(py_datetime, "tzinfo");
-  if (!py_tzinfo)
-    {
-      PyErr_Format(PyExc_ValueError, "Error obtaining tzinfo");
-      return NULL;
-    }
-  PyObject *py_epoch = PyDateTimeAPI->DateTime_FromDateAndTime(1970, 1, 1, 0, 0, 0, 0, py_tzinfo,
-                       PyDateTimeAPI->DateTimeType);
-
-  PyObject *py_delta = _py_invoke_method_by_name(py_datetime, "__sub__", py_epoch,
-                                                 "PyDateTime", "py_datetime_to_logstamp");
-  if (!py_delta)
-    {
-      Py_XDECREF(py_tzinfo);
-      Py_XDECREF(py_epoch);
-      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
-      return NULL;
-    }
-
-  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_delta, "total_seconds", NULL,
-                                                           "PyDateTime", "py_datetime_to_logstamp");
-  Py_XDECREF(py_tzinfo);
-  Py_XDECREF(py_delta);
-  Py_XDECREF(py_epoch);
-
-  return py_posix_timestamp;
-}
-
-static gboolean
-_datetime_get_gmtoff(PyObject *py_datetime, gint *utcoffset)
-{
-  *utcoffset = -1;
-  PyObject *py_utcoffset = _py_invoke_method_by_name(py_datetime, "utcoffset", NULL, "PyDateTime",
-                                                     "py_datetime_to_logstamp");
-  if (!py_utcoffset)
-    {
-      PyErr_Format(PyExc_ValueError, "Error obtaining timezone info");
-      return FALSE;
-    }
-
-  if (py_utcoffset != Py_None)
-    {
-      *utcoffset = PyDateTime_DELTA_GET_SECONDS(py_utcoffset);
-    }
-
-  Py_XDECREF(py_utcoffset);
-  return TRUE;
-}
-
-gboolean
-py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
-{
-  if (!PyDateTime_Check(py_timestamp))
-    {
-      PyErr_Format(PyExc_TypeError, "datetime expected in the first parameter");
-      return FALSE;
-    }
-
-  PyObject *py_posix_timestamp = _datetime_timestamp(py_timestamp);
-  if (!py_posix_timestamp)
-    return FALSE;
-
-  gdouble posix_timestamp = PyFloat_AsDouble(py_posix_timestamp);
-
-  Py_XDECREF(py_posix_timestamp);
-
-  gint local_gmtoff;
-  if (!_datetime_get_gmtoff(py_timestamp, &local_gmtoff))
-    return FALSE;
-  if (local_gmtoff == -1)
-    local_gmtoff = get_local_timezone_ofs(posix_timestamp);
-
-  logstamp->ut_sec = (time_t) posix_timestamp;
-  logstamp->ut_usec = posix_timestamp * 10e5 - logstamp->ut_sec * 10e5;
-  logstamp->ut_gmtoff = local_gmtoff;
-
-  return TRUE;
-}
 
 gint
 pyobject_as_int(PyObject *object)

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -68,6 +68,27 @@ _datetime_timestamp(PyObject *py_datetime)
   return py_posix_timestamp;
 }
 
+static gboolean
+_datetime_get_gmtoff(PyObject *py_datetime, gint *utcoffset)
+{
+  *utcoffset = -1;
+  PyObject *py_utcoffset = _py_invoke_method_by_name(py_datetime, "utcoffset", NULL, "PyDateTime",
+                                                     "py_datetime_to_logstamp");
+  if (!py_utcoffset)
+    {
+      PyErr_Format(PyExc_ValueError, "Error obtaining timezone info");
+      return FALSE;
+    }
+
+  if (py_utcoffset != Py_None)
+    {
+      *utcoffset = PyDateTime_DELTA_GET_SECONDS(py_utcoffset);
+    }
+
+  Py_XDECREF(py_utcoffset);
+  return TRUE;
+}
+
 gboolean
 py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
 {

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -46,6 +46,27 @@ py_datetime_init(void)
   PyDateTime_IMPORT;
 }
 
+static PyObject *
+_datetime_timestamp(PyObject *py_datetime)
+{
+  PyObject *py_epoch = PyDateTime_FromDateAndTime(1970, 1, 1, 0, 0, 0, 0);
+  PyObject *py_delta = _py_invoke_method_by_name(py_datetime, "__sub__", py_epoch,
+                                                 "PyDateTime", "py_datetime_to_logstamp");
+  if (!py_delta)
+    {
+      Py_XDECREF(py_epoch);
+      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
+      return NULL;
+    }
+
+  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_delta, "total_seconds", NULL,
+                                                           "PyDateTime", "py_datetime_to_logstamp");
+  Py_XDECREF(py_delta);
+  Py_XDECREF(py_epoch);
+
+  return py_posix_timestamp;
+}
+
 gboolean
 py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
 {
@@ -55,23 +76,13 @@ py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
       return FALSE;
     }
 
-  PyObject *py_epoch = PyDateTime_FromDateAndTime(1970, 1, 1, 0, 0, 0, 0);
-  PyObject *py_delta = _py_invoke_method_by_name(py_timestamp, "__sub__", py_epoch,
-                                                 "PyDateTime", "py_datetime_to_logstamp");
-  if (!py_delta)
-    {
-      Py_XDECREF(py_epoch);
-      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
-      return FALSE;
-    }
+  PyObject *py_posix_timestamp = _datetime_timestamp(py_timestamp);
+  if (!py_posix_timestamp)
+    return FALSE;
 
-  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_delta, "total_seconds", NULL,
-                                                           "PyDateTime", "py_datetime_to_logstamp");
   gdouble posix_timestamp = PyFloat_AsDouble(py_posix_timestamp);
 
   Py_XDECREF(py_posix_timestamp);
-  Py_XDECREF(py_delta);
-  Py_XDECREF(py_epoch);
 
   logstamp->ut_sec = (time_t) posix_timestamp;
   logstamp->ut_usec = posix_timestamp * 10e5 - logstamp->ut_sec * 10e5;

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -41,12 +41,6 @@ int_as_pyobject(gint num)
   return PyInt_FromLong(num);
 };
 
-void
-py_datetime_init(void)
-{
-  PyDateTime_IMPORT;
-}
-
 static PyObject *
 _datetime_timestamp(PyObject *py_datetime)
 {

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -27,6 +27,7 @@
 
 #include <datetime.h>
 
+
 void
 py_init_argv(void)
 {

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -106,9 +106,15 @@ py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
 
   Py_XDECREF(py_posix_timestamp);
 
+  gint local_gmtoff;
+  if (!_datetime_get_gmtoff(py_timestamp, &local_gmtoff))
+    return FALSE;
+  if (local_gmtoff == -1)
+    local_gmtoff = get_local_timezone_ofs(posix_timestamp);
+
   logstamp->ut_sec = (time_t) posix_timestamp;
   logstamp->ut_usec = posix_timestamp * 10e5 - logstamp->ut_sec * 10e5;
-  logstamp->ut_gmtoff = get_local_timezone_ofs(posix_timestamp);
+  logstamp->ut_gmtoff = local_gmtoff;
 
   return TRUE;
 }

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -24,8 +24,6 @@
 #include "compat-python.h"
 #include "python-helpers.h"
 
-#include <datetime.h>
-
 void
 py_init_argv(void)
 {
@@ -38,45 +36,6 @@ int_as_pyobject(gint num)
 {
   return PyLong_FromLong(num);
 };
-
-gboolean
-py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
-{
-  if (!PyDateTime_Check(py_timestamp))
-    {
-      PyErr_Format(PyExc_TypeError, "datetime expected in the first parameter");
-      return FALSE;
-    }
-
-  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_timestamp, "timestamp", NULL,
-                                                           "PyDateTime", "py_datetime_to_logstamp");
-  if (!py_posix_timestamp)
-    {
-      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
-      return FALSE;
-    }
-
-  PyObject *py_utcoffset = _py_invoke_method_by_name(py_timestamp, "utcoffset", NULL,
-                                                     "PyDateTime", "py_datetime_to_logstamp");
-  if (!py_utcoffset)
-    {
-      Py_DECREF(py_posix_timestamp);
-      PyErr_Format(PyExc_ValueError, "Error retrieving utcoffset");
-      return FALSE;
-    }
-
-  gdouble posix_timestamp = PyFloat_AsDouble(py_posix_timestamp);
-  gint zone_offset = py_utcoffset == Py_None ? 0 : PyDateTime_DELTA_GET_SECONDS(py_utcoffset);
-
-  Py_DECREF(py_utcoffset);
-  Py_DECREF(py_posix_timestamp);
-
-  logstamp->ut_sec = (time_t) posix_timestamp;
-  logstamp->ut_usec = posix_timestamp * 10e5 - logstamp->ut_sec * 10e5;
-  logstamp->ut_gmtoff = zone_offset;
-
-  return TRUE;
-}
 
 gint
 pyobject_as_int(PyObject *object)

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -39,12 +39,6 @@ int_as_pyobject(gint num)
   return PyLong_FromLong(num);
 };
 
-void
-py_datetime_init(void)
-{
-  PyDateTime_IMPORT;
-}
-
 gboolean
 py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
 {

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -26,7 +26,6 @@
 
 #include <Python.h>
 #include "syslog-ng.h"
-#include "timeutils/unixtime.h"
 
 #if (SYSLOG_NG_ENABLE_PYTHONv2)
 #define PYTHON_BUILTIN_MODULE_NAME "__builtin__"
@@ -45,9 +44,6 @@
 
 void py_init_argv(void);
 PyObject *int_as_pyobject(gint num);
-
-void py_datetime_init(void);
-gboolean py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp);
 
 gint pyobject_as_int(PyObject *object);
 #endif

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -31,6 +31,11 @@
 #if (SYSLOG_NG_ENABLE_PYTHONv2)
 #define PYTHON_BUILTIN_MODULE_NAME "__builtin__"
 #define PYTHON_MODULE_VERSION "python2"
+
+/*
+ * Macro from python3 Include/datetime.h file
+ */
+#define PyDateTime_DELTA_GET_SECONDS(o)      (((PyDateTime_Delta*)o)->seconds)
 #endif
 
 #if (SYSLOG_NG_ENABLE_PYTHONv3)

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -349,6 +349,7 @@ PyTypeObject py_log_message_type =
 void
 py_log_message_init(void)
 {
+  PyDateTime_IMPORT;
   PyType_Ready(&py_log_message_type);
   PyModule_AddObject(PyImport_AddModule("syslogng"), "LogMessage", (PyObject *) &py_log_message_type);
 }

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -83,7 +83,6 @@ _py_init_interpreter(void)
       py_init_argv();
 
       PyEval_InitThreads();
-      py_datetime_init();
       py_log_message_init();
       py_log_template_init();
       py_integer_pointer_init();


### PR DESCRIPTION
The current `LogMessage.set_timestamp` behaved differently for py2 or py3; and had issue with *aware* datetime.

Fixes:
* py3 use local timezone in case of *naive* datetime
* py2 could not accept *aware* datetime

Also creates a code that is compatible with both py2 and py3 so does not have to be in compat layer.

Example for creating *aware* datetime
```
import datetime
import pytz

datetime.datetime(2019,9,14,12,34,56,tzinfo=pytz.timezone('Asia/Shanghai'))
```
