### PR TITLE
Dynamic fc

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -166,6 +166,7 @@ set(LIB_SOURCES
     children.c
     dnscache.c
     driver.c
+    dynamic-window.c
     dynamic-window-counter.c
     fdhelpers.c
     file-perms.c

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -77,6 +77,7 @@ set (LIB_HEADERS
     crypto.h
     dnscache.h
     driver.h
+    dynamic-window-counter.h
     fdhelpers.h
     file-perms.h
     find-crlf.h

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -78,6 +78,7 @@ set (LIB_HEADERS
     dnscache.h
     driver.h
     dynamic-window-counter.h
+    dynamic-window.h
     fdhelpers.h
     file-perms.h
     find-crlf.h

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -166,6 +166,7 @@ set(LIB_SOURCES
     children.c
     dnscache.c
     driver.c
+    dynamic-window-counter.c
     fdhelpers.c
     file-perms.c
     find-crlf.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -201,6 +201,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/children.c			\
 	lib/dnscache.c			\
 	lib/driver.c			\
+	lib/dynamic-window-counter.c \
 	lib/fdhelpers.c			\
 	lib/file-perms.c		\
 	lib/find-crlf.c			\

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -201,6 +201,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/children.c			\
 	lib/dnscache.c			\
 	lib/driver.c			\
+	lib/dynamic-window.c \
 	lib/dynamic-window-counter.c \
 	lib/fdhelpers.c			\
 	lib/file-perms.c		\

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -114,6 +114,7 @@ pkginclude_HEADERS			+= \
 	lib/dnscache.h			\
 	lib/driver.h			\
 	lib/dynamic-window-counter.h \
+	lib/dynamic-window.h \
 	lib/fdhelpers.h			\
 	lib/file-perms.h		\
 	lib/find-crlf.h			\

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -113,6 +113,7 @@ pkginclude_HEADERS			+= \
 	lib/crypto.h			\
 	lib/dnscache.h			\
 	lib/driver.h			\
+	lib/dynamic-window-counter.h \
 	lib/fdhelpers.h			\
 	lib/file-perms.h		\
 	lib/find-crlf.h			\

--- a/lib/dynamic-window-counter.c
+++ b/lib/dynamic-window-counter.c
@@ -45,3 +45,8 @@ void dynamic_window_counter_free(DynamicWindowCounter *self)
 
   g_free(self);
 }
+
+void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_size)
+{
+  self->iw_size = iw_size;
+}

--- a/lib/dynamic-window-counter.c
+++ b/lib/dynamic-window-counter.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2019 One Identity
  * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ * Copyright (c) 2019 László Várady <laszlo.varady@balabit.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,21 +23,25 @@
  *
  */
 
-#ifndef DYNAMIC_WINDOW_COUNTER_H_INCLUDED
-#define DYNAMIC_WINDOW_COUNTER_H_INCLUDED
+#include <syslog-ng.h>
+#include "dynamic-window-counter.h"
 
-#include "syslog-ng.h"
-
-typedef struct _DynamicWindowCounter DynamicWindowCounter;
-
-struct _DynamicWindowCounter
+DynamicWindowCounter *
+dynamic_window_counter_new(void)
 {
-  gsize iw_size;
-  gsize window;
-};
+  DynamicWindowCounter *self = g_new0(DynamicWindowCounter, 1);
+  return self;
+}
 
-DynamicWindowCounter *dynamic_window_counter_new(void);
-void dynamic_window_counter_init(DynamicWindowCounter *self);
-void dynamic_window_counter_free(DynamicWindowCounter *self);
+void dynamic_window_counter_init(DynamicWindowCounter *self)
+{
+  self->window = self->iw_size;
+}
 
-#endif
+void dynamic_window_counter_free(DynamicWindowCounter *self)
+{
+  if (!self)
+    return;
+
+  g_free(self);
+}

--- a/lib/dynamic-window-counter.c
+++ b/lib/dynamic-window-counter.c
@@ -27,10 +27,12 @@
 #include "dynamic-window-counter.h"
 
 DynamicWindowCounter *
-dynamic_window_counter_new(void)
+dynamic_window_counter_new(gsize iw_size)
 {
   DynamicWindowCounter *self = g_new0(DynamicWindowCounter, 1);
   g_atomic_counter_set(&self->ref_cnt, 1);
+
+  self->iw_size = iw_size;
 
   return self;
 }
@@ -59,11 +61,6 @@ void dynamic_window_counter_unref(DynamicWindowCounter *self)
     {
       g_free(self);
     }
-}
-
-void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_size)
-{
-  self->iw_size = iw_size;
 }
 
 gsize

--- a/lib/dynamic-window-counter.c
+++ b/lib/dynamic-window-counter.c
@@ -50,3 +50,18 @@ void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_siz
 {
   self->iw_size = iw_size;
 }
+
+gsize
+dynamic_window_counter_request(DynamicWindowCounter *self, gsize requested_size)
+{
+  gsize offered = MIN(self->window, requested_size);
+  self->window -= offered;
+
+  return offered;
+}
+
+void dynamic_window_counter_release(DynamicWindowCounter *self, gsize release_size)
+{
+  self->window += release_size;
+  g_assert(self->window <= self->iw_size);
+}

--- a/lib/dynamic-window-counter.h
+++ b/lib/dynamic-window-counter.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2019 One Identity
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DYNAMIC_WINDOW_COUNTER_H_INCLUDED
+#define DYNAMIC_WINDOW_COUNTER_H_INCLUDED
+
+#include "syslog-ng.h"
+
+typedef struct _DynamicWindowCounter DynamicWindowCounter;
+
+struct _DynamicWindowCounter
+{
+  gsize iw_size;
+  gsize window;
+};
+
+#endif

--- a/lib/dynamic-window-counter.h
+++ b/lib/dynamic-window-counter.h
@@ -40,5 +40,7 @@ void dynamic_window_counter_init(DynamicWindowCounter *self);
 void dynamic_window_counter_free(DynamicWindowCounter *self);
 
 void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_size);
+gsize dynamic_window_counter_request(DynamicWindowCounter *self, gsize requested_size);
+void dynamic_window_counter_release(DynamicWindowCounter *self, gsize release_size);
 
 #endif

--- a/lib/dynamic-window-counter.h
+++ b/lib/dynamic-window-counter.h
@@ -26,18 +26,22 @@
 #define DYNAMIC_WINDOW_COUNTER_H_INCLUDED
 
 #include "syslog-ng.h"
+#include "atomic.h"
 
 typedef struct _DynamicWindowCounter DynamicWindowCounter;
 
 struct _DynamicWindowCounter
 {
+  GAtomicCounter ref_cnt;
+
   gsize iw_size;
   gsize window;
 };
 
 DynamicWindowCounter *dynamic_window_counter_new(void);
 void dynamic_window_counter_init(DynamicWindowCounter *self);
-void dynamic_window_counter_free(DynamicWindowCounter *self);
+DynamicWindowCounter *dynamic_window_counter_ref(DynamicWindowCounter *self);
+void dynamic_window_counter_unref(DynamicWindowCounter *self);
 
 void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_size);
 gsize dynamic_window_counter_request(DynamicWindowCounter *self, gsize requested_size);

--- a/lib/dynamic-window-counter.h
+++ b/lib/dynamic-window-counter.h
@@ -38,12 +38,11 @@ struct _DynamicWindowCounter
   gsize window;
 };
 
-DynamicWindowCounter *dynamic_window_counter_new(void);
+DynamicWindowCounter *dynamic_window_counter_new(gsize iw_size);
 void dynamic_window_counter_init(DynamicWindowCounter *self);
 DynamicWindowCounter *dynamic_window_counter_ref(DynamicWindowCounter *self);
 void dynamic_window_counter_unref(DynamicWindowCounter *self);
 
-void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_size);
 gsize dynamic_window_counter_request(DynamicWindowCounter *self, gsize requested_size);
 void dynamic_window_counter_release(DynamicWindowCounter *self, gsize release_size);
 

--- a/lib/dynamic-window-counter.h
+++ b/lib/dynamic-window-counter.h
@@ -39,4 +39,6 @@ DynamicWindowCounter *dynamic_window_counter_new(void);
 void dynamic_window_counter_init(DynamicWindowCounter *self);
 void dynamic_window_counter_free(DynamicWindowCounter *self);
 
+void dynamic_window_counter_set_iw_size(DynamicWindowCounter *self, gsize iw_size);
+
 #endif

--- a/lib/dynamic-window.c
+++ b/lib/dynamic-window.c
@@ -50,6 +50,9 @@ dynamic_window_stat_reset(DynamicWindow *self)
 gsize
 dynamic_window_stat_get_avg(DynamicWindow *self)
 {
+  if (self->window_stat.n == 0)
+    return 0;
+
   return self->window_stat.sum / self->window_stat.n;
 }
 
@@ -64,4 +67,3 @@ dynamic_window_stat_get_sum(DynamicWindow *self)
 {
   return self->window_stat.sum;
 }
-

--- a/lib/dynamic-window.c
+++ b/lib/dynamic-window.c
@@ -64,24 +64,24 @@ dynamic_window_stat_get_sum(DynamicWindowStat *self)
 void
 dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr)
 {
-  self->window_ctr = ctr;
+  self->ctr = ctr;
   dynamic_window_stat_reset(&self->stat);
 }
 
 gsize
 dynamic_window_request(DynamicWindow *self, gsize size)
 {
-  if (!self->window_ctr)
+  if (!self->ctr)
     return 0;
 
-  return dynamic_window_counter_request(self->window_ctr, size);
+  return dynamic_window_counter_request(self->ctr, size);
 }
 
 void
 dynamic_window_release(DynamicWindow *self, gsize size)
 {
-  if (!self->window_ctr)
+  if (!self->ctr)
     return;
 
-  dynamic_window_counter_release(self->window_ctr, size);
+  dynamic_window_counter_release(self->ctr, size);
 }

--- a/lib/dynamic-window.c
+++ b/lib/dynamic-window.c
@@ -40,14 +40,28 @@ dynamic_window_stat_update(DynamicWindow *self, gsize window)
   self->window_stat.n++;
 }
 
-void dynamic_window_stat_reset(DynamicWindow *self)
+void
+dynamic_window_stat_reset(DynamicWindow *self)
 {
   self->window_stat.sum = 0;
   self->window_stat.n = 0;
 }
 
-gsize dynamic_window_stat_get_avg(DynamicWindow *self)
+gsize
+dynamic_window_stat_get_avg(DynamicWindow *self)
 {
   return self->window_stat.sum / self->window_stat.n;
+}
+
+gsize
+dynamic_window_stat_get_number_of_samples(DynamicWindow *self)
+{
+  return self->window_stat.n;
+}
+
+gsize
+dynamic_window_stat_get_sum(DynamicWindow *self)
+{
+  return self->window_stat.sum;
 }
 

--- a/lib/dynamic-window.c
+++ b/lib/dynamic-window.c
@@ -67,3 +67,21 @@ dynamic_window_stat_get_sum(DynamicWindow *self)
 {
   return self->window_stat.sum;
 }
+
+gsize
+dynamic_window_request(DynamicWindow *self, gsize size)
+{
+  if (!self->window_ctr)
+    return 0;
+
+  return dynamic_window_counter_request(self->window_ctr, size);
+}
+
+void
+dynamic_window_release(DynamicWindow *self, gsize size)
+{
+  if (!self->window_ctr)
+    return;
+
+  dynamic_window_counter_release(self->window_ctr, size);
+}

--- a/lib/dynamic-window.c
+++ b/lib/dynamic-window.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2019 One Identity
  * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ * Copyright (c) 2019 László Várady <laszlo.varady@balabit.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,27 +23,31 @@
  *
  */
 
-#ifndef DYNAMIC_WINDOW_H_INCLUDED
-#define DYNAMIC_WINDOW_H_INCLUDED
+#include <syslog-ng.h>
+#include "dynamic-window.h"
 
-#include "syslog-ng.h"
-#include "dynamic-window-counter.h"
-
-typedef struct _DynamicWindow DynamicWindow;
-
-struct _DynamicWindow
+void
+dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr)
 {
-  DynamicWindowCounter *window_ctr;
-  struct
-  {
-    gsize n;
-    gsize sum;
-  } window_stat;
-};
+  self->window_ctr = ctr;
+  dynamic_window_stat_reset(self);
+}
 
-void dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr);
-void dynamic_window_stat_update(DynamicWindow *self, gsize window);
-void dynamic_window_stat_reset(DynamicWindow *self);
-gsize dynamic_window_stat_get_avg(DynamicWindow *self);
+void
+dynamic_window_stat_update(DynamicWindow *self, gsize window)
+{
+  self->window_stat.sum += window;
+  self->window_stat.n++;
+}
 
-#endif
+void dynamic_window_stat_reset(DynamicWindow *self)
+{
+  self->window_stat.sum = 0;
+  self->window_stat.n = 0;
+}
+
+gsize dynamic_window_stat_get_avg(DynamicWindow *self)
+{
+  return self->window_stat.sum / self->window_stat.n;
+}
+

--- a/lib/dynamic-window.c
+++ b/lib/dynamic-window.c
@@ -27,45 +27,45 @@
 #include "dynamic-window.h"
 
 void
+dynamic_window_stat_update(DynamicWindowStat *self, gsize value)
+{
+  self->sum += value;
+  self->n++;
+}
+
+void
+dynamic_window_stat_reset(DynamicWindowStat *self)
+{
+  self->sum = 0;
+  self->n = 0;
+}
+
+gsize
+dynamic_window_stat_get_avg(DynamicWindowStat *self)
+{
+  if (self->n == 0)
+    return 0;
+
+  return self->sum / self->n;
+}
+
+gsize
+dynamic_window_stat_get_number_of_samples(DynamicWindowStat *self)
+{
+  return self->n;
+}
+
+gsize
+dynamic_window_stat_get_sum(DynamicWindowStat *self)
+{
+  return self->sum;
+}
+
+void
 dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr)
 {
   self->window_ctr = ctr;
-  dynamic_window_stat_reset(self);
-}
-
-void
-dynamic_window_stat_update(DynamicWindow *self, gsize window)
-{
-  self->window_stat.sum += window;
-  self->window_stat.n++;
-}
-
-void
-dynamic_window_stat_reset(DynamicWindow *self)
-{
-  self->window_stat.sum = 0;
-  self->window_stat.n = 0;
-}
-
-gsize
-dynamic_window_stat_get_avg(DynamicWindow *self)
-{
-  if (self->window_stat.n == 0)
-    return 0;
-
-  return self->window_stat.sum / self->window_stat.n;
-}
-
-gsize
-dynamic_window_stat_get_number_of_samples(DynamicWindow *self)
-{
-  return self->window_stat.n;
-}
-
-gsize
-dynamic_window_stat_get_sum(DynamicWindow *self)
-{
-  return self->window_stat.sum;
+  dynamic_window_stat_reset(&self->stat);
 }
 
 gsize

--- a/lib/dynamic-window.h
+++ b/lib/dynamic-window.h
@@ -48,6 +48,7 @@ struct _DynamicWindow
 {
   DynamicWindowCounter *ctr;
   DynamicWindowStat stat;
+  DynamicWindowStat ack_rate;
 };
 
 void dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr);

--- a/lib/dynamic-window.h
+++ b/lib/dynamic-window.h
@@ -46,7 +46,7 @@ gsize dynamic_window_stat_get_sum(DynamicWindowStat *self);
 
 struct _DynamicWindow
 {
-  DynamicWindowCounter *window_ctr;
+  DynamicWindowCounter *ctr;
   DynamicWindowStat stat;
 };
 

--- a/lib/dynamic-window.h
+++ b/lib/dynamic-window.h
@@ -46,5 +46,7 @@ void dynamic_window_stat_reset(DynamicWindow *self);
 gsize dynamic_window_stat_get_avg(DynamicWindow *self);
 gsize dynamic_window_stat_get_number_of_samples(DynamicWindow *self);
 gsize dynamic_window_stat_get_sum(DynamicWindow *self);
+gsize dynamic_window_request(DynamicWindow *self, gsize size);
+void dynamic_window_release(DynamicWindow *self, gsize size);
 
 #endif

--- a/lib/dynamic-window.h
+++ b/lib/dynamic-window.h
@@ -44,5 +44,7 @@ void dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr);
 void dynamic_window_stat_update(DynamicWindow *self, gsize window);
 void dynamic_window_stat_reset(DynamicWindow *self);
 gsize dynamic_window_stat_get_avg(DynamicWindow *self);
+gsize dynamic_window_stat_get_number_of_samples(DynamicWindow *self);
+gsize dynamic_window_stat_get_sum(DynamicWindow *self);
 
 #endif

--- a/lib/dynamic-window.h
+++ b/lib/dynamic-window.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2019 One Identity
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DYNAMIC_WINDOW_H_INCLUDED
+#define DYNAMIC_WINDOW_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "dynamic-window-counter.h"
+
+typedef struct _DynamicWindow DynamicWindow;
+
+struct _DynamicWindow
+{
+  DynamicWindowCounter window;
+  struct
+  {
+    gsize n;
+    gsize sum;
+  } window_stat;
+};
+
+#endif

--- a/lib/dynamic-window.h
+++ b/lib/dynamic-window.h
@@ -30,22 +30,27 @@
 
 typedef struct _DynamicWindow DynamicWindow;
 
+typedef struct _DynamicWindowStat DynamicWindowStat;
+
+struct _DynamicWindowStat
+{
+  gsize n;
+  gsize sum;
+};
+
+void dynamic_window_stat_update(DynamicWindowStat *self, gsize value);
+void dynamic_window_stat_reset(DynamicWindowStat *self);
+gsize dynamic_window_stat_get_avg(DynamicWindowStat *self);
+gsize dynamic_window_stat_get_number_of_samples(DynamicWindowStat *self);
+gsize dynamic_window_stat_get_sum(DynamicWindowStat *self);
+
 struct _DynamicWindow
 {
   DynamicWindowCounter *window_ctr;
-  struct
-  {
-    gsize n;
-    gsize sum;
-  } window_stat;
+  DynamicWindowStat stat;
 };
 
 void dynamic_window_set_counter(DynamicWindow *self, DynamicWindowCounter *ctr);
-void dynamic_window_stat_update(DynamicWindow *self, gsize window);
-void dynamic_window_stat_reset(DynamicWindow *self);
-gsize dynamic_window_stat_get_avg(DynamicWindow *self);
-gsize dynamic_window_stat_get_number_of_samples(DynamicWindow *self);
-gsize dynamic_window_stat_get_sum(DynamicWindow *self);
 gsize dynamic_window_request(DynamicWindow *self, gsize size);
 void dynamic_window_release(DynamicWindow *self, gsize size);
 

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -38,7 +38,10 @@ typedef struct LateAckTracker
 {
   AckTracker super;
   LateAckRecord *pending_ack_record;
-  RingBuffer ack_record_storage;
+ // RingBuffer ack_record_storage;
+  GList *ack_record_storage;
+  GList *ack_record_storage_tail;
+  gsize ack_record_storage_size;
   GStaticMutex storage_mutex;
   AckTrackerOnAllAcked on_all_acked;
 } LateAckTracker;
@@ -92,37 +95,13 @@ late_ack_tracker_on_all_acked_call(AckTracker *s)
       handler->func(handler->user_data);
     }
 }
+
 static inline gboolean
 _ack_range_is_continuous(void *data)
 {
   LateAckRecord *ack_rec = (LateAckRecord *)data;
 
   return ack_rec->acked;
-}
-
-static inline guint32
-_get_continuous_range_length(LateAckTracker *self)
-{
-  return ring_buffer_get_continual_range_length(&self->ack_record_storage, _ack_range_is_continuous);
-}
-
-static inline void
-_drop_range(LateAckTracker *self, guint32 n)
-{
-  int i;
-  LateAckRecord *ack_rec;
-
-  for (i = 0; i < n; i++)
-    {
-      ack_rec = ring_buffer_element_at(&self->ack_record_storage, i);
-      ack_rec->acked = FALSE;
-
-      late_ack_record_destroy(ack_rec);
-
-      ack_rec->bookmark.save = NULL;
-      ack_rec->bookmark.destroy = NULL;
-    }
-  ring_buffer_drop(&self->ack_record_storage, n);
 }
 
 static void
@@ -139,9 +118,17 @@ late_ack_tracker_track_msg(AckTracker *s, LogMessage *msg)
 
   late_ack_tracker_lock(s);
   {
-    LateAckRecord *ack_rec;
-    ack_rec = (LateAckRecord *)ring_buffer_push(&self->ack_record_storage);
-    g_assert(ack_rec == self->pending_ack_record);
+    if (self->ack_record_storage == NULL)
+      {
+        self->ack_record_storage = g_list_append(self->ack_record_storage, self->pending_ack_record);
+        self->ack_record_storage_tail = self->ack_record_storage;
+      }
+    else
+      {
+        g_list_append(self->ack_record_storage_tail, self->pending_ack_record);
+        self->ack_record_storage_tail = self->ack_record_storage_tail->next;
+      }
+    self->ack_record_storage_size++;
   }
   late_ack_tracker_unlock(s);
 
@@ -163,23 +150,35 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
 
   late_ack_tracker_lock(s);
   {
-    ack_range_length = _get_continuous_range_length(self);
+    GList *it = NULL;
+    GList *last = NULL;
+    for (it = self->ack_record_storage; it != NULL && _ack_range_is_continuous(it->data); it = it->next)
+      {
+        ++ack_range_length;
+        last = it;
+      }
+    if (ack_range_length > 0 && it == NULL) //all acked...
+      it = self->ack_record_storage;
     if (ack_range_length > 0)
       {
-        last_in_range = ring_buffer_element_at(&self->ack_record_storage, ack_range_length - 1);
+        last_in_range = (LateAckRecord *)last->data;
         if (ack_type != AT_ABORTED)
           {
             Bookmark *bookmark = &(last_in_range->bookmark);
             bookmark->save(bookmark);
           }
-        _drop_range(self, ack_range_length);
+        GList *delete_head = self->ack_record_storage;
+        self->ack_record_storage = last->next;
+        self->ack_record_storage_size -= ack_range_length;
+        last->next = NULL;
+        g_list_free_full(delete_head, g_free);
 
         if (ack_type == AT_SUSPENDED)
           log_source_flow_control_adjust_when_suspended(self->super.source, ack_range_length);
         else
           log_source_flow_control_adjust(self->super.source, ack_range_length);
 
-        if (ring_buffer_is_empty(&self->ack_record_storage))
+        if (!self->ack_record_storage || self->ack_record_storage_size == 0)
           late_ack_tracker_on_all_acked_call(s);
       }
   }
@@ -193,7 +192,15 @@ gboolean
 late_ack_tracker_is_empty(AckTracker *s)
 {
   LateAckTracker *self = (LateAckTracker *)s;
-  return ring_buffer_is_empty(&self->ack_record_storage);
+  return !self->ack_record_storage || self->ack_record_storage_size == 0;
+}
+
+static LateAckRecord *
+_alloc_ack_record(void)
+{
+  LateAckRecord *record = g_new0(LateAckRecord, 1);
+
+  return record;
 }
 
 static Bookmark *
@@ -201,11 +208,8 @@ late_ack_tracker_request_bookmark(AckTracker *s)
 {
   LateAckTracker *self = (LateAckTracker *)s;
 
-  late_ack_tracker_lock(s);
-  {
-    self->pending_ack_record = ring_buffer_tail(&self->ack_record_storage);
-  }
-  late_ack_tracker_unlock(s);
+  if (!self->pending_ack_record)
+    self->pending_ack_record = _alloc_ack_record();
 
   if (self->pending_ack_record)
     {
@@ -230,13 +234,13 @@ late_ack_tracker_free(AckTracker *s)
       handler->user_data_free_fn(handler->user_data);
     }
 
-  guint32 count = ring_buffer_count(&self->ack_record_storage);
-
   g_static_mutex_free(&self->storage_mutex);
+  if (self->pending_ack_record)
+    g_free(self->pending_ack_record);
 
-  _drop_range(self, count);
+  g_list_free_full(self->ack_record_storage, g_free);
+  self->ack_record_storage = NULL;
 
-  ring_buffer_free(&self->ack_record_storage);
   g_free(self);
 }
 
@@ -254,7 +258,6 @@ late_ack_tracker_init_instance(LateAckTracker *self, LogSource *source)
 {
   self->super.source = source;
   source->ack_tracker = (AckTracker *)self;
-  ring_buffer_alloc(&self->ack_record_storage, sizeof(LateAckRecord), log_source_get_init_window_size(source));
   g_static_mutex_init(&self->storage_mutex);
   _setup_callbacks(self);
 }

--- a/lib/late_ack_tracker.c
+++ b/lib/late_ack_tracker.c
@@ -107,6 +107,25 @@ _ack_range_is_continuous(void *data)
 }
 
 static void
+_ack_records_track_msg(LateAckTracker *self, LogMessage *msg)
+{
+  if (self->ack_records.head == NULL)
+    {
+      self->ack_records.head = g_list_append(self->ack_records.head, self->pending_ack_record);
+      self->ack_records.tail = self->ack_records.head;
+    }
+  else
+    {
+      g_assert(g_list_append(self->ack_records.tail, self->pending_ack_record) == self->ack_records.tail);
+      self->ack_records.tail = self->ack_records.tail->next;
+    }
+  self->ack_records.size++;
+
+  msg->ack_record = (AckRecord *)self->pending_ack_record;
+  self->pending_ack_record = NULL;
+}
+
+static void
 late_ack_tracker_track_msg(AckTracker *s, LogMessage *msg)
 {
   LateAckTracker *self = (LateAckTracker *)s;
@@ -116,25 +135,76 @@ late_ack_tracker_track_msg(AckTracker *s, LogMessage *msg)
 
   log_pipe_ref((LogPipe *)source);
 
-  msg->ack_record = (AckRecord *)self->pending_ack_record;
-
   late_ack_tracker_lock(s);
   {
-    if (self->ack_records.head == NULL)
-      {
-        self->ack_records.head = g_list_append(self->ack_records.head, self->pending_ack_record);
-        self->ack_records.tail = self->ack_records.head;
-      }
-    else
-      {
-        g_assert(g_list_append(self->ack_records.tail, self->pending_ack_record) == self->ack_records.tail);
-        self->ack_records.tail = self->ack_records.tail->next;
-      }
-    self->ack_records.size++;
+    _ack_records_track_msg(self, msg);
   }
   late_ack_tracker_unlock(s);
+}
 
-  self->pending_ack_record = NULL;
+static guint32
+_ack_records_get_ack_range_length(LateAckTracker *self, GList **last_in_range)
+{
+  GList *last = NULL;
+  guint32 ack_range_length = 0;
+
+  for (GList *it = self->ack_records.head;
+       it != NULL && _ack_range_is_continuous(it->data);
+       it = it->next)
+    {
+      ++ack_range_length;
+      last = it;
+    }
+
+  if (last_in_range)
+    *last_in_range = last;
+
+  return ack_range_length;
+}
+
+static void
+_ack_records_save_bookmark(GList *ack_record_node)
+{
+  LateAckRecord *record = (LateAckRecord *) ack_record_node->data;
+
+  Bookmark *bookmark = &(record->bookmark);
+  bookmark->save(bookmark);
+}
+
+static void
+_ack_records_delete_range(LateAckTracker *self, GList *last, guint32 ack_range_length)
+{
+  GList *delete_head = self->ack_records.head;
+  self->ack_records.head = last->next;
+  self->ack_records.size -= ack_range_length;
+  last->next = NULL;
+  g_list_free_full(delete_head, g_free);
+}
+
+static guint32
+_ack_records_untrack_msg(LateAckTracker *self, LogMessage *msg, AckType ack_type)
+{
+  GList *last = NULL;
+  guint32 ack_range_length = 0;
+
+  ack_range_length = _ack_records_get_ack_range_length(self, &last);
+
+  if (ack_range_length > 0)
+    {
+      if (ack_type != AT_ABORTED)
+        {
+          _ack_records_save_bookmark(last);
+        }
+      _ack_records_delete_range(self, last, ack_range_length);
+    }
+
+  return ack_range_length;
+}
+
+static gboolean
+_ack_records_is_all_acked(LateAckTracker *self)
+{
+  return (!self->ack_records.head || self->ack_records.size == 0);
 }
 
 static void
@@ -142,8 +212,6 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
 {
   LateAckTracker *self = (LateAckTracker *)s;
   LateAckRecord *ack_rec = (LateAckRecord *)msg->ack_record;
-  LateAckRecord *last_in_range = NULL;
-  guint32 ack_range_length = 0;
 
   ack_rec->acked = TRUE;
 
@@ -152,37 +220,15 @@ late_ack_tracker_manage_msg_ack(AckTracker *s, LogMessage *msg, AckType ack_type
 
   late_ack_tracker_lock(s);
   {
-    GList *it = NULL;
-    GList *last = NULL;
-    for (it = self->ack_records.head; it != NULL && _ack_range_is_continuous(it->data); it = it->next)
-      {
-        ++ack_range_length;
-        last = it;
-      }
-    if (ack_range_length > 0 && it == NULL) //all acked...
-      it = self->ack_records.head;
-    if (ack_range_length > 0)
-      {
-        last_in_range = (LateAckRecord *)last->data;
-        if (ack_type != AT_ABORTED)
-          {
-            Bookmark *bookmark = &(last_in_range->bookmark);
-            bookmark->save(bookmark);
-          }
-        GList *delete_head = self->ack_records.head;
-        self->ack_records.head = last->next;
-        self->ack_records.size -= ack_range_length;
-        last->next = NULL;
-        g_list_free_full(delete_head, g_free);
+    guint32 ack_range_length = _ack_records_untrack_msg(self, msg, ack_type);
 
-        if (ack_type == AT_SUSPENDED)
-          log_source_flow_control_adjust_when_suspended(self->super.source, ack_range_length);
-        else
-          log_source_flow_control_adjust(self->super.source, ack_range_length);
+    if (ack_type == AT_SUSPENDED)
+      log_source_flow_control_adjust_when_suspended(self->super.source, ack_range_length);
+    else
+      log_source_flow_control_adjust(self->super.source, ack_range_length);
 
-        if (!self->ack_records.head || self->ack_records.size == 0)
-          late_ack_tracker_on_all_acked_call(s);
-      }
+    if (_ack_records_is_all_acked(self))
+      late_ack_tracker_on_all_acked_call(s);
   }
   late_ack_tracker_unlock(s);
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -23,44 +23,9 @@
  */
 
 #include "logreader.h"
-#include "mainloop-io-worker.h"
 #include "mainloop-call.h"
 #include "ack_tracker.h"
 #include "scratch-buffers.h"
-
-#include <iv_event.h>
-
-struct _LogReader
-{
-  LogSource super;
-  LogProtoServer *proto;
-  gboolean immediate_check;
-  LogPipe *control;
-  LogReaderOptions *options;
-  PollEvents *poll_events;
-  GSockAddr *peer_addr;
-
-  /* NOTE: these used to be LogReaderWatch members, which were merged into
-   * LogReader with the multi-thread refactorization */
-
-  struct iv_task restart_task;
-  struct iv_event schedule_wakeup;
-  struct iv_event last_msg_sent_event;
-  MainLoopIOWorkerJob io_job;
-  gboolean watches_running:1, suspended:1;
-  gint notify_code;
-
-
-  /* proto & poll_events pending to be applied. As long as the previous
-   * processing is being done, we can't replace these in self->proto and
-   * self->poll_events, they get applied to the production ones as soon as
-   * the previous work is finished */
-  gboolean pending_close;
-  GCond *pending_close_cond;
-  GStaticMutex pending_close_lock;
-
-  struct iv_timer idle_timer;
-};
 
 static void log_reader_io_handle_in(gpointer s);
 static gboolean log_reader_fetch_log(LogReader *self);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -388,6 +388,11 @@ log_reader_work_finished(void *s)
       /* reenable polling the source assuming that we're still in
        * business (e.g. the reader hasn't been uninitialized) */
 
+      if (self->realloc_window_after_fetch)
+        {
+          self->realloc_window_after_fetch = FALSE;
+          log_source_dynamic_window_realloc(s);
+        }
       log_proto_server_reset_error(self->proto);
       log_reader_update_watches(self);
     }
@@ -653,8 +658,16 @@ static void
 _schedule_dynamic_window_realloc(LogSource *s)
 {
   LogReader *self = (LogReader *)s;
+
   msg_trace("LogReader::dynamic_window_realloc called");
-  //TODO
+
+  if (self->io_job.working)
+    {
+      self->realloc_window_after_fetch = TRUE;
+      return;
+    }
+
+  log_source_dynamic_window_realloc(s);
 }
 
 LogReader *

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -650,7 +650,7 @@ log_reader_free(LogPipe *s)
 }
 
 static void
-_dynamic_window_realloc(LogSource *s)
+_schedule_dynamic_window_realloc(LogSource *s)
 {
   LogReader *self = (LogReader *)s;
   msg_trace("LogReader::dynamic_window_realloc called");
@@ -668,7 +668,7 @@ log_reader_new(GlobalConfig *cfg)
   self->super.super.free_fn = log_reader_free;
   self->super.wakeup = log_reader_wakeup;
   self->super.window_empty_cb = log_reader_window_empty;
-  self->super.dynamic_window_realloc = _dynamic_window_realloc;
+  self->super.schedule_dynamic_window_realloc = _schedule_dynamic_window_realloc;
   self->immediate_check = FALSE;
   log_reader_init_watches(self);
   g_static_mutex_init(&self->pending_close_lock);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -649,6 +649,14 @@ log_reader_free(LogPipe *s)
   log_source_free(s);
 }
 
+static void
+_dynamic_window_realloc(LogSource *s)
+{
+  LogReader *self = (LogReader *)s;
+  msg_trace("LogReader::dynamic_window_realloc called");
+  //TODO
+}
+
 LogReader *
 log_reader_new(GlobalConfig *cfg)
 {
@@ -660,6 +668,7 @@ log_reader_new(GlobalConfig *cfg)
   self->super.super.free_fn = log_reader_free;
   self->super.wakeup = log_reader_wakeup;
   self->super.window_empty_cb = log_reader_window_empty;
+  self->super.dynamic_window_realloc = _dynamic_window_realloc;
   self->immediate_check = FALSE;
   log_reader_init_watches(self);
   g_static_mutex_init(&self->pending_close_lock);

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -69,7 +69,7 @@ struct _LogReader
   struct iv_event schedule_wakeup;
   struct iv_event last_msg_sent_event;
   MainLoopIOWorkerJob io_job;
-  gboolean watches_running:1, suspended:1;
+  gboolean watches_running:1, suspended:1, realloc_window_after_fetch:1;
   gint notify_code;
 
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -183,9 +183,9 @@ log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_c
 void
 log_source_dynamic_window_update_statistics(LogSource *self)
 {
-  dynamic_window_stat_update(&self->dynamic_window, window_size_counter_get(&self->window_size, NULL));
+  dynamic_window_stat_update(&self->dynamic_window.stat, window_size_counter_get(&self->window_size, NULL));
   msg_trace("Updating dynamic window statistic", evt_tag_int("avg window size",
-                                                             dynamic_window_stat_get_avg(&self->dynamic_window)));
+                                                             dynamic_window_stat_get_avg(&self->dynamic_window.stat)));
 }
 
 static inline void
@@ -247,14 +247,14 @@ log_source_dynamic_window_realloc(LogSource *self)
    * only incrementation is possible by destination threads */
 
   /* TODO: add abstraction for heuristics */
-  gsize free_avg = dynamic_window_stat_get_avg(&self->dynamic_window);
+  gsize free_avg = dynamic_window_stat_get_avg(&self->dynamic_window.stat);
   if (free_avg > self->full_window_size * (self->options->dynamic_window_decrease_threshold / 100.0f))
     _decrease_window(self);
 
   if (free_avg < self->full_window_size * (self->options->dynamic_window_increase_threshold / 100.0f))
     _increase_window(self);
 
-  dynamic_window_stat_reset(&self->dynamic_window);
+  dynamic_window_stat_reset(&self->dynamic_window.stat);
 }
 
 void

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -175,9 +175,9 @@ log_source_flow_control_suspend(LogSource *self)
 }
 
 void
-log_source_enable_dynamic_window(LogSource *self, DynamicWindow *dynamic_window)
+log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_ctr)
 {
-  if (self->pos_tracked && dynamic_window)
+  if (self->pos_tracked && window_ctr)
     {
       msg_warning("WARNING: dynamic window size control works only with non-position tracking sources"
                   "Falling back to static window size (dynamic won't be used).",
@@ -185,7 +185,7 @@ log_source_enable_dynamic_window(LogSource *self, DynamicWindow *dynamic_window)
       return;
     }
 
-  self->dynamic_window = dynamic_window;
+  dynamic_window_set_counter(&self->dynamic_window, window_ctr);
 }
 
 void

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -206,7 +206,7 @@ _decrease_window(LogSource *self)
   if (empty_window <= subtrahend)
     {
       subtrahend = empty_window == 0 ? 0 : empty_window - 1;
-      new_full_window_size = self->full_window_size - empty_window;
+      new_full_window_size = self->full_window_size - subtrahend;
     }
 
   window_size_counter_sub(&self->window_size, subtrahend, NULL);
@@ -254,7 +254,7 @@ log_source_dynamic_window_realloc(LogSource *self)
 
   /* TODO: add abstraction for heuristics */
   gsize free_avg = dynamic_window_stat_get_avg(&self->dynamic_window);
-  if (free_avg >= self->full_window_size / 2)
+  if (free_avg > self->full_window_size / 2)
     _decrease_window(self);
 
   if (free_avg < self->full_window_size * 0.05f)

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -235,9 +235,9 @@ _release_dynamic_window(LogSource *self)
             log_pipe_location_tag(&self->super));
   self->full_window_size -= dynamic_part;
   window_size_counter_sub(&self->window_size, dynamic_part, NULL);
-  dynamic_window_release(&self->dynamic_window, dynamic_part);
+  dynamic_window_release(&self->dynamic_window, dynamic_part); //TODO: rename release to ...
 
-  dynamic_window_counter_unref(self->dynamic_window.window_ctr);
+  dynamic_window_counter_unref(self->dynamic_window.ctr); //TODO: move to dynamic_window_release_counter()
 }
 
 void

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -185,7 +185,7 @@ log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_c
       return;
     }
 
-  dynamic_window_set_counter(&self->dynamic_window, window_ctr);
+  dynamic_window_set_counter(&self->dynamic_window, dynamic_window_counter_ref(window_ctr));
 }
 
 void
@@ -244,6 +244,8 @@ _release_dynamic_window(LogSource *self)
   self->full_window_size -= dynamic_part;
   window_size_counter_sub(&self->window_size, dynamic_part, NULL);
   dynamic_window_release(&self->dynamic_window, dynamic_part);
+
+  dynamic_window_counter_unref(self->dynamic_window.window_ctr);
 }
 
 void

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -233,6 +233,19 @@ _increase_window(LogSource *self)
     log_source_wakeup(self);
 }
 
+static void
+_release_dynamic_window(LogSource *self)
+{
+  g_assert(self->ack_tracker == NULL);
+
+  gsize dynamic_part = self->full_window_size - self->options->init_window_size;
+  msg_trace("Releasing dynamic part of the window", evt_tag_int("dynamic_window_to_be_released", dynamic_part),
+            log_pipe_location_tag(&self->super));
+  self->full_window_size -= dynamic_part;
+  window_size_counter_sub(&self->window_size, dynamic_part, NULL);
+  dynamic_window_counter_release(self->dynamic_window.window_ctr, dynamic_part);
+}
+
 void
 log_source_dynamic_window_realloc(LogSource *self)
 {
@@ -537,6 +550,8 @@ log_source_free(LogPipe *s)
   log_pipe_free_method(s);
 
   ack_tracker_free(self->ack_tracker);
+  self->ack_tracker = NULL;
+  _release_dynamic_window(self);
 }
 
 void

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -568,7 +568,7 @@ log_source_options_defaults(LogSourceOptions *options)
   options->tags = NULL;
   options->read_old_records = TRUE;
   options->dynamic_window_decrease_threshold = 50;
-  options->dynamic_window_increase_threshold = 5;
+  options->dynamic_window_increase_threshold = 20;
   host_resolve_options_defaults(&options->host_resolve_options);
 }
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -215,13 +215,13 @@ _decrease_window(LogSource *self)
             evt_tag_int("new_window", new_full_window_size), log_pipe_location_tag(&self->super));
 
   self->full_window_size = new_full_window_size;
-  dynamic_window_counter_release(self->dynamic_window.window_ctr, subtrahend);
+  dynamic_window_release(&self->dynamic_window, subtrahend);
 }
 
 static inline void
 _increase_window(LogSource *self)
 {
-  gsize offered_dynamic = dynamic_window_counter_request(self->dynamic_window.window_ctr, self->full_window_size);
+  gsize offered_dynamic = dynamic_window_request(&self->dynamic_window, self->full_window_size);
 
   msg_trace("Increasing dynamic window", evt_tag_int("previous_window", self->full_window_size),
             evt_tag_int("new_window", self->full_window_size + offered_dynamic), log_pipe_location_tag(&self->super));
@@ -243,7 +243,7 @@ _release_dynamic_window(LogSource *self)
             log_pipe_location_tag(&self->super));
   self->full_window_size -= dynamic_part;
   window_size_counter_sub(&self->window_size, dynamic_part, NULL);
-  dynamic_window_counter_release(self->dynamic_window.window_ctr, dynamic_part);
+  dynamic_window_release(&self->dynamic_window, dynamic_part);
 }
 
 void

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -177,14 +177,6 @@ log_source_flow_control_suspend(LogSource *self)
 void
 log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_ctr)
 {
-  if (self->pos_tracked && window_ctr)
-    {
-      msg_warning("WARNING: dynamic window size control works only with non-position tracking sources"
-                  "Falling back to static window size (dynamic won't be used).",
-                  log_pipe_location_tag(&self->super));
-      return;
-    }
-
   dynamic_window_set_counter(&self->dynamic_window, dynamic_window_counter_ref(window_ctr));
 }
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -254,10 +254,10 @@ log_source_dynamic_window_realloc(LogSource *self)
 
   /* TODO: add abstraction for heuristics */
   gsize free_avg = dynamic_window_stat_get_avg(&self->dynamic_window);
-  if (free_avg > self->full_window_size / 2)
+  if (free_avg > self->full_window_size * (self->options->dynamic_window_decrease_threshold / 100.0f))
     _decrease_window(self);
 
-  if (free_avg < self->full_window_size * 0.05f)
+  if (free_avg < self->full_window_size * (self->options->dynamic_window_increase_threshold / 100.0f))
     _increase_window(self);
 
   dynamic_window_stat_reset(&self->dynamic_window);
@@ -565,6 +565,8 @@ log_source_options_defaults(LogSourceOptions *options)
   options->host_override_len = -1;
   options->tags = NULL;
   options->read_old_records = TRUE;
+  options->dynamic_window_decrease_threshold = 50;
+  options->dynamic_window_increase_threshold = 5;
   host_resolve_options_defaults(&options->host_resolve_options);
 }
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -189,6 +189,14 @@ log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_c
 }
 
 void
+log_source_dynamic_window_update_statistics(LogSource *self)
+{
+  dynamic_window_stat_update(&self->dynamic_window, window_size_counter_get(&self->window_size, NULL));
+  msg_trace("Updating dynamic window statistic", evt_tag_int("avg window size",
+                                                             dynamic_window_stat_get_avg(&self->dynamic_window)));
+}
+
+void
 log_source_mangle_hostname(LogSource *self, LogMessage *msg)
 {
   const gchar *resolved_name;

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -175,6 +175,20 @@ log_source_flow_control_suspend(LogSource *self)
 }
 
 void
+log_source_enable_dynamic_window(LogSource *self, DynamicWindow *dynamic_window)
+{
+  if (self->pos_tracked && dynamic_window)
+    {
+      msg_warning("WARNING: dynamic window size control works only with non-position tracking sources"
+                  "Falling back to static window size (dynamic won't be used).",
+                  log_pipe_location_tag(&self->super));
+      return;
+    }
+
+  self->dynamic_window = dynamic_window;
+}
+
+void
 log_source_mangle_hostname(LogSource *self, LogMessage *msg)
 {
   const gchar *resolved_name;
@@ -428,6 +442,7 @@ log_source_set_options(LogSource *self, LogSourceOptions *options,
   self->stats_instance = stats_instance ? g_strdup(stats_instance): NULL;
   self->threaded = threaded;
   self->pos_tracked = pos_tracked;
+
   log_pipe_detach_expr_node(&self->super);
   log_pipe_attach_expr_node(&self->super, expr_node);
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -28,6 +28,7 @@
 #include "logpipe.h"
 #include "stats/stats-registry.h"
 #include "window-size-counter.h"
+#include "dynamic-window.h"
 
 typedef struct _LogSourceOptions
 {
@@ -68,6 +69,7 @@ struct _LogSource
   gchar *stats_id;
   gchar *stats_instance;
   WindowSizeCounter window_size;
+  DynamicWindow *dynamic_window;
   StatsCounterItem *last_message_seen;
   StatsCounterItem *recvd_messages;
   guint32 last_ack_count;

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -69,7 +69,7 @@ struct _LogSource
   gchar *stats_id;
   gchar *stats_instance;
   WindowSizeCounter window_size;
-  DynamicWindow *dynamic_window;
+  DynamicWindow dynamic_window;
   StatsCounterItem *last_message_seen;
   StatsCounterItem *recvd_messages;
   guint32 last_ack_count;
@@ -113,7 +113,7 @@ void log_source_window_empty(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);
-void log_source_enable_dynamic_window(LogSource *self, DynamicWindow *dynamic_window);
+void log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_ctr);
 
 void log_source_global_init(void);
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -80,7 +80,7 @@ struct _LogSource
 
   void (*wakeup)(LogSource *s);
   void (*window_empty_cb)(LogSource *s);
-  void (*dynamic_window_realloc)(LogSource *s);
+  void (*schedule_dynamic_window_realloc)(LogSource *s);
 };
 
 static inline gboolean
@@ -96,11 +96,11 @@ log_source_get_init_window_size(LogSource *self)
 }
 
 static inline void
-log_source_dynamic_window_realloc(LogSource *s)
+log_source_schedule_dynamic_window_realloc(LogSource *s)
 {
-  if (!s || !s->dynamic_window_realloc)
+  if (!s || !s->schedule_dynamic_window_realloc)
     return;
-  s->dynamic_window_realloc(s);
+  s->schedule_dynamic_window_realloc(s);
 }
 
 gboolean log_source_init(LogPipe *s);

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -80,6 +80,7 @@ struct _LogSource
 
   void (*wakeup)(LogSource *s);
   void (*window_empty_cb)(LogSource *s);
+  void (*dynamic_window_realloc)(LogSource *s);
 };
 
 static inline gboolean
@@ -92,6 +93,14 @@ static inline gint
 log_source_get_init_window_size(LogSource *self)
 {
   return self->options->init_window_size;
+}
+
+static inline void
+log_source_dynamic_window_realloc(LogSource *s)
+{
+  if (!s || !s->dynamic_window_realloc)
+    return;
+  s->dynamic_window_realloc(s);
 }
 
 gboolean log_source_init(LogPipe *s);
@@ -114,6 +123,7 @@ void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increme
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);
 void log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *window_ctr);
+void log_source_dynamic_window_update_statistics(LogSource *self);
 
 void log_source_global_init(void);
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -68,6 +68,7 @@ struct _LogSource
   gboolean pos_tracked;
   gchar *stats_id;
   gchar *stats_instance;
+  gsize full_window_size;
   WindowSizeCounter window_size;
   DynamicWindow dynamic_window;
   StatsCounterItem *last_message_seen;
@@ -126,5 +127,8 @@ void log_source_enable_dynamic_window(LogSource *self, DynamicWindowCounter *win
 void log_source_dynamic_window_update_statistics(LogSource *self);
 
 void log_source_global_init(void);
+
+/* protected */
+void log_source_dynamic_window_realloc(LogSource *self);
 
 #endif

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -113,6 +113,7 @@ void log_source_window_empty(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);
+void log_source_enable_dynamic_window(LogSource *self, DynamicWindow *dynamic_window);
 
 void log_source_global_init(void);
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -33,6 +33,10 @@
 typedef struct _LogSourceOptions
 {
   gint init_window_size;
+
+  gint dynamic_window_increase_threshold;
+  gint dynamic_window_decrease_threshold;
+
   const gchar *group_name;
   gboolean keep_timestamp;
   gboolean keep_hostname;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_unit_test(CRITERION TARGET test_messages)
 add_unit_test(CRITERION TARGET test_atomic_gssize)
 add_unit_test(CRITERION TARGET test_window_size_counter)
 add_unit_test(CRITERION TARGET test_apphook)
+add_unit_test(CRITERION TARGET test_dynamic_window)
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES
   ADDITIONAL_MAKE_CLEAN_FILES

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -18,7 +18,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_str-utils \
 	lib/tests/test_atomic_gssize \
 	lib/tests/test_window_size_counter \
-	lib/tests/test_apphook
+	lib/tests/test_apphook \
+	lib/tests/test_dynamic_window
 
 EXTRA_DIST += lib/tests/CMakeLists.txt
 
@@ -127,6 +128,11 @@ lib_tests_test_window_size_counter_LDADD	=	\
 lib_tests_test_apphook_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_apphook_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_dynamic_window_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_dynamic_window_LDADD	=	\
 	$(TEST_LDADD)
 
 

--- a/lib/tests/test_dynamic_window.c
+++ b/lib/tests/test_dynamic_window.c
@@ -47,5 +47,9 @@ Test(dynamic_window, window_stat_avg)
   dynamic_window_stat_update(&win, 12);
   dynamic_window_stat_update(&win, 4);
   cr_expect_eq(dynamic_window_stat_get_avg(&win), 8);
+  cr_expect_eq(dynamic_window_stat_get_number_of_samples(&win), 2);
+  cr_expect_eq(dynamic_window_stat_get_sum(&win), 16);
+  cr_expect_eq(dynamic_window_stat_get_avg(&win),
+               dynamic_window_stat_get_sum(&win) / dynamic_window_stat_get_number_of_samples(&win));
 }
 

--- a/lib/tests/test_dynamic_window.c
+++ b/lib/tests/test_dynamic_window.c
@@ -27,29 +27,29 @@
 Test(dynamic_window, window_stat_reset)
 {
   DynamicWindow win;
-  dynamic_window_stat_reset(&win);
-  cr_expect_eq(win.window_stat.sum, 0);
-  cr_expect_eq(win.window_stat.n, 0);
+  dynamic_window_stat_reset(&win.stat);
+  cr_expect_eq(win.stat.sum, 0);
+  cr_expect_eq(win.stat.n, 0);
 }
 
 Test(dynamic_window, window_stat_reset_when_counter_is_set)
 {
   DynamicWindow win;
   dynamic_window_set_counter(&win, NULL);
-  cr_expect_eq(win.window_stat.sum, 0);
-  cr_expect_eq(win.window_stat.n, 0);
+  cr_expect_eq(win.stat.sum, 0);
+  cr_expect_eq(win.stat.n, 0);
 }
 
 Test(dynamic_window, window_stat_avg)
 {
   DynamicWindow win;
-  dynamic_window_stat_reset(&win);
-  dynamic_window_stat_update(&win, 12);
-  dynamic_window_stat_update(&win, 4);
-  cr_expect_eq(dynamic_window_stat_get_avg(&win), 8);
-  cr_expect_eq(dynamic_window_stat_get_number_of_samples(&win), 2);
-  cr_expect_eq(dynamic_window_stat_get_sum(&win), 16);
-  cr_expect_eq(dynamic_window_stat_get_avg(&win),
-               dynamic_window_stat_get_sum(&win) / dynamic_window_stat_get_number_of_samples(&win));
+  dynamic_window_stat_reset(&win.stat);
+  dynamic_window_stat_update(&win.stat, 12);
+  dynamic_window_stat_update(&win.stat, 4);
+  cr_expect_eq(dynamic_window_stat_get_avg(&win.stat), 8);
+  cr_expect_eq(dynamic_window_stat_get_number_of_samples(&win.stat), 2);
+  cr_expect_eq(dynamic_window_stat_get_sum(&win.stat), 16);
+  cr_expect_eq(dynamic_window_stat_get_avg(&win.stat),
+               dynamic_window_stat_get_sum(&win.stat) / dynamic_window_stat_get_number_of_samples(&win.stat));
 }
 

--- a/lib/tests/test_dynamic_window.c
+++ b/lib/tests/test_dynamic_window.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "dynamic-window.h"
+#include <criterion/criterion.h>
+
+Test(dynamic_window, window_stat_reset)
+{
+  DynamicWindow win;
+  dynamic_window_stat_reset(&win);
+  cr_expect_eq(win.window_stat.sum, 0);
+  cr_expect_eq(win.window_stat.n, 0);
+}
+
+Test(dynamic_window, window_stat_reset_when_counter_is_set)
+{
+  DynamicWindow win;
+  dynamic_window_set_counter(&win, NULL);
+  cr_expect_eq(win.window_stat.sum, 0);
+  cr_expect_eq(win.window_stat.n, 0);
+}
+
+Test(dynamic_window, window_stat_avg)
+{
+  DynamicWindow win;
+  dynamic_window_stat_reset(&win);
+  dynamic_window_stat_update(&win, 12);
+  dynamic_window_stat_update(&win, 4);
+  cr_expect_eq(dynamic_window_stat_get_avg(&win), 8);
+}
+

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -168,6 +168,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_FAILBACK
 %token KW_TCP_PROBE_INTERVAL
 %token KW_SUCCESSFUL_PROBES_REQUIRED
+%token KW_DYNAMIC_WINDOW_SIZE
 
 /* SSL support */
 
@@ -386,6 +387,7 @@ source_afsocket_stream_params
 	: KW_KEEP_ALIVE '(' yesno ')'		{ afsocket_sd_set_keep_alive(last_driver, $3); }
 	| KW_MAX_CONNECTIONS '(' positive_integer ')'	 { afsocket_sd_set_max_connections(last_driver, $3); }
 	| KW_LISTEN_BACKLOG '(' positive_integer ')'	{ afsocket_sd_set_listen_backlog(last_driver, $3); }
+	| KW_DYNAMIC_WINDOW_SIZE '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_size(last_driver, $3); }
 	;
 
 source_afsyslog

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -391,7 +391,8 @@ source_afsocket_stream_params
 	| KW_LISTEN_BACKLOG '(' positive_integer ')'	{ afsocket_sd_set_listen_backlog(last_driver, $3); }
 	| KW_DYNAMIC_WINDOW_SIZE '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_size(last_driver, $3); }
   | KW_DYNAMIC_WINDOW_STATS_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
-  | KW_DYNAMIC_WINDOW_REALLOC_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_realloc_freq(last_driver, $3); }
+  | KW_DYNAMIC_WINDOW_STATS_FREQ '(' LL_FLOAT ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
+  | KW_DYNAMIC_WINDOW_REALLOC_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_realloc_ticks(last_driver, $3); }
 	;
 
 source_afsyslog

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -171,6 +171,8 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_DYNAMIC_WINDOW_SIZE
 %token KW_DYNAMIC_WINDOW_STATS_FREQ
 %token KW_DYNAMIC_WINDOW_REALLOC_TICKS
+%token KW_DYNAMIC_WINDOW_INCREASE_THRESHOLD
+%token KW_DYNAMIC_WINDOW_DECREASE_THRESHOLD
 
 /* SSL support */
 
@@ -393,6 +395,8 @@ source_afsocket_stream_params
   | KW_DYNAMIC_WINDOW_STATS_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
   | KW_DYNAMIC_WINDOW_STATS_FREQ '(' LL_FLOAT ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
   | KW_DYNAMIC_WINDOW_REALLOC_TICKS '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_realloc_ticks(last_driver, $3); }
+  | KW_DYNAMIC_WINDOW_INCREASE_THRESHOLD '(' nonnegative_integer ')' { last_reader_options->super.dynamic_window_increase_threshold = $3; }
+  | KW_DYNAMIC_WINDOW_DECREASE_THRESHOLD '(' nonnegative_integer ')' { last_reader_options->super.dynamic_window_decrease_threshold = $3; }
 	;
 
 source_afsyslog

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -169,6 +169,8 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_TCP_PROBE_INTERVAL
 %token KW_SUCCESSFUL_PROBES_REQUIRED
 %token KW_DYNAMIC_WINDOW_SIZE
+%token KW_DYNAMIC_WINDOW_STATS_FREQ
+%token KW_DYNAMIC_WINDOW_REALLOC_FREQ
 
 /* SSL support */
 
@@ -388,6 +390,8 @@ source_afsocket_stream_params
 	| KW_MAX_CONNECTIONS '(' positive_integer ')'	 { afsocket_sd_set_max_connections(last_driver, $3); }
 	| KW_LISTEN_BACKLOG '(' positive_integer ')'	{ afsocket_sd_set_listen_backlog(last_driver, $3); }
 	| KW_DYNAMIC_WINDOW_SIZE '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_size(last_driver, $3); }
+  | KW_DYNAMIC_WINDOW_STATS_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
+  | KW_DYNAMIC_WINDOW_REALLOC_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_realloc_freq(last_driver, $3); }
 	;
 
 source_afsyslog

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -170,7 +170,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_SUCCESSFUL_PROBES_REQUIRED
 %token KW_DYNAMIC_WINDOW_SIZE
 %token KW_DYNAMIC_WINDOW_STATS_FREQ
-%token KW_DYNAMIC_WINDOW_REALLOC_FREQ
+%token KW_DYNAMIC_WINDOW_REALLOC_TICKS
 
 /* SSL support */
 
@@ -392,7 +392,7 @@ source_afsocket_stream_params
 	| KW_DYNAMIC_WINDOW_SIZE '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_size(last_driver, $3); }
   | KW_DYNAMIC_WINDOW_STATS_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
   | KW_DYNAMIC_WINDOW_STATS_FREQ '(' LL_FLOAT ')' { afsocket_sd_set_dynamic_window_stats_freq(last_driver, $3); }
-  | KW_DYNAMIC_WINDOW_REALLOC_FREQ '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_realloc_ticks(last_driver, $3); }
+  | KW_DYNAMIC_WINDOW_REALLOC_TICKS '(' nonnegative_integer ')' { afsocket_sd_set_dynamic_window_realloc_ticks(last_driver, $3); }
 	;
 
 source_afsyslog

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -96,6 +96,8 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "dynamic_window_size", KW_DYNAMIC_WINDOW_SIZE },
   { "dynamic_window_stats_freq", KW_DYNAMIC_WINDOW_STATS_FREQ },
   { "dynamic_window_realloc_ticks", KW_DYNAMIC_WINDOW_REALLOC_TICKS },
+  { "dynamic_window_increase_threshold", KW_DYNAMIC_WINDOW_INCREASE_THRESHOLD },
+  { "dynamic_window_decrease_threshold", KW_DYNAMIC_WINDOW_DECREASE_THRESHOLD },
   { NULL }
 };
 

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -93,6 +93,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "servers",            KW_SERVERS },
   { "tcp_probe_interval", KW_TCP_PROBE_INTERVAL },
   { "successful_probes_required", KW_SUCCESSFUL_PROBES_REQUIRED },
+  { "dynamic_window_size", KW_DYNAMIC_WINDOW_SIZE },
   { NULL }
 };
 

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -94,6 +94,8 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "tcp_probe_interval", KW_TCP_PROBE_INTERVAL },
   { "successful_probes_required", KW_SUCCESSFUL_PROBES_REQUIRED },
   { "dynamic_window_size", KW_DYNAMIC_WINDOW_SIZE },
+  { "dynamic_window_stats_freq", KW_DYNAMIC_WINDOW_STATS_FREQ },
+  { "dynamic_window_realloc_freq", KW_DYNAMIC_WINDOW_REALLOC_FREQ },
   { NULL }
 };
 

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -95,7 +95,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "successful_probes_required", KW_SUCCESSFUL_PROBES_REQUIRED },
   { "dynamic_window_size", KW_DYNAMIC_WINDOW_SIZE },
   { "dynamic_window_stats_freq", KW_DYNAMIC_WINDOW_STATS_FREQ },
-  { "dynamic_window_realloc_freq", KW_DYNAMIC_WINDOW_REALLOC_FREQ },
+  { "dynamic_window_realloc_ticks", KW_DYNAMIC_WINDOW_REALLOC_TICKS },
   { NULL }
 };
 

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -519,7 +519,7 @@ _on_dynamic_window_timer_elapsed(gpointer cookie)
       AFSocketSourceConnection *conn = (AFSocketSourceConnection *) conn_it->data;
       if (self->dynamic_window_timer_tick >= self->dynamic_window_realloc_freq)
         {
-          log_source_dynamic_window_realloc(&conn->reader->super);
+          log_source_schedule_dynamic_window_realloc(&conn->reader->super);
         }
       else
         {

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -466,7 +466,7 @@ afsocket_sd_close_connection(AFSocketSourceDriver *self, AFSocketSourceConnectio
 }
 
 static void
-afsocket_sd_start_watches(AFSocketSourceDriver *self)
+_listen_fd_init(AFSocketSourceDriver *self)
 {
   IV_FD_INIT(&self->listen_fd);
   self->listen_fd.fd = self->fd;
@@ -476,10 +476,22 @@ afsocket_sd_start_watches(AFSocketSourceDriver *self)
 }
 
 static void
-afsocket_sd_stop_watches(AFSocketSourceDriver *self)
+_listen_fd_deinit(AFSocketSourceDriver *self)
 {
   if (iv_fd_registered (&self->listen_fd))
     iv_fd_unregister(&self->listen_fd);
+}
+
+static void
+afsocket_sd_start_watches(AFSocketSourceDriver *self)
+{
+  _listen_fd_init(self);
+}
+
+static void
+afsocket_sd_stop_watches(AFSocketSourceDriver *self)
+{
+  _listen_fd_deinit(self);
 }
 
 static gboolean

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -40,8 +40,8 @@ int allow_severity = 0;
 int deny_severity = 0;
 #endif
 
-static const gfloat DYNAMIC_WINDOW_TIMER_MSECS = 1000;
-static const gsize DYNAMIC_WINDOW_REALLOC_TICKS = 5;
+static const gfloat DYNAMIC_WINDOW_TIMER_MSECS = 100;
+static const gsize DYNAMIC_WINDOW_REALLOC_TICKS = 10;
 
 typedef struct _AFSocketSourceConnection
 {

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -42,6 +42,7 @@ struct _AFSocketSourceDriver
           window_size_initialized:1;
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
+  gsize dynamic_window_timer_tick;
   gint fd;
   LogReaderOptions reader_options;
   DynamicWindowCounter *dynamic_window_ctr;

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -29,6 +29,7 @@
 #include "transport-mapper.h"
 #include "driver.h"
 #include "logreader.h"
+#include "dynamic-window-counter.h"
 
 #include <iv.h>
 
@@ -42,6 +43,7 @@ struct _AFSocketSourceDriver
   struct iv_fd listen_fd;
   gint fd;
   LogReaderOptions reader_options;
+  DynamicWindowCounter *dynamic_window_ctr;
   LogProtoServerFactory *proto_factory;
   GSockAddr *bind_addr;
   gint max_connections;
@@ -70,6 +72,7 @@ struct _AFSocketSourceDriver
 void afsocket_sd_set_keep_alive(LogDriver *self, gint enable);
 void afsocket_sd_set_max_connections(LogDriver *self, gint max_connections);
 void afsocket_sd_set_listen_backlog(LogDriver *self, gint listen_backlog);
+void afsocket_sd_set_dynamic_window_size(LogDriver *self, gint dynamic_window_size);
 
 static inline gboolean
 afsocket_sd_acquire_socket(AFSocketSourceDriver *s, gint *fd)

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -42,6 +42,7 @@ struct _AFSocketSourceDriver
           window_size_initialized:1;
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
+  gsize dynamic_window_size;
   gsize dynamic_window_timer_tick;
   gfloat dynamic_window_stats_freq;
   gint dynamic_window_realloc_ticks;

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -43,6 +43,8 @@ struct _AFSocketSourceDriver
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
   gsize dynamic_window_timer_tick;
+  gint dynamic_window_stats_freq;
+  gint dynamic_window_realloc_freq;
   gint fd;
   LogReaderOptions reader_options;
   DynamicWindowCounter *dynamic_window_ctr;
@@ -75,6 +77,8 @@ void afsocket_sd_set_keep_alive(LogDriver *self, gint enable);
 void afsocket_sd_set_max_connections(LogDriver *self, gint max_connections);
 void afsocket_sd_set_listen_backlog(LogDriver *self, gint listen_backlog);
 void afsocket_sd_set_dynamic_window_size(LogDriver *self, gint dynamic_window_size);
+void afsocket_sd_set_dynamic_window_stats_freq(LogDriver *self, gint stats_freq);
+void afsocket_sd_set_dynamic_window_realloc_freq(LogDriver *self, gint realloc_freq);
 
 static inline gboolean
 afsocket_sd_acquire_socket(AFSocketSourceDriver *s, gint *fd)

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -41,6 +41,7 @@ struct _AFSocketSourceDriver
   guint32 connections_kept_alive_across_reloads:1,
           window_size_initialized:1;
   struct iv_fd listen_fd;
+  struct iv_timer dynamic_window_timer;
   gint fd;
   LogReaderOptions reader_options;
   DynamicWindowCounter *dynamic_window_ctr;

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -43,8 +43,8 @@ struct _AFSocketSourceDriver
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
   gsize dynamic_window_timer_tick;
-  gint dynamic_window_stats_freq;
-  gint dynamic_window_realloc_freq;
+  gfloat dynamic_window_stats_freq;
+  gint dynamic_window_realloc_ticks;
   gint fd;
   LogReaderOptions reader_options;
   DynamicWindowCounter *dynamic_window_ctr;
@@ -77,8 +77,8 @@ void afsocket_sd_set_keep_alive(LogDriver *self, gint enable);
 void afsocket_sd_set_max_connections(LogDriver *self, gint max_connections);
 void afsocket_sd_set_listen_backlog(LogDriver *self, gint listen_backlog);
 void afsocket_sd_set_dynamic_window_size(LogDriver *self, gint dynamic_window_size);
-void afsocket_sd_set_dynamic_window_stats_freq(LogDriver *self, gint stats_freq);
-void afsocket_sd_set_dynamic_window_realloc_freq(LogDriver *self, gint realloc_freq);
+void afsocket_sd_set_dynamic_window_stats_freq(LogDriver *self, gfloat stats_freq);
+void afsocket_sd_set_dynamic_window_realloc_ticks(LogDriver *self, gint realloc_ticks);
 
 static inline gboolean
 afsocket_sd_acquire_socket(AFSocketSourceDriver *s, gint *fd)


### PR DESCRIPTION
First PR that implements dynamic window functionality.

# Dynamic window

Motivation/problem to be solved: 
 * when a network connection has a high number of clients
 * AND only a small subset of the active clients sends messages at a high rate AND
 * there is a limited amount of memory, 
then it would be nice from syslog-ng if it could somehow dynamically re-calculate window sizes (periodically during runtime).

The proposed solution is dynamic-window.

Key points during implementation:
 * 100% backward compatibility when someone don't want to use
 * default is static only
 * dynamic windowing performance should be very close to the static case
 * starvation is not an option, so a static window is always guaranteed (`iw-size`/`max-connections`)

Keep in mind that main goal of this PR is to implement the 'framework' of dynamic windowing and to show an example for a simple heuristic.
In a future PR we want to make it easier to use and also want to provide more/better heuristic.

How it works from users point of view?
* "Main" option
   * `dynamic-window-size(N)` : enable and set dynamic window
* Tuning parameters
   * `dynamic-window-stats-freq(x milliseconds)` : every x milliseconds syslog-ng check and update window stats
   * `dynamic-window-realloc-ticks(k)`           : after k window-stats-freq() dynamic window will be reallocated
   * `dynamic-window-decrease-threshold(y %)`    : when (free/used) * 100 > y then syslog-ng decrease the dynamic window
   * `dynamic-window-increase-threshold(x %)`    : when (free/used) * 100 < x then syslog-ng increase the dynamic window

Typical network source with dynamic window could be:

```
@version: 3.20
options {
 min-iw-size-per-reader(1);
 stats_level(2);
};

source s_network_dynamic {
  network(ip(0.0.0.0)
    port(61001)
    log_fetch_limit(1000)
    log_iw_size(10000)
    max_connections(10000)
    dynamic-window-size(100000)
    dynamic-window-stats-freq(0.1)
    dynamic-window-realloc-ticks(10)
    dynamic-window-decrease-threshold(50)
    dynamic-window-increase-threshold(20)
    flags(no-parse) 
  );
};
```

In this case, the static window per connection is `1` (the `min-iw-size-per-reader(1)` makes it possible to set such a small window size, in the future this option will be enabled by default when `dynamic-window-size()` is used).
When 50% of the available window is free for a connection, syslog-ng will decrease the window (but never goes under the static window size, which is 1 in this example).
When only 20% of the available window is free (or, in other words, if 80% of the available window is used) for a connection, syslog-ng will try to increase the window.

### Some UML diagrams (more details will be shared little bit later on diagrams, for reviewers):
![dynamic-fc-class-dia](https://user-images.githubusercontent.com/5908786/57072246-4ef8a100-6cdd-11e9-92d9-64e26e1d6a60.png)

![dynamic-fc-seq](https://user-images.githubusercontent.com/5908786/57072253-56b84580-6cdd-11e9-8373-c81ed2510774.png)
