### PR TITLE
Fixup expedite threaded flush at reload

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -502,7 +502,7 @@ _insert_batched(LogThreadedDestWorker *s, LogMessage *msg)
 
   if (_should_initiate_flush(self))
     {
-      return log_threaded_dest_worker_flush(&self->super, FALSE);
+      return log_threaded_dest_worker_flush(&self->super, LTF_FLUSH_NORMAL);
     }
   return LTR_QUEUED;
 }
@@ -514,7 +514,7 @@ _insert_single(LogThreadedDestWorker *s, LogMessage *msg)
 
   self->request_headers = _format_request_headers(self, msg);
   _add_message_to_batch(self, msg);
-  return log_threaded_dest_worker_flush(&self->super, FALSE);
+  return log_threaded_dest_worker_flush(&self->super, LTF_FLUSH_NORMAL);
 }
 
 static gboolean

--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -376,7 +376,7 @@ _insert_single(RiemannDestWorker *self, LogMessage *msg)
       return LTR_DROP;
     }
 
-  return log_threaded_dest_worker_flush(&self->super, FALSE);
+  return log_threaded_dest_worker_flush(&self->super, LTF_FLUSH_NORMAL);
 }
 
 static LogThreadedResult


### PR DESCRIPTION
Note: the expedite flush feature is not available in compatibility mode (dests: Java, Python, amqp, mongodb, smtp, sql, stomp, redis).