### PR TITLE
dbld/xenial: add netbase package for getent tests

### DIFF
--- a/dbld/images/required-apt/all.txt
+++ b/dbld/images/required-apt/all.txt
@@ -53,3 +53,6 @@ docbook
 docbook-xsl
 dh-exec
 gnupg
+
+# required for kira
+netbase


### PR DESCRIPTION
Kira uses files from netbase when testing the $(getent) function.

Signed-off-by: Balazs Scheidler <balazs.scheidler@balabit.com>