### PR TITLE
[WIP] Travis: Move bash logic from .travis.yml into bash script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,34 +80,7 @@ before_script:
       "
   - ./configure $CONFIGURE_FLAGS
 script:
-  - . tests/build-log-cflags-propagation.sh;
-    if [ "$CC" = "gcc" ]; then
-      export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_FLAGS";
-      exec_prop_check "make distcheck -j 3 V=1 --keep-going" ||
-      {
-        S=$?;
-        make V=1 distcheck;
-        find . -name test-suite.log | xargs cat;
-        return $S;
-      };
-      find . -name test-suite.log | xargs cat;
-    else
-      make --keep-going -j $(nproc);
-      S=$?;
-      if [ "$S" = "0" ]; then
-        make install
-        . scripts/get-libjvm-path.sh || return $?;
-        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$JNI_LIBDIR";
-        make func-test V=1;
-        make pytest-self-check;
-        make pytest-check;
-      elif [ "$S" = "42" ]; then
-        return $S;
-      else
-        make V=1 install;
-        return $S;
-      fi;
-    fi
+  - tests/travis-common-script.sh
 compiler:
   - gcc
   - clang

--- a/tests/travis-common-script.sh
+++ b/tests/travis-common-script.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+function main() {
+    . tests/build-log-cflags-propagation.sh;
+    if [ "$CC" = "gcc" ]; then
+      export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_FLAGS";
+      exec_prop_check "make distcheck -j 3 V=1 --keep-going";
+      find . -name test-suite.log | xargs cat;
+    else
+      make --keep-going -j $(nproc);
+      S=$?;
+      if [ "$S" = "0" ]; then
+        make install
+        . scripts/get-libjvm-path.sh || return $?;
+        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$JNI_LIBDIR";
+        make func-test V=1;
+        make pytest-self-check;
+        make pytest-check;
+      elif [ "$S" = "42" ]; then
+        return $S;
+      else
+        make V=1 install;
+        return $S;
+      fi;
+    fi
+}
+
+main


### PR DESCRIPTION
The main goal is to move the bash logic (described in section "script") from .travis.yml into a separate bash file(s): Imho this is the recommended way to use bash logic in .travis.yml.

The current working mode (adding bash logic to .travis.yml) is not so debug friendly, and after found a place where one of the shell line in .travis.yml did not propagated back the error to the Travis this solution even more needed.

Expected result from this PR:
- better reading of .travis.yml
- exclude the unpropagated bash returns
- possible to run scripts from dev machine

Todo:
- [ ] Decide how to use bash commands (Travis way (with "-") or from executable bash file)
- [ ] Deal with "--keep-going"
- [ ] Cleanup bash logic from .travis.yml

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>