### PR TITLE
system-source: remove unused app-parser

### DIFF
--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -132,6 +132,12 @@ _generate_applications(AppParserGenerator *self, AppModelContext *appmodel)
 
 
 static void
+_generate_empty_frame(AppParserGenerator *self)
+{
+  g_string_append(self->block, "\nchannel { filter { tags('.app.doesnotexist'); }; flags(final); };");
+}
+
+static void
 _generate_framing(AppParserGenerator *self, AppModelContext *appmodel)
 {
   g_string_append(self->block,
@@ -139,16 +145,11 @@ _generate_framing(AppParserGenerator *self, AppModelContext *appmodel)
                   "    junction {\n");
 
   _generate_applications(self, appmodel);
-
+  _generate_empty_frame(self);
   g_string_append(self->block, "    };\n");
   g_string_append(self->block, "}");
 }
 
-static void
-_generate_empty_frame(AppParserGenerator *self)
-{
-  g_string_append(self->block, "\nchannel {}");
-}
 
 static gboolean
 _parse_auto_parse_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference)

--- a/modules/appmodel/tests/test_app_parser_generator.c
+++ b/modules/appmodel/tests/test_app_parser_generator.c
@@ -200,6 +200,7 @@ Test(app_parser_generator, app_parser_with_no_apps_registered_generates_empty_fr
 {
   _app_parser_generate("port514");
   _assert_parser_framing_is_present();
+  _assert_snippet_is_present("tags('.app.doesnotexist')");
   _assert_config_is_valid("port514", NULL);
 }
 
@@ -248,7 +249,7 @@ Test(app_parser_generator, app_parser_is_disabled_if_auto_parse_is_set_to_no)
   _register_sample_application("bar", "port514");
 
   _app_parser_generate_with_args("port514", _build_cfg_args("auto-parse", "no", NULL));
-  cr_assert_str_eq(result->str, "\nchannel {}", "result is expected to be an empty channel, but it is %s", result->str);
+  _assert_snippet_is_present("tags('.app.doesnotexist')");
 
   _app_parser_generate_with_args("port514", _build_cfg_args("auto-parse", "yes", NULL));
   _assert_parser_framing_is_present();

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -339,14 +339,13 @@ system_generate_app_parser(GlobalConfig *cfg, GString *sysblock, CfgArgs *args)
                          "channel {\n"
                          "  channel {\n"
                          "    parser {\n"
-                         "      app-parser(topic(system-unix) %s);\n"
                          "      app-parser(topic(syslog) %s);\n"
                          "    };\n"
                          "    flags(final);\n"
                          "  };\n"
                          "  channel { flags(final); };\n"
                          "};\n",
-                         varargs, varargs);
+                         varargs);
   g_free(varargs);
 }
 


### PR DESCRIPTION
App-parsers usage, including using the "system-unix" topic
introduced in 286e1a64b001f12e6be2b4bf5cccab4b21c2081b.

I think removing an unused code is a good step,
especially that it could cause problems when the first system-unix topic
would be introduced.

Reason:
- app-parser creates a channel, which groups some junctions-channels
- 2 app-parsers following each other therefore means 2 channels, i.e. a log pipe sequence.
If a drop happens in the first part, then it will never reach the second part, i.e. the 2nd app-parser topic.

Conclusion is that we either remove the unused app-parser,
or fix it with an additional junction-channel/if-else.
