### PR TITLE
 copyright: accept "One Identity" in copyright notices

### DIFF
--- a/tests/copyright/check.sh
+++ b/tests/copyright/check.sh
@@ -384,7 +384,7 @@ is_balabit_copyright() {
  grep --quiet --extended-regexp "\
 ^\
 (Copyright \(c\) ([0-9, -]+) [^ <][^<]*<br>)*\
-Copyright \(c\) ([0-9, -]+) Bala[bB]it<br>\
+Copyright \(c\) ([0-9, -]+) (Bala[bB]it)|(One Identity)<br>\
 (Copyright \(c\) ([0-9, -]+) [^ <][^<]*<br>)*\
 $"
  return $?

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -70,10 +70,10 @@ modules/java/(tools|[^/]*$)
 modules/java-modules/(dummy|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|date|diskq|dbparser|geoip|geoip2|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|snmptrapd-parser|xml|openbsd|examples|[^/]*$)
 modules/(add-contextual-data|tagsparser|map-value-pairs|hook-commands|appmodel|[^/]*$)
-modules/http/(http-loadbalancer)\.[ch]$
+modules/http/(http-loadbalancer|http-worker)\.[ch]$
 scl
 scripts
 modules/http/tests
  GPLv2+_SSL,non-balabit
-modules/http/(http|http-parser|http-worker|http-plugin|)\.[ch]
+modules/http/(http|http-parser|http-plugin|)\.[ch]
 modules/http/http-grammar.ym


### PR DESCRIPTION
The copyright checker checks for corporate copyright header lines, so it detects when we forget to add them.

This PR extends this validation and accepts "One Identity" as well as "Balabit".

Please note that  the `non-balabit` section of the policy file is for marking units that do not contain corporate copyright lines **deliberately**.