### PR TITLE
filter: Fix "!=" filter

### DIFF
--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -78,11 +78,11 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg)
     }
   else if (cmp < 0)
     {
-      result = self->cmp_op & FCMP_LT || self->cmp_op == 0;
+      result = !!(self->cmp_op & FCMP_LT);
     }
   else
     {
-      result = self->cmp_op & FCMP_GT || self->cmp_op == 0;
+      result = !!(self->cmp_op & FCMP_GT);
     }
 
   msg_trace("cmp() evaluation started",
@@ -141,7 +141,7 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, gint op)
     case KW_NUM_NE:
       self->cmp_op = FCMP_NUM;
     case KW_NE:
-      self->cmp_op |= 0;
+      self->cmp_op |= FCMP_LT | FCMP_GT;
       self->super.type = "!=";
       break;
 

--- a/lib/filter/tests/test_filters_fop_cmp.c
+++ b/lib/filter/tests/test_filters_fop_cmp.c
@@ -53,7 +53,7 @@ ParameterizedTestParameters(filter, test_filter_fop_cmp)
   static FilterParamFopCmp test_data_list[] =
   {
     {.msg = "<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", .template1 = "$LEVEL_NUM", .template2 = "7", .op = KW_NUM_EQ, .expected_result = TRUE},
-    {.msg = "<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", .template1 = "$LEVEL_NUM", .template2 = "5", .op = KW_NUM_NE, .expected_result = FALSE},
+    {.msg = "<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", .template1 = "$LEVEL_NUM", .template2 = "5", .op = KW_NUM_NE, .expected_result = TRUE},
     {.msg = "<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", .template1 = "$LEVEL_NUM", .template2 = "8", .op = KW_NUM_LT, .expected_result = TRUE},
     {.msg = "<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", .template1 = "$LEVEL_NUM", .template2 = "10", .op = KW_NUM_LT, .expected_result = TRUE},
     /* 7 lt 10 is FALSE as 10 orders lower when interpreted as a string */


### PR DESCRIPTION
The `KW_NUM_NE` and `KW_NE` keywords did not set any comparison flag for `fop_cmp_eval()`. It was handled by checking for no flag set (`self->cmp_op == 0`), which is not true in case of `KW_NUM_NE`, because with `KW_NUM_NE` the `FCMP_NUM` flag is set.

After this the `|| self->cmp_op == 0` check is not needed, but we have to make a boolean from `self->cmp_op & FCMP_LT`, which was passively done by having `|| self->cmp_op == 0` after it. I cleaned it up with double negation.

Sample config for reproduction:
```
@version: 3.20
@include "scl.conf"

filter f_even { "$(% ${R_SEC} 2)" == "0" };
filter f_odd { "$(% ${R_SEC} 2)" != "0" };

destination d_local {
	file("/tmp/ne_test.log");
};

log {
	source { example-msg-generator(); };
	filter(f_even);
	destination(d_local);
};

log {
	source { example-msg-generator(); };
	filter(f_odd);
	destination(d_local);
};

```
Erroneous logs:
```
[2019-04-16T13:36:55.776895] cmp() evaluation started; left='1', operator='!=', right='0', msg='0x22242a0'
[2019-04-16T13:36:55.776967] <<<<<< filter rule evaluation result; result='UNMATCHED - Dropping message from LogPipe', rule='f_odd', location='/home/alltilla/install/etc/syslog-ng.conf:5:15', msg='0x22242a0'
```

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>