### PR TITLE
db-parser: fix memory leak

### DIFF
--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -477,9 +477,6 @@ _pdbl_rules_start(PDBLoader *state, const gchar *element_name, const gchar **att
 
   if (strcmp(element_name, "rule") == 0)
     {
-      if (state->current_rule)
-        pdb_rule_unref(state->current_rule);
-
       state->current_rule = pdb_rule_new();
       for (i = 0; attribute_names[i]; i++)
         {
@@ -610,7 +607,7 @@ _pdbl_rule_end(PDBLoader *state, const gchar *element_name, GError **error)
       /* valid, but we don't do anything */
     }
   else if (_pop_state_for_closing_tag_with_alternatives(state, element_name, "rule",
-                                                        "</patterns>, </description>, </tags>, </urls>, </values>", error) == 0)
+                                                        "</patterns>, </description>, </tags>, </urls>, </values>", error))
     {
       if (state->current_rule)
         {


### PR DESCRIPTION
There was earlier a memory leak in pattern-db: the rules in patterndb were leaked. This was attempted to be fixed in https://github.com/balabit/syslog-ng/pull/2311. However the fix was incomplete, the last rule was still not be freed.

The problem was in the end element logic: due to the `== 0`, the pdb_rule_unref was called only in case of parse error. Hence rule was never freed at the `</rule>` end element.

This patch reverts https://github.com/balabit/syslog-ng/pull/2311, and fixes the return value problem.