### PR TITLE
amqp: fixing double connect

### DIFF
--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -473,12 +473,12 @@ afamqp_dd_login(AMQPDestDriver *self)
 }
 
 static gboolean
-afamqp_dd_connect(AMQPDestDriver *self, gboolean reconnect)
+afamqp_dd_connect(AMQPDestDriver *self)
 {
   int sockfd_ret;
   amqp_rpc_reply_t ret;
 
-  if (reconnect && self->conn)
+  if (self->conn)
     {
       ret = amqp_get_rpc_reply(self->conn);
       if (ret.reply_type == AMQP_RESPONSE_NORMAL)
@@ -645,7 +645,7 @@ afamqp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)s;
 
-  if (!afamqp_dd_connect(self, TRUE))
+  if (!afamqp_dd_connect(self))
     return LTR_NOT_CONNECTED;
 
   if (!afamqp_worker_publish (self, msg))
@@ -714,7 +714,7 @@ static gboolean
 afamqp_dd_worker_connect(LogThreadedDestDriver *s)
 {
   AMQPDestDriver *self = (AMQPDestDriver *)s;
-  return afamqp_dd_connect(self, FALSE);
+  return afamqp_dd_connect(self);
 }
 
 /*

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -654,14 +654,6 @@ afamqp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
   return LTR_SUCCESS;
 }
 
-static void
-afamqp_worker_thread_init(LogThreadedDestDriver *d)
-{
-  AMQPDestDriver *self = (AMQPDestDriver *)d;
-
-  afamqp_dd_connect(self, FALSE);
-}
-
 /*
  * Main thread
  */
@@ -740,7 +732,6 @@ afamqp_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = afamqp_dd_free;
   self->super.super.super.super.generate_persist_name = afamqp_dd_format_persist_name;
 
-  self->super.worker.thread_init = afamqp_worker_thread_init;
   self->super.worker.connect = afamqp_dd_worker_connect;
   self->super.worker.disconnect = afamqp_dd_disconnect;
   self->super.worker.insert = afamqp_worker_insert;


### PR DESCRIPTION
During startup: connect was called two times in amqp destination, hence amqp destination built two connections towards the rabbitmq server. One connect was called from thread_init, the other one is called because of worker.connect virtual function:
https://github.com/balabit/syslog-ng/blob/5a03be7255736941a55ed67fb27c6a08c84dd275/modules/afamqp/afamqp.c#L662
and
https://github.com/balabit/syslog-ng/blob/5a03be7255736941a55ed67fb27c6a08c84dd275/modules/afamqp/afamqp.c#L744

Interestingly, this did not cause any particular problem on its own, even valgrind did not show any error. However, if someone wants to [add heartbeat to amqp](https://github.com/balabit/syslog-ng/issues/189) at some point, this would cause a little headache, as the first connection would be terminated due to timeout, as only the second was used for messaging, hence a false-positive error message is visible in the rabbitmq server logs.
