### PR TITLE
patterndb: Add sort option to pdbtool merge

### DIFF
--- a/modules/dbparser/pdb-file.h
+++ b/modules/dbparser/pdb-file.h
@@ -29,5 +29,7 @@
 gint pdb_file_detect_version(const gchar *pdbfile, GError **error);
 gboolean pdb_file_validate(const gchar *filename, GError **error);
 gboolean pdb_file_validate_in_tests(const gchar *filename, GError **error);
+GPtrArray *pdb_get_filenames(const gchar *dir_path, gboolean recursive, gchar *pattern, GError **error);
+void pdb_sort_filenames(GPtrArray *filenames);
 
 #endif


### PR DESCRIPTION
Adds sort option to `pdbtool merge`:
`  -s, --sort                      Sort files during merge (alphabetic order, with files first, directories after)
`

By default the option is not set, and the file sequence is not guaranteed to be sorted.

Fixes #294.