### PR TITLE
Reset the timezone on config reload event.

### DIFF
--- a/lib/timeutils/misc.c
+++ b/lib/timeutils/misc.c
@@ -26,6 +26,8 @@
 #include "timeutils/cache.h"
 #include "messages.h"
 
+#include <apphook.h>
+
 #include <string.h>
 
 /**
@@ -141,4 +143,23 @@ glong
 timespec_diff_nsec(struct timespec *t1, struct timespec *t2)
 {
   return (glong)((t1->tv_sec - t2->tv_sec) * 1e9) + (t1->tv_nsec - t2->tv_nsec);
+}
+
+void timeutils_setup_timezone_hook(void);
+
+static void
+timeutils_reset_timezone(gint type, gpointer context)
+{
+  tzset();
+
+  // Invalidate time cache to apply time zone as soon as possible.
+  invalidate_cached_time();
+  clean_time_cache();
+  timeutils_setup_timezone_hook();
+}
+
+void
+timeutils_setup_timezone_hook(void)
+{
+  register_application_hook(AH_CONFIG_CHANGED, timeutils_reset_timezone, NULL);
 }

--- a/lib/timeutils/misc.h
+++ b/lib/timeutils/misc.h
@@ -36,4 +36,6 @@ void timespec_add_msec(struct timespec *ts, glong msec);
 glong timespec_diff_msec(const struct timespec *t1, const struct timespec *t2);
 glong timespec_diff_nsec(struct timespec *t1, struct timespec *t2);
 
+void timeutils_setup_timezone_hook(void);
+
 #endif

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -38,6 +38,7 @@
 #include "plugin.h"
 #include "reloc.h"
 #include "resolved-configurable-paths.h"
+#include "timeutils/misc.h"
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -276,6 +277,9 @@ main(int argc, char *argv[])
    */
   g_process_start();
   app_startup();
+
+  timeutils_setup_timezone_hook();
+
   main_loop_options.server_mode = ((SYSLOG_NG_ENABLE_FORCED_SERVER_MODE) == 1 ? TRUE : FALSE);
   main_loop_init(main_loop, &main_loop_options);
   rc = main_loop_read_and_init_config(main_loop);


### PR DESCRIPTION
Currently, the behaviour of syslog-ng regarding timezone changes handling
depends on SYSLOG_NG_HAVE_LOCALTIME_R configuration parameter. If
SYSLOG_NG_HAVE_LOCALTIME_R is set to '1', the timezone is not updated
in run time and vise versa. However, timezone setting is considered as
a costly operation, so it can be not desired to perform it
frequently. One of the wice options is setting the timezone on-demand.
The code sets timezone on config reload event.