### PR TITLE
fix grouping by deadlock

### DIFF
--- a/modules/dbparser/correllation-key.c
+++ b/modules/dbparser/correllation-key.c
@@ -86,7 +86,7 @@ correllation_key_equal(gconstpointer k1, gconstpointer k2)
 
 /* fills a CorrellationKey structure with borrowed values */
 void
-correllation_key_setup(CorrellationKey *self, CorrellationScope scope, LogMessage *msg, gchar *session_id)
+correllation_key_init(CorrellationKey *self, CorrellationScope scope, LogMessage *msg, gchar *session_id)
 {
   memset(self, 0, sizeof(*self));
   self->scope = scope;

--- a/modules/dbparser/correllation-key.h
+++ b/modules/dbparser/correllation-key.h
@@ -58,6 +58,6 @@ typedef struct _CorrellationKey
 
 guint correllation_key_hash(gconstpointer k);
 gboolean correllation_key_equal(gconstpointer k1, gconstpointer k2);
-void correllation_key_setup(CorrellationKey *self, CorrellationScope scope, LogMessage *msg, gchar *session_id);
+void correllation_key_init(CorrellationKey *self, CorrellationScope scope, LogMessage *msg, gchar *session_id);
 
 #endif

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -252,9 +252,10 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
   GString *buffer = g_string_sized_new(256);
 
   msg = synthetic_message_generate_with_context(self->synthetic_message, context, buffer);
+  g_string_free(buffer, TRUE);
+
   stateful_parser_emit_synthetic(&self->super, msg);
   log_msg_unref(msg);
-  g_string_free(buffer, TRUE);
 }
 
 static void

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -302,7 +302,13 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 
   g_static_mutex_lock(&self->lock);
   grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP]);
-  if (self->key_template)
+  if (!self->key_template)
+    {
+      g_static_mutex_unlock(&self->lock);
+
+      return TRUE;
+    }
+  else
     {
       CorrellationContext *context = NULL;
       CorrellationKey key;
@@ -368,12 +374,6 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 
       g_string_free(buffer, TRUE);
 
-      g_static_mutex_unlock(&self->lock);
-
-      return TRUE;
-    }
-  else
-    {
       g_static_mutex_unlock(&self->lock);
 
       return TRUE;

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -26,6 +26,7 @@
 #include "synthetic-message.h"
 #include "messages.h"
 #include "str-utils.h"
+#include "scratch-buffers.h"
 #include "filter/filter-expr.h"
 #include "timeutils/cache.h"
 #include "timeutils/misc.h"
@@ -306,7 +307,7 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
 {
   CorrellationContext *context;
   CorrellationKey key;
-  GString *buffer = g_string_sized_new(32);
+  GString *buffer = scratch_buffers_alloc();
 
   log_template_format(self->key_template, msg, NULL, LTZ_LOCAL, 0, NULL, buffer);
   log_msg_set_value(msg, context_id_handle, buffer->str, -1);
@@ -334,8 +335,6 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
                 evt_tag_int("num_messages", context->messages->len),
                 log_pipe_location_tag(&self->super.super.super));
     }
-
-  g_string_free(buffer, TRUE);
 
   return context;
 }

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -367,6 +367,8 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 
       LogMessage *genmsg = grouping_by_update_context_and_generate_msg(self, context);
 
+      g_static_mutex_unlock(&self->lock);
+
       if (genmsg)
         {
           stateful_parser_emit_synthetic(&self->super, genmsg);
@@ -374,8 +376,6 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
         }
 
       log_msg_write_protect(msg);
-
-      g_static_mutex_unlock(&self->lock);
 
       return TRUE;
     }

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -249,10 +249,7 @@ grouping_by_generate_synthetic_msg(GroupingBy *self, CorrellationContext *contex
       return NULL;
     }
 
-  GString *buffer = g_string_sized_new(256);
-
-  msg = synthetic_message_generate_with_context(self->synthetic_message, context, buffer);
-  g_string_free(buffer, TRUE);
+  msg = synthetic_message_generate_with_context(self->synthetic_message, context);
 
   return msg;
 }

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -257,6 +257,23 @@ grouping_by_generate_synthetic_msg(GroupingBy *self, CorrellationContext *contex
   return msg;
 }
 
+static LogMessage *
+grouping_by_update_context_and_generate_msg(GroupingBy *self, CorrellationContext *context)
+{
+  if (self->sort_key_template)
+    correllation_context_sort(context, self->sort_key_template);
+
+  LogMessage *msg = grouping_by_generate_synthetic_msg(self, context);
+
+  g_hash_table_remove(self->correllation->state, &context->key);
+
+  /* correllation_context_free is automatically called when returning from
+     this function by the timerwheel code as a destroy notify
+     callback. */
+
+  return msg;
+}
+
 static void
 grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
 {
@@ -268,21 +285,12 @@ grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
             evt_tag_str("context-id", context->key.session_id),
             log_pipe_location_tag(&self->super.super.super));
 
-  if (self->sort_key_template)
-    correllation_context_sort(context, self->sort_key_template);
-
-  LogMessage *msg = grouping_by_generate_synthetic_msg(self, context);
+  LogMessage *msg = grouping_by_update_context_and_generate_msg(self, context);
   if (msg)
     {
       stateful_parser_emit_synthetic(&self->super, msg);
       log_msg_unref(msg);
     }
-
-  g_hash_table_remove(self->correllation->state, &context->key);
-
-  /* correllation_context_free is automatically called when returning from
-     this function by the timerwheel code as a destroy notify
-     callback. */
 }
 
 
@@ -356,7 +364,14 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
       /* close down state */
       if (context->timer)
         timer_wheel_del_timer(self->timer_wheel, context->timer);
-      grouping_by_expire_entry(self->timer_wheel, timer_wheel_get_time(self->timer_wheel), context);
+
+      LogMessage *genmsg = grouping_by_update_context_and_generate_msg(self, context);
+
+      if (genmsg)
+        {
+          stateful_parser_emit_synthetic(&self->super, genmsg);
+          log_msg_unref(genmsg);
+        }
     }
   else
     {

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -254,7 +254,6 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
   msg = synthetic_message_generate_with_context(self->synthetic_message, context, buffer);
   g_string_free(buffer, TRUE);
 
-  stateful_parser_emit_synthetic(&self->super, msg);
   return msg;
 }
 
@@ -271,9 +270,14 @@ grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
 
   if (self->sort_key_template)
     correllation_context_sort(context, self->sort_key_template);
+
   LogMessage *msg = grouping_by_emit_synthetic(self, context);
   if (msg)
-    log_msg_unref(msg);
+    {
+      stateful_parser_emit_synthetic(&self->super, msg);
+      log_msg_unref(msg);
+    }
+
   g_hash_table_remove(self->correllation->state, &context->key);
 
   /* correllation_context_free is automatically called when returning from

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -299,12 +299,12 @@ grouping_by_format_persist_name(LogParser *s)
 static gboolean
 _perform_groupby(GroupingBy *self, LogMessage *msg)
 {
-  CorrellationContext *context = NULL;
 
   g_static_mutex_lock(&self->lock);
   grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP]);
   if (self->key_template)
     {
+      CorrellationContext *context = NULL;
       CorrellationKey key;
       GString *buffer = g_string_sized_new(32);
 
@@ -363,17 +363,13 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
                                                      correllation_context_ref(context), (GDestroyNotify) correllation_context_unref);
             }
         }
+
+      log_msg_write_protect(msg);
+
       g_string_free(buffer, TRUE);
-    }
-  else
-    {
-      context = NULL;
     }
 
   g_static_mutex_unlock(&self->lock);
-
-  if (context)
-    log_msg_write_protect(msg);
 
   return TRUE;
 }

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -237,7 +237,7 @@ _evaluate_trigger(GroupingBy *self, CorrellationContext *context)
 }
 
 static LogMessage *
-grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
+grouping_by_generate_synthetic_msg(GroupingBy *self, CorrellationContext *context)
 {
   LogMessage *msg = NULL;
 
@@ -271,7 +271,7 @@ grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
   if (self->sort_key_template)
     correllation_context_sort(context, self->sort_key_template);
 
-  LogMessage *msg = grouping_by_emit_synthetic(self, context);
+  LogMessage *msg = grouping_by_generate_synthetic_msg(self, context);
   if (msg)
     {
       stateful_parser_emit_synthetic(&self->super, msg);

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -367,11 +367,17 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
       log_msg_write_protect(msg);
 
       g_string_free(buffer, TRUE);
+
+      g_static_mutex_unlock(&self->lock);
+
+      return TRUE;
     }
+  else
+    {
+      g_static_mutex_unlock(&self->lock);
 
-  g_static_mutex_unlock(&self->lock);
-
-  return TRUE;
+      return TRUE;
+    }
 }
 
 static gboolean

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -302,12 +302,6 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 
   g_static_mutex_lock(&self->lock);
   grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP]);
-  if (!self->key_template)
-    {
-      g_static_mutex_unlock(&self->lock);
-
-      return TRUE;
-    }
 
   CorrellationContext *context = NULL;
   CorrellationKey key;

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -241,7 +241,13 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
 {
   LogMessage *msg;
 
-  if (_evaluate_having(self, context))
+  if (!_evaluate_having(self, context))
+    {
+      msg_debug("groupingby() dropping context, because having() is FALSE",
+                evt_tag_str("key", context->key.session_id),
+                log_pipe_location_tag(&self->super.super.super));
+    }
+  else
     {
       GString *buffer = g_string_sized_new(256);
 
@@ -249,12 +255,6 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
       stateful_parser_emit_synthetic(&self->super, msg);
       log_msg_unref(msg);
       g_string_free(buffer, TRUE);
-    }
-  else
-    {
-      msg_debug("groupingby() dropping context, because having() is FALSE",
-                evt_tag_str("key", context->key.session_id),
-                log_pipe_location_tag(&self->super.super.super));
     }
 }
 

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -372,6 +372,12 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
           stateful_parser_emit_synthetic(&self->super, genmsg);
           log_msg_unref(genmsg);
         }
+
+      log_msg_write_protect(msg);
+
+      g_static_mutex_unlock(&self->lock);
+
+      return TRUE;
     }
   else
     {

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -296,14 +296,10 @@ grouping_by_format_persist_name(LogParser *s)
   return persist_name;
 }
 
-static gboolean
-_perform_groupby(GroupingBy *self, LogMessage *msg)
+static CorrellationContext *
+_lookup_or_create_context(GroupingBy *self, LogMessage *msg)
 {
-
-  g_static_mutex_lock(&self->lock);
-  grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP]);
-
-  CorrellationContext *context = NULL;
+  CorrellationContext *context;
   CorrellationKey key;
   GString *buffer = g_string_sized_new(32);
 
@@ -334,6 +330,19 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
                 log_pipe_location_tag(&self->super.super.super));
     }
 
+  g_string_free(buffer, TRUE);
+
+  return context;
+}
+
+static gboolean
+_perform_groupby(GroupingBy *self, LogMessage *msg)
+{
+
+  g_static_mutex_lock(&self->lock);
+  grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP]);
+
+  CorrellationContext *context = _lookup_or_create_context(self, msg);
   g_ptr_array_add(context->messages, log_msg_ref(msg));
 
   if (_evaluate_trigger(self, context))
@@ -364,8 +373,6 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
     }
 
   log_msg_write_protect(msg);
-
-  g_string_free(buffer, TRUE);
 
   g_static_mutex_unlock(&self->lock);
 

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -321,7 +321,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
   if (!context)
     {
       msg_debug("Correllation context lookup failure, starting a new context",
-                evt_tag_str("key", buffer->str),
+                evt_tag_str("key", key.session_id),
                 evt_tag_int("timeout", self->timeout),
                 evt_tag_int("expiration", timer_wheel_get_time(self->timer_wheel) + self->timeout),
                 log_pipe_location_tag(&self->super.super.super));
@@ -333,7 +333,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
   else
     {
       msg_debug("Correllation context lookup successful",
-                evt_tag_str("key", buffer->str),
+                evt_tag_str("key", key.session_id),
                 evt_tag_int("timeout", self->timeout),
                 evt_tag_int("expiration", timer_wheel_get_time(self->timer_wheel) + self->timeout),
                 evt_tag_int("num_messages", context->messages->len),

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -246,16 +246,15 @@ grouping_by_emit_synthetic(GroupingBy *self, CorrellationContext *context)
       msg_debug("groupingby() dropping context, because having() is FALSE",
                 evt_tag_str("key", context->key.session_id),
                 log_pipe_location_tag(&self->super.super.super));
+      return;
     }
-  else
-    {
-      GString *buffer = g_string_sized_new(256);
 
-      msg = synthetic_message_generate_with_context(self->synthetic_message, context, buffer);
-      stateful_parser_emit_synthetic(&self->super, msg);
-      log_msg_unref(msg);
-      g_string_free(buffer, TRUE);
-    }
+  GString *buffer = g_string_sized_new(256);
+
+  msg = synthetic_message_generate_with_context(self->synthetic_message, context, buffer);
+  stateful_parser_emit_synthetic(&self->super, msg);
+  log_msg_unref(msg);
+  g_string_free(buffer, TRUE);
 }
 
 static void

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -316,7 +316,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
   log_template_format(self->key_template, msg, NULL, LTZ_LOCAL, 0, NULL, buffer);
   log_msg_set_value(msg, context_id_handle, buffer->str, -1);
 
-  correllation_key_setup(&key, self->scope, msg, buffer->str);
+  correllation_key_init(&key, self->scope, msg, buffer->str);
   context = g_hash_table_lookup(self->correllation->state, &key);
   if (!context)
     {

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -299,7 +299,6 @@ grouping_by_format_persist_name(LogParser *s)
 static gboolean
 _perform_groupby(GroupingBy *self, LogMessage *msg)
 {
-  GString *buffer = g_string_sized_new(32);
   CorrellationContext *context = NULL;
 
   g_static_mutex_lock(&self->lock);
@@ -307,6 +306,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
   if (self->key_template)
     {
       CorrellationKey key;
+      GString *buffer = g_string_sized_new(32);
 
       log_template_format(self->key_template, msg, NULL, LTZ_LOCAL, 0, NULL, buffer);
       log_msg_set_value(msg, context_id_handle, buffer->str, -1);
@@ -363,6 +363,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
                                                      correllation_context_ref(context), (GDestroyNotify) correllation_context_unref);
             }
         }
+      g_string_free(buffer, TRUE);
     }
   else
     {
@@ -374,7 +375,6 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
   if (context)
     log_msg_write_protect(msg);
 
-  g_string_free(buffer, TRUE);
   return TRUE;
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -215,7 +215,7 @@ _is_action_within_rate_limit(PatternDB *db, PDBProcessParams *process_params)
     return TRUE;
 
   g_string_printf(buffer, "%s:%d", rule->rule_id, action->id);
-  correllation_key_setup(&key, rule->context.scope, msg, buffer->str);
+  correllation_key_init(&key, rule->context.scope, msg, buffer->str);
 
   rl = g_hash_table_lookup(db->rate_limits, &key);
   if (!rl)
@@ -342,7 +342,7 @@ _execute_action_create_context(PatternDB *db, PDBProcessParams *process_params)
             evt_tag_int("context_timeout", syn_context->timeout),
             evt_tag_int("context_expiration", timer_wheel_get_time(db->timer_wheel) + syn_context->timeout));
 
-  correllation_key_setup(&key, syn_context->scope, context_msg, buffer->str);
+  correllation_key_init(&key, syn_context->scope, context_msg, buffer->str);
   new_context = pdb_context_new(&key);
   g_hash_table_insert(db->correllation.state, &new_context->super.key, new_context);
   g_string_steal(buffer);
@@ -609,7 +609,7 @@ _pattern_db_process_matching_rule(PatternDB *self, PDBProcessParams *process_par
       log_template_format(rule->context.id_template, msg, NULL, LTZ_LOCAL, 0, NULL, buffer);
       log_msg_set_value(msg, context_id_handle, buffer->str, -1);
 
-      correllation_key_setup(&key, rule->context.scope, msg, buffer->str);
+      correllation_key_init(&key, rule->context.scope, msg, buffer->str);
       context = g_hash_table_lookup(self->correllation.state, &key);
       if (!context)
         {

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -25,6 +25,7 @@
 #include "template/templates.h"
 #include "logmsg/logmsg.h"
 #include "logpipe.h"
+#include "scratch-buffers.h"
 
 void
 synthetic_message_set_inherit_mode(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode)
@@ -126,7 +127,8 @@ synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, Lo
 
   if (self->values)
     {
-      GString *buffer = g_string_sized_new(256);
+      ScratchBuffersMarker marker;
+      GString *buffer = scratch_buffers_alloc_and_mark(&marker);
       for (i = 0; i < self->values->len; i++)
         {
           log_template_format_with_context(g_ptr_array_index(self->values, i),
@@ -138,7 +140,7 @@ synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, Lo
                                     buffer->str,
                                     buffer->len);
         }
-      g_string_free(buffer, TRUE);
+      scratch_buffers_reclaim_marked(marker);
     }
 
 }

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -114,7 +114,7 @@ synthetic_message_add_value_template(SyntheticMessage *self, const gchar *name, 
 }
 
 void
-synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer)
+synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg)
 {
   gint i;
 
@@ -126,6 +126,7 @@ synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, Lo
 
   if (self->values)
     {
+      GString *buffer = g_string_sized_new(256);
       for (i = 0; i < self->values->len; i++)
         {
           log_template_format_with_context(g_ptr_array_index(self->values, i),
@@ -137,6 +138,7 @@ synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, Lo
                                     buffer->str,
                                     buffer->len);
         }
+      g_string_free(buffer, TRUE);
     }
 
 }
@@ -196,7 +198,7 @@ _generate_default_message_from_context(SyntheticMessageInheritMode inherit_mode,
 }
 
 LogMessage *
-synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context, GString *buffer)
+synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context)
 {
   LogMessage *genmsg;
 
@@ -216,13 +218,13 @@ synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationCont
       break;
     }
   g_ptr_array_add(context->messages, genmsg);
-  synthetic_message_apply(self, context, genmsg, buffer);
+  synthetic_message_apply(self, context, genmsg);
   g_ptr_array_remove_index_fast(context->messages, context->messages->len - 1);
   return genmsg;
 }
 
 LogMessage *
-synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg, GString *buffer)
+synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg)
 {
   LogMessage *genmsg;
 
@@ -240,7 +242,7 @@ synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *m
   GPtrArray dummy_ptr_array = { .pdata = (void **) dummy_msgs, .len = 2 };
   CorrellationContext dummy_context = { .messages = &dummy_ptr_array, 0 };
 
-  synthetic_message_apply(self, &dummy_context, genmsg, buffer);
+  synthetic_message_apply(self, &dummy_context, genmsg);
   return genmsg;
 }
 

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -41,12 +41,11 @@ typedef struct _SyntheticMessage
   GPtrArray *values;
 } SyntheticMessage;
 
-LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg, GString *buffer);
-LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context,
-                                                    GString *buffer);
+LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg);
+LogMessage *synthetic_message_generate_with_context(SyntheticMessage *self, CorrellationContext *context);
 
 
-void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg, GString *buffer);
+void synthetic_message_apply(SyntheticMessage *self, CorrellationContext *context, LogMessage *msg);
 gboolean synthetic_message_add_value_template_string(SyntheticMessage *self, GlobalConfig *cfg, const gchar *name,
                                                      const gchar *value, GError **error);
 void synthetic_message_set_inherit_mode(SyntheticMessage *self, SyntheticMessageInheritMode inherit_mode);


### PR DESCRIPTION
The `grouping-by` parser holds a lock during it processing a message.

This happens when in the source thread a `grouping-by` is triggered and hold the lock.
The same time the associated timer is triggered in the main thread, which also wants to hold the same lock (but the source thread has it).
In the source thread, in the end of the processing it sends toward the next pipe till it reaches the destination.
Where the destination wants to do some operation  (for details see the issue) in the main thread, so it triggers a task to be done and waits for that to finish.

Here comes the issue, the main thread still executing the triggered timer waiting for the same thread source to leave the lock, which waits the main thread to execute a piece of code.

In truths the `grouping-by` parser does not need to hold the lock, when it triggers the next pipe (as it is already did its job in the unsafe place interacting with the context). This patch just unlock the lock before triggering the next pipe.

Fixes #2630