### PR TITLE
stats: deindex pruned counters/clusters

### DIFF
--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -438,3 +438,16 @@ stats_query_index_counter(StatsCluster *cluster, gint type)
 {
   _add_counter_to_index(cluster, type);
 }
+
+static void
+_deindex_cluster_helper(StatsCluster *cluster, gint type, StatsCounterItem *item, gpointer user_data)
+{
+  if (stats_cluster_is_indexed(cluster, type))
+    _remove_counter_from_index(cluster, type);
+}
+
+void
+stats_query_deindex_cluster(StatsCluster *cluster)
+{
+  stats_cluster_foreach_counter(cluster, _deindex_cluster_helper, NULL);
+}

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -43,4 +43,5 @@ void stats_query_deinit(void);
 
 void stats_register_view(gchar *name, GList *queries, const AggregatedMetricsCb aggregate);
 void stats_query_index_counter(StatsCluster *cluster, gint type);
+void stats_query_deindex_cluster(StatsCluster *cluster);
 #endif

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -115,7 +115,7 @@ typedef struct _StatsTimerState
 } StatsTimerState;
 
 static gboolean
-stats_prune_counter(StatsCluster *sc, StatsTimerState *st)
+stats_prune_cluster(StatsCluster *sc, StatsTimerState *st)
 {
   gboolean expired;
 
@@ -137,7 +137,7 @@ stats_format_and_prune_cluster(StatsCluster *sc, gpointer user_data)
 
   if (st->stats_event)
     stats_log_format_cluster(sc, st->stats_event);
-  return stats_prune_counter(sc, st);
+  return stats_prune_cluster(sc, st);
 }
 
 void

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -126,6 +126,7 @@ stats_prune_cluster(StatsCluster *sc, StatsTimerState *st)
       if ((st->oldest_counter) == 0 || st->oldest_counter > tstamp)
         st->oldest_counter = tstamp;
       st->dropped_counters++;
+      stats_query_deindex_cluster(sc);
     }
   return expired;
 }


### PR DESCRIPTION
Dynamic counters/clusters were freed after they became expired, but they stayed in the `counter_index`, which is used for `get` queries. When we tried to access these freed counters from the index, we got undefined behavior, possibly SEGFAULT.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>