### PR TITLE
stats: fix register control commands leak for unit tests

### DIFF
--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -42,6 +42,7 @@
 #include "resolved-configurable-paths.h"
 #include "scratch-buffers.h"
 #include "timeutils/misc.h"
+#include "stats/stats-control.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -613,6 +614,7 @@ main_loop_read_and_init_config(MainLoop *self)
     }
   self->control_server = control_init(resolvedConfigurablePaths.ctlfilename);
   main_loop_register_control_commands(self);
+  stats_register_control_commands();
   return 0;
 }
 

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -240,7 +240,6 @@ stats_init(void)
 {
   stats_registry_init();
   stats_query_init();
-  stats_register_control_commands();
 }
 
 void
@@ -285,4 +284,3 @@ stats_number_of_dynamic_clusters_limit(void)
     return -1;
   return stats_options->max_dynamic;
 }
-


### PR DESCRIPTION
There is a minor leak in unit tests that this patch intends to fix. Only unit tests are affected. However, every unit test is affected that calls `app_startup`, which is very common. For example `test_filter_call`:

```
==3039== 24 bytes in 1 blocks are still reachable in loss record 9 of 23
==3039==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3039==    by 0x5A057B8: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==3039==    by 0x5A1C9C2: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==3039==    by 0x59FC3C3: g_list_append (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==3039==    by 0x4E9B8F7: control_register_command (control-commands.c:68)
==3039==    by 0x4EB5FD8: stats_register_control_commands (stats-control.c:52)
==3039==    by 0x4EB5E30: stats_init (stats.c:243)
==3039==    by 0x4E6E838: app_startup (apphook.c:165)
==3039==    by 0x40111C: setup (test_filter_call.c:44)
==3039==    by 0x514802B: criterion_internal_test_setup (in /usr/lib/libcriterion.so.3.1.0)
==3039==    by 0x400E7C: filter_call_undefined_filter_ref_jmp (test_filter_call.c:31)
==3039==    by 0x5147382: run_test_child (in /usr/lib/libcriterion.so.3.1.0)
==3039==    by 0x518F821: bxfi_main (in /usr/lib/libcriterion.so.3.1.0)
==3039==    by 0x705682F: (below main) (libc-start.c:291)
```

`stats_register_control_commands` is registered in `stats_init`, which is
called in `app_startup`. However, its free method (`control_deinit`) is
called in `main_loop_deinit`.

Another parameter to know: besides stats related control commands,
there are other commands that are registered:
`main_loop_register_control_commands` in `main_loop_read_and_init_config`,
and not in `app_startup`.

Call order is:
```
app_startup : stats_register_control_commands
main_loop_init : None
main_loop_read_and_init_config : main_loop_register_control_commands
main_loop_deinit : control_deinit
app_shutdown : None
```

`control_server` itself is created in
`main_loop_read_and_init_config`. Practically it is not necessary
to call `control_init` for the registration to work, but this is an
implementation detail. That's why I think the problem is that the
`stats_register_control_commands` is happening earlier than `control_init`.

To resolve this, `stats_init` and `stats_register_control_commands` is
separated, and `stats_register_control_commands` is delayed, and called
in `main_loop_read_and_init_config`, next to the other registration
function.