### PR TITLE
logthrsourcedrv: support position tracking

### DIFF
--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -105,8 +105,7 @@ log_threaded_source_worker_set_options(LogThreadedSourceWorker *self, LogThreade
                                        LogThreadedSourceWorkerOptions *options,
                                        const gchar *stats_id, const gchar *stats_instance)
 {
-  /* TODO: support position tracking */
-  log_source_set_options(&self->super, &options->super, stats_id, stats_instance, TRUE, FALSE,
+  log_source_set_options(&self->super, &options->super, stats_id, stats_instance, TRUE, options->position_tracked,
                          control->super.super.super.expr_node);
 
   log_pipe_unref(&self->control->super.super.super);

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -43,6 +43,7 @@ typedef struct _LogThreadedSourceWorkerOptions
 {
   LogSourceOptions super;
   MsgFormatOptions parse_options;
+  gboolean position_tracked;
 } LogThreadedSourceWorkerOptions;
 
 struct _LogThreadedSourceDriver


### PR DESCRIPTION
There was a todo about support position tracking in
logthrsourcedrv. The default value is the same as the original:
early ack tracking is used. However, children can override this in
[child_driver]_new() time using

```
  self->super[.super(if inheriting from logthrsourcefetcher)].worker_options.position_tracked = TRUE;
```