### PR TITLE
http: allow URLs to be specified by a space/comma separated string

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -26,13 +26,22 @@
 /* HTTPDestinationDriver */
 
 void
-http_dd_set_urls(LogDriver *d, GList *urls)
+http_dd_set_urls(LogDriver *d, GList *url_strings)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
   http_load_balancer_drop_all_targets(self->load_balancer);
-  for (GList *l = urls; l; l = l->next)
-    http_load_balancer_add_target(self->load_balancer, l->data);
+  for (GList *l = url_strings; l; l = l->next)
+    {
+      const gchar *url_string = (const gchar *) l->data;
+      gchar **urls = g_strsplit(url_string, " ", -1);
+
+      for (gint url = 0; urls[url]; url++)
+        {
+          http_load_balancer_add_target(self->load_balancer, urls[url]);
+        }
+      g_strfreev(urls);
+    }
 }
 
 void


### PR DESCRIPTION
**NOTE:** This PR has been changed since the last round to allow comma as well as space as a separator.

It is pretty common that we get a list of things via a string argument. For
instance, for Java/Python based destinations that's the only way to
pass a list. An example is the java based kafka driver, where
kafka-bootstrap-servers() is one such attribute.

I recently encountered a case, where someone wanted to use a similar format
to HTTP and was surprised it didn't support this case.

This patch changes the url() parameter, it now supports the following cases:

  * url("server1", "server2", "server3"); # commas are optional
  * url("server1 server2 server3");        # space separated within a single string
  * url("server1,server2,server3");        # comma separated within a single string

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>