### PR TITLE
amqp: heartbeat support

### DIFF
--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -60,6 +60,7 @@
 %token KW_USERNAME
 %token KW_MAX_CHANNEL
 %token KW_FRAME_SIZE
+%token KW_HEARTBEAT
 %token KW_CA_FILE
 %token KW_KEY_FILE
 %token KW_CERT_FILE
@@ -82,21 +83,22 @@ afamqp_options
 	;
 
 afamqp_option
-	: KW_HOST '(' string ')'                  { afamqp_dd_set_host(last_driver, $3); free($3); }
-	| KW_PORT '(' positive_integer ')'        { afamqp_dd_set_port(last_driver, $3); }
-	| KW_VHOST '(' string ')'                 { afamqp_dd_set_vhost(last_driver, $3); free($3); }
-	| KW_EXCHANGE '(' string ')'              { afamqp_dd_set_exchange(last_driver, $3); free($3); }
-	| KW_EXCHANGE_DECLARE '(' yesno ')'       { afamqp_dd_set_exchange_declare(last_driver, $3); }
-	| KW_EXCHANGE_TYPE '(' string ')'         { afamqp_dd_set_exchange_type(last_driver, $3); free($3); }
-	| KW_ROUTING_KEY '(' string ')'           { afamqp_dd_set_routing_key(last_driver, $3); free($3); }
-	| KW_BODY '(' string ')'                  { afamqp_dd_set_body(last_driver, $3); free($3); }
-	| KW_PERSISTENT '(' yesno ')'             { afamqp_dd_set_persistent(last_driver, $3); }
-	| KW_AUTH_METHOD '(' string ')'           { CHECK_ERROR(afamqp_dd_set_auth_method(last_driver, $3), @3, "unknown auth-method() argument"); free($3); }
-	| KW_USERNAME '(' string ')'              { afamqp_dd_set_user(last_driver, $3); free($3); }
-	| KW_PASSWORD '(' string ')'              { afamqp_dd_set_password(last_driver, $3); free($3); }
-	| KW_MAX_CHANNEL '(' positive_integer ')' { afamqp_dd_set_max_channel(last_driver, $3); }
-	| KW_FRAME_SIZE '(' positive_integer ')'  { afamqp_dd_set_frame_size(last_driver, $3); }
-	| value_pair_option                       { afamqp_dd_set_value_pairs(last_driver, $1); }
+	: KW_HOST '(' string ')'                   { afamqp_dd_set_host(last_driver, $3); free($3); }
+	| KW_PORT '(' positive_integer ')'         { afamqp_dd_set_port(last_driver, $3); }
+	| KW_VHOST '(' string ')'                  { afamqp_dd_set_vhost(last_driver, $3); free($3); }
+	| KW_EXCHANGE '(' string ')'               { afamqp_dd_set_exchange(last_driver, $3); free($3); }
+	| KW_EXCHANGE_DECLARE '(' yesno ')'        { afamqp_dd_set_exchange_declare(last_driver, $3); }
+	| KW_EXCHANGE_TYPE '(' string ')'          { afamqp_dd_set_exchange_type(last_driver, $3); free($3); }
+	| KW_ROUTING_KEY '(' string ')'            { afamqp_dd_set_routing_key(last_driver, $3); free($3); }
+	| KW_BODY '(' string ')'                   { afamqp_dd_set_body(last_driver, $3); free($3); }
+	| KW_PERSISTENT '(' yesno ')'              { afamqp_dd_set_persistent(last_driver, $3); }
+	| KW_AUTH_METHOD '(' string ')'            { CHECK_ERROR(afamqp_dd_set_auth_method(last_driver, $3), @3, "unknown auth-method() argument"); free($3); }
+	| KW_USERNAME '(' string ')'               { afamqp_dd_set_user(last_driver, $3); free($3); }
+	| KW_PASSWORD '(' string ')'               { afamqp_dd_set_password(last_driver, $3); free($3); }
+	| KW_MAX_CHANNEL '(' positive_integer ')'  { afamqp_dd_set_max_channel(last_driver, $3); }
+	| KW_FRAME_SIZE '(' positive_integer ')'   { afamqp_dd_set_frame_size(last_driver, $3); }
+	| KW_HEARTBEAT '(' nonnegative_integer ')' { afamqp_dd_set_offered_heartbeat(last_driver, $3); }
+	| value_pair_option                        { afamqp_dd_set_value_pairs(last_driver, $1); }
 	| threaded_dest_driver_option
 	| afamqp_tls_option
 	| KW_TLS '(' afamqp_tls_options ')'

--- a/modules/afamqp/afamqp-parser.c
+++ b/modules/afamqp/afamqp-parser.c
@@ -45,6 +45,7 @@ static CfgLexerKeyword afamqp_keywords[] =
   { "password",     KW_PASSWORD },
   { "max_channel",     KW_MAX_CHANNEL },
   { "frame_size",     KW_FRAME_SIZE },
+  { "heartbeat",     KW_HEARTBEAT },
   { "body",     KW_BODY },
   { "ca_file",        KW_CA_FILE },
   { "key_file",           KW_KEY_FILE },

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -697,6 +697,8 @@ _handle_heartbeat(void *cookie)
       msg_error("Unexpected error while reading from amqp server",
                 log_pipe_location_tag((LogPipe *)self),
                 evt_tag_str("error", amqp_error_string2(status)));
+      log_threaded_dest_worker_disconnect(&self->super.worker.instance);
+      return;
     }
 
   iv_validate_now();

--- a/modules/afamqp/afamqp.h
+++ b/modules/afamqp/afamqp.h
@@ -44,6 +44,7 @@ void afamqp_dd_set_user(LogDriver *d, const gchar *user);
 void afamqp_dd_set_password(LogDriver *d, const gchar *password);
 void afamqp_dd_set_max_channel(LogDriver *d, gint max_channel);
 void afamqp_dd_set_frame_size(LogDriver *d, gint frame_size);
+void afamqp_dd_set_offered_heartbeat(LogDriver *d, gint heartbeat);
 void afamqp_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
 void afamqp_dd_set_ca_file(LogDriver *d, const gchar *cacrt);
 void afamqp_dd_set_key_file(LogDriver *d, const gchar *key);


### PR DESCRIPTION
Users can provide heartbeat in their configuration, that is negotiated with the server. In case heartbeat is enabled, amqp destination will send heartbeats periodically.

Heartbeat is measured in seconds. Default value is zero.

Example configuration:
```
    destination { amqp(vhost("/")
                  exchange("logs")
                  body("hello world")
                  heartbeat(10)
                  username(guest) password(guest)); };
```

Fixes: https://github.com/balabit/syslog-ng/issues/189
