### PR TITLE
support for vhost:port in common/combined log formats

### DIFF
--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -47,7 +47,6 @@ block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) 
                     delimiters(":")
                     dialect(escape-none)
                     columns("vhost", "port"));
-
             };
 
         # if traditional log format

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -20,9 +20,21 @@
 #
 #############################################################################
 
-# combined & common format including vhost
+# Parse apache access.log
+#
+# Formats recognized:
+#
 # LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+#    virtualhost:443 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
+#
 # LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b" vhost_common
+#    virtualhost:443 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+#
+# LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
+#    127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
+#
+# LogFormat "%h %l %u %t \"%r\" %>s %b" common
+#    127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
 block parser apache-accesslog-parser-vhost(prefix() template()) {
     channel {
         rewrite {
@@ -73,6 +85,8 @@ block parser apache-accesslog-parser-combined(prefix() template()) {
 };
 
 block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
+    # parse into a logstash-like schema
+    # https://github.com/elastic/logstash/blob/v1.4.2/patterns/grok-patterns#L90
     channel {
 
         # parser for formats including vhost:port
@@ -84,7 +98,8 @@ block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) 
             parser { apache-accesslog-parser-combined(prefix(`prefix`) template(`template`)); };
         };
 
-        # parser for all formats
+        # mungle values to match Kibana/elastic schema and common to all
+        # supported formats.
         parser {
             csv-parser(
                 prefix(`prefix`)

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -20,22 +20,54 @@
 #
 #############################################################################
 block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
-
-
     channel {
-        parser {
-            csv-parser(
-                prefix(`prefix`)
-                dialect(escape-double-char)
-                flags(strip-whitespace)
-                delimiters(" ")
-                template(`template`)
-                quote-pairs('""[]')
-                # field names match of that of Logstash
-                columns("clientip", "ident", "auth",
-                        "timestamp", "rawrequest", "response",
-                        "bytes", "referrer", "agent"));
+        rewrite {
+            set("`template`" value("1"));
+        };
 
+        # if log line begins with vhost:port
+        if {
+            filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
+            parser {
+                csv-parser(
+                    dialect(escape-double-char)
+                    flags(strip-whitespace)
+                    delimiters(" ")
+                    template($1)
+                    quote-pairs('""[]')
+                    columns("2", "`prefix`clientip", "`prefix`ident",
+                            "`prefix`auth", "`prefix`timestamp",
+                            "`prefix`rawrequest", "`prefix`response",
+                            "`prefix`bytes", "`prefix`referrer",
+                            "`prefix`agent"));
+
+                csv-parser(
+                    prefix(`prefix`)
+                    template("$2")
+                    delimiters(":")
+                    dialect(escape-none)
+                    columns("vhost", "port"));
+
+            };
+
+        # if traditional log format
+        } else {
+            parser {
+                csv-parser(
+                    prefix(`prefix`)
+                    dialect(escape-double-char)
+                    flags(strip-whitespace)
+                    delimiters(" ")
+                    template($1)
+                    quote-pairs('""[]')
+                    columns("clientip", "ident", "auth",
+                            "timestamp", "rawrequest", "response",
+                            "bytes", "referrer", "agent"));
+            };
+        };
+
+        # common to both log formats
+        parser {
             csv-parser(
                 prefix(`prefix`)
                 template("${`prefix`rawrequest}")
@@ -44,12 +76,12 @@ block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) 
                 flags(strip-whitespace)
                 columns("verb", "request", "httpversion"));
 
-	    date-parser(format("%d/%b/%Y:%H:%M:%S %z")
-                        template("${`prefix`timestamp}"));
+            date-parser(format("%d/%b/%Y:%H:%M:%S %z")
+                template("${`prefix`timestamp}"));
+        };
 
-	};
-	rewrite {
-	    subst("^HTTP/(.*)$", "$1", value("`prefix`httpversion"));
-	};
+        rewrite {
+            subst("^HTTP/(.*)$", "$1", value("`prefix`httpversion"));
+        };
     };
 };

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -19,53 +19,72 @@
 # COPYING for details.
 #
 #############################################################################
+
+# combined & common format including vhost
+# LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+# LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b" vhost_common
+block parser apache-accesslog-parser-vhost(prefix() template()) {
+    channel {
+        parser {
+            csv-parser(
+                dialect(escape-double-char)
+                flags(strip-whitespace)
+                delimiters(" ")
+                template($1)
+                quote-pairs('""[]')
+                columns("2", "`prefix`clientip", "`prefix`ident",
+                        "`prefix`auth", "`prefix`timestamp",
+                        "`prefix`rawrequest", "`prefix`response",
+                        "`prefix`bytes", "`prefix`referrer",
+                        "`prefix`agent"));
+
+            csv-parser(
+                prefix(`prefix`)
+                template("$2")
+                delimiters(":")
+                dialect(escape-none)
+                columns("vhost", "port"));
+        };
+    };
+};
+
+# combined & common format without vhost
+# LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+# LogFormat "%h %l %u %t \"%r\" %>s %b" common
+block parser apache-accesslog-parser-combined(prefix() template()) {
+    channel {
+        parser {
+            csv-parser(
+                prefix(`prefix`)
+                dialect(escape-double-char)
+                flags(strip-whitespace)
+                delimiters(" ")
+                template($1)
+                quote-pairs('""[]')
+                columns("clientip", "ident", "auth",
+                        "timestamp", "rawrequest", "response",
+                        "bytes", "referrer", "agent"));
+        };
+    };
+};
+
 block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
     channel {
         rewrite {
             set("`template`" value("1"));
         };
 
-        # if log line begins with vhost:port
+        # parser for formats including vhost:port
         if {
             filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
-            parser {
-                csv-parser(
-                    dialect(escape-double-char)
-                    flags(strip-whitespace)
-                    delimiters(" ")
-                    template($1)
-                    quote-pairs('""[]')
-                    columns("2", "`prefix`clientip", "`prefix`ident",
-                            "`prefix`auth", "`prefix`timestamp",
-                            "`prefix`rawrequest", "`prefix`response",
-                            "`prefix`bytes", "`prefix`referrer",
-                            "`prefix`agent"));
+            parser { apache-accesslog-parser-vhost(prefix(`prefix`) template("$1")); };
 
-                csv-parser(
-                    prefix(`prefix`)
-                    template("$2")
-                    delimiters(":")
-                    dialect(escape-none)
-                    columns("vhost", "port"));
-            };
-
-        # if traditional log format
+        # parser for standard formats
         } else {
-            parser {
-                csv-parser(
-                    prefix(`prefix`)
-                    dialect(escape-double-char)
-                    flags(strip-whitespace)
-                    delimiters(" ")
-                    template($1)
-                    quote-pairs('""[]')
-                    columns("clientip", "ident", "auth",
-                            "timestamp", "rawrequest", "response",
-                            "bytes", "referrer", "agent"));
-            };
+            parser { apache-accesslog-parser-combined(prefix(`prefix`) template("$1")); };
         };
 
-        # common to both log formats
+        # parser for all formats
         parser {
             csv-parser(
                 prefix(`prefix`)

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -25,6 +25,10 @@
 # LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b" vhost_common
 block parser apache-accesslog-parser-vhost(prefix() template()) {
     channel {
+        rewrite {
+            set("`template`" value("1"));
+        };
+        filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
         parser {
             csv-parser(
                 dialect(escape-double-char)
@@ -59,7 +63,7 @@ block parser apache-accesslog-parser-combined(prefix() template()) {
                 dialect(escape-double-char)
                 flags(strip-whitespace)
                 delimiters(" ")
-                template($1)
+                template(`template`)
                 quote-pairs('""[]')
                 columns("clientip", "ident", "auth",
                         "timestamp", "rawrequest", "response",
@@ -70,18 +74,14 @@ block parser apache-accesslog-parser-combined(prefix() template()) {
 
 block parser apache-accesslog-parser(prefix(".apache.") template("${MESSAGE}")) {
     channel {
-        rewrite {
-            set("`template`" value("1"));
-        };
 
         # parser for formats including vhost:port
         if {
-            filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
-            parser { apache-accesslog-parser-vhost(prefix(`prefix`) template("$1")); };
+            parser { apache-accesslog-parser-vhost(prefix(`prefix`) template(`template`)); };
 
         # parser for standard formats
         } else {
-            parser { apache-accesslog-parser-combined(prefix(`prefix`) template("$1")); };
+            parser { apache-accesslog-parser-combined(prefix(`prefix`) template(`template`)); };
         };
 
         # parser for all formats


### PR DESCRIPTION
This patch will add support for vhost & port in common & combined apache logs as discussed @ https://github.com/balabit/syslog-ng/issues/2670.  Here is that format -

```
foo.com:443 1.2.3.4 - - [15/Apr/2019:14:30:16 -0400] "GET /bar.html HTTP/2.0" 500 - "https://foo.com/referer.html" "Mozilla/5.0 ..."
```

Below is my use case that I'm using on a test server, using the `${.apache.vhost}` macro to create a directory then logging using combined format -

apache:
```
LogFormat "%v:%p %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" vcombined
CustomLog "|/usr/bin/logger -S 65536 -t apache -p info -d -n 127.0.0.1 -P 5141" vcombined
```

syslog-ng:
```
source s_apache_access {
  network(ip(127.0.0.1) port(5141) transport(udp) flags(syslog-protocol));
};

destination d_apache_access {
  file (
    "/var/log/httpd/${.apache.vhost}/access_log_${YEAR}${MONTH}${DAY}"
    template("${.apache.clientip} ${.apache.ident} ${.apache.auth} [${.apache.timestamp}] \"${.apache.rawrequest}\" ${.apache.response} ${.apache.bytes} \"${.apache.referrer}\" \"${.apache.agent}\"\n")
  );
};

log {
  source(s_apache_access);
  parser { apache-accesslog-parser(); };
  destination(d_apache_access);
};
```