### PR TITLE
cmake: disable_all_modules support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include(CheckIncludeFiles)
 include(ExternalProject)
 include(external_or_find_package)
 include(add_tests)
+include(module_switch)
 
 set(MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/tests/valgrind/unit-test-leak.supp")
 set(MEMORYCHECK_COMMAND_OPTIONS "--num-callers=30 --sim-hints=no-nptl-pthread-stackcache --gen-suppressions=all --leak-check=full --freelist-vol=200000000 --freelist-big-blocks=10000000 --malloc-fill=55 --free-fill=AA")
@@ -88,7 +89,7 @@ check_struct_member ("struct msghdr" "msg_control" "sys/types.h;sys/socket.h" SY
 
 include(CheckIPv6)
 
-option(ENABLE_IPV6 "Enable IPv6" ON)
+module_switch(ENABLE_IPV6 "Enable IPv6")
 if (ENABLE_IPV6)
     set(SYSLOG_NG_ENABLE_IPV6 ${HAVE_IPV6})
 endif()
@@ -182,11 +183,7 @@ find_package(Inotify)
 find_package(LIBCAP)
 
 find_package(systemd)
-if (Libsystemd_FOUND)
-  option (ENABLE_JOURNALD "Enable systemd-journal" ON)
-else()
-  option (ENABLE_JOURNALD "Enable systemd-journal" OFF)
-endif()
+module_switch(ENABLE_JOURNALD "Enable systemd-journal" Libsystemd_FOUND)
 set(WITH_SYSTEMD_JOURNAL "system" CACHE STRING "Link against the system supplied or the wrapper library")
 set_property(CACHE WITH_SYSTEMD_JOURNAL PROPERTY STRINGS system wrapper)
 

--- a/cmake/module_switch.cmake
+++ b/cmake/module_switch.cmake
@@ -1,0 +1,44 @@
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+option(DISABLE_ALL_MODULES "disable all switchable modules by default" "OFF")
+
+function (module_switch NAME HELP_STRING)
+  if (DEFINED ${NAME})
+    return()
+  endif()
+
+  if (DISABLE_ALL_MODULES)
+    option(${NAME} ${HELP_STRING} "OFF")
+    return ()
+  endif()
+
+  foreach (symbol ${ARGN})
+    if (NOT ${symbol})
+      option(${NAME} "${HELP_STRING}" "OFF")
+      return()
+    endif()
+  endforeach()
+
+  option(${NAME} "${HELP_STRING}" "ON")
+endfunction ()

--- a/dev-utils/plugin_skeleton_creator/plugin_template_CMakeLists.txt
+++ b/dev-utils/plugin_skeleton_creator/plugin_template_CMakeLists.txt
@@ -16,8 +16,7 @@ bison_target(@PLUGIN_NAME@Grammar
     ${CMAKE_CURRENT_BINARY_DIR}/@PLUGIN_NAME@-grammar.c
 COMPILE_FLAGS ${BISON_FLAGS})
 
-option(ENABLE_@PLUGIN_NAME_US@ "Enable @PLUGIN_NAME@" ON)
-
+module_switch(ENABLE_@PLUGIN_NAME_US@ "Enable @PLUGIN_NAME@")
 if (ENABLE_@PLUGIN_NAME_US@)
   add_library(@PLUGIN_NAME_US@ SHARED ${@PLUGIN_NAME@_SOURCES})
   target_include_directories(@PLUGIN_NAME_US@

--- a/lib/filter/tests/CMakeLists.txt
+++ b/lib/filter/tests/CMakeLists.txt
@@ -42,7 +42,9 @@ add_unit_test(CRITERION TARGET test_filters_netmask SOURCES ${TEST_FILTERS_NETMA
 
 add_unit_test(CRITERION TARGET test_filters_in_list DEPENDS syslogformat)
 
+if (ENABLE_IPV6)
 add_unit_test(CRITERION TARGET test_filters_netmask6 SOURCES ${TEST_FILTERS_NETMASK6_SOURCE} DEPENDS syslogformat)
+endif()
 
 add_unit_test(CRITERION TARGET test_filters_statistics DEPENDS syslogformat)
 

--- a/modules/afamqp/CMakeLists.txt
+++ b/modules/afamqp/CMakeLists.txt
@@ -1,11 +1,6 @@
 find_package(RabbitMQ)
 
-if (RabbitMQ_FOUND)
-  option(ENABLE_AFAMQP "Enable afamqp module" ON)
-else()
-  option(ENABLE_AFAMQP "Enable afamqp module" OFF)
-endif()
-
+module_switch(ENABLE_AFAMQP "Enable afamqp module" RabbitMQ_FOUND)
 if (ENABLE_AFAMQP)
 
 set(AFAMQP_HEADERS

--- a/modules/afsmtp/CMakeLists.txt
+++ b/modules/afsmtp/CMakeLists.txt
@@ -16,12 +16,7 @@ COMPILE_FLAGS ${BISON_FLAGS})
 
 generate_y_from_ym(modules/afsmtp/afsmtp-grammar)
 
-if (ESMTP_FOUND)
-    option(ENABLE_AFSMTP "Enable SMTP destination" ON)
-else()
-    option(ENABLE_AFSMTP "Enable SMTP destination" OFF)
-endif()
-
+module_switch(ENABLE_AFSMTP "Enable SMTP destination" ESMTP_FOUND)
 if (ENABLE_AFSMTP)
     add_library(afsmtp MODULE ${AFSMTP_SOURCES})
     target_link_libraries (afsmtp PUBLIC ${ESMTP_LIBRARIES})

--- a/modules/afsql/CMakeLists.txt
+++ b/modules/afsql/CMakeLists.txt
@@ -11,12 +11,7 @@ set(AFSQL_SOURCES
 find_package(LibDBI)
 find_package(OpenSSL)
 
-if(LIBDBI_FOUND)
-    option(ENABLE_SQL "Enable SQL plugin" ON)
-else()
-    option(ENABLE_SQL "Enable SQL plugin" OFF)
-endif()
-
+module_switch(ENABLE_SQL "Enable SQL plugin" LIBDBI_FOUND)
 if (ENABLE_SQL)
     generate_y_from_ym(modules/afsql/afsql-grammar)
 

--- a/modules/afstomp/CMakeLists.txt
+++ b/modules/afstomp/CMakeLists.txt
@@ -11,7 +11,7 @@ set(AFSTOMP_SOURCES
 
 set(AFSTOMP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-option(ENABLE_STOMP "Enable STOMP destination" ON)
+module_switch(ENABLE_STOMP "Enable STOMP destination")
 
 if (ENABLE_STOMP)
     generate_y_from_ym(modules/afstomp/afstomp-grammar)

--- a/modules/afstreams/CMakeLists.txt
+++ b/modules/afstreams/CMakeLists.txt
@@ -12,12 +12,7 @@ include (CheckIncludeFile)
 check_include_file(sys/strlog.h HAVE_STRLOG)
 check_include_file(stropts.h HAVE_STROPTS)
 
-if(HAVE_STRLOG AND HAVE_STROPTS)
-    option(ENABLE_SUN_STREAMS "Enable Sun Streams source" ON)
-else()
-    option(ENABLE_SUN_STREAMS "Enable Sun Streams source" OFF)
-endif()
-
+module_switch(ENABLE_SUN_STREAMS "Enable Sun Streams source" HAVE_STRLOG HAVE_STROPTS)
 if (ENABLE_SUN_STREAMS)
     generate_y_from_ym(modules/afstreams/afstreams-grammar)
 

--- a/modules/afuser/CMakeLists.txt
+++ b/modules/afuser/CMakeLists.txt
@@ -18,7 +18,7 @@ bison_target(AfuserGrammar
   ${CMAKE_CURRENT_BINARY_DIR}/afuser-grammar.c
 COMPILE_FLAGS ${BISON_FLAGS})
 
-option(ENABLE_AFUSER "Enable afuser module" ON)
+module_switch(ENABLE_AFUSER "Enable afuser module")
 
 if (ENABLE_AFUSER)
   add_library(afuser MODULE ${AFUSER_SOURCES})

--- a/modules/appmodel/CMakeLists.txt
+++ b/modules/appmodel/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(ENABLE_APPMODEL "Enable AppModel" ON)
+module_switch(ENABLE_APPMODEL "Enable AppModel")
 
 if (ENABLE_APPMODEL)
 

--- a/modules/basicfuncs/CMakeLists.txt
+++ b/modules/basicfuncs/CMakeLists.txt
@@ -1,15 +1,11 @@
-option(ENABLE_BASICFUNCS "Enable basic template functions" ON)
+set (BASICFUNCS_SOURCES
+  basic-funcs.c
+)
 
-if (ENABLE_BASICFUNCS)
-  set (BASICFUNCS_SOURCES
-    basic-funcs.c
-  )
+add_library(basicfuncs SHARED ${BASICFUNCS_SOURCES})
+target_include_directories (basicfuncs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(basicfuncs PRIVATE syslog-ng)
 
-  add_library(basicfuncs SHARED ${BASICFUNCS_SOURCES})
-  target_include_directories (basicfuncs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_link_libraries(basicfuncs PRIVATE syslog-ng)
+install(TARGETS basicfuncs LIBRARY DESTINATION lib/syslog-ng/ COMPONENT basicfuncs)
 
-  install(TARGETS basicfuncs LIBRARY DESTINATION lib/syslog-ng/ COMPONENT basicfuncs)
-
-  add_test_subdirectory(tests)
-endif (ENABLE_BASICFUNCS)
+add_test_subdirectory(tests)

--- a/modules/geoip/CMakeLists.txt
+++ b/modules/geoip/CMakeLists.txt
@@ -15,12 +15,7 @@ generate_y_from_ym(modules/geoip/geoip-parser-grammar)
 
 find_package(LibGeoIP)
 
-if(LIBGEOIP_FOUND)
-    option(ENABLE_GEOIP "Enable GeoIP parser" ON)
-else()
-    option(ENABLE_GEOIP "Enable GeoIP parser" OFF)
-endif()
-
+module_switch(ENABLE_GEOIP "Enable GeoIP parser" LIBGEOIP_FOUND)
 if (ENABLE_GEOIP)
     bison_target(GeoIPGrammar
         ${CMAKE_CURRENT_BINARY_DIR}/geoip-parser-grammar.y

--- a/modules/geoip2/CMakeLists.txt
+++ b/modules/geoip2/CMakeLists.txt
@@ -1,9 +1,6 @@
 find_package(LibMaxMindDB)
-if (LIBMAXMINDDB_FOUND)
-  option(ENABLE_GEOIP2 "Enable geoip2 parser and template function" ON)
-else()
-  option(ENABLE_GEOIP2 "Enable geoip2 parser and template function" OFF)
-endif()
+
+module_switch(ENABLE_GEOIP2 "Enable geoip2 parser and template function" LIBMAXMINDDB_FOUND)
 
 if (NOT ENABLE_GEOIP2)
   return ()

--- a/modules/getent/CMakeLists.txt
+++ b/modules/getent/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(ENABLE_GETENT "Enable getent" ON)
+module_switch(ENABLE_GETENT "Enable getent")
 
 if (NOT ENABLE_GETENT)
   return ()

--- a/modules/hook-commands/CMakeLists.txt
+++ b/modules/hook-commands/CMakeLists.txt
@@ -13,7 +13,7 @@ set(HOOK_COMMANDS_SOURCES
 
 generate_y_from_ym(modules/hook-commands/hook-commands-grammar)
 
-option(ENABLE_HOOK_COMMANDS "Enable hook-commands module" ON)
+module_switch(ENABLE_HOOK_COMMANDS "Enable hook-commands module")
 
 if (ENABLE_HOOK_COMMANDS)
   bison_target(HookCommandsGrammar
@@ -30,4 +30,3 @@ if (ENABLE_HOOK_COMMANDS)
 
   install(TARGETS hook-commands LIBRARY DESTINATION lib/syslog-ng/ COMPONENT hook-commands)
 endif()
-

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -1,11 +1,6 @@
 find_package(Curl)
 
-if (Curl_FOUND)
-  option(ENABLE_CURL "Enable http destination" ON)
-else ()
-  option(ENABLE_CURL "Enable http destination" OFF)
-endif()
-
+module_switch(ENABLE_CURL "Enable http destination" Curl_FOUND)
 if (NOT ENABLE_CURL)
   return ()
 endif ()

--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -66,22 +66,10 @@ bison_target(ModJavaGrammar
 
 find_package(Java 1.7)
 
-if (JAVA_FOUND AND Java_JAVAH_EXECUTABLE)
-  OPTION(ENABLE_JAVA "Enable java module" ON)
-else()
-  OPTION(ENABLE_JAVA "Enable java module" OFF)
-endif()
-
+module_switch(ENABLE_JAVA "Enable java module" JAVA_FOUND Java_JAVAH_EXECUTABLE)
 if (ENABLE_JAVA)
 
-find_package(JNI)
-
-if (Java_JAVAH_EXECUTABLE)
-  OPTION(ENABLE_JAVA "Enable java module" ON)
-else()
-  OPTION(ENABLE_JAVA "Enable java module" OFF)
-endif()
-
+  find_package(JNI)
   include(UseJava)
 
   add_jar(syslog-ng-core

--- a/modules/json/CMakeLists.txt
+++ b/modules/json/CMakeLists.txt
@@ -16,12 +16,7 @@ set(JSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 external_or_find_package(JSONC)
 
-if(JSONC_FOUND)
-    option(ENABLE_JSON "Enable JSON plugin" ON)
-else()
-    option(ENABLE_JSON "Enable JSON plugin" OFF)
-endif()
-
+module_switch(ENABLE_JSON "Enable JSON plugin" JSONC_FOUND)
 if (ENABLE_JSON)
     generate_y_from_ym(modules/json/json-parser-grammar)
 

--- a/modules/json/CMakeLists.txt
+++ b/modules/json/CMakeLists.txt
@@ -41,6 +41,5 @@ if (JSONC_INTERNAL)
 endif()
 
     install(TARGETS json-plugin LIBRARY DESTINATION lib/syslog-ng/ COMPONENT json)
+    add_test_subdirectory(tests)
 endif()
-
-add_test_subdirectory(tests)

--- a/modules/map-value-pairs/CMakeLists.txt
+++ b/modules/map-value-pairs/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(ENABLE_MAP_VALUE_PAIRS "Enable map-value-pairs" ON)
+module_switch(ENABLE_MAP_VALUE_PAIRS "Enable map-value-pairs")
 
 if (NOT ENABLE_MAP_VALUE_PAIRS)
   return()

--- a/modules/native/CMakeLists.txt
+++ b/modules/native/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(ENABLE_NATIVE "Enable to build native bindings (for Rust, C++)" ON)
+module_switch(ENABLE_NATIVE "Enable to build native bindings (for Rust, C++)")
 
 set (NATIVE_SOURCES
     native-parser.c

--- a/modules/openbsd/CMakeLists.txt
+++ b/modules/openbsd/CMakeLists.txt
@@ -1,8 +1,9 @@
 if (CMAKE_SYSTEM_NAME EQUAL "OpenBSD")
-    option(ENABLE_OPENBSD_SYS_DRIVER "Enable openBSD system source driver" ON)
+  set(IS_OPENBSD "ON")
 else()
-    option(ENABLE_OPENBSD_SYS_DRIVER "Enable openBSD system source driver" OFF)
+  set(IS_OPENBSD "OFF")
 endif()
+module_switch(ENABLE_OPENBSD_SYS_DRIVER "Enable openBSD system source driver" IS_OPENBSD)
 
 if (ENABLE_OPENBSD_SYS_DRIVER AND NOT CMAKE_SYSTEM_NAME EQUAL "OpenBSD")
     message(FATAL_ERROR "OpenBSD source was explicitely enabled, but OS is not OpenBSD")

--- a/modules/pacctformat/CMakeLists.txt
+++ b/modules/pacctformat/CMakeLists.txt
@@ -5,10 +5,11 @@ set(PACCT_FORMAT_SOURCES
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL Linux)
-    option(ENABLE_PACCT "Enable support for reading Process Accounting files (EXPERIMENTAL, Linux only)." ON)
+  set(IS_LINUX "ON")
 else()
-    option(ENABLE_PACCT "Enable support for reading Process Accounting files (EXPERIMENTAL, Linux only)." OFF)
+  set(IS_LINUX "OFF")
 endif()
+module_switch(ENABLE_PACCT "Enable support for reading Process Accounting files (EXPERIMENTAL, Linux only)." IS_LINUX)
 
 if (ENABLE_PACCT)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -1,9 +1,4 @@
-if (PYTHONLIBS_FOUND)
-  option(ENABLE_PYTHON "Enable Python module" ON)
-else()
-  option(ENABLE_PYTHON "Enable Python module" OFF)
-endif()
-
+module_switch(ENABLE_PYTHON "Enable Python module" PYTHONLIBS_FOUND)
 if (NOT ENABLE_PYTHON)
   return()
 endif ()

--- a/modules/redis/CMakeLists.txt
+++ b/modules/redis/CMakeLists.txt
@@ -14,12 +14,7 @@ generate_y_from_ym(modules/redis/redis-grammar)
 
 find_package(Hiredis)
 
-if (HIREDIS_FOUND)
-  option(ENABLE_REDIS "Enable redis module" ON)
-else()
-  option(ENABLE_REDIS "Enable redis module" OFF)
-endif()
-
+module_switch(ENABLE_REDIS "Enable redis module" HIREDIS_FOUND)
 if (ENABLE_REDIS)
   bison_target(RedisGrammar
       ${CMAKE_CURRENT_BINARY_DIR}/redis-grammar.y

--- a/modules/riemann/CMakeLists.txt
+++ b/modules/riemann/CMakeLists.txt
@@ -23,12 +23,7 @@ if (SYSLOG_NG_HAVE_RIEMANN_MICROSECONDS)
   add_definitions("-DSYSLOG_NG_HAVE_RIEMANN_MICROSECONDS=1")
 endif()
 
-if (Riemann_FOUND)
-    option(ENABLE_RIEMANN "Enable riemann destination" ON)
-else()
-    option(ENABLE_RIEMANN "Enable riemann destination" OFF)
-endif()
-
+module_switch(ENABLE_RIEMANN "Enable riemann destination" Riemann_FOUND)
 if (NOT ENABLE_RIEMANN)
   return()
 endif()

--- a/modules/snmptrapd-parser/CMakeLists.txt
+++ b/modules/snmptrapd-parser/CMakeLists.txt
@@ -19,7 +19,7 @@ bison_target(snmptrapd-parserGrammar
     ${CMAKE_CURRENT_BINARY_DIR}/snmptrapd-parser-grammar.c
 COMPILE_FLAGS ${BISON_FLAGS})
 
-option(ENABLE_SNMPTRAPD_PARSER "Enable snmptrapd-parser" ON)
+module_switch(ENABLE_SNMPTRAPD_PARSER "Enable snmptrapd-parser")
 
 if (ENABLE_SNMPTRAPD_PARSER)
   add_library(snmptrapd_parser SHARED ${SNMPTRAPD_PARSER_SOURCES})

--- a/modules/stardate/CMakeLists.txt
+++ b/modules/stardate/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(ENABLE_STARDATE "Enable stardate" ON)
+module_switch(ENABLE_STARDATE "Enable stardate")
 
 if (ENABLE_STARDATE)
   set(stardate_SOURCES
@@ -7,7 +7,7 @@ if (ENABLE_STARDATE)
   add_library(stardate SHARED ${stardate_SOURCES})
   target_link_libraries(stardate PRIVATE syslog-ng m)
 
-  install(TARGETS stardate LIBRARY DESTINATION lib/syslog-ng/ COMPONENT stardate) 
+  install(TARGETS stardate LIBRARY DESTINATION lib/syslog-ng/ COMPONENT stardate)
 
   add_test_subdirectory(tests)
 endif()

--- a/modules/xml/CMakeLists.txt
+++ b/modules/xml/CMakeLists.txt
@@ -18,7 +18,7 @@ bison_target(xmlGrammar
     ${CMAKE_CURRENT_BINARY_DIR}/xml-grammar.c
 COMPILE_FLAGS ${BISON_FLAGS})
 
-option(ENABLE_XML "Enable xml" ON)
+module_switch(ENABLE_XML "Enable xml")
 
 if (ENABLE_XML)
   add_library(xml SHARED ${xml_SOURCES})


### PR DESCRIPTION
- If `-DDISABLE_ALL_MODULES=yes` specified for cmake, all switchable modules are disabled by default. One can still override specific modules by: `-DDISABLE_ALL_MODULES=yes -DENABLE_PYTHON=yes`. The order of definitions do not matter.
- Fixed a bug, when `-DENABLE_IPV6=no` resulted in compile error in a unit test.
- Fixed a bug when json unit tests were still tried to compiled even without json support.
- Removed `-DENABLE_BASICFUNCS`, as it causes compile error in some unit tests, it is not switchable in autotools, and does not have any external dependencies.
