### PR TITLE
logreader/logwriter: fix race condition of idle timer and scheduled I/O job

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -197,6 +197,7 @@ log_reader_io_handle_in(gpointer s)
   LogReader *self = (LogReader *) s;
 
   log_reader_stop_watches(self);
+  log_reader_stop_idle_timer(self);
   if ((self->options->flags & LR_THREADED))
     {
       main_loop_io_worker_job_submit(&self->io_job, G_IO_IN);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -633,6 +633,7 @@ log_reader_idle_timeout(void *cookie)
 {
   LogReader *self = (LogReader *) cookie;
 
+  g_assert(!self->io_job.working);
   msg_notice("Source timeout has elapsed, closing connection",
              evt_tag_int("fd", log_proto_server_get_fd(self->proto)));
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -92,7 +92,7 @@ struct _LogWriter
   gboolean work_result;
   gint pollable_state;
   LogProtoClient *proto, *pending_proto;
-  gboolean watches_running:1, suspended:1, working:1, waiting_for_throttle:1;
+  gboolean watches_running:1, suspended:1, waiting_for_throttle:1;
   gboolean pending_proto_present;
   GCond *pending_proto_cond;
   GStaticMutex pending_proto_lock;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -252,6 +252,7 @@ log_writer_io_handler(gpointer s, GIOCondition cond)
   main_loop_assert_main_thread();
 
   log_writer_stop_watches(self);
+  log_writer_stop_idle_timer(self);
   if ((self->options->options & LWO_THREADED))
     {
       main_loop_io_worker_job_submit(&self->io_job, cond);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1307,6 +1307,7 @@ log_writer_idle_timeout(void *cookie)
 {
   LogWriter *self = (LogWriter *) cookie;
 
+  g_assert(!self->io_job.working);
   msg_notice("Destination timeout has elapsed, closing connection",
              evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
 


### PR DESCRIPTION
There is a race condition between scheduled I/O operations in worker threads and closing the idle connections (response/ack_timeout timer).
There is no protection - in afsocket source-driver - to not destroy connections(readers), which have scheduled I/O operation (not like when we reap writers on file dest. side).

The idle timer is not stopped, just when an I/O operation finished and we would like to re-schedule the next action on source side (update_watches() ).
The timer can trigger a connection closing, although there is schedule I/O operation.

Timer should be stopped when we schedule an I/O.
This way we eliminate the race condition between 2 sides.
We do stop I/O polling (see calling log_reader_stop_watches() in log_reader_io_handle_in()), so stopping the idle timer makes sens.

UPDATE:
    About stop_idle_timer cals in update_watches:
    Initially I thought that calling idle_timer is unnecessary in update_watches,
    since we stop the timer in io_handle. I've ven put an assertion to the timer registration,
    disabling timer re-registering.
    I forgot that in case of suspend, we will call an update_watches again, where an idle_timer
    registration will fail due to the assertion.
