### PR TITLE
fix infinite loop

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -82,7 +82,7 @@ register_application_hook(gint type, ApplicationHookFunc func, gpointer user_dat
       entry->func = func;
       entry->user_data = user_data;
 
-      application_hooks = g_list_append(application_hooks, entry);
+      application_hooks = g_list_prepend(application_hooks, entry);
     }
   else
     {

--- a/lib/tests/test_apphook.c
+++ b/lib/tests/test_apphook.c
@@ -102,6 +102,35 @@ Test(test_apphook, reopen_hook)
   cr_assert_eq(triggered_count, 1);
 }
 
+static void
+_re_registering_hook(gint type, gpointer user_data)
+{
+  _hook_counter(type, user_data);
+  register_application_hook(type, _re_registering_hook, user_data);
+}
+
+Test(test_apphook, hook_register_from_hook)
+{
+  gint triggered_count = 0;
+
+  register_application_hook(AH_REOPEN_FILES, _re_registering_hook, (gpointer)&triggered_count);
+
+  app_reopen_files();
+  cr_assert_eq(triggered_count, 1);
+}
+
+Test(test_apphook, hook_register_from_hook_and_other_not_triggered_hooks)
+{
+  gint triggered_count = 0;
+
+  register_application_hook(AH_PRE_SHUTDOWN, NULL, NULL);
+  register_application_hook(AH_REOPEN_FILES, _re_registering_hook, (gpointer)&triggered_count);
+  register_application_hook(AH_PRE_SHUTDOWN, NULL, NULL);
+
+  app_reopen_files();
+  cr_assert_eq(triggered_count, 1);
+}
+
 Test(test_apphook, trigger_all_state_hook)
 {
   gint triggered_count = 0;


### PR DESCRIPTION
A `reopen` after a `reload` could cause infinite loop, as all of the registered `reopen` hook was linked into the list after the current; creating an infinite loop.