### PR TITLE
groupingby: add sort-key() option

### DIFF
--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -79,6 +79,10 @@ _calculate_triviality(LogTemplate *self)
 
   LogTemplateElem *e = (LogTemplateElem *) self->compiled_template->data;
 
+  /* reference to non-last element of the context, that's not trivial */
+  if (e->msg_ref > 0)
+    return FALSE;
+
   switch (e->type)
     {
     case LTE_FUNC:

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -28,11 +28,90 @@
 #include "template/escaping.h"
 #include "cfg.h"
 
+gboolean
+log_template_is_trivial(LogTemplate *self)
+{
+  return self->trivial;
+}
+
+const gchar *
+log_template_get_trivial_value(LogTemplate *self, LogMessage *msg, gssize *value_len)
+{
+  g_assert(self->trivial);
+
+  LogTemplateElem *e = (LogTemplateElem *) self->compiled_template->data;
+
+  switch (e->type)
+    {
+    case LTE_MACRO:
+      if (e->text_len > 0)
+        {
+          if (value_len)
+            *value_len = e->text_len;
+          return e->text;
+        }
+      else if (e->macro == M_MESSAGE)
+        return log_msg_get_value(msg, LM_V_MESSAGE, value_len);
+      else if (e->macro == M_HOST)
+        return log_msg_get_value(msg, LM_V_HOST, value_len);
+      g_assert_not_reached();
+    case LTE_VALUE:
+      return log_msg_get_value(msg, e->value_handle, value_len);
+    default:
+      g_assert_not_reached();
+    }
+}
+
+static gboolean
+_calculate_triviality(LogTemplate *self)
+{
+  /* if we need to escape, that's not trivial */
+  if (self->escape)
+    return FALSE;
+
+  /* no compiled template */
+  if (self->compiled_template == NULL)
+    return FALSE;
+
+  /* more than one element */
+  if (self->compiled_template->next != NULL)
+    return FALSE;
+
+  LogTemplateElem *e = (LogTemplateElem *) self->compiled_template->data;
+
+  switch (e->type)
+    {
+    case LTE_FUNC:
+      /* functions are never trivial */
+      return FALSE;
+    case LTE_MACRO:
+      /* Macros are trivial if they only contain a text but not a real
+       * macro.  Empty strings are represented this way.  */
+      if (e->macro == M_NONE)
+        return TRUE;
+      if (e->text_len > 0)
+        return FALSE;
+
+      /* we have macros for MESSAGE and HOST for compatibility reasons, but
+       * they should be considered trivial */
+
+      if (e->macro == M_MESSAGE || e->macro == M_HOST)
+        return TRUE;
+      return FALSE;
+    case LTE_VALUE:
+      /* values are trivial if they don't contain text */
+      return e->text_len == 0;
+    default:
+      g_assert_not_reached();
+    }
+}
+
 static void
 log_template_reset_compiled(LogTemplate *self)
 {
   log_template_elem_free_list(self->compiled_template);
   self->compiled_template = NULL;
+  self->trivial = FALSE;
 }
 
 gboolean
@@ -51,6 +130,8 @@ log_template_compile(LogTemplate *self, const gchar *template, GError **error)
   log_template_compiler_init(&compiler, self);
   result = log_template_compiler_compile(&compiler, &self->compiled_template, error);
   log_template_compiler_clear(&compiler);
+
+  self->trivial = _calculate_triviality(self);
   return result;
 }
 
@@ -67,7 +148,6 @@ log_template_set_type_hint(LogTemplate *self, const gchar *type_hint, GError **e
 
   return type_hint_parse(type_hint, &self->type_hint, error);
 }
-
 
 void
 log_template_append_format_with_context(LogTemplate *self, LogMessage **messages, gint num_messages,

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -60,9 +60,8 @@ typedef struct _LogTemplate
   gchar *name;
   gchar *template;
   GList *compiled_template;
-  gboolean escape;
-  gboolean def_inline;
   GlobalConfig *cfg;
+  guint escape:1, def_inline:1, trivial:1;
   TypeHint type_hint;
 } LogTemplate;
 
@@ -91,6 +90,8 @@ struct _LogTemplateOptions
 void log_template_set_escape(LogTemplate *self, gboolean enable);
 gboolean log_template_set_type_hint(LogTemplate *self, const gchar *hint, GError **error);
 gboolean log_template_compile(LogTemplate *self, const gchar *template, GError **error);
+gboolean log_template_is_trivial(LogTemplate *self);
+const gchar *log_template_get_trivial_value(LogTemplate *self, LogMessage *msg, gssize *value_len);
 void log_template_format(LogTemplate *self, LogMessage *lm, const LogTemplateOptions *opts, gint tz, gint32 seq_num,
                          const gchar *context_id, GString *result);
 void log_template_append_format(LogTemplate *self, LogMessage *lm, const LogTemplateOptions *opts, gint tz,

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -325,3 +325,36 @@ Test(template, test_template_function_args)
                          "33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 "
                          "49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64");
 }
+
+Test(template, test_single_values_and_literal_strings_are_considered_trivial)
+{
+  LogTemplate *template;
+  LogMessage *msg = create_sample_message();
+
+  template = compile_template("literal", FALSE);
+  cr_assert(log_template_is_trivial(template));
+  cr_assert_str_eq(log_template_get_trivial_value(template, msg, NULL), "literal");
+  log_template_unref(template);
+
+  template = compile_template("$1", FALSE);
+  cr_assert(log_template_is_trivial(template));
+  cr_assert_str_eq(log_template_get_trivial_value(template, msg, NULL), "first-match");
+  log_template_unref(template);
+
+  template = compile_template("$MSG", FALSE);
+  cr_assert(log_template_is_trivial(template));
+  cr_assert_str_eq(log_template_get_trivial_value(template, msg, NULL), "árvíztűrőtükörfúrógép");
+  log_template_unref(template);
+
+  template = compile_template("$HOST", FALSE);
+  cr_assert(log_template_is_trivial(template));
+  cr_assert_str_eq(log_template_get_trivial_value(template, msg, NULL), "bzorp");
+  log_template_unref(template);
+
+  template = compile_template("${APP.VALUE}", FALSE);
+  cr_assert(log_template_is_trivial(template));
+  cr_assert_str_eq(log_template_get_trivial_value(template, msg, NULL), "value");
+  log_template_unref(template);
+
+  log_msg_unref(msg);
+}

--- a/modules/dbparser/correllation-context.h
+++ b/modules/dbparser/correllation-context.h
@@ -26,6 +26,8 @@
 #include "syslog-ng.h"
 #include "correllation-key.h"
 #include "timerwheel.h"
+#include "logmsg/logmsg.h"
+#include "template/templates.h"
 
 /* This class encapsulates a correllation context, keyed by CorrellationKey, type == PSK_RULE. */
 typedef struct _CorrellationContext CorrellationContext;
@@ -49,6 +51,7 @@ correllation_context_get_last_message(CorrellationContext *self)
 
 void correllation_context_init(CorrellationContext *self, const CorrellationKey *key);
 void correllation_context_free_method(CorrellationContext *self);
+void correllation_context_sort(CorrellationContext *self, LogTemplate *sort_key);
 CorrellationContext *correllation_context_new(CorrellationKey *key);
 CorrellationContext *correllation_context_ref(CorrellationContext *self);
 void correllation_context_unref(CorrellationContext *self);

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -68,6 +68,7 @@ SyntheticMessage *last_message;
 %token KW_FILE
 %token KW_PROGRAM_TEMPLATE
 %token KW_MESSAGE_TEMPLATE
+%token KW_SORT_KEY
 
 %type <num> stateful_parser_inject_mode
 %type <ptr> synthetic_message
@@ -133,6 +134,7 @@ grouping_by_opts
 
 grouping_by_opt
 	: KW_KEY '(' template_content ')'                       { grouping_by_set_key_template(last_parser, $3); log_template_unref($3); }
+        | KW_SORT_KEY '(' template_content ')'			{ grouping_by_set_sort_key_template(last_parser, $3); log_template_unref($3); }
         | KW_SCOPE '(' context_scope ')'                        { grouping_by_set_scope(last_parser, $3); }
         | KW_WHERE '('
           {

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -39,6 +39,7 @@ static CfgLexerKeyword dbparser_keywords[] =
   { "inject_mode",        KW_INJECT_MODE },
   { "drop_unmatched",     KW_DROP_UNMATCHED },
   { "key",                KW_KEY },
+  { "sort_key",           KW_SORT_KEY },
   { "scope",              KW_SCOPE },
   { "timeout",            KW_TIMEOUT },
   { "aggregate",          KW_AGGREGATE },

--- a/modules/dbparser/groupingby.h
+++ b/modules/dbparser/groupingby.h
@@ -27,6 +27,7 @@
 #include "filter/filter-expr.h"
 
 void grouping_by_set_key_template(LogParser *s, LogTemplate *context_id);
+void grouping_by_set_sort_key_template(LogParser *s, LogTemplate *sort_key);
 void grouping_by_set_timeout(LogParser *s, gint timeout);
 void grouping_by_set_scope(LogParser *s, CorrellationScope scope);
 void grouping_by_set_synthetic_message(LogParser *s, SyntheticMessage *message);


### PR DESCRIPTION
This patch implements sorting of the elements accumulated into a context.
It is useful when entries are not received in order.

Example:
```
block parser cisco-ise-parser() {
    channel {
        parser {
            csv-parser(columns('1', '2', '3', 'MSG') flags(greedy));
            grouping-by(
                        scope("host")
                        key("$1")
                        sort-key("$3")
                        trigger("$(context-length)" eq "$2")
                        timeout(5)
                        aggregate(
                            inherit-mode(last-message)
                            value("MESSAGE", "$(if ('$(context-length)' eq '$(+ $2 1)')
                                                        '$1 1 0 $(implode \" \" $(list-slice :-1 $(context-values $MSG)))'
                                                        '$1 1 0 SYSLOG TRUNCATED $(list-slice :-1 $(context-values $3-$MSG))')")
                            tags(".cise.joined_message"))
            );
        };
        filter { tags(".cise.joined_message"); };
    };
};
```

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>