### PR TITLE
Debug mode does not imply stderr

### DIFF
--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -260,11 +260,6 @@ main(int argc, char *argv[])
       debug_flag = TRUE;
     }
 
-  if (debug_flag)
-    {
-      log_stderr = TRUE;
-    }
-
   gboolean exit_before_main_loop_run = main_loop_options.syntax_only || main_loop_options.preprocess_into;
   if (debug_flag || exit_before_main_loop_run)
     {

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -260,6 +260,11 @@ main(int argc, char *argv[])
       debug_flag = TRUE;
     }
 
+  if (debug_flag && !log_stderr)
+    {
+      g_process_message("The -d/--debug option no longer implies -e/--stderr, if you want to redirect internal() source to stderr please also include -e/--stderr option");
+    }
+
   gboolean exit_before_main_loop_run = main_loop_options.syntax_only || main_loop_options.preprocess_into;
   if (debug_flag || exit_before_main_loop_run)
     {

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -212,6 +212,7 @@ main(int argc, char *argv[])
 
   z_mem_trace_init("syslog-ng.trace");
 
+  g_process_set_name("syslog-ng");
   g_process_set_argv_space(argc, (gchar **) argv);
 
   resolved_configurable_paths_init(&resolvedConfigurablePaths);
@@ -269,7 +270,6 @@ main(int argc, char *argv[])
     {
       g_process_set_mode(G_PM_FOREGROUND);
     }
-  g_process_set_name("syslog-ng");
 
   /* in this case we switch users early while retaining a limited set of
    * credentials in order to initialize/reinitialize the configuration.


### PR DESCRIPTION
Now the `syslog-ng -d` does not mean `syslog-ng -de` (same goes with `-r` option).

This solves #2730