### PR TITLE
Make: enable bison error flags: conflicts-sr/rr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(syslog-ng C)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${PROJECT_SOURCE_DIR}/cmake/)
 set(CMAKE_POSITION_INDEPENDENT_CODE 1)
-set(BISON_FLAGS "-Wno-other")
+set(BISON_FLAGS "-Wno-other -Werror=conflicts-sr -Werror=conflicts-rr")
 
 include(CheckIncludeFiles)
 include(ExternalProject)

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@
 SUBDIRS			=
 DIST_SUBDIRS		=
 AM_MAKEFLAGS		= --no-print-directory
-AM_YFLAGS		= -Wno-yacc -Wno-other
+AM_YFLAGS		= -Wno-yacc -Wno-other -Werror=conflicts-sr -Werror=conflicts-rr
 
 AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)"
 


### PR DESCRIPTION
They will produce error on shift/reduce and reduce/reduce
problems.

Now we can detect these problems in travis,
so problematic PRs will not be merged accidentally.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>