### PR TITLE
Template support in match

### DIFF
--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -46,7 +46,7 @@
 #include "plugin.h"
 #include "cfg-grammar.h"
 
-FilterRE *last_re_filter;
+FilterExprNode *last_filter_expr;
 
 }
 
@@ -140,7 +140,7 @@ filter_simple_expr
             free($3);
             free($6);
           }
-	| filter_re					{ $$ = &last_re_filter->super; }
+	| filter_re					{ $$ = last_filter_expr; }
 	| filter_plugin
 	| filter_comparison
 	;
@@ -199,11 +199,11 @@ operator
 	;
 
 filter_re
-        : KW_PROGRAM { last_re_filter = filter_re_new(LM_V_PROGRAM); } filter_re_params
-	| KW_HOST    { last_re_filter = filter_re_new(LM_V_HOST); } filter_re_params
-	| KW_MESSAGE { last_re_filter = filter_re_new(LM_V_MESSAGE); } filter_re_params
-        | KW_SOURCE  { last_re_filter = filter_source_new();  } filter_re_params
-	| KW_MATCH   { last_re_filter = filter_match_new(); } filter_match_params
+        : KW_PROGRAM { last_filter_expr = filter_re_new(LM_V_PROGRAM); } filter_re_params
+	| KW_HOST    { last_filter_expr = filter_re_new(LM_V_HOST); } filter_re_params
+	| KW_MESSAGE { last_filter_expr = filter_re_new(LM_V_MESSAGE); } filter_re_params
+        | KW_SOURCE  { last_filter_expr = filter_source_new();  } filter_re_params
+	| KW_MATCH   { last_filter_expr = filter_match_new(); } filter_match_params
 	;
 
 filter_re_params
@@ -211,7 +211,7 @@ filter_re_params
           {
             GError *error = NULL;
 
-            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_re_filter, configuration, $2, &error), @2, error, "error compiling search pattern");
+            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_filter_expr, configuration, $2, &error), @2, error, "error compiling search pattern");
             free($2);
           }
 	;
@@ -222,7 +222,7 @@ filter_re_opts
         ;
 
 filter_re_opt
-	: { last_matcher_options = &last_re_filter->matcher_options; } matcher_option
+	: { last_matcher_options = filter_re_get_matcher_options(last_filter_expr); } matcher_option
         ;
 
 
@@ -231,22 +231,17 @@ filter_match_params
           {
             GError *error = NULL;
 
-            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_re_filter, configuration, $2, &error), @2, error, "error compiling search pattern");
+            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_filter_expr, configuration, $2, &error), @2, error, "error compiling search pattern");
             free($2);
 
-            if (last_re_filter->value_handle == 0)
+            if (filter_match_is_usage_obsolete(last_filter_expr))
               {
-                static gboolean warn_written = FALSE;
-
-                if (!warn_written)
-                  {
-                    msg_warning("WARNING: the match() filter without the use of the value() "
-                                "option is deprecated and hinders performance, please use a "
-                                "more specific filter like message() and/or program() instead",
-                                cfg_lexer_format_location_tag(lexer, &@0));
-                    warn_written = TRUE;
-                  }
+                msg_warning_once("WARNING: the match() filter without the use of the value() "
+                                 "option is deprecated and hinders performance, please use a "
+                                 "more specific filter like message() and/or program() instead",
+                                 cfg_lexer_format_location_tag(lexer, &@0));
               }
+
           }
 
 filter_match_opts
@@ -266,7 +261,7 @@ filter_match_opt
                             cfg_lexer_format_location_tag(lexer, &@3));
                 p++;
               }
-            last_re_filter->value_handle = log_msg_get_value_handle(p);
+            filter_match_set_value_handle(last_filter_expr, log_msg_get_value_handle(p));
             free($3);
           }
         ;

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -256,18 +256,27 @@ filter_match_opt
             const gchar *p = $3;
             if (p[0] == '$')
               {
-                msg_warning("Value references in filters should not use the '$' prefix, those are only needed in templates",
+                msg_warning("WARNING: value references in filters should not use the '$' prefix, those are only needed in templates, removing automatically",
                             evt_tag_str("value", $3),
                             cfg_lexer_format_location_tag(lexer, &@3));
                 p++;
               }
+            if (p[0] == '(' || strchr(p, '$') != NULL)
+              {
+                msg_error("value() reference for the match() filter cannot contain a full template string, use the template() option or stick to a single value",
+                          evt_tag_str("value", $3),
+                          cfg_lexer_format_location_tag(lexer, &@3));
+                free($3);
+                YYERROR;
+              }
             filter_match_set_value_handle(last_filter_expr, log_msg_get_value_handle(p));
             free($3);
           }
+	| KW_TEMPLATE '(' template_content ')'
+	  {
+            filter_match_set_template_ref(last_filter_expr, $3);
+          }
         ;
-
-
-
 
 filter_fac_list
 	: filter_fac filter_fac_list		{ $$ = $1 | $2; }

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -45,12 +45,12 @@ filter_re_eval_string(FilterExprNode *s, LogMessage *msg, gint value_handle, con
 
   if (str_len < 0)
     str_len = strlen(str);
-  result = log_matcher_match(self->matcher, msg, value_handle, str, str_len);
   msg_trace("match() evaluation started",
             evt_tag_str("input", str),
             evt_tag_str("pattern", self->matcher->pattern),
             evt_tag_str("value", log_msg_get_value_name(value_handle, NULL)),
             evt_tag_printf("msg", "%p", msg));
+  result = log_matcher_match(self->matcher, msg, value_handle, str, str_len);
   return result ^ s->comp;
 }
 

--- a/lib/filter/filter-re.h
+++ b/lib/filter/filter-re.h
@@ -36,6 +36,7 @@ FilterExprNode *filter_source_new(void);
 
 gboolean filter_match_is_usage_obsolete(FilterExprNode *s);
 void filter_match_set_value_handle(FilterExprNode *s, NVHandle value_handle);
+void filter_match_set_template_ref(FilterExprNode *s, LogTemplate *template);
 FilterExprNode *filter_match_new(void);
 
 #endif

--- a/lib/filter/filter-re.h
+++ b/lib/filter/filter-re.h
@@ -28,20 +28,14 @@
 #include "filter-expr.h"
 #include "logmatcher.h"
 
-typedef struct _FilterRE
-{
-  FilterExprNode super;
-  NVHandle value_handle;
-  LogMatcherOptions matcher_options;
-  LogMatcher *matcher;
-} FilterRE;
+LogMatcherOptions *filter_re_get_matcher_options(FilterExprNode *s);
+gboolean filter_re_compile_pattern(FilterExprNode *s, GlobalConfig *cfg, const gchar *re, GError **error);
 
-typedef struct _FilterMatch FilterMatch;
+FilterExprNode *filter_re_new(NVHandle value_handle);
+FilterExprNode *filter_source_new(void);
 
-gboolean filter_re_compile_pattern(FilterRE *self, GlobalConfig *cfg, const gchar *re, GError **error);
-
-FilterRE *filter_re_new(NVHandle value_handle);
-FilterRE *filter_source_new(void);
-FilterRE *filter_match_new(void);
+gboolean filter_match_is_usage_obsolete(FilterExprNode *s);
+void filter_match_set_value_handle(FilterExprNode *s, NVHandle value_handle);
+FilterExprNode *filter_match_new(void);
 
 #endif

--- a/lib/filter/tests/CMakeLists.txt
+++ b/lib/filter/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ set(TEST_FILTERS_NETMASK6_SOURCE
 
 add_unit_test(CRITERION TARGET test_filters_facility SOURCES ${TEST_FILTERS_FACILITY_SOURCE} DEPENDS syslogformat)
 add_unit_test(CRITERION TARGET test_filters_level_new SOURCES ${TEST_FILTERS_LEVEL_NEW_SOURCE} DEPENDS syslogformat)
-add_unit_test(CRITERION TARGET test_filters_regexp SOURCES ${TEST_FILTERS_REGEXP_SOURCE} DEPENDS syslogformat)
+add_unit_test(LIBTEST CRITERION TARGET test_filters_regexp SOURCES ${TEST_FILTERS_REGEXP_SOURCE} DEPENDS syslogformat)
 add_unit_test(CRITERION TARGET test_filters_fop_cmp SOURCES ${TEST_FILTERS_FOP_CMP_SOURCE} DEPENDS syslogformat)
 add_unit_test(CRITERION TARGET test_filters_netmask SOURCES ${TEST_FILTERS_NETMASK_SOURCE} DEPENDS syslogformat)
 

--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -70,19 +70,19 @@ level_range(const gchar *from, const gchar *to)
 FilterExprNode *
 compile_pattern(FilterExprNode *f, const gchar *regexp, const gchar *type, gint flags)
 {
-  FilterRE *fre = (FilterRE *) f;
+  LogMatcherOptions *matcher_options = filter_re_get_matcher_options(f);
   gboolean result;
 
-  log_matcher_options_defaults(&fre->matcher_options);
-  f->matcher_options.flags = flags;
-  log_matcher_options_set_type(&fre->matcher_options, type);
+  log_matcher_options_defaults(matcher_options);
+  matcher_options->flags = flags;
+  log_matcher_options_set_type(matcher_options, type);
 
   result = filter_re_compile_pattern(f, configuration, regexp, NULL);
 
   if (result)
-    return &f->super;
+    return f;
 
-  filter_expr_unref(&f->super);
+  filter_expr_unref(f);
   return NULL;
 }
 

--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -36,6 +36,7 @@
 #include "logmsg/logmsg.h"
 #include "apphook.h"
 #include "plugin.h"
+#include "scratch-buffers.h"
 #include <criterion/criterion.h>
 
 #include <time.h>
@@ -234,6 +235,7 @@ setup(void)
 void
 teardown(void)
 {
+  scratch_buffers_explicit_gc();
   app_shutdown();
 }
 

--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -68,13 +68,14 @@ level_range(const gchar *from, const gchar *to)
 }
 
 FilterExprNode *
-compile_pattern(FilterRE *f, const gchar *regexp, const gchar *type, gint flags)
+compile_pattern(FilterExprNode *f, const gchar *regexp, const gchar *type, gint flags)
 {
+  FilterRE *fre = (FilterRE *) f;
   gboolean result;
 
-  log_matcher_options_defaults(&f->matcher_options);
+  log_matcher_options_defaults(&fre->matcher_options);
   f->matcher_options.flags = flags;
-  log_matcher_options_set_type(&f->matcher_options, type);
+  log_matcher_options_set_type(&fre->matcher_options, type);
 
   result = filter_re_compile_pattern(f, configuration, regexp, NULL);
 

--- a/lib/filter/tests/test_filters_common.h
+++ b/lib/filter/tests/test_filters_common.h
@@ -44,7 +44,7 @@ testcase_with_backref_chk(const gchar *msg,
 FilterExprNode *create_pcre_regexp_filter(gint field, const gchar *regexp, gint flags);
 FilterExprNode *create_pcre_regexp_match(const gchar *regexp, gint flags);
 LogTemplate *create_template(const gchar *template);
-FilterExprNode *compile_pattern(FilterRE *f, const gchar *regexp, const gchar *type, gint flags);
+FilterExprNode *compile_pattern(FilterExprNode *f, const gchar *regexp, const gchar *type, gint flags);
 
 gint facility_bits(const gchar *fac);
 gint level_bits(const gchar *lev);

--- a/lib/filter/tests/test_filters_regexp.c
+++ b/lib/filter/tests/test_filters_regexp.c
@@ -27,6 +27,7 @@
 #include "filter/filter-op.h"
 #include "cfg.h"
 #include "test_filters_common.h"
+#include "libtest/cr_template.h"
 
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
@@ -174,4 +175,34 @@ ParameterizedTest(FilterParamRegexp *param, filter, test_filter_regexp_match)
 {
   FilterExprNode *filter = create_pcre_regexp_match(param->regexp, param->flags);
   testcase(param->msg, filter, param->expected_result);
+}
+
+Test(filter, test_match_with_value)
+{
+  FilterExprNode *filter;
+
+  filter = create_pcre_regexp_match("^PTHREAD", 0);
+  filter_match_set_value_handle(filter, LM_V_MESSAGE);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter, TRUE);
+
+  filter = create_pcre_regexp_match("^2499", 0);
+  filter_match_set_value_handle(filter, LM_V_PID);
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter, TRUE);
+}
+
+Test(filter, test_match_with_template)
+{
+  FilterExprNode *filter;
+
+  filter = create_pcre_regexp_match("^PTHREAD", 0);
+  filter_match_set_template_ref(filter, compile_template("$MSG", FALSE));
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter, TRUE);
+
+  filter = create_pcre_regexp_match("^2499", 0);
+  filter_match_set_template_ref(filter, compile_template("$PID", FALSE));
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter, TRUE);
+
+  filter = create_pcre_regexp_match("^2499 openvpn", 0);
+  filter_match_set_template_ref(filter, compile_template("$PID $PROGRAM", FALSE));
+  testcase("<15>Oct 15 16:17:01 host openvpn[2499]: PTHREAD support initialized", filter, TRUE);
 }

--- a/scl/apache/apache.conf
+++ b/scl/apache/apache.conf
@@ -37,16 +37,13 @@
 #    127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
 block parser apache-accesslog-parser-vhost(prefix() template()) {
     channel {
-        rewrite {
-            set("`template`" value("1"));
-        };
-        filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " value("1")); };
+        filter { match("^[A-Za-z0-9\-\._]+:[0-9]+ " template(`template`)); };
         parser {
             csv-parser(
                 dialect(escape-double-char)
                 flags(strip-whitespace)
                 delimiters(" ")
-                template($1)
+                template(`template`)
                 quote-pairs('""[]')
                 columns("2", "`prefix`clientip", "`prefix`ident",
                         "`prefix`auth", "`prefix`timestamp",

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -41,24 +41,20 @@
 #
 block parser cisco-timestamp-parser(template()) {
     channel {
-        rewrite {
-            set("`template`" value('1'));
-        };
-
         if {
             # timestamp from Cisco Unified Call Manager, example "Jun 14 11:57:27 PM.685 UTC"
             # NOTE: drops msecs and timezone
-            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2} ((AM)|(PM)))' value('1') flags(store-matches)); };
+            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2} ((AM)|(PM)))' template(`template`) flags(store-matches)); };
             parser { date-parser(format('%b %d %H:%M:%S %p') template("$1")); };
         } elif {
             # timestamp without AM/PM mark, example: "Apr 29 13:58:40.411"
             # NOTE: drops msecs and timezone
 
-            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2})' value('1') flags(store-matches)); };
+            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
             parser { date-parser(format('%b %d %H:%M:%S') template("$1")); };
         } else {
             # timestamp with year information, example: "Apr 29 2017 13:58:40.411"
-            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{4} \d{2}:\d{2}:\d{2})' value('1') flags(store-matches)); };
+            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{4} \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
             parser { date-parser(format('%b %d %Y %H:%M:%S') template("$1")); };
         };
     };
@@ -105,12 +101,12 @@ block parser cisco-parser(prefix(".cisco.")) {
         if {
             parser { cisco-timestamp-parser(template("$1")); };
         } elif {
-            filter { match("^(?'HOST'[^:]+): (.*)" value('1') flags(store-matches) type(pcre)); };
+            filter { match("^(?'HOST'[^:]+): (.*)" template('$1') flags(store-matches) type(pcre)); };
             parser { cisco-timestamp-parser(template("$2")); };
         } elif {
-            filter { match("^(?'HOST'[^:]+)$" value('1') flags(store-matches) type(pcre)); };
+            filter { match("^(?'HOST'[^:]+)$" template('$1') flags(store-matches) type(pcre)); };
         } else {
-            filter { match("^$" value('1') flags(store-matches) type(pcre)); };
+            filter { match("^$" template('$1') flags(store-matches) type(pcre)); };
         };
     };
 };


### PR DESCRIPTION
This branch adds support for the template() option for match() expressions, e.g. previously we could only do name-value references like this:

```
    match("^foobarregexp" value("HOST"));
```

Now we can also do this:

```
    match("^foobarregexp" template("$HOST"));
```

Or even complex template expressions:
```
    match("^foobarregexp" template("$HOST|$PROGRAM$PID|$MSG"));
```

The "simple" templates are handled specially so they are as fast as match(value()). This branch also makes use of this feature in the cisco and apache parsers in SCL to show that it can be done.

NOTE: this branch shares two patches with #2701 if either goes in first, the other can be rebased and those two patches skipped.
