### PR TITLE
$(template) dynamic binding

### DIFF
--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -29,6 +29,7 @@
 #include "common-template-typedefs.h"
 #include "timeutils/zoneinfo.h"
 #include "type-hinting.h"
+#include "atomic.h"
 
 #define LTZ_LOCAL 0
 #define LTZ_SEND  1
@@ -56,7 +57,7 @@ typedef enum
 /* structure that represents an expandable syslog-ng template */
 typedef struct _LogTemplate
 {
-  gint ref_cnt;
+  GAtomicCounter ref_cnt;
   gchar *name;
   gchar *template;
   GList *compiled_template;

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -128,6 +128,7 @@ create_sample_message(void)
   log_msg_set_value_by_name(msg, "null", "binary\0stuff", 12);
   log_msg_set_value_by_name(msg, "comma_value", "value,with,a,comma", -1);
   log_msg_set_value_by_name(msg, "empty_value", "", -1);
+  log_msg_set_value_by_name(msg, "template_name", "dummy", -1);
 
   return msg;
 }

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -35,6 +35,21 @@
 #include <errno.h>
 #include <string.h>
 
+/* helper functions available for all modules */
+
+void
+_append_args_with_separator(gint argc, GString *argv[], GString *result, gchar separator)
+{
+  gint i;
+
+  for (i = 0; i < argc; i++)
+    {
+      g_string_append_len(result, argv[i]->str, argv[i]->len);
+      if (i < argc - 1)
+        g_string_append_c(result, separator);
+    }
+}
+
 /* in order to avoid having to declare all construct functions, we
  * include them all here. If it causes compilation times to increase
  * drastically, we should probably make them into separate compilation

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -26,20 +26,6 @@
 #include <ctype.h>
 
 static void
-_append_args_with_separator(gint argc, GString *argv[], GString *result, gchar separator)
-{
-  gint i;
-
-  for (i = 0; i < argc; i++)
-    {
-      g_string_append_len(result, argv[i]->str, argv[i]->len);
-      if (i < argc - 1)
-        g_string_append_c(result, separator);
-    }
-}
-
-
-static void
 tf_echo(LogMessage *msg, gint argc, GString *argv[], GString *result)
 {
   _append_args_with_separator(argc, argv, result, ' ');

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -313,8 +313,16 @@ Test(basicfuncs, test_misc_funcs)
 
 Test(basicfuncs, test_tf_template)
 {
+  /* static binding */
   assert_template_format("foo $(template dummy) bar", "foo dummy template expanded bzorp bar");
   assert_template_failure("foo $(template unknown) bar", "Unknown template function or template \"unknown\"");
+
+  /* dynamic binding */
+  assert_template_format("foo $(template ${template_name}) bar", "foo dummy template expanded bzorp bar");
+  assert_template_format("foo $(template '${unknown:-unknown}' fallback) bar", "foo fallback bar");
+  assert_template_format("foo $(template '${unknown:-unknown}' fallback more args $HOST) bar",
+                         "foo fallback more args bzorp bar");
+  assert_template_format("foo $(template '${unknown:-unknown}') bar", "foo  bar");
 }
 
 Test(basicfuncs, test_list_funcs)

--- a/modules/basicfuncs/tf-template.c
+++ b/modules/basicfuncs/tf-template.c
@@ -24,32 +24,69 @@
 
 #include "cfg.h"
 
+/*
+ * $(template <template-name> ...)
+ *
+ *   This template function looks up <template-name> in the configuration
+ *   and uses that format its result.  The template name can either be a
+ *   static or a dynamic reference.
+ *
+ *     * static: means that we perform lookup at configuration read time
+ *
+ *     * dynamic: the template name is actually a template (e.g.
+ *       ${foobar}), its result are taken as the name of the template and
+ *       that is looked up at runtime.
+ *
+ *   Dynamic references are slower, but more flexible.  syslog-ng uses the
+ *   following algorithm to determine which one to use:
+ *
+ *     * static: if the name of the template can be resolved at compile
+ *       time, the binding becomes static.
+ *
+ *     * dynamic: if static lookup fails and the template name contains at
+ *       least one '$' character to indicate that it is actually a template.
+ *
+ *   In case of dynamic we allow 2nd and further arguments which will be
+ *   used as content if the lookup fails.
+ *
+ *   Examples:
+ *      $(template foobar)     -> static binding
+ *      $(template ${foobar})  -> dynamic binding
+ *      $(template ${foobar} '$DATE $HOST $MSGHDR$MSG\n') -> dynamic binding with fallback
+ *
+ */
 typedef struct _TFTemplateState
 {
+  TFSimpleFuncState super;
+  GlobalConfig *cfg;
   LogTemplate *invoked_template;
 } TFTemplateState;
 
-static gboolean
+static LogTemplate *
 tf_template_lookup_invoked_template(TFTemplateState *state, GlobalConfig *cfg, const gchar *function_name,
                                     GError **error)
 {
-  state->invoked_template = cfg_tree_lookup_template(&cfg->tree, function_name);
-  if (!state->invoked_template)
-    {
-      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
-                  "$(template) Unknown template function or template \"%s\"",
-                  function_name);
-      return FALSE;
-    }
-  return TRUE;
+  return cfg_tree_lookup_template(&cfg->tree, function_name);
 }
 
 static const gchar *
 tf_template_extract_invoked_template_name_from_args(gint argc, gchar *argv[])
 {
-  if (argc == 2 && strcmp(argv[0], "template") == 0)
+  if (argc >= 2 && strcmp(argv[0], "template") == 0)
     return argv[1];
   return NULL;
+}
+
+static gboolean
+tf_template_statically_bound(TFTemplateState *state)
+{
+  return state->invoked_template != NULL;
+}
+
+static gboolean
+tf_template_dynamically_bound(TFTemplateState *state)
+{
+  return !tf_template_statically_bound(state);
 }
 
 static gboolean
@@ -68,16 +105,73 @@ tf_template_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, 
       return FALSE;
     }
 
-  return tf_template_lookup_invoked_template(state, parent->cfg, invoked_template_name, error);
+  state->invoked_template = tf_template_lookup_invoked_template(state, parent->cfg, invoked_template_name, error);
+  if (tf_template_statically_bound(state))
+    return TRUE;
+
+  /* compile time lookup failed, let's check if it's a dynamically bound invocation */
+  if (strchr(invoked_template_name, '$') == NULL)
+    {
+      /* our argument is not a template, no chance of being better at
+       * runtime, raise as an error */
+
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(template) Unknown template function or template \"%s\"",
+                  invoked_template_name);
+      return FALSE;
+    }
+
+  state->cfg = parent->cfg;
+  return tf_simple_func_prepare(self, s, parent, argc, argv, error);
+}
+
+static void
+tf_template_eval(LogTemplateFunction *self, gpointer s, LogTemplateInvokeArgs *args)
+{
+  TFTemplateState *state = (TFTemplateState *) s;
+
+  if (tf_template_dynamically_bound(state))
+    tf_simple_func_eval(self, s, args);
+}
+
+static LogTemplate *
+tf_template_get_template_to_be_invoked(TFTemplateState *state, const LogTemplateInvokeArgs *args)
+{
+  LogTemplate *invoked_template;
+
+  if (tf_template_dynamically_bound(state))
+    {
+      const gchar *template_name = args->argv[0]->str;
+
+      invoked_template = cfg_tree_lookup_template(&state->cfg->tree, template_name);
+
+      msg_trace("$(template) dynamic template lookup result",
+                evt_tag_str("template", template_name),
+                evt_tag_int("found", invoked_template != NULL));
+    }
+  else
+    {
+      invoked_template = log_template_ref(state->invoked_template);
+    }
+  return invoked_template;
 }
 
 static void
 tf_template_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
   TFTemplateState *state = (TFTemplateState *) s;
+  LogTemplate *invoked_template = NULL;
 
-  log_template_append_format_with_context(state->invoked_template, args->messages, args->num_messages, args->opts,
+  invoked_template = tf_template_get_template_to_be_invoked(state, args);
+  if (!invoked_template)
+    {
+      _append_args_with_separator(state->super.argc - 1, (GString **) &args->argv[1], result, ' ');
+      return;
+    }
+
+  log_template_append_format_with_context(invoked_template, args->messages, args->num_messages, args->opts,
                                           args->tz, args->seq_num, args->context_id, result);
+  log_template_unref(invoked_template);
 }
 
 static void
@@ -86,7 +180,9 @@ tf_template_free_state(gpointer s)
   TFTemplateState *state = (TFTemplateState *) s;
 
   log_template_unref(state->invoked_template);
+  tf_simple_func_free_state(s);
 }
 
-TEMPLATE_FUNCTION(TFTemplateState, tf_template, tf_template_prepare, NULL, tf_template_call, tf_template_free_state,
+TEMPLATE_FUNCTION(TFTemplateState, tf_template,
+                  tf_template_prepare, tf_template_eval, tf_template_call, tf_template_free_state,
                   NULL);


### PR DESCRIPTION
Extends the $(template) template function to allow dynamic binding, e.g. the name of the template to be invoked coming from a name-value pair, e.g. a template.

Some more details:
```
/*
 * $(template <template-name> ...)
 *
 *   This template function looks up <template-name> in the configuration
 *   and uses that format its result.  The template name can either be a
 *   static or a dynamic reference.
 *
 *     * static: means that we perform lookup at configuration read time
 *
 *     * dynamic: the template name is actually a template (e.g.
 *       ${foobar}), its result are taken as the name of the template and
 *       that is looked up at runtime.
 *
 *   Dynamic references are slower, but more flexible.  syslog-ng uses the
 *   following algorithm to determine which one to use:
 *
 *     * static: if the name of the template can be resolved at compile
 *       time, the binding becomes static.
 *
 *     * dynamic: if static lookup fails and the template name contains at
 *       least one '$' character to indicate that it is actually a template.
 *
 *   In case of dynamic we allow 2nd and further arguments which will be
 *   used as content if the lookup fails.
 *
 *   Examples:
 *      $(template foobar)     -> static binding
 *      $(template ${foobar})  -> dynamic binding
 *      $(template ${foobar} '$DATE $HOST $MSGHDR$MSG\n') -> dynamic binding with fallback
 *
 */
```
