### PR TITLE
db-parser: support for program_template

### DIFF
--- a/modules/dbparser/CMakeLists.txt
+++ b/modules/dbparser/CMakeLists.txt
@@ -24,6 +24,7 @@ set(PATTERNDB_SOURCES
     pdb-ratelimit.c
     pdb-ratelimit.h
     pdb-lookup-params.h
+    pdb-lookup-params.c
     correllation.c
     correllation.h
     correllation-key.c

--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -26,6 +26,7 @@ modules_dbparser_libsyslog_ng_patterndb_la_SOURCES	=	\
 	modules/dbparser/pdb-ratelimit.c			\
 	modules/dbparser/pdb-ratelimit.h			\
 	modules/dbparser/pdb-lookup-params.h			\
+	modules/dbparser/pdb-lookup-params.c			\
 	modules/dbparser/correllation.c				\
 	modules/dbparser/correllation.h				\
 	modules/dbparser/correllation-key.c			\

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -67,6 +67,7 @@ SyntheticMessage *last_message;
 %token KW_DROP_UNMATCHED
 %token KW_FILE
 %token KW_PROGRAM_TEMPLATE
+%token KW_MESSAGE_TEMPLATE
 
 %type <num> stateful_parser_inject_mode
 %type <ptr> synthetic_message
@@ -106,6 +107,7 @@ parser_db_opt
           {
              log_db_parser_set_program_template_ref(last_parser, $3);
           }
+        | KW_MESSAGE_TEMPLATE '(' template_content ')'    { log_parser_set_template(last_parser, $3); }
 	| stateful_parser_opt
         ;
 

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -66,6 +66,7 @@ SyntheticMessage *last_message;
 %token KW_VALUE
 %token KW_DROP_UNMATCHED
 %token KW_FILE
+%token KW_PROGRAM_TEMPLATE
 
 %type <num> stateful_parser_inject_mode
 %type <ptr> synthetic_message
@@ -101,6 +102,10 @@ parser_db_opts
 parser_db_opt
         : KW_FILE '(' string ')'                		{ log_db_parser_set_db_file(((LogDBParser *) last_parser), $3); free($3); }
 	| KW_DROP_UNMATCHED '(' yesno ')'			{ log_db_parser_set_drop_unmatched(((LogDBParser *) last_parser), $3); };
+        | KW_PROGRAM_TEMPLATE '(' template_content ')'
+          {
+             log_db_parser_set_program_template_ref(last_parser, $3);
+          }
 	| stateful_parser_opt
         ;
 
@@ -201,4 +206,3 @@ context_scope
 /* INCLUDE_RULES */
 
 %%
-

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -48,6 +48,7 @@ static CfgLexerKeyword dbparser_keywords[] =
   { "trigger",            KW_TRIGGER },
   { "value",              KW_VALUE },
   { "program_template",   KW_PROGRAM_TEMPLATE },
+  { "message_template",   KW_MESSAGE_TEMPLATE },
   { NULL }
 };
 

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -47,6 +47,7 @@ static CfgLexerKeyword dbparser_keywords[] =
   { "having",             KW_HAVING },
   { "trigger",            KW_TRIGGER },
   { "value",              KW_VALUE },
+  { "program_template",   KW_PROGRAM_TEMPLATE },
   { NULL }
 };
 

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -32,6 +32,7 @@
 typedef struct _LogDBParser LogDBParser;
 
 void log_db_parser_set_drop_unmatched(LogDBParser *self, gboolean setting);
+void log_db_parser_set_program_template_ref(LogParser *s, LogTemplate *program_template);
 void log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file);
 LogParser *log_db_parser_new(GlobalConfig *cfg);
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -714,9 +714,7 @@ pattern_db_process_with_custom_message(PatternDB *self, LogMessage *msg, const g
   PDBLookupParams lookup;
 
   pdb_lookup_params_init(&lookup, msg);
-  lookup.message_handle = LM_V_NONE;
-  lookup.message_string = message;
-  lookup.message_len = message_len;
+  pdb_lookup_params_override_message(&lookup, message, message_len);
   return _pattern_db_process(self, &lookup, NULL);
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -65,6 +65,7 @@ struct _PatternDB
   GStaticRWLock lock;
   PDBRuleSet *ruleset;
   CorrellationState correllation;
+  LogTemplate *program_template;
   GHashTable *rate_limits;
   TimerWheel *timer_wheel;
   GTimeVal last_tick;
@@ -560,6 +561,13 @@ pattern_db_set_emit_func(PatternDB *self, PatternDBEmitFunc emit, gpointer emit_
   self->emit_data = emit_data;
 }
 
+void
+pattern_db_set_program_template(PatternDB *self, LogTemplate *program_template)
+{
+  log_template_unref(self->program_template);
+  self->program_template = log_template_ref(program_template);
+}
+
 const gchar *
 pattern_db_get_ruleset_pub_date(PatternDB *self)
 {
@@ -786,6 +794,7 @@ pattern_db_new(void)
 void
 pattern_db_free(PatternDB *self)
 {
+  log_template_unref(self->program_template);
   if (self->ruleset)
     pdb_rule_set_free(self->ruleset);
   _destroy_state(self);

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -712,7 +712,7 @@ pattern_db_process(PatternDB *self, LogMessage *msg)
 {
   PDBLookupParams lookup;
 
-  pdb_lookup_params_init(&lookup, msg);
+  pdb_lookup_params_init(&lookup, msg, self->program_template);
   return _pattern_db_process(self, &lookup, NULL);
 }
 
@@ -721,7 +721,7 @@ pattern_db_process_with_custom_message(PatternDB *self, LogMessage *msg, const g
 {
   PDBLookupParams lookup;
 
-  pdb_lookup_params_init(&lookup, msg);
+  pdb_lookup_params_init(&lookup, msg, self->program_template);
   pdb_lookup_params_override_message(&lookup, message, message_len);
   return _pattern_db_process(self, &lookup, NULL);
 }
@@ -731,7 +731,7 @@ pattern_db_debug_ruleset(PatternDB *self, LogMessage *msg, GArray *dbg_list)
 {
   PDBLookupParams lookup;
 
-  pdb_lookup_params_init(&lookup, msg);
+  pdb_lookup_params_init(&lookup, msg, NULL);
   _pattern_db_process(self, &lookup, dbg_list);
 }
 

--- a/modules/dbparser/patterndb.h
+++ b/modules/dbparser/patterndb.h
@@ -32,6 +32,7 @@ typedef struct _PatternDB PatternDB;
 
 typedef void (*PatternDBEmitFunc)(LogMessage *msg, gboolean synthetic, gpointer user_data);
 void pattern_db_set_emit_func(PatternDB *self, PatternDBEmitFunc emit_func, gpointer emit_data);
+void pattern_db_set_program_template(PatternDB *self, LogTemplate *program_template);
 
 PDBRuleSet *pattern_db_get_ruleset(PatternDB *self);
 const gchar *pattern_db_get_ruleset_version(PatternDB *self);

--- a/modules/dbparser/pdb-lookup-params.c
+++ b/modules/dbparser/pdb-lookup-params.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2017 Balabit
- * Copyright (c) 1998-2017 Balázs Scheidler
+ * Copyright (c) 2019 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,30 +20,28 @@
  *
  */
 
-#ifndef PATTERNDB_PDB_LOOKUP_PARAMS_H_INCLUDED
-#define PATTERNDB_PDB_LOOKUP_PARAMS_H_INCLUDED
+#include "pdb-lookup-params.h"
 
-#include <template/templates.h>
-#include "logmsg/logmsg.h"
-
-typedef struct _PDBLookupParams PDBLookupParams;
-struct _PDBLookupParams
+static void
+_set_program_template(PDBLookupParams *lookup, LogTemplate *program_template)
 {
-  LogMessage *msg;
-  NVHandle program_handle;
-  LogTemplate *program_template;
-  NVHandle message_handle;
-  const gchar *message_string;
-  gssize message_len;
+  if (program_template)
+    {
+      lookup->program_handle = LM_V_NONE;
+      lookup->program_template = program_template;
+    }
+  else
+    {
+      lookup->program_handle = LM_V_PROGRAM;
+    }
 };
 
-void pdb_lookup_params_init(PDBLookupParams *lookup, LogMessage *msg, LogTemplate *program_template);
-
-static inline void
-pdb_lookup_params_override_message(PDBLookupParams *lookup, const gchar *message, gssize message_len)
+void
+pdb_lookup_params_init(PDBLookupParams *lookup, LogMessage *msg, LogTemplate *program_template)
 {
-  lookup->message_handle = LM_V_NONE;
-  lookup->message_string = message;
-  lookup->message_len = message_len;
+  lookup->msg = msg;
+  lookup->message_handle = LM_V_MESSAGE;
+  lookup->message_len = 0;
+
+  _set_program_template(lookup, program_template);
 }
-#endif

--- a/modules/dbparser/pdb-lookup-params.h
+++ b/modules/dbparser/pdb-lookup-params.h
@@ -43,4 +43,11 @@ pdb_lookup_params_init(PDBLookupParams *lookup, LogMessage *msg)
   lookup->message_len = 0;
 }
 
+static inline void
+pdb_lookup_params_override_message(PDBLookupParams *lookup, const gchar *message, gssize message_len)
+{
+  lookup->message_handle = LM_V_NONE;
+  lookup->message_string = message;
+  lookup->message_len = message_len;
+}
 #endif

--- a/modules/dbparser/pdb-ruleset.c
+++ b/modules/dbparser/pdb-ruleset.c
@@ -64,6 +64,11 @@ _add_matches_to_message(LogMessage *msg, GArray *matches, NVHandle ref_handle, c
     }
 }
 
+const gchar *
+_calculate_program(PDBLookupParams *lookup, LogMessage *msg, gssize *program_len)
+{
+  return log_msg_get_value(msg, lookup->program_handle, program_len);
+}
 
 /*
  * Looks up a matching rule in the ruleset.
@@ -82,7 +87,7 @@ pdb_ruleset_lookup(PDBRuleSet *rule_set, PDBLookupParams *lookup, GArray *dbg_li
   if (G_UNLIKELY(!rule_set->programs))
     return FALSE;
 
-  program_value = log_msg_get_value(msg, lookup->program_handle, &program_len);
+  program_value = _calculate_program(lookup, msg, &program_len);
   prg_matches = g_array_new(FALSE, TRUE, sizeof(RParserMatch));
   node = r_find_node(rule_set->programs, (gchar *) program_value, program_len, prg_matches);
 

--- a/modules/dbparser/pdb-ruleset.c
+++ b/modules/dbparser/pdb-ruleset.c
@@ -23,6 +23,7 @@
 #include "pdb-ruleset.h"
 #include "pdb-program.h"
 #include "pdb-lookup-params.h"
+#include "scratch-buffers.h"
 
 static NVHandle class_handle = 0;
 static NVHandle rule_id_handle = 0;
@@ -67,7 +68,13 @@ _add_matches_to_message(LogMessage *msg, GArray *matches, NVHandle ref_handle, c
 const gchar *
 _calculate_program(PDBLookupParams *lookup, LogMessage *msg, gssize *program_len)
 {
-  return log_msg_get_value(msg, lookup->program_handle, program_len);
+  if (lookup->program_handle)
+    return log_msg_get_value(msg, lookup->program_handle, program_len);
+
+  GString *program = scratch_buffers_alloc();
+  log_template_format(lookup->program_template, msg, NULL, LTZ_LOCAL, 0, NULL, program);
+  *program_len = program->len;
+  return program->str;
 }
 
 /*

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -738,6 +738,20 @@ Test(test_pathutils, test_pdb_get_filenames, .init = test_pdb_get_filenames_setu
   g_ptr_array_free(filenames, TRUE);
 }
 
+Test(pattern_db, match_in_program)
+{
+  gchar *filename;
+  PatternDB *patterndb = _create_pattern_db(pdb_test_match_in_program, &filename);
+
+  LogMessage *msg = _construct_message("sshd 5", "almafa");
+  _process(patterndb, msg);
+  assert_log_message_value(msg, log_msg_get_value_handle("num"), "5");
+
+  _destroy_pattern_db(patterndb, filename);
+  log_msg_unref(msg);
+  g_free(filename);
+}
+
 void setup(void)
 {
   app_startup();

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -752,6 +752,26 @@ Test(pattern_db, match_in_program)
   g_free(filename);
 }
 
+Test(pattern_db, test_program_template)
+{
+  gchar *filename;
+  PatternDB *patterndb = _create_pattern_db(pdb_test_program_template, &filename);
+
+  LogTemplate *template = log_template_new(configuration, NULL);
+  cr_assert(log_template_compile(template, "sshd 5", NULL));
+  pattern_db_set_program_template(patterndb, template);
+
+  LogMessage *msg = _construct_message("somethingelsethatdoesnotmatch", "almafa kortefa");
+  _process(patterndb, msg);
+  assert_log_message_value(msg, log_msg_get_value_handle("num"), "5");
+  assert_log_message_value(msg, log_msg_get_value_handle("str"), "kortefa");
+
+  _destroy_pattern_db(patterndb, filename);
+  log_msg_unref(msg);
+  g_free(filename);
+  log_template_unref(template);
+}
+
 void setup(void)
 {
   app_startup();

--- a/modules/dbparser/tests/test_patterndb.h
+++ b/modules/dbparser/tests/test_patterndb.h
@@ -535,4 +535,18 @@
  </ruleset>\
 </patterndb>"
 
+
+#define pdb_test_match_in_program "<patterndb version='5' pub_date='2010-02-22'>\
+<ruleset name='sshd' id='1'>\
+<patterns>\
+  <pattern>sshd @NUMBER:num@</pattern>\
+</patterns>\
+<rules>\
+  <rule id='12347598' class='sshd' provider='batman'>\
+     <patterns><pattern>almafa</pattern></patterns>\
+  </rule>\
+</rules>\
+</ruleset>\
+</patterndb>"
+
 #endif

--- a/modules/dbparser/tests/test_patterndb.h
+++ b/modules/dbparser/tests/test_patterndb.h
@@ -549,4 +549,17 @@
 </ruleset>\
 </patterndb>"
 
+#define pdb_test_program_template "<patterndb version='5' pub_date='2010-02-22'>\
+<ruleset name='sshd' id='1'>\
+<patterns>\
+  <pattern>sshd @NUMBER:num@</pattern>\
+</patterns>\
+<rules>\
+  <rule id='12347598' class='sshd' provider='batman'>\
+     <patterns><pattern>almafa @STRING:str@</pattern></patterns>\
+  </rule>\
+</rules>\
+</ruleset>\
+</patterndb>"
+
 #endif


### PR DESCRIPTION
Fixes: https://github.com/balabit/syslog-ng/issues/141

For now, the rule selection in db-parser is based on the `PROGRAM` macro value. This patchset makes this configurable: the selector can be specified by template.

There is a `template` option already available in `db-parser`, which defines the message that is processed by the parser (similarly to any other parsers). To avoid confusion with `program-template`, this patchset adds an alias for it: `message-template`.

There is an interesting feature in db-parser: pattern matching works in `PROGRAM`. It turned out that I do not need to deal with this functionality separately, it automatically worked after my changes. While I was in doubt, I saw that was not covered by a unit test, so I added one. In the example below, you can see an example for matching in program (`num`).

Example:
In the example below, `example-msg-generator` generates a general message. The reason we have a match is because the `program-template` and `message-template` is set in `db-parser`.

syslog-ng.conf
```
@version: 3.20

log {
  source { example-msg-generator(); };
  rewrite { set("5" value("foo")); };
  parser { db-parser(file("sshd.xml") message-template("sshd\n") program-template("sshd ${foo}")); };
  destination { file(/dev/stdout template("${.classifier.class} || ${num}\n")); };
};
```

sshd.xml
```
<patterndb version='5'><ruleset name='sshd' id='12345678'>
<patterns>
<pattern>sshd @NUMBER:num@</pattern>
</patterns>
<rules>
  <rule id='12347598' class='sshd' provider='balabit'>
     <patterns><pattern>sshd</pattern></patterns>
  </rule>
</rules>
</ruleset>
</patterndb>
```

Notes to reviewers:
- The functionality is generalized, but I still used `program-template` as a name, although `selector` or similar might have been better. The reason I stayed with it is because the term `program` is deeply part of the thought process in the module (grep for program in the module).
- grouping-by: grouping-by works a little bit differently, and the key is not only the program, but the collection of host+program+pid is used as a pre filter, then there is the `key-template` option. This changeset should not affect that behaviour.
-  pdbtool: pdbtool uses program for two reasons. One is to match an example message against the database. `pdbtool match` already has a `-P` option, that can be used to specify the program string. That option does not support templates, but for match testing I think that is good enough as it is. The other usage is testing message against an example message. Example message can be specified inside a patterndb database, and it can be used to make the database unit test-able. Similarly to match, it might make sense to support templates there too, but I think it is good enough for its purpose.