### PR TITLE
Version generation improvement

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -26,9 +26,8 @@ BASEDIR=$(dirname "$0")
 
 cd $BASEDIR/../
 
-if [ -d .git ]; then
-  git describe --tags --dirty --abbrev=7 | sed 's/^syslog-ng-//' | tr '-' '.' | tr -d '\n'
+if [ -d .git ] && GIT_VERSION=$(git describe --tags --dirty --abbrev=7); then
+  echo $GIT_VERSION | sed 's/^syslog-ng-//' | tr '-' '.' | tr -d '\n'
 else
   cat VERSION
 fi
-

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -29,5 +29,5 @@ cd $BASEDIR/../
 if [ -d .git ] && GIT_VERSION=$(git describe --tags --dirty --abbrev=7); then
   echo $GIT_VERSION | sed 's/^syslog-ng-//' | tr '-' '.' | tr -d '\n'
 else
-  cat VERSION
+  cat VERSION | tr -d '\n'
 fi


### PR DESCRIPTION
In case when git is not installed or no tags exist, we should fall back to the VERSION file.

This commit fixes the compilation in environments where git is not available or where `git clone --depth` is used, such as Travis.