### PR TITLE
cfg-parser: add aliases for yesno

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1029,9 +1029,17 @@ string
 	;
 
 yesno
-	: KW_YES				{ $$ = 1; }
-	| KW_NO					{ $$ = 0; }
-	| LL_NUMBER				{ $$ = $1; }
+  : LL_IDENTIFIER
+    {
+      gboolean value;
+      gboolean success = cfg_process_yesno($1, &value);
+      CHECK_ERROR((TRUE == success), @1, "invalid yesno value: %s. Use one of the following: yes/no, on/off, true/false, enable/disable, enabled/disabled", $1);
+      $$ = value;
+    }
+  | LL_NUMBER
+    {
+      $$ = $1;
+    }
 	;
 
 dnsmode

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -168,11 +168,6 @@ static CfgLexerKeyword main_keywords[] =
   { "type",               KW_TYPE },
   { "tags",               KW_TAGS },
 
-  /* on/off switches */
-  { "yes",                KW_YES },
-  { "on",                 KW_YES },
-  { "no",                 KW_NO },
-  { "off",                KW_NO },
   { NULL, 0 }
 };
 
@@ -453,9 +448,41 @@ cfg_process_flag(CfgFlagHandler *handlers, gpointer base, const gchar *flag_)
 }
 
 gboolean
-cfg_process_yesno(const gchar *yesno)
+cfg_process_yesno(const gchar *yesno, gboolean *value)
 {
-  if (strcasecmp(yesno, "yes") == 0 || atoi(yesno) > 0)
-    return TRUE;
+  gchar *yes[] =
+  {
+    "yes",
+    "on",
+    "true",
+    "enable",
+    "enabled"
+  };
+  gchar *no[] =
+  {
+    "no",
+    "off",
+    "false",
+    "disable",
+    "disabled"
+  };
+
+  for (int i = 0; i < G_N_ELEMENTS(yes); ++i)
+    if (strcasecmp(yesno, yes[i]) == 0)
+      {
+        *value = TRUE;
+        return TRUE;
+      }
+  for (int i = 0; i < G_N_ELEMENTS(no); ++i)
+    if (strcasecmp(yesno, no[i]) == 0)
+      {
+        *value = FALSE;
+        return TRUE;
+      }
+  if (atoi(yesno) > 0)
+    {
+      *value = TRUE;
+      return TRUE;
+    }
   return FALSE;
 }

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -66,7 +66,7 @@ typedef struct _CfgFlagHandler
 } CfgFlagHandler;
 
 gboolean cfg_process_flag(CfgFlagHandler *handlers, gpointer base, const gchar *flag);
-gboolean cfg_process_yesno(const gchar *yesno);
+gboolean cfg_process_yesno(const gchar *yesno, gboolean *value);
 
 
 extern CfgParser main_parser;

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -156,9 +156,16 @@ _parse_auto_parse_arg(AppParserGenerator *self, CfgArgs *args, const gchar *refe
   const gchar *v = cfg_args_get(args, "auto-parse");
 
   if (v)
-    self->is_parsing_enabled = cfg_process_yesno(v);
+    {
+      gboolean value = FALSE;
+      gboolean success = cfg_process_yesno(v, &value);
+      self->is_parsing_enabled = value;
+      return success;
+    }
   else
-    self->is_parsing_enabled = TRUE;
+    {
+      self->is_parsing_enabled = TRUE;
+    }
   return TRUE;
 }
 


### PR DESCRIPTION
New aliases:
 * true/false
 * enable/disable
 * enabled/disabled

Fixes #906.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>