### PR TITLE
graylog2 support tls, udp

### DIFF
--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -25,10 +25,11 @@
 
 template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
-block destination graylog2(host("127.0.0.1") port(12201) template("$(format-gelf)") ...) {
+block destination graylog2(host("127.0.0.1") port(12201) transport(tcp) template("$(format-gelf)") ...) {
 	network("`host`"
                 port(`port`)
-		transport(tcp)
+		transport(`transport`)
 		template("`template`")
 		`__VARARGS__`);
 };
+


### PR DESCRIPTION
Updated @Gorian work(https://github.com/balabit/syslog-ng/pull/2637) based on @furiel comments (https://github.com/balabit/syslog-ng/pull/2637#discussion_r268035221).

With this modification the `graylog2` can be configured with any transport (`tcp`, `udp`, `tls`, ...).
A `tls` example:
```
graylog2(
   transport(tls)
   tls(
     ca-dir("/etc/ssl/certs")
     peer-verify("required-trusted")
   )
);
```