### PR TITLE
Trim large messages

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -177,9 +177,9 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_BLOCK                       10007
 %token KW_JUNCTION                    10008
 %token KW_CHANNEL                     10009
-%token KW_IF			      10010
-%token KW_ELSE			      10011
-%token KW_ELIF			      10012
+%token KW_IF                          10010
+%token KW_ELSE                        10011
+%token KW_ELIF                        10012
 
 /* source & destination items */
 %token KW_INTERNAL                    10020
@@ -189,7 +189,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_MARK_FREQ                   10071
 %token KW_STATS_FREQ                  10072
 %token KW_STATS_LEVEL                 10073
-%token KW_STATS_LIFETIME	      10074
+%token KW_STATS_LIFETIME              10074
 %token KW_FLUSH_LINES                 10075
 %token KW_SUPPRESS                    10076
 %token KW_FLUSH_TIMEOUT               10077
@@ -203,6 +203,7 @@ extern struct _StatsOptions *last_stats_options;
 %token KW_MIN_IW_SIZE_PER_READER      10085
 %token KW_BATCH_LINES                 10087
 %token KW_BATCH_TIMEOUT               10088
+%token KW_TRIM_LARGE_MESSAGES         10089
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -214,7 +215,7 @@ extern struct _StatsOptions *last_stats_options;
 
 %token KW_USE_DNS                     10110
 %token KW_USE_FQDN                    10111
-%token KW_CUSTOM_DOMAIN	              10112
+%token KW_CUSTOM_DOMAIN               10112
 
 %token KW_DNS_CACHE                   10120
 %token KW_DNS_CACHE_SIZE              10121
@@ -977,12 +978,13 @@ options_item
 	| KW_LOG_IW_SIZE '(' positive_integer ')'	{ msg_warning("WARNING: Support for the global log-iw-size() option was removed, please use a per-source log-iw-size()", cfg_lexer_format_location_tag(lexer, &@1)); }
 	| KW_LOG_FETCH_LIMIT '(' positive_integer ')'	{ msg_warning("WARNING: Support for the global log-fetch-limit() option was removed, please use a per-source log-fetch-limit()", cfg_lexer_format_location_tag(lexer, &@1)); }
 	| KW_LOG_MSG_SIZE '(' positive_integer ')'	{ configuration->log_msg_size = $3; }
+	| KW_TRIM_LARGE_MESSAGES '(' yesno ')'	{ configuration->trim_large_messages = $3; }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ configuration->keep_timestamp = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ configuration->create_dirs = $3; }
-  | KW_CUSTOM_DOMAIN '(' string ')'       { configuration->custom_domain = g_strdup($3); free($3); }
+	| KW_CUSTOM_DOMAIN '(' string ')'	{ configuration->custom_domain = g_strdup($3); free($3); }
 	| KW_FILE_TEMPLATE '(' string ')'	{ configuration->file_template_name = g_strdup($3); free($3); }
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
-	| KW_RECV_TIME_ZONE '(' string ')'      { configuration->recv_time_zone = g_strdup($3); free($3); }
+	| KW_RECV_TIME_ZONE '(' string ')'	{ configuration->recv_time_zone = g_strdup($3); free($3); }
 	| KW_MIN_IW_SIZE_PER_READER '(' positive_integer ')' { configuration->min_iw_size_per_reader = $3; }
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
@@ -1258,7 +1260,8 @@ source_proto_option
                         "unknown encoding %s", $3);
             free($3);
           }
-	| KW_LOG_MSG_SIZE '(' positive_integer ')'	{ last_proto_server_options->max_msg_size = $3; }
+        | KW_LOG_MSG_SIZE '(' positive_integer ')'      { last_proto_server_options->max_msg_size = $3; }
+        | KW_TRIM_LARGE_MESSAGES '(' yesno ')'          { last_proto_server_options->trim_large_messages = $3; }
         ;
 
 host_resolve_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -131,6 +131,7 @@ static CfgLexerKeyword main_keywords[] =
   { "log_fetch_limit",    KW_LOG_FETCH_LIMIT },
   { "log_iw_size",        KW_LOG_IW_SIZE },
   { "log_msg_size",       KW_LOG_MSG_SIZE },
+  { "trim_large_messages", KW_TRIM_LARGE_MESSAGES },
   { "log_prefix",         KW_LOG_PREFIX, KWS_OBSOLETE, "program_override" },
   { "program_override",   KW_PROGRAM_OVERRIDE },
   { "host_override",      KW_HOST_OVERRIDE },

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -93,6 +93,7 @@ struct _GlobalConfig
 
   gint log_fifo_size;
   gint log_msg_size;
+  gboolean trim_large_messages;
 
   gboolean create_dirs;
   FilePermOptions file_perm_options;

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -31,8 +31,6 @@
 #define LPFSS_FRAME_READ    0
 #define LPFSS_MESSAGE_READ  1
 
-#define LPFS_FRAME_BUFFER 10
-
 typedef struct _LogProtoFramedServer
 {
   LogProtoServer super;
@@ -201,20 +199,6 @@ read_frame:
                         evt_tag_int("frame_length", self->frame_len));
               log_transport_aux_data_reinit(aux);
               return LPS_ERROR;
-            }
-          if (self->buffer_size < self->super.options->max_buffer_size &&
-              self->frame_len > self->buffer_size - self->buffer_pos)
-            {
-              /* a larger buffer would have prevented moving of data, grow
-               * the buffer up to max_buffer_size */
-
-              self->buffer_size = 16 * (self->frame_len + LPFS_FRAME_BUFFER);
-
-              if (self->buffer_size > self->super.options->max_buffer_size)
-                self->buffer_size = self->super.options->max_buffer_size;
-              self->buffer = g_realloc(self->buffer, self->buffer_size);
-              msg_debug("Resizing input buffer",
-                        evt_tag_int("new_size", self->buffer_size));
             }
           if (self->buffer_pos + self->frame_len > self->buffer_size)
             {

--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -150,6 +150,7 @@ log_proto_server_options_defaults(LogProtoServerOptions *options)
 {
   memset(options, 0, sizeof(*options));
   options->max_msg_size = -1;
+  options->trim_large_messages = -1;
   options->init_buffer_size = -1;
   options->max_buffer_size = -1;
   options->position_tracking_enabled = FALSE;
@@ -164,6 +165,10 @@ log_proto_server_options_init(LogProtoServerOptions *options, GlobalConfig *cfg)
   if (options->max_msg_size == -1)
     {
       options->max_msg_size = cfg->log_msg_size;
+    }
+  if (options->trim_large_messages == -1)
+    {
+      options->trim_large_messages = cfg->trim_large_messages;
     }
   if (options->max_buffer_size == -1)
     {

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -49,6 +49,7 @@ struct _LogProtoServerOptions
   gchar *encoding;
   /* maximum message length in bytes */
   gint max_msg_size;
+  gboolean trim_large_messages;
   gint max_buffer_size;
   gint init_buffer_size;
   gboolean position_tracking_enabled;

--- a/lib/logproto/tests/test-framed-server.c
+++ b/lib/logproto/tests/test-framed-server.c
@@ -109,6 +109,96 @@ Test(log_proto, test_log_proto_framed_server_too_long_line)
   log_proto_server_free(proto);
 }
 
+Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed)
+{
+  LogProtoServer *proto;
+
+  /* the simplest trimming scenario as a base test */
+
+  proto_server_options.max_msg_size = 32;
+  proto_server_options.trim_large_messages = TRUE;
+  proto = log_proto_framed_server_new(
+            log_transport_mock_stream_new(
+              "48 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", 32);
+  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_multiple_cycles)
+{
+  LogProtoServer *proto;
+
+  /* - accepting one normal sized message
+   * - trimming a "multi buffer size" message
+   * - checking with a normal message, that the buffer is still handled correctly.
+   */
+
+  proto_server_options.max_msg_size = 2;
+  proto_server_options.trim_large_messages = TRUE;
+  proto = log_proto_framed_server_new(
+            log_transport_mock_records_new(
+              "1 0", -1,
+              "7 1abcdef", -1,
+              "1 2", -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+  assert_proto_server_fetch(proto, "0",  1);
+  assert_proto_server_fetch(proto, "1a", 2);
+  assert_proto_server_fetch(proto, "2",  1);
+  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+}
+
+Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_frame_at_the_end)
+{
+  LogProtoServer *proto;
+
+  /* - accepting one normal sized message, which fills the buffer partially
+   * - receiving a message which has to be trimmed
+   *     -> despite we have one part of the message in the buffer,
+   *        we had to memmove it so we can read one 'max_msg_size' message
+   * - consume the end of the trimmed message, but the trimming will already read the
+   *   first character of the next 'frame length'.
+   *     -> need to memmove the partial data, so we can read the 'frame length' properly
+   * - checking with a normal message, that the buffer is still handled correctly
+   */
+
+  proto_server_options.max_msg_size = 8;
+  proto_server_options.trim_large_messages = TRUE;
+  proto = log_proto_framed_server_new(
+            log_transport_mock_records_new(
+              "3 01\n15 ", -1,
+              "1abcdefg",  -1,
+              "12345674",  -1,
+              " 2abc",     -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+  assert_proto_server_fetch(proto, "01\n",     3);
+  assert_proto_server_fetch(proto, "1abcdefg", 8);
+  // dropping: 1234567
+  assert_proto_server_fetch(proto, "2abc",  4);
+  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+}
+
+Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_one_big_message)
+{
+
+  /* Input is bigger than the buffer size. With a small and a bigger (expected to be trimmed) message.
+   * There is a small message and a large message.*/
+  LogProtoServer *proto;
+  proto_server_options.max_msg_size = 10;
+  proto_server_options.trim_large_messages = TRUE;
+  proto = log_proto_framed_server_new(
+            log_transport_mock_stream_new(
+              "2 ab16 0123456789ABCDEF", -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+  assert_proto_server_fetch(proto, "ab",          2);
+  assert_proto_server_fetch(proto, "0123456789", 10);
+}
+
 Test(log_proto, test_log_proto_framed_server_message_exceeds_buffer)
 {
   LogProtoServer *proto;


### PR DESCRIPTION
Add the `trim-large-messages` option to the logproto-framed-server. (syslog source driver)

Without trimming, the framed server simply drops oversized messages (>log_msg_size) and closes the incoming connection.
With trim-large-messages enabled, framed server will create a log message from the first (`log_msg_size` sized) part of the message, and ignores the rest of it. The communication will continue uniterrupted with the following message.

TODO:
- [ ] The trim action can be propagated back towards `LogReader` via `LogTransportAuxData`, and can be marked on the new log message i.e. with a `tag`. But I don't like the idea, that `LogReader` has to deal with a property from one specific protocol.