### PR TITLE
Date parser to support guess timezone

### DIFF
--- a/modules/date/date-grammar.ym
+++ b/modules/date/date-grammar.ym
@@ -70,9 +70,10 @@ date_parser_options
         ;
 
 date_parser_option
-        : KW_FORMAT '(' string ')'             { date_parser_set_format(last_parser, $3); free($3); }
-        | KW_TIME_ZONE '(' string ')'          { date_parser_set_timezone(last_parser, $3); free($3); }
+        : KW_FORMAT '(' string ')'                  { date_parser_set_format(last_parser, $3); free($3); }
+        | KW_TIME_ZONE '(' string ')'               { date_parser_set_timezone(last_parser, $3); free($3); }
 	| KW_TIME_STAMP '(' date_parser_stamp ')'   { date_parser_set_time_stamp(last_parser, $3); }
+	| KW_FLAGS '(' date_parser_flags ')'
         | parser_opt
         ;
 
@@ -83,6 +84,11 @@ date_parser_stamp
             CHECK_ERROR($$ != -1, @1, "unknown time stamp name %s", $1);
             free($1);
           }
+
+date_parser_flags
+	: string date_parser_flags         { CHECK_ERROR(date_parser_process_flag(last_parser, $1), @1, "Unknown flag %s", $1); free($1); }
+        |
+        ;
 
 /* INCLUDE_RULES */
 

--- a/modules/date/date-parser.h
+++ b/modules/date/date-parser.h
@@ -32,5 +32,6 @@ void date_parser_set_offset(LogParser *s, goffset offset);
 void date_parser_set_format(LogParser *s, const gchar *format);
 void date_parser_set_timezone(LogParser *s, gchar *tz);
 void date_parser_set_time_stamp(LogParser *s, LogMessageTimeStamp timestamp);
+gboolean date_parser_process_flag(LogParser *s, gchar *flag);
 
 #endif


### PR DESCRIPTION
This patch adds support for flags(guess-timezone) to date-parser() in a similar vein to how
the tcp() driver supports this option.

Example:
```
  date-parser(flags(guess-timezone));
```

The rest of the options works just as previously.
