### PR TITLE
LightAutomation: Update reorder-python-imports hook

### DIFF
--- a/tests/python_functional/.pre-commit-config.yaml
+++ b/tests/python_functional/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v1.4.0
     hooks:
     -   id: reorder-python-imports
+        args: [--application-directories=tests/python_functional/]
         files: 'tests/python_functional/'
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v1.0.0

--- a/tests/python_functional/conftest.py
+++ b/tests/python_functional/conftest.py
@@ -26,6 +26,7 @@ from datetime import datetime
 
 import pytest
 from pathlib2 import Path
+
 from src.message_builder.bsd_format import BSDFormat
 from src.message_builder.log_message import LogMessage
 from src.syslog_ng.syslog_ng import SyslogNg

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -23,6 +23,7 @@
 import logging
 
 from pathlib2 import Path
+
 from src.common.operations import calculate_testcase_name
 from src.common.operations import copy_file
 

--- a/tests/python_functional/src/conftest.py
+++ b/tests/python_functional/src/conftest.py
@@ -22,6 +22,7 @@
 #
 #############################################################################
 import pytest
+
 from src.testcase_parameters.testcase_parameters import TestcaseParameters
 
 

--- a/tests/python_functional/src/executors/command_executor.py
+++ b/tests/python_functional/src/executors/command_executor.py
@@ -23,6 +23,7 @@
 import logging
 
 import psutil
+
 from src.driver_io.file.file import File
 
 logger = logging.getLogger(__name__)

--- a/tests/python_functional/src/executors/process_executor.py
+++ b/tests/python_functional/src/executors/process_executor.py
@@ -23,6 +23,7 @@
 import logging
 
 import psutil
+
 from src.driver_io.file.file import File
 from src.executors.command_executor import prepare_executable_command
 from src.executors.command_executor import prepare_printable_command

--- a/tests/python_functional/src/executors/tests/test_command_executor.py
+++ b/tests/python_functional/src/executors/tests/test_command_executor.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 import pytest
+
 from src.executors.command_executor import CommandExecutor
 
 

--- a/tests/python_functional/src/message_reader/tests/test_message_reader.py
+++ b/tests/python_functional/src/message_reader/tests/test_message_reader.py
@@ -22,6 +22,7 @@
 #
 #############################################################################
 import pytest
+
 from src.common.operations import open_file
 from src.message_reader.message_reader import MessageReader
 from src.message_reader.message_reader import READ_ALL_MESSAGES

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -23,6 +23,7 @@
 import logging
 
 from pathlib2 import Path
+
 from src.common.blocking import wait_until_false
 from src.common.blocking import wait_until_true
 from src.syslog_ng.console_log_reader import ConsoleLogReader

--- a/tests/python_functional/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_paths.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from pathlib2 import Path
+
 from src.common.random_id import get_unique_id
 
 

--- a/tests/python_functional/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/python_functional/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -22,6 +22,7 @@
 #############################################################################
 import pytest
 from pathlib2 import PosixPath
+
 from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
 
 

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from pathlib2 import Path
+
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
 

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from pathlib2 import Path
+
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 

--- a/tests/python_functional/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
+++ b/tests/python_functional/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from pathlib2 import Path
+
 from src.executors.command_executor import CommandExecutor
 
 

--- a/tests/python_functional/src/testcase_parameters/testcase_parameters.py
+++ b/tests/python_functional/src/testcase_parameters/testcase_parameters.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from pathlib2 import Path
+
 from src.common.operations import calculate_testcase_name
 
 


### PR DESCRIPTION
reorder-python-imports hook should be updated with an extra command line argument:
```
--application-directories=tests/python_functional/
```

* Apply reorder-python-imports again
* This fix sets where Light is rooted
* Without this reorder-python-imports will set imports in wrong order

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>