### PR TITLE
Fix unit test with function pointer dereference in case of ASLR, Criterion

### DIFF
--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -321,63 +321,63 @@ queue_new(gboolean reliable, DiskQueueOptions *options, const gchar *persist_nam
   return log_queue_disk_non_reliable_new(options, persist_name);
 }
 
-Test(diskq, testcase_diskbuffer_restart_corrupted)
+ParameterizedTestParameters(diskq, testcase_diskbuffer_restart_corrupted)
 {
-
-  restart_test_parameters parameters[] =
+  static restart_test_parameters test_cases[] =
   {
     {"test-diskq-restart.qf", FALSE},
     {"test-diskq-restart.rqf", TRUE},
   };
 
+  return cr_make_param_array(restart_test_parameters, test_cases, sizeof(test_cases) / sizeof(test_cases[0]));
+}
+
+ParameterizedTest(restart_test_parameters *test_case, diskq, testcase_diskbuffer_restart_corrupted)
+{
   guint64 const original_disk_buf_size = 1000123;
-  gsize number_of_variants = sizeof(parameters)/sizeof(restart_test_parameters);
-  for (gsize i = 0; i < number_of_variants; i++)
-    {
-      DiskQueueOptions options;
-      _construct_options(&options, original_disk_buf_size, 100000, parameters[i].reliable);
-      LogQueue *q = queue_new(parameters[i].reliable, &options, NULL);
-      log_queue_set_use_backlog(q, FALSE);
+  DiskQueueOptions options;
+  _construct_options(&options, original_disk_buf_size, 100000, test_case->reliable);
+  LogQueue *q = queue_new(test_case->reliable, &options, NULL);
+  log_queue_set_use_backlog(q, FALSE);
 
-      gchar *filename = parameters[i].filename;
-      gchar filename_corrupted_dq[100];
-      g_snprintf(filename_corrupted_dq, 100, "%s.corrupted", filename);
-      unlink(filename);
-      unlink(filename_corrupted_dq);
+  gchar *filename = test_case->filename;
+  gchar filename_corrupted_dq[100];
+  g_snprintf(filename_corrupted_dq, 100, "%s.corrupted", filename);
+  unlink(filename);
+  unlink(filename_corrupted_dq);
 
-      log_queue_disk_load_queue(q, filename);
-      fed_messages = 0;
-      feed_some_messages(q, 100);
-      cr_assert_eq(fed_messages, 100, "Failed to push all messages to the disk-queue!\n");
+  log_queue_disk_load_queue(q, filename);
+  fed_messages = 0;
+  feed_some_messages(q, 100);
+  cr_assert_eq(fed_messages, 100, "Failed to push all messages to the disk-queue!\n");
 
-      LogQueueDisk *disk_queue = (LogQueueDisk *)q;
-      log_queue_disk_restart_corrupted(disk_queue);
+  LogQueueDisk *disk_queue = (LogQueueDisk *)q;
+  log_queue_disk_restart_corrupted(disk_queue);
 
-      struct stat file_stat;
-      cr_assert_eq(stat(filename, &file_stat), 0,
-                   "New disk-queue file does not exists!!");
-      cr_assert_eq(S_ISREG(file_stat.st_mode), TRUE,
-                   "New disk-queue file expected to be a regular file!! st_mode value=%04o",
-                   (file_stat.st_mode & S_IFMT));
-      stat(filename_corrupted_dq, &file_stat);
-      cr_assert_eq(S_ISREG(file_stat.st_mode), TRUE,
-                   "Corrupted disk-queue file does not exists!!");
-      assert_string(qdisk_get_filename(disk_queue->qdisk), filename,
-                    "New disk-queue file's name should be the same\n");
-      cr_assert_eq(qdisk_get_size(disk_queue->qdisk), original_disk_buf_size,
-                   "Disk-queue option does not match the original configured value!\n");
-      cr_assert_eq(qdisk_get_length(disk_queue->qdisk), 0,
-                   "New disk-queue file should be empty!\n");
-      cr_assert_eq(qdisk_get_writer_head(disk_queue->qdisk), QDISK_RESERVED_SPACE,
-                   "Invalid write pointer!\n");
-      cr_assert_eq(qdisk_get_reader_head(disk_queue->qdisk), QDISK_RESERVED_SPACE,
-                   "Invalid read pointer!\n");
+  struct stat file_stat;
+  cr_assert_eq(stat(filename, &file_stat), 0,
+               "New disk-queue file does not exists!!");
+  cr_assert_eq(S_ISREG(file_stat.st_mode), TRUE,
+               "New disk-queue file expected to be a regular file!! st_mode value=%04o",
+               (file_stat.st_mode & S_IFMT));
+  stat(filename_corrupted_dq, &file_stat);
+  cr_assert_eq(S_ISREG(file_stat.st_mode), TRUE,
+               "Corrupted disk-queue file does not exists!!");
+  assert_string(qdisk_get_filename(disk_queue->qdisk), filename,
+                "New disk-queue file's name should be the same\n");
+  cr_assert_eq(qdisk_get_size(disk_queue->qdisk), original_disk_buf_size,
+               "Disk-queue option does not match the original configured value!\n");
+  cr_assert_eq(qdisk_get_length(disk_queue->qdisk), 0,
+               "New disk-queue file should be empty!\n");
+  cr_assert_eq(qdisk_get_writer_head(disk_queue->qdisk), QDISK_RESERVED_SPACE,
+               "Invalid write pointer!\n");
+  cr_assert_eq(qdisk_get_reader_head(disk_queue->qdisk), QDISK_RESERVED_SPACE,
+               "Invalid read pointer!\n");
 
-      log_queue_unref(q);
-      unlink(filename);
-      unlink(filename_corrupted_dq);
-      disk_queue_options_destroy(&options);
-    }
+  log_queue_unref(q);
+  unlink(filename);
+  unlink(filename_corrupted_dq);
+  disk_queue_options_destroy(&options);
 }
 
 static gboolean

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -306,14 +306,15 @@ Test(diskq, testcase_with_threads)
   fprintf(stderr, "Feed speed: %.2lf\n", (double) TEST_RUNS * MESSAGES_SUM * 1000000 / sum_time);
 }
 
+typedef struct restart_test_parameters
+{
+  gchar *filename;
+  LogQueue *(*lqdisk_new_func)(DiskQueueOptions *options, const gchar *persist_name);
+  gboolean reliable;
+} restart_test_parameters;
+
 Test(diskq, testcase_diskbuffer_restart_corrupted)
 {
-  typedef struct restart_test_parameters
-  {
-    gchar *filename;
-    LogQueue *(*lqdisk_new_func)(DiskQueueOptions *options, const gchar *persist_name);
-    gboolean reliable;
-  } restart_test_parameters;
 
   restart_test_parameters parameters[] =
   {


### PR DESCRIPTION
The `test_diskq_statistics` could crash under certain conditions.
If the linux ASLR is enabled, and the compiler creates executable
that is position independent(`-fPIC`).

The function pointer could became invalid, in the unit test.
As the Criterion does *fork* and *exec* before executing tests.

Additionally the parameters are created in the *parent*,
and passed down to the *child* process, which - because of ASLR -
possible stores the referenced function in a different address.

This patch does not solves the above issue, but hides this behaviour
with additionally calling the function pointer passed by
via function pointer.

Because of this, a `@PLT` trampoline function is created, which
address is used, that can be made position independent hence
valid after *fork* plus *exec* if compiled with `-fno-pie`,
which is done in our case.

There is a nice post about related topics: https://www.macieira.org/blog/2012/01/sorry-state-of-dynamic-libraries-on-linux/