### PR TITLE
snmp dest leak template

### DIFF
--- a/modules/snmp-dest/snmpdest-grammar.ym
+++ b/modules/snmp-dest/snmpdest-grammar.ym
@@ -104,15 +104,13 @@ dest_snmpdest_option
         | KW_TRAP_OBJ '(' string string string ')' { snmpdest_dd_set_trap_obj(last_driver, configuration, $3, $4, $5); free($3); free($4); free($5); }
         | KW_COMMUNITY '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v2c))
-            msg_warning("WARNING: SNMP: the 'community' is a v2c option",
-                        NULL);
+            msg_warning("WARNING: SNMP: the 'community' is a v2c option");
           snmpdest_dd_set_community(last_driver, $3); free($3);
           }
         | KW_ENGINE_ID '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v3))
             {
-              msg_warning("WARNING: SNMP: the 'engine_id' is a v3 option",
-                          NULL);
+              msg_warning("WARNING: SNMP: the 'engine_id' is a v3 option");
             }
           else 
             {
@@ -127,35 +125,30 @@ dest_snmpdest_option
           }
         | KW_AUTH_USERNAME '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v3))
-            msg_warning("WARNING: SNMP: the 'auth_username' is a v3 option",
-                        NULL);
+            msg_warning("WARNING: SNMP: the 'auth_username' is a v3 option");
 
           snmpdest_dd_set_auth_username(last_driver, $3); free($3);
           }
         | KW_AUTH_ALGORITHM '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v3))
-            msg_warning("WARNING: SNMP: the 'auth_algorithm' is a v3 option",
-                        NULL);
+            msg_warning("WARNING: SNMP: the 'auth_algorithm' is a v3 option");
           CHECK_ERROR(snmpdest_dd_check_auth_algorithm($3), @1, "SNMP: wrong auth algorithm: %s", $3);
           snmpdest_dd_set_auth_algorithm(last_driver, $3); free($3);
           }
         | KW_AUTH_PASSWORD '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v3))
-            msg_warning("WARNING: SNMP: the 'auth_password' is a v3 option",
-                        NULL);
+            msg_warning("WARNING: SNMP: the 'auth_password' is a v3 option");
           snmpdest_dd_set_auth_password(last_driver, $3); free($3);
           }
         | KW_ENC_ALGORITHM '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v3))
-            msg_warning("WARNING: SNMP: the 'enc_algorithm' is a v3 option",
-                        NULL);
+            msg_warning("WARNING: SNMP: the 'enc_algorithm' is a v3 option");
           CHECK_ERROR(snmpdest_dd_check_enc_algorithm($3), @1, "SNMP: wrong enc algorithm: %s", $3);
           snmpdest_dd_set_enc_algorithm(last_driver, $3); free($3);
           }
         | KW_ENC_PASSWORD '(' string ')' {
           if (strcmp(snmpdest_dd_get_version(last_driver), s_v3))
-            msg_warning("WARNING: SNMP: the 'enc_password' is a v3 option",
-                        NULL);
+            msg_warning("WARNING: SNMP: the 'enc_password' is a v3 option");
           snmpdest_dd_set_enc_password(last_driver, $3); free($3);
           }
         | KW_LOCAL_TIME_ZONE '(' string ')'           { snmpdest_dd_set_time_zone(last_driver, $3); free($3); }

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -187,6 +187,8 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
   if (log_template_compile(template, value, NULL) == FALSE)
     {
       msg_error("SNMP: invalid log template");
+      log_template_unref(template);
+      return FALSE;
     }
 
   self->snmp_templates = g_list_append(self->snmp_templates, template);

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -144,7 +144,7 @@ snmp_dd_compare_object_ids(gconstpointer a, gconstpointer b)
 }
 
 gboolean
-snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, const gchar *type, const gchar *value)
+snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *objectid, const gchar *type, const gchar *value)
 {
   SNMPDestDriver *self = (SNMPDestDriver *)d;
   LogTemplate *template = NULL;
@@ -172,7 +172,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
     }
 
   /* register the string values */
-  self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(oid));
+  self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(objectid));
   self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(type));
   self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(value));
 
@@ -197,7 +197,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
 }
 
 void
-snmpdest_dd_set_trap_obj(LogDriver *d, GlobalConfig *cfg,const gchar *oid, const gchar *type, const gchar *value)
+snmpdest_dd_set_trap_obj(LogDriver *d, GlobalConfig *cfg,const gchar *objectid, const gchar *type, const gchar *value)
 {
   SNMPDestDriver *self = (SNMPDestDriver *)d;
 
@@ -205,7 +205,7 @@ snmpdest_dd_set_trap_obj(LogDriver *d, GlobalConfig *cfg,const gchar *oid, const
   g_free(self->trap_type);
   g_free(self->trap_value);
 
-  self->trap_oid = g_strdup(oid);
+  self->trap_oid = g_strdup(objectid);
   self->trap_type = g_strdup(type);
   self->trap_value = g_strdup(value);
 

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -172,18 +172,15 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
     }
 
   /* register the string values */
-  GList *newitem = g_list_append(self->snmp_objs, g_strdup(oid));
-  if (!self->snmp_objs)
-    self->snmp_objs = newitem;
-  newitem = g_list_append(self->snmp_objs, g_strdup(type));
-  newitem = g_list_append(self->snmp_objs, g_strdup(value));
+  self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(oid));
+  self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(type));
+  self->snmp_objs = g_list_append(self->snmp_objs, g_strdup(value));
 
   /* register the type code, therefore we won't need to calculate it for each incoming message */
   gint *pcode = g_new(gint, 1);
   *pcode = code;
-  newitem = g_list_append(self->snmp_codes, pcode);
-  if (!self->snmp_codes)
-    self->snmp_codes = newitem;
+
+  self->snmp_codes = g_list_append(self->snmp_codes, pcode);
 
   /* register the template */
   template = log_template_new(cfg, NULL);
@@ -192,9 +189,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
       msg_error("SNMP: invalid log template");
     }
 
-  newitem = g_list_append(self->snmp_templates, template);
-  if (!self->snmp_templates)
-    self->snmp_templates = newitem;
+  self->snmp_templates = g_list_append(self->snmp_templates, template);
 
   return TRUE;
 }

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -153,8 +153,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
   if (snmp_dd_find_object_type(type, &code) == FALSE)
     {
       msg_error("SNMP: invalid oid type",
-                evt_tag_str("oid", type),
-                NULL);
+                evt_tag_str("oid", type));
       return FALSE;
     }
 
@@ -167,7 +166,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
 
       if (item != NULL)
         {
-          msg_error("SNMP: multiple Objectid", NULL);
+          msg_error("SNMP: multiple Objectid");
           return FALSE;
         }
     }
@@ -190,7 +189,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, cons
   template = log_template_new(cfg, NULL);
   if (log_template_compile(template, value, NULL) == FALSE)
     {
-      msg_error("SNMP: invalid log template", NULL);
+      msg_error("SNMP: invalid log template");
     }
 
   newitem = g_list_append(self->snmp_templates, template);
@@ -353,8 +352,7 @@ sanitize_fs(GString *fs, gint code)
       if (replace)
         {
           msg_warning("SNMP: invalid number replaced with '0'",
-                      evt_tag_str("value", fs->str),
-                      NULL);
+                      evt_tag_str("value", fs->str));
           g_string_assign(fs, "0");
         }
     }
@@ -373,8 +371,7 @@ snmpdest_worker_insert(SNMPDestDriver *self, LogMessage *msg, LogPathOptions *pa
         {
           msg_warning("SNMP: error in session init, message dropped",
                       evt_tag_str("host", self->host),
-                      evt_tag_int("port", self->port),
-                      NULL);
+                      evt_tag_int("port", self->port));
           log_msg_unref(msg);
           return FALSE;
         }
@@ -405,8 +402,7 @@ snmpdest_worker_insert(SNMPDestDriver *self, LogMessage *msg, LogPathOptions *pa
       if (snmp_add_var(pdu, parsed_oids, oid_cnt, type_code, fs->str) != 0)
         {
           msg_warning("SNMP: error adding variable",
-                      evt_tag_str("value", fs->str),
-                      NULL);
+                      evt_tag_str("value", fs->str));
           log_msg_unref(msg);
           return FALSE;
         }
@@ -422,8 +418,7 @@ snmpdest_worker_insert(SNMPDestDriver *self, LogMessage *msg, LogPathOptions *pa
     {
       msg_error("SNMP: send error",
                 evt_tag_int("code", snmp_errno),
-                evt_tag_str("message", snmp_api_errstring(snmp_errno)),
-                NULL);
+                evt_tag_str("message", snmp_api_errstring(snmp_errno)));
       stats_counter_inc(self->dropped_messages);
       snmp_free_pdu(pdu);
     }
@@ -458,8 +453,7 @@ snmpdest_worker_thread(gpointer arg)
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
   msg_debug ("Worker thread started",
-             evt_tag_str("driver", self->super.super.id),
-             NULL);
+             evt_tag_str("driver", self->super.super.id));
 
   gboolean popped = TRUE; /* the success of the _pop_head() */
   while (!self->writer_thread_terminate)
@@ -489,8 +483,7 @@ snmpdest_worker_thread(gpointer arg)
     }
 
   msg_debug ("Worker thread finished",
-             evt_tag_str("driver", self->super.super.id),
-             NULL);
+             evt_tag_str("driver", self->super.super.id));
 
 }
 
@@ -704,8 +697,7 @@ snmpdest_dd_init(LogPipe *s)
 
   msg_verbose("Initializing SNMP destination",
               evt_tag_str("host", self->host),
-              evt_tag_int("port", self->port),
-              NULL);
+              evt_tag_int("port", self->port));
 
   GlobalConfig *cfg = log_pipe_get_config(s);
 

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -761,7 +761,7 @@ snmpdest_dd_free(LogPipe *d)
 
   g_list_free_full(self->snmp_objs, g_free);
   g_list_free_full(self->snmp_codes, g_free);
-  g_list_free_full(self->snmp_templates, g_free);
+  g_list_free_full(self->snmp_templates, (GDestroyNotify)log_template_unref);
   g_free(self->trap_oid);
   g_free(self->trap_type);
   g_free(self->trap_value);

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -153,7 +153,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *objectid,
   if (snmp_dd_find_object_type(type, &code) == FALSE)
     {
       msg_error("SNMP: invalid oid type",
-                evt_tag_str("oid", type));
+                evt_tag_str("type", type));
       return FALSE;
     }
 

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -96,17 +96,12 @@ snmp_dd_find_object_type(const gchar *type, gint *type_index)
   /* check the type */
   for (index = 0; index < object_types_count; ++index)
     if (!strcasecmp(type, snmp_obj_types[index].type))
-      break;
+      {
+        *type_index = index;
+        return TRUE;
+      }
 
-  if (index == object_types_count)
-    {
-      return FALSE;
-    }
-  else
-    {
-      *type_index = index;
-      return TRUE;
-    }
+  return FALSE;
 }
 
 static gchar

--- a/modules/snmp-dest/snmpdest.h
+++ b/modules/snmp-dest/snmpdest.h
@@ -86,9 +86,10 @@ LogDriver *snmpdest_dd_new(GlobalConfig *cfg);
 void snmpdest_dd_set_version(LogDriver *d, const gchar *version);
 void snmpdest_dd_set_host(LogDriver *d, const gchar *host);
 void snmpdest_dd_set_port(LogDriver *d, gint port);
-gboolean snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg,const gchar *oid, const gchar *type,
+gboolean snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg,const gchar *objectid, const gchar *type,
                                   const gchar *value);
-void snmpdest_dd_set_trap_obj(LogDriver *d, GlobalConfig *cfg, const gchar *oid, const gchar *type, const gchar *value);
+void snmpdest_dd_set_trap_obj(LogDriver *d, GlobalConfig *cfg, const gchar *objectid, const gchar *type,
+                              const gchar *value);
 void snmpdest_dd_set_community(LogDriver *d, const gchar *community);
 void snmpdest_dd_set_engine_id(LogDriver *d, const gchar *eid);
 void snmpdest_dd_set_auth_username(LogDriver *d, const gchar *auth_username);

--- a/modules/snmp-dest/tests/test_snmp_dest.c
+++ b/modules/snmp-dest/tests/test_snmp_dest.c
@@ -44,6 +44,7 @@ _teardown(void)
 {
   log_pipe_unref((LogPipe *)&snmp_driver->super.super);
   app_shutdown();
+  cfg_free(cfg);
 }
 
 TestSuite(test_snmp_dest, .init = _init, .fini = _teardown);

--- a/modules/snmp-dest/tests/test_snmp_dest.c
+++ b/modules/snmp-dest/tests/test_snmp_dest.c
@@ -37,7 +37,6 @@ _init(void)
   app_startup();
   cfg = cfg_new_snippet();
   snmp_driver = (SNMPDestDriver *)snmpdest_dd_new(cfg);
-  cr_assert_eq(log_pipe_init((LogPipe *)&snmp_driver->super.super), TRUE);
 }
 
 static void

--- a/modules/snmp-dest/tests/test_snmp_dest.c
+++ b/modules/snmp-dest/tests/test_snmp_dest.c
@@ -35,7 +35,7 @@ static void
 _init(void)
 {
   app_startup();
-  cfg = cfg_new(VERSION_VALUE);
+  cfg = cfg_new_snippet();
   snmp_driver = (SNMPDestDriver *)snmpdest_dd_new(cfg);
   cr_assert_eq(log_pipe_init((LogPipe *)&snmp_driver->super.super), TRUE);
 }

--- a/modules/snmp-dest/tests/test_snmp_dest.c
+++ b/modules/snmp-dest/tests/test_snmp_dest.c
@@ -176,7 +176,7 @@ Test(test_snmp_dest, check_required_params)
 
 typedef struct _snmp_obj_test_param
 {
-  const gchar *oid;
+  const gchar *objectid;
   const gchar *type;
   const gchar *value;
   gboolean  expected_result;
@@ -187,43 +187,43 @@ ParameterizedTestParameters(test_snmp_dest, test_set_snmp_obj)
   static SnmpObjTestParam parser_params[] =
   {
     {
-      .oid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
+      .objectid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
       .type = "integer",
       .value = "123",
       .expected_result = TRUE
     },
     {
-      .oid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
+      .objectid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
       .type = "timeticks",
       .value = "0",
       .expected_result = TRUE
     },
     {
-      .oid = ".1.3.6.1.4.1.18372.3.1.1.1.1.1.0",
+      .objectid = ".1.3.6.1.4.1.18372.3.1.1.1.1.1.0",
       .type = "octetstring",
       .value = "Test SNMP trap",
       .expected_result = TRUE
     },
     {
-      .oid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
+      .objectid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
       .type = "counter32",
       .value = "1234567",
       .expected_result = TRUE
     },
     {
-      .oid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
+      .objectid = ".1.3.6.1.4.1.18372.3.1.1.1.1.3.0",
       .type = "ipaddress",
       .value = "127.0.0.1",
       .expected_result = TRUE
     },
     {
-      .oid = ".1.3.6.1.6.3.1.1.4.1.0",
+      .objectid = ".1.3.6.1.6.3.1.1.4.1.0",
       .type = "objectid",
       .value = ".1.3.6.1.4.1.18372.3.1.1.1.2.1",
       .expected_result = TRUE
     },
     {
-      .oid = "my_object_id",
+      .objectid = "my_object_id",
       .type = "pacalporkolt",
       .value = "krumpli",
       .expected_result = FALSE
@@ -236,7 +236,7 @@ ParameterizedTest(SnmpObjTestParam *param, test_snmp_dest, test_set_snmp_obj)
 {
   LogDriver *driver = (LogDriver *)snmp_driver;
 
-  gboolean result = snmpdest_dd_set_snmp_obj(driver, cfg, param->oid, param->type, param->value);
+  gboolean result = snmpdest_dd_set_snmp_obj(driver, cfg, param->objectid, param->type, param->value);
 
   cr_assert_eq(result, param->expected_result);
 }


### PR DESCRIPTION
* Fix unit test issues:
  * `cfg_new_snippet` should be used instead of `cfg_new` in UT
  * `log_pipe_init` should not be used before setter methods (as it is not done in syslog-ng normal execution either)
* Some minor refactors
* Removed tailing `NULL` from `msg_` macros (`scripts/rm-extra-msg-sentinel.sh`)
