### PR TITLE
Add implode and explode template functions

### DIFF
--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -73,6 +73,8 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_replace_delimiter, "replace-delimiter"),
   TEMPLATE_FUNCTION_PLUGIN(tf_string_padding, "padding"),
   TEMPLATE_FUNCTION_PLUGIN(tf_binary, "binary"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_implode, "implode"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_explode, "explode"),
 
   /* fname-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_dirname, "dirname"),

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -400,6 +400,14 @@ Test(basicfuncs, test_list_funcs)
   assert_template_format("$(list-slice :-6 foo,bar,xxx,baz,bad)", "");
 
   assert_template_format("$(list-count foo,bar,xxx, baz bad)", "5");
+
+  assert_template_format("$(explode ' ' foo bar xxx baz bad)", "foo,bar,xxx,baz,bad");
+  assert_template_format("$(explode ' ' 'foo bar xxx baz bad')", "foo,bar,xxx,baz,bad");
+  assert_template_format("$(explode ';' foo;bar;xxx;baz;bad)", "foo,bar,xxx,baz,bad");
+  assert_template_format("$(explode ';' foo;bar xxx;baz;bad)", "foo,bar,xxx,baz,bad");
+
+  assert_template_format("$(implode ' ' foo,bar,xxx,baz,bad)", "foo bar xxx baz bad");
+  assert_template_format("$(implode ' ' $(list-slice :3 foo,bar,xxx,baz,bad))", "foo bar xxx");
 }
 
 Test(basicfuncs, test_context_funcs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -21,9 +21,10 @@
  *
  */
 
+#include "libtest/cr_template.h"
+#include "libtest/grab-logging.h"
 #include <criterion/criterion.h>
 
-#include "libtest/cr_template.h"
 #include "apphook.h"
 #include "plugin.h"
 #include "cfg.h"
@@ -243,11 +244,13 @@ _test_macros_with_context(const gchar *id, const gchar *numbers[], const MacroAn
 {
   GPtrArray *messages = create_log_messages_with_values(id, numbers);
 
+  start_grabbing_messages();
   for (const MacroAndResult *test_case = test_cases; test_case->macro; test_case++)
     assert_template_format_with_context_msgs(
       test_case->macro, test_case->result,
       (LogMessage **)messages->pdata, messages->len);
 
+  stop_grabbing_messages();
   free_log_message_array(messages);
 }
 


### PR DESCRIPTION
This branch adds $(explode) and $(implode) template functions. The first one turns a string separated by a specific character into a list, the other turns a list into a string gluing the pieces together with a separator.

Example:

                            value("MESSAGE", "$1 1 0 $(implode ' ' $(list-slice :-1 $(context-values $MSG)))")
