### PR TITLE
[WIP] light: Refactor SyslogNgConfig API (external/internal)

### DIFF
--- a/dbld/images/helpers/pip_packages.manifest
+++ b/dbld/images/helpers/pip_packages.manifest
@@ -6,7 +6,6 @@ ply                     [centos, debian, ubuntu]
 pylint                  [centos-7, debian, ubuntu]
 
 # pip packages for python functional tests
-mockito                 [centos, debian, ubuntu]
 pathlib2                [centos, debian, ubuntu]
 psutil                  [centos, debian, ubuntu]
 pytest                  [centos, debian, ubuntu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ pep8==1.7.1
 pylint==1.8.2
 astroid==1.6.1
 logilab-common<=0.63.0
-colorlog
-mockito
 pathlib2
 psutil
 pytest

--- a/tests/python_functional/conftest.py
+++ b/tests/python_functional/conftest.py
@@ -97,8 +97,8 @@ def testcase_parameters(request):
 
 
 @pytest.fixture
-def config(request, testcase_parameters):
-    return SyslogNgConfig(testcase_parameters.get_working_dir(), request.getfixturevalue("version"))
+def config(request):
+    return SyslogNgConfig(request.getfixturevalue("version"))
 
 
 @pytest.fixture

--- a/tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -23,8 +23,8 @@
 
 
 def test_manipulating_config_between_reload(config, syslog_ng):
-    file_source = config.create_file_source(file_name="input.log")
-    file_destination = config.create_file_destination(file_name="output.log")
+    file_source = config.file_source(file_name="input.log")
+    file_destination = config.file_destination(file_name="output.log")
     destination_group = config.create_statement_group(file_destination)
 
     logpath = config.create_logpath(statements=[file_source, destination_group])
@@ -38,11 +38,11 @@ def test_manipulating_config_between_reload(config, syslog_ng):
     file_source.options["log_iw_size"] = "100"
 
     # create new file source and add to separate source group
-    file_source2 = config.create_file_source(file_name="input2.log")
+    file_source2 = config.file_source(file_name="input2.log")
     source_group2 = config.create_statement_group(file_source2)
 
     # create new file destination and update first destination group
-    file_destination2 = config.create_file_destination(file_name="output2.log")
+    file_destination2 = config.file_destination(file_name="output2.log")
     destination_group.append(file_destination2)
 
     # update first logpath group with new source group

--- a/tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py
+++ b/tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py
@@ -32,7 +32,7 @@ def test_manipulating_config_between_reload(config, syslog_ng):
     syslog_ng.start(config)
 
     # update positional value of file source
-    file_source.set_path("updated_input.log")
+    file_source.set_file_path("updated_input.log")
 
     # add new option to file source
     file_source.options["log_iw_size"] = "100"

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -24,8 +24,8 @@ import logging
 
 from pathlib2 import Path
 
-from src.common.operations import calculate_testcase_name
 from src.common.operations import copy_file
+from src.common.pytest_operations import calculate_testcase_name
 
 logger = logging.getLogger(__name__)
 

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -24,6 +24,7 @@ import logging
 
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.operations import copy_file
 from src.common.pytest_operations import calculate_testcase_name
 
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 def pytest_runtest_setup(item):
     def prepare_testcase_working_dir(pytest_request):
         testcase_parameters = pytest_request.getfixturevalue("testcase_parameters")
-        working_directory = testcase_parameters.get_working_dir()
+        tc_parameters.WORKING_DIR = working_directory = testcase_parameters.get_working_dir()
         if not working_directory.exists():
             working_directory.mkdir(parents=True)
         testcase_file_path = testcase_parameters.get_testcase_file()

--- a/tests/python_functional/functional_tests/logpath/test_flags_catch_all.py
+++ b/tests/python_functional/functional_tests/logpath/test_flags_catch_all.py
@@ -32,9 +32,9 @@ def test_flags_catch_all(config, syslog_ng, log_message, bsd_formatter):
     # input logs:
     # Oct 11 22:14:15 host-A testprogram: message from host-A
 
-    file_source = config.create_file_source(file_name="input.log")
-    file_destination = config.create_file_destination(file_name="output.log")
-    catch_all_destination = config.create_file_destination(file_name="catchall_output.log")
+    file_source = config.file_source(file_name="input.log")
+    file_destination = config.file_destination(file_name="output.log")
+    catch_all_destination = config.file_destination(file_name="catchall_output.log")
 
     inner_logpath = config.create_inner_logpath(statements=[file_destination])
 

--- a/tests/python_functional/functional_tests/logpath/test_flags_fallback.py
+++ b/tests/python_functional/functional_tests/logpath/test_flags_fallback.py
@@ -45,7 +45,7 @@ def test_flags_fallback(config, syslog_ng, bsd_formatter):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.file_source(file_name="input.log")
-    host_filter = config.create_filter(host="'host-A'")
+    host_filter = config.filter(host="'host-A'")
     file_destination1 = config.file_destination(file_name="output1.log")
     file_destination2 = config.file_destination(file_name="output2.log")
 

--- a/tests/python_functional/functional_tests/logpath/test_flags_fallback.py
+++ b/tests/python_functional/functional_tests/logpath/test_flags_fallback.py
@@ -44,10 +44,10 @@ def test_flags_fallback(config, syslog_ng, bsd_formatter):
 
     config.create_global_options(keep_hostname="yes")
 
-    file_source = config.create_file_source(file_name="input.log")
+    file_source = config.file_source(file_name="input.log")
     host_filter = config.create_filter(host="'host-A'")
-    file_destination1 = config.create_file_destination(file_name="output1.log")
-    file_destination2 = config.create_file_destination(file_name="output2.log")
+    file_destination1 = config.file_destination(file_name="output1.log")
+    file_destination2 = config.file_destination(file_name="output2.log")
 
     inner_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1])
     inner_logpath2 = config.create_inner_logpath(statements=[file_destination2], flags="fallback")

--- a/tests/python_functional/functional_tests/logpath/test_flags_final.py
+++ b/tests/python_functional/functional_tests/logpath/test_flags_final.py
@@ -44,10 +44,10 @@ def test_flags_final(config, syslog_ng, bsd_formatter):
 
     config.create_global_options(keep_hostname="yes")
 
-    file_source = config.create_file_source(file_name="input.log")
+    file_source = config.file_source(file_name="input.log")
     host_filter = config.create_filter(host="'host-A'")
-    file_destination1 = config.create_file_destination(file_name="output1.log")
-    file_destination2 = config.create_file_destination(file_name="output2.log")
+    file_destination1 = config.file_destination(file_name="output1.log")
+    file_destination2 = config.file_destination(file_name="output2.log")
 
     inner_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1], flags="final")
     inner_logpath2 = config.create_inner_logpath(statements=[file_destination2])

--- a/tests/python_functional/functional_tests/logpath/test_flags_final.py
+++ b/tests/python_functional/functional_tests/logpath/test_flags_final.py
@@ -45,7 +45,7 @@ def test_flags_final(config, syslog_ng, bsd_formatter):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.file_source(file_name="input.log")
-    host_filter = config.create_filter(host="'host-A'")
+    host_filter = config.filter(host="'host-A'")
     file_destination1 = config.file_destination(file_name="output1.log")
     file_destination2 = config.file_destination(file_name="output2.log")
 

--- a/tests/python_functional/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/python_functional/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -94,4 +94,4 @@ def test_multiple_embedded_logpaths(config, syslog_ng, bsd_formatter):
 
     # no messages should arrived into destination4,
     # no source() or flags(catch-all) is added
-    assert file_destination4.get_path().exists() is False
+    assert file_destination4.get_file_path().exists() is False

--- a/tests/python_functional/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/python_functional/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -48,13 +48,13 @@ def test_multiple_embedded_logpaths(config, syslog_ng, bsd_formatter):
 
     config.create_global_options(keep_hostname="yes")
 
-    file_source = config.create_file_source(file_name="input.log")
+    file_source = config.file_source(file_name="input.log")
     host_filter = config.create_filter(host="'host-A'")
     program_filter = config.create_filter(program="'app-A'")
-    file_destination1 = config.create_file_destination(file_name="output1.log")
-    file_destination2 = config.create_file_destination(file_name="output2.log")
-    file_destination3 = config.create_file_destination(file_name="output3.log")
-    file_destination4 = config.create_file_destination(file_name="output4.log")
+    file_destination1 = config.file_destination(file_name="output1.log")
+    file_destination2 = config.file_destination(file_name="output2.log")
+    file_destination3 = config.file_destination(file_name="output3.log")
+    file_destination4 = config.file_destination(file_name="output4.log")
 
     second_level_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1])
 

--- a/tests/python_functional/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/python_functional/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -49,8 +49,8 @@ def test_multiple_embedded_logpaths(config, syslog_ng, bsd_formatter):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.file_source(file_name="input.log")
-    host_filter = config.create_filter(host="'host-A'")
-    program_filter = config.create_filter(program="'app-A'")
+    host_filter = config.filter(host="'host-A'")
+    program_filter = config.filter(program="'app-A'")
     file_destination1 = config.file_destination(file_name="output1.log")
     file_destination2 = config.file_destination(file_name="output2.log")
     file_destination3 = config.file_destination(file_name="output3.log")

--- a/tests/python_functional/functional_tests/logpath/test_multiple_flags.py
+++ b/tests/python_functional/functional_tests/logpath/test_multiple_flags.py
@@ -48,13 +48,13 @@ def test_multiple_flags(config, syslog_ng, bsd_formatter):
 
     config.create_global_options(keep_hostname="yes")
 
-    file_source = config.create_file_source(file_name="input.log")
+    file_source = config.file_source(file_name="input.log")
     host_filter = config.create_filter(host="'host-A'")
     program_filter = config.create_filter(program="'app-A'")
-    file_destination1 = config.create_file_destination(file_name="output1.log")
-    file_destination2 = config.create_file_destination(file_name="output2.log")
-    file_destination3 = config.create_file_destination(file_name="output3.log")
-    file_destination4 = config.create_file_destination(file_name="output4.log")
+    file_destination1 = config.file_destination(file_name="output1.log")
+    file_destination2 = config.file_destination(file_name="output2.log")
+    file_destination3 = config.file_destination(file_name="output3.log")
+    file_destination4 = config.file_destination(file_name="output4.log")
 
     second_level_logpath1 = config.create_inner_logpath(statements=[host_filter, file_destination1], flags="final")
     second_level_logpath2 = config.create_inner_logpath(statements=[program_filter, file_destination2])

--- a/tests/python_functional/functional_tests/logpath/test_multiple_flags.py
+++ b/tests/python_functional/functional_tests/logpath/test_multiple_flags.py
@@ -49,8 +49,8 @@ def test_multiple_flags(config, syslog_ng, bsd_formatter):
     config.create_global_options(keep_hostname="yes")
 
     file_source = config.file_source(file_name="input.log")
-    host_filter = config.create_filter(host="'host-A'")
-    program_filter = config.create_filter(program="'app-A'")
+    host_filter = config.filter(host="'host-A'")
+    program_filter = config.filter(program="'app-A'")
     file_destination1 = config.file_destination(file_name="output1.log")
     file_destination2 = config.file_destination(file_name="output2.log")
     file_destination3 = config.file_destination(file_name="output3.log")

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog.py
@@ -39,8 +39,8 @@ def test_application_syslog(config, syslog_ng, input_message, template, expected
     config.add_include("scl.conf")
 
     generator_source = config.example_msg_generator_source(num=1, template=config.stringify(input_message))
-    syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
-    app_parser = config.create_app_parser(topic="syslog")
+    syslog_parser = config.syslog_parser(flags="syslog-protocol")
+    app_parser = config.app_parser(topic="syslog")
     file_destination = config.file_destination(file_name="output.log", template=config.stringify(template + '\n'))
     config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
 

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog.py
@@ -41,7 +41,7 @@ def test_application_syslog(config, syslog_ng, input_message, template, expected
     generator_source = config.create_example_msg_generator(num=1, template=config.stringify(input_message))
     syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
     app_parser = config.create_app_parser(topic="syslog")
-    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template + '\n'))
+    file_destination = config.file_destination(file_name="output.log", template=config.stringify(template + '\n'))
     config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
 
     syslog_ng.start(config)

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog.py
@@ -38,7 +38,7 @@ test_parameters_syslog = [
 def test_application_syslog(config, syslog_ng, input_message, template, expected_value):
     config.add_include("scl.conf")
 
-    generator_source = config.create_example_msg_generator(num=1, template=config.stringify(input_message))
+    generator_source = config.example_msg_generator_source(num=1, template=config.stringify(input_message))
     syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
     app_parser = config.create_app_parser(topic="syslog")
     file_destination = config.file_destination(file_name="output.log", template=config.stringify(template + '\n'))

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
@@ -43,7 +43,7 @@ def test_application_raw(config, syslog_ng, input_message, template, expected_va
     config.add_include("scl.conf")
 
     generator_source = config.example_msg_generator_source(num=1, template=config.stringify(input_message))
-    app_parser = config.create_app_parser(topic="syslog-raw")
+    app_parser = config.app_parser(topic="syslog-raw")
 
     file_destination = config.file_destination(file_name="output.log", template=config.stringify(template + '\n'))
     config.create_logpath(statements=[generator_source, app_parser, file_destination])

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
@@ -42,7 +42,7 @@ test_parameters_raw = [
 def test_application_raw(config, syslog_ng, input_message, template, expected_value):
     config.add_include("scl.conf")
 
-    generator_source = config.create_example_msg_generator(num=1, template=config.stringify(input_message))
+    generator_source = config.example_msg_generator_source(num=1, template=config.stringify(input_message))
     app_parser = config.create_app_parser(topic="syslog-raw")
 
     file_destination = config.file_destination(file_name="output.log", template=config.stringify(template + '\n'))

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
@@ -45,7 +45,7 @@ def test_application_raw(config, syslog_ng, input_message, template, expected_va
     generator_source = config.create_example_msg_generator(num=1, template=config.stringify(input_message))
     app_parser = config.create_app_parser(topic="syslog-raw")
 
-    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template + '\n'))
+    file_destination = config.file_destination(file_name="output.log", template=config.stringify(template + '\n'))
     config.create_logpath(statements=[generator_source, app_parser, file_destination])
 
     syslog_ng.start(config)

--- a/tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py
+++ b/tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py
@@ -35,8 +35,8 @@ expected_log = "Feb 11 21:27:22 {} testprogram[9999]: test message\n".format(soc
     ], ids=["with_one_log", "with_ten_logs"],
 )
 def test_acceptance(config, syslog_ng, input_log, expected_log, counter):
-    file_source = config.create_file_source(file_name="input.log")
-    file_destination = config.create_file_destination(file_name="output.log")
+    file_source = config.file_source(file_name="input.log")
+    file_destination = config.file_destination(file_name="output.log")
     config.create_logpath(statements=[file_source, file_destination])
 
     file_source.write_log(input_log, counter)

--- a/tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py
+++ b/tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py
@@ -24,7 +24,7 @@
 
 def test_generator_source(config, syslog_ng):
     generator_source = config.create_example_msg_generator(num=1)
-    file_destination = config.create_file_destination(file_name="output.log", template="'$MSG\n'")
+    file_destination = config.file_destination(file_name="output.log", template="'$MSG\n'")
 
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)

--- a/tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py
+++ b/tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py
@@ -23,7 +23,7 @@
 
 
 def test_generator_source(config, syslog_ng):
-    generator_source = config.create_example_msg_generator(num=1)
+    generator_source = config.example_msg_generator_source(num=1)
     file_destination = config.file_destination(file_name="output.log", template="'$MSG\n'")
 
     config.create_logpath(statements=[generator_source, file_destination])

--- a/tests/python_functional/src/common/operations.py
+++ b/tests/python_functional/src/common/operations.py
@@ -24,6 +24,8 @@ import shutil
 
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
+
 
 def open_file(file_path, mode):
     # Python 2 compatibility note: open() can work only with string representation of path
@@ -43,11 +45,9 @@ def cast_to_list(items):
 
 def copy_shared_file(shared_file_name, syslog_ng_testcase):
     shared_dir = syslog_ng_testcase.testcase_parameters.get_shared_dir()
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    copy_file(Path(shared_dir, shared_file_name), working_dir)
+    copy_file(Path(shared_dir, shared_file_name), tc_parameters.WORKING_DIR)
 
 
-def delete_session_file(shared_file_name, syslog_ng_testcase):
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    shared_file_name = Path(working_dir, shared_file_name)
+def delete_session_file(shared_file_name):
+    shared_file_name = Path(tc_parameters.WORKING_DIR, shared_file_name)
     shared_file_name.unlink()

--- a/tests/python_functional/src/common/pytest_operations.py
+++ b/tests/python_functional/src/common/pytest_operations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #############################################################################
-# Copyright (c) 2015-2018 Balabit
+# Copyright (c) 2015-2019 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -20,34 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
-import shutil
-
-from pathlib2 import Path
 
 
-def open_file(file_path, mode):
-    # Python 2 compatibility note: open() can work only with string representation of path
-    return open(str(file_path), mode)
-
-
-def copy_file(src_file_path, dst_dir):
-    # Python 2 compatibility note: shutil.copy() can work only with string representation of path
-    shutil.copy(str(src_file_path), str(dst_dir))
-
-
-def cast_to_list(items):
-    if isinstance(items, list):
-        return items
-    return [items]
-
-
-def copy_shared_file(shared_file_name, syslog_ng_testcase):
-    shared_dir = syslog_ng_testcase.testcase_parameters.get_shared_dir()
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    copy_file(Path(shared_dir, shared_file_name), working_dir)
-
-
-def delete_session_file(shared_file_name, syslog_ng_testcase):
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    shared_file_name = Path(working_dir, shared_file_name)
-    shared_file_name.unlink()
+def calculate_testcase_name(pytest_request):
+    # In case of parametrized tests we need to replace "[" and "]" because
+    # testcase name will appear in directory name
+    return pytest_request.node.name.replace("[", "_").replace("]", "_")

--- a/tests/python_functional/src/conftest.py
+++ b/tests/python_functional/src/conftest.py
@@ -23,6 +23,7 @@
 #############################################################################
 import pytest
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.testcase_parameters.testcase_parameters import TestcaseParameters
 
 
@@ -35,6 +36,7 @@ def test_message():
 def fake_testcase_parameters(request, tmpdir):
     orig_installdir = request.config.option.installdir
     orig_reportdir = request.config.option.reports
+    tc_parameters.WORKING_DIR = tmpdir.join("workingdir")
     request.config.option.installdir = tmpdir.join("installdir")
     request.config.option.reports = tmpdir.join("reports")
     request.config.option.runwithvalgrind = False

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -24,6 +24,7 @@ import logging
 
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.blocking import wait_until_false
 from src.common.blocking import wait_until_true
 from src.syslog_ng.console_log_reader import ConsoleLogReader
@@ -149,6 +150,6 @@ class SyslogNgCli(object):
                 core_file_found = True
                 self.__process = None
                 self.__syslog_ng_executor.get_backtrace_from_core(core_file=str(core_file))
-                core_file.replace(Path(self.__instance_paths.get_working_dir(), core_file))
+                core_file.replace(Path(tc_parameters.WORKING_DIR, core_file))
             if core_file_found:
                 raise Exception("syslog-ng core file was found and processed")

--- a/tests/python_functional/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_paths.py
@@ -22,6 +22,7 @@
 #############################################################################
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.random_id import get_unique_id
 
 
@@ -35,14 +36,14 @@ class SyslogNgPaths(object):
         if self.__instance_name is not None:
             raise Exception("Instance already configured")
         self.__instance_name = instance_name
-        working_dir = self.__testcase_parameters.get_working_dir()
+        working_dir = tc_parameters.WORKING_DIR
         relative_working_dir = self.__testcase_parameters.get_relative_working_dir()
         install_dir = self.__testcase_parameters.get_install_dir()
         if not install_dir:
             raise ValueError("Missing --installdir start parameter")
 
         self.__syslog_ng_paths = {
-            "dirs": {"working_dir": working_dir, "install_dir": Path(install_dir)},
+            "dirs": {"install_dir": Path(install_dir)},
             "file_paths": {
                 "config_path": Path(working_dir, "syslog_ng_{}.conf".format(instance_name)),
                 "persist_path": Path(working_dir, "syslog_ng_{}.persist".format(instance_name)),
@@ -63,9 +64,6 @@ class SyslogNgPaths(object):
 
     def get_instance_name(self):
         return self.__instance_name
-
-    def get_working_dir(self):
-        return self.__syslog_ng_paths["dirs"]["working_dir"]
 
     def get_install_dir(self):
         return self.__syslog_ng_paths["dirs"]["install_dir"]

--- a/tests/python_functional/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/python_functional/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -30,7 +30,7 @@ def test_syslog_ng_paths(fake_testcase_parameters):
     syslog_ng_paths = SyslogNgPaths(fake_testcase_parameters)
     syslog_ng_paths.set_syslog_ng_paths(instance_name="server")
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths)) == {"dirs", "file_paths", "binary_file_paths"}
-    assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["dirs"])) == {"working_dir", "install_dir"}
+    assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["dirs"])) == {"install_dir"}
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["file_paths"])) == {
         "config_path",
         "persist_path",

--- a/tests/python_functional/src/syslog_ng_config/file_based_option_handler.py
+++ b/tests/python_functional/src/syslog_ng_config/file_based_option_handler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #############################################################################
-# Copyright (c) 2015-2018 Balabit
+# Copyright (c) 2015-2019 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -20,25 +20,27 @@
 # COPYING for details.
 #
 #############################################################################
-from src.driver_io.file.file_io import FileIO
-from src.syslog_ng_config.file_based_option_handler import FileBasedOptionHandler
-from src.syslog_ng_config.statements.sources.source_writer import SourceWriter
+from pathlib2 import Path
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.syslog_ng_config.option_handler import OptionHandler
 
 
-class FileSource(object):
-    def __init__(self, file_name=None, **options):
-        self.driver_name = "file"
-        self.group_type = "source"
-        self.options = options
-        self.source_writer = SourceWriter(FileIO)
+class FileBasedOptionHandler(OptionHandler):
+    def __init__(self, options):
+        super(FileBasedOptionHandler, self).__init__(options)
+        self.file_path = None
 
-        self.file_based_option_handler = FileBasedOptionHandler(self.options)
-        self.file_based_option_handler.init_file_path(file_name)
+    def init_file_path(self, file_name):
+        if file_name or file_name == "":
+            # note if file_name defined or file_name is ""
+            self.file_path = Path(tc_parameters.WORKING_DIR, file_name)
+        elif not file_name:
+            # note if not file_name defined we will provide own name
+            self.file_path = Path(tc_parameters.WORKING_DIR, "default_file_path")
 
-        self.get_file_path = self.file_based_option_handler.get_file_path
-        self.set_file_path = self.file_based_option_handler.set_file_path
+    def get_file_path(self):
+        return self.file_path
 
-        self.positional_parameters = [self.get_file_path()]
-
-    def write_log(self, formatted_log, counter=1):
-        self.source_writer.write_log(self.get_file_path(), formatted_log, counter)
+    def set_file_path(self, new_file_name):
+        self.file_path = Path(tc_parameters.WORKING_DIR, new_file_name)

--- a/tests/python_functional/src/syslog_ng_config/option_handler.py
+++ b/tests/python_functional/src/syslog_ng_config/option_handler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #############################################################################
-# Copyright (c) 2015-2018 Balabit
+# Copyright (c) 2015-2019 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -20,25 +20,19 @@
 # COPYING for details.
 #
 #############################################################################
-from src.driver_io.file.file_io import FileIO
-from src.syslog_ng_config.file_based_option_handler import FileBasedOptionHandler
-from src.syslog_ng_config.statements.sources.source_writer import SourceWriter
+from pathlib2 import Path
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
 
 
-class FileSource(object):
-    def __init__(self, file_name=None, **options):
-        self.driver_name = "file"
-        self.group_type = "source"
+class OptionHandler(object):
+    def __init__(self, options):
         self.options = options
-        self.source_writer = SourceWriter(FileIO)
 
-        self.file_based_option_handler = FileBasedOptionHandler(self.options)
-        self.file_based_option_handler.init_file_path(file_name)
+        self.path_type_options = ["file_name", "cert_file"]
+        self.set_path_for_options_if_needed()
 
-        self.get_file_path = self.file_based_option_handler.get_file_path
-        self.set_file_path = self.file_based_option_handler.set_file_path
-
-        self.positional_parameters = [self.get_file_path()]
-
-    def write_log(self, formatted_log, counter=1):
-        self.source_writer.write_log(self.get_file_path(), formatted_log, counter)
+    def set_path_for_options_if_needed(self):
+        for option in self.options:
+            if option in self.path_type_options:
+                self.options[option] = Path(tc_parameters.WORKING_DIR, self.options[option])

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -23,9 +23,8 @@
 
 
 class ConfigRenderer(object):
-    def __init__(self, syslog_ng_config, working_dir):
+    def __init__(self, syslog_ng_config):
         self.__syslog_ng_config = syslog_ng_config
-        self.__working_dir = working_dir
         self.__syslog_ng_config_content = ""
         self.__render()
 

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -24,12 +24,13 @@ from pathlib2 import Path
 
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+import src.testcase_parameters.testcase_parameters as tc_parameters
 
 
 class FileDestination(DestinationDriver):
-    def __init__(self, working_dir, file_name, **options):
+    def __init__(self, file_name, **options):
         self.driver_name = "file"
-        self.path = Path(working_dir, file_name)
+        self.path = Path(tc_parameters.WORKING_DIR, file_name)
         super(FileDestination, self).__init__(FileIO, [self.path], options)
 
     def get_path(self):

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -20,11 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
-
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.message_reader.single_line_parser import SingleLineParser
+from src.syslog_ng_config.file_based_option_handler import FileBasedOptionHandler
 from src.syslog_ng_config.statements.destinations.destination_reader import DestinationReader
 
 
@@ -32,16 +30,19 @@ class FileDestination(object):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
         self.group_type = "destination"
-        self.path = Path(tc_parameters.WORKING_DIR, file_name)
-        self.destination_reader = DestinationReader(FileIO, SingleLineParser)
-        self.positional_parameters = [self.path]
         self.options = options
+        self.destination_reader = DestinationReader(FileIO, SingleLineParser)
 
-    def get_path(self):
-        return self.path
+        self.file_based_option_handler = FileBasedOptionHandler(self.options)
+        self.file_based_option_handler.init_file_path(file_name)
+
+        self.get_file_path = self.file_based_option_handler.get_file_path
+        self.set_file_path = self.file_based_option_handler.set_file_path
+
+        self.positional_parameters = [self.get_file_path()]
 
     def read_log(self):
-        return self.destination_reader.read_logs(self.get_path(), counter=1)[0]
+        return self.destination_reader.read_logs(self.get_file_path(), counter=1)[0]
 
     def read_logs(self, counter):
-        return self.destination_reader.read_logs(self.get_path(), counter)
+        return self.destination_reader.read_logs(self.get_file_path(), counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -22,22 +22,26 @@
 #############################################################################
 from pathlib2 import Path
 
-from src.driver_io.file.file_io import FileIO
-from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
 import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.driver_io.file.file_io import FileIO
+from src.message_reader.single_line_parser import SingleLineParser
+from src.syslog_ng_config.statements.destinations.destination_reader import DestinationReader
 
 
-class FileDestination(DestinationDriver):
+class FileDestination(object):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
+        self.group_type = "destination"
         self.path = Path(tc_parameters.WORKING_DIR, file_name)
-        super(FileDestination, self).__init__(FileIO, [self.path], options)
+        self.destination_reader = DestinationReader(FileIO, SingleLineParser)
+        self.positional_parameters = [self.path]
+        self.options = options
 
     def get_path(self):
         return self.path
 
     def read_log(self):
-        return self.dd_read_logs(self.get_path(), counter=1)[0]
+        return self.destination_reader.read_logs(self.get_path(), counter=1)[0]
 
     def read_logs(self, counter):
-        return self.dd_read_logs(self.get_path(), counter=counter)
+        return self.destination_reader.read_logs(self.get_path(), counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
@@ -23,9 +23,8 @@
 
 
 class Filter(object):
-    group_type = "filter"
-
-    def __init__(self, **kwargs):
-        self.options = kwargs
+    def __init__(self, **options):
+        self.options = options
         self.driver_name = ""
         self.positional_parameters = []
+        self.group_type = "filter"

--- a/tests/python_functional/src/syslog_ng_config/statements/parsers/parser.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/parsers/parser.py
@@ -23,9 +23,18 @@
 
 
 class Parser(object):
-    group_type = "parser"
-
-    def __init__(self, driver_name, **kwargs):
+    def __init__(self, driver_name, **options):
         self.driver_name = driver_name
-        self.options = kwargs
+        self.options = options
         self.positional_parameters = []
+        self.group_type = "parser"
+
+
+class AppParser(Parser):
+    def __init__(self, **options):
+        super(AppParser, self).__init__("app-parser", **options)
+
+
+class SyslogParser(Parser):
+    def __init__(self, **options):
+        super(SyslogParser, self).__init__("syslog-parser", **options)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/example_msg_generator_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/example_msg_generator_source.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #############################################################################
-# Copyright (c) 2015-2018 Balabit
+# Copyright (c) 2015-2019 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -20,30 +20,12 @@
 # COPYING for details.
 #
 #############################################################################
-import logging
-logger = logging.getLogger(__name__)
 
 
-class SourceDriver(object):
-    group_type = "source"
-
-    def __init__(self, IOClass, positional_parameters=None, options=None):
-        self.__IOClass = IOClass
-        self.__writer = None
-        if positional_parameters is None:
-            positional_parameters = []
-        self.positional_parameters = positional_parameters
-        if options is None:
-            options = {}
+class ExampleMsgGeneratorSource(object):
+    def __init__(self, **options):
+        self.group_type = "source"
+        self.driver_name = "example_msg_generator"
+        self.DEFAULT_MESSAGE = "-- Generated message. --"
         self.options = options
-
-    def __construct_writer(self, path):
-        if not self.__writer:
-            self.__writer = self.__IOClass(path)
-
-    def sd_write_log(self, path, formatted_log, counter):
-        self.__construct_writer(path)
-        for __i in range(0, counter):
-            self.__writer.write(formatted_log)
-        written_description = "Content has been written to\nresource: {}\nnumber of times: {}\ncontent: {}\n".format(path, counter, formatted_log)
-        logger.info(written_description)
+        self.positional_parameters = []

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -24,20 +24,19 @@ from pathlib2 import Path
 
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
-
+import src.testcase_parameters.testcase_parameters as tc_parameters
 
 class FileSource(SourceDriver):
-    def __init__(self, working_dir, file_name, **options):
-        self.working_dir = working_dir
+    def __init__(self, file_name, **options):
         self.driver_name = "file"
-        self.path = Path(working_dir, file_name)
+        self.path = Path(tc_parameters.WORKING_DIR, file_name)
         super(FileSource, self).__init__(FileIO, [self.path], options)
 
     def get_path(self):
         return self.path
 
     def set_path(self, pathname):
-        self.path = Path(self.working_dir, pathname)
+        self.path = Path(tc_parameters.WORKING_DIR, pathname)
 
     def write_log(self, formatted_log, counter=1):
         self.sd_write_log(self.get_path(), formatted_log, counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -37,8 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class SyslogNgConfig(object):
-    def __init__(self, working_dir, version):
-        self.__working_dir = working_dir
+    def __init__(self, version):
         self.__raw_config = None
         self.__syslog_ng_config = {
             "version": version,
@@ -61,7 +60,7 @@ class SyslogNgConfig(object):
         if self.__raw_config:
             rendered_config = self.__raw_config
         else:
-            rendered_config = ConfigRenderer(self.__syslog_ng_config, self.__working_dir).get_rendered_config()
+            rendered_config = ConfigRenderer(self.__syslog_ng_config).get_rendered_config()
         logger.info("Generated syslog-ng config\n{}\n".format(rendered_config))
         FileIO(config_path).rewrite(rendered_config)
 
@@ -90,10 +89,10 @@ class SyslogNgConfig(object):
         self.__syslog_ng_config["global_options"].update(kwargs)
 
     def create_file_source(self, **kwargs):
-        return FileSource(self.__working_dir, **kwargs)
+        return FileSource(**kwargs)
 
     def create_file_destination(self, **kwargs):
-        return FileDestination(self.__working_dir, **kwargs)
+        return FileDestination(**kwargs)
 
     def create_filter(self, **kwargs):
         return Filter(**kwargs)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -92,8 +92,8 @@ class SyslogNgConfig(object):
             logpath.add_flags(cast_to_list(flags))
         return logpath
 
-    def create_global_options(self, **kwargs):
-        self.__syslog_ng_config["global_options"].update(kwargs)
+    def create_global_options(self, **options):
+        self.__syslog_ng_config["global_options"].update(options)
 
     def create_statement_group(self, statements):
         statement_group = StatementGroup(statements)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -29,9 +29,9 @@ from src.syslog_ng_config.statement_group import StatementGroup
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
-from src.syslog_ng_config.statements.parsers.parser import Parser
+from src.syslog_ng_config.statements.parser.parser import Parser
+from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
 from src.syslog_ng_config.statements.sources.file_source import FileSource
-from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,7 @@ class SyslogNgConfig(object):
             "logpath_groups": [],
         }
         self.file_source = FileSource
+        self.example_msg_generator_source = ExampleMsgGeneratorSource
         self.file_destination = FileDestination
 
     def set_version(self, version):
@@ -106,13 +107,6 @@ class SyslogNgConfig(object):
     def create_inner_logpath(self, statements=None, flags=None):
         inner_logpath = self.__create_logpath_with_conversion(statements, flags)
         return inner_logpath
-
-    def create_example_msg_generator(self, **options):
-        generator_source = SourceDriver(None)
-        generator_source.driver_name = "example_msg_generator"
-        generator_source.DEFAULT_MESSAGE = "-- Generated message. --"
-        generator_source.options = options
-        return generator_source
 
     def create_app_parser(self, **options):
         return Parser("app-parser", **options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -29,7 +29,8 @@ from src.syslog_ng_config.statement_group import StatementGroup
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
-from src.syslog_ng_config.statements.parser.parser import Parser
+from src.syslog_ng_config.statements.parsers.parser import AppParser
+from src.syslog_ng_config.statements.parsers.parser import SyslogParser
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
 from src.syslog_ng_config.statements.sources.file_source import FileSource
 
@@ -50,6 +51,8 @@ class SyslogNgConfig(object):
         self.example_msg_generator_source = ExampleMsgGeneratorSource
         self.file_destination = FileDestination
         self.filter = Filter
+        self.app_parser = AppParser
+        self.syslog_parser = SyslogParser
 
     def set_version(self, version):
         self.__syslog_ng_config["version"] = version
@@ -105,12 +108,6 @@ class SyslogNgConfig(object):
     def create_inner_logpath(self, statements=None, flags=None):
         inner_logpath = self.__create_logpath_with_conversion(statements, flags)
         return inner_logpath
-
-    def create_app_parser(self, **options):
-        return Parser("app-parser", **options)
-
-    def create_syslog_parser(self, **options):
-        return Parser("syslog-parser", **options)
 
     @staticmethod
     def stringify(s):

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -46,6 +46,8 @@ class SyslogNgConfig(object):
             "statement_groups": [],
             "logpath_groups": [],
         }
+        self.file_source = FileSource
+        self.file_destination = FileDestination
 
     def set_version(self, version):
         self.__syslog_ng_config["version"] = version
@@ -87,12 +89,6 @@ class SyslogNgConfig(object):
 
     def create_global_options(self, **kwargs):
         self.__syslog_ng_config["global_options"].update(kwargs)
-
-    def create_file_source(self, **kwargs):
-        return FileSource(**kwargs)
-
-    def create_file_destination(self, **kwargs):
-        return FileDestination(**kwargs)
 
     def create_filter(self, **kwargs):
         return Filter(**kwargs)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -49,6 +49,7 @@ class SyslogNgConfig(object):
         self.file_source = FileSource
         self.example_msg_generator_source = ExampleMsgGeneratorSource
         self.file_destination = FileDestination
+        self.filter = Filter
 
     def set_version(self, version):
         self.__syslog_ng_config["version"] = version
@@ -90,9 +91,6 @@ class SyslogNgConfig(object):
 
     def create_global_options(self, **kwargs):
         self.__syslog_ng_config["global_options"].update(kwargs)
-
-    def create_filter(self, **kwargs):
-        return Filter(**kwargs)
 
     def create_statement_group(self, statements):
         statement_group = StatementGroup(statements)

--- a/tests/python_functional/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
+++ b/tests/python_functional/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
@@ -22,13 +22,13 @@
 #############################################################################
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.executors.command_executor import CommandExecutor
 
 
 class SyslogNgCtlExecutor(object):
     def __init__(self, instance_paths):
         self.__instance_paths = instance_paths
-        self.__working_dir = instance_paths.get_working_dir()
         self.__syslog_ng_control_tool_path = instance_paths.get_syslog_ng_ctl_bin()
         self.__syslog_ng_control_socket_path = instance_paths.get_control_socket_path()
         self.__command_executor = CommandExecutor()
@@ -42,7 +42,7 @@ class SyslogNgCtlExecutor(object):
 
     def __construct_std_file_path(self, command_short_name, std_type):
         instance_name = self.__instance_paths.get_instance_name()
-        return Path(self.__working_dir, "syslog_ng_ctl_{}_{}_{}".format(instance_name, command_short_name, std_type))
+        return Path(tc_parameters.WORKING_DIR, "syslog_ng_ctl_{}_{}_{}".format(instance_name, command_short_name, std_type))
 
     def __construct_ctl_command(self, command):
         ctl_command = [self.__syslog_ng_control_tool_path]

--- a/tests/python_functional/src/testcase_parameters/testcase_parameters.py
+++ b/tests/python_functional/src/testcase_parameters/testcase_parameters.py
@@ -24,6 +24,8 @@ from pathlib2 import Path
 
 from src.common.pytest_operations import calculate_testcase_name
 
+WORKING_DIR = None
+
 
 class TestcaseParameters(object):
     def __init__(self, pytest_request):

--- a/tests/python_functional/src/testcase_parameters/testcase_parameters.py
+++ b/tests/python_functional/src/testcase_parameters/testcase_parameters.py
@@ -22,7 +22,7 @@
 #############################################################################
 from pathlib2 import Path
 
-from src.common.operations import calculate_testcase_name
+from src.common.pytest_operations import calculate_testcase_name
 
 
 class TestcaseParameters(object):


### PR DESCRIPTION
This patch set provides a general API for syslog-ng config drivers with the following changes:
- `working_dir` class variable has been converted into a global variable (it was also a main dependency of SyslogNgConfig classes)
- After that driver/parser/filter related wrapper functions (such as create_file_source()) could be removed from SyslogNgConfig() (they were boilerplates).
- Start using own classes (such as FileSource, FileDestination) for creating driver/parser/filter like objects in testcases
- Change functionality of SourceDriver and DestinationDriver to SourceWriter and DestinationReader, 
from now these classes are responsible only for general driver related input/output functionalities.
- Expose file related option handling into a new class: `FileBasedOptionHandler()`
- Follow the changes in functional testcases

Todos:
- find a better place to config.stringify()
- separate logpath related wrappers from SyslogNgConfig
- automatically create logpath (if needed)
- add missing functional testcase: change file-path during testrun
- add missing functional testcase: add new file based option during testrun (an example usage for OptionHandler() class)
