### PR TITLE
logthrfetcher: new constants

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -41,6 +41,7 @@
 #include "logmatcher.h"
 #include "logthrdest/logthrdestdrv.h"
 #include "logthrsource/logthrsourcedrv.h"
+#include "logthrsource/logthrfetcherdrv.h"
 #include "str-utils.h"
 
 /* uses struct declarations instead of the typedefs to avoid having to
@@ -347,6 +348,7 @@ extern struct _StatsOptions *last_stats_options;
 
 %token KW_RETRIES                     10512
 
+%token KW_FETCH_NO_DATA_DELAY         10513
 /* END_DECLS */
 
 %code {
@@ -1207,6 +1209,10 @@ threaded_source_driver_option
         | { last_msg_format_options = log_threaded_source_driver_get_parse_options(last_driver); } msg_format_option
         | { last_source_options = log_threaded_source_driver_get_source_options(last_driver); } source_option
         | source_driver_option
+        ;
+
+threaded_fetcher_driver_option
+        : KW_FETCH_NO_DATA_DELAY '(' nonnegative_integer ')' { log_threaded_fetcher_driver_set_fetch_no_data_delay(last_driver, $3); }
         ;
 
 threaded_source_driver_option_flags

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -164,6 +164,7 @@ static CfgLexerKeyword main_keywords[] =
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 
   { "read_old_records",   KW_READ_OLD_RECORDS},
+  { "fetch_no_data_delay", KW_FETCH_NO_DATA_DELAY},
   /* filter items */
   { "type",               KW_TYPE },
   { "tags",               KW_TAGS },

--- a/lib/logthrsource/logthrfetcherdrv.h
+++ b/lib/logthrsource/logthrfetcherdrv.h
@@ -39,7 +39,9 @@ typedef enum
 {
   THREADED_FETCH_ERROR,
   THREADED_FETCH_NOT_CONNECTED,
-  THREADED_FETCH_SUCCESS
+  THREADED_FETCH_SUCCESS,
+  THREADED_FETCH_TRY_AGAIN,
+  THREADED_FETCH_NO_DATA
 } ThreadedFetchResult;
 
 typedef struct _LogThreadedFetchResult
@@ -52,10 +54,12 @@ struct _LogThreadedFetcherDriver
 {
   LogThreadedSourceDriver super;
   time_t time_reopen;
+  time_t no_data_delay;
   struct iv_task fetch_task;
   struct iv_event wakeup_event;
   struct iv_event shutdown_event;
   struct iv_timer reconnect_timer;
+  struct iv_timer no_data_timer;
   gboolean suspended;
   gboolean under_termination;
 
@@ -72,5 +76,7 @@ void log_threaded_fetcher_driver_init_instance(LogThreadedFetcherDriver *self, G
 gboolean log_threaded_fetcher_driver_init_method(LogPipe *s);
 gboolean log_threaded_fetcher_driver_deinit_method(LogPipe *s);
 void log_threaded_fetcher_driver_free_method(LogPipe *s);
+
+void log_threaded_fetcher_driver_set_fetch_no_data_delay(LogDriver *self, time_t no_data_delay);
 
 #endif

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source-grammar.ym
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source-grammar.ym
@@ -85,9 +85,9 @@ threaded_diskq_source_option
       free($3);
     }
   | threaded_source_driver_option
+  | threaded_fetcher_driver_option
   ;
 
 /* INCLUDE_RULES */
 
 %%
-

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -159,6 +159,8 @@ _ulong_to_fetch_result(unsigned long ulong, ThreadedFetchResult *result)
     case THREADED_FETCH_ERROR:
     case THREADED_FETCH_NOT_CONNECTED:
     case THREADED_FETCH_SUCCESS:
+    case THREADED_FETCH_TRY_AGAIN:
+    case THREADED_FETCH_NO_DATA:
       *result = (ThreadedFetchResult) ulong;
       return TRUE;
 
@@ -565,6 +567,10 @@ py_log_fetcher_init(void)
   PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_NOT_CONNECTED",
                        PyLong_FromLong(THREADED_FETCH_NOT_CONNECTED));
   PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_SUCCESS",
+                       PyLong_FromLong(THREADED_FETCH_SUCCESS));
+  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_TRY_AGAIN",
+                       PyLong_FromLong(THREADED_FETCH_SUCCESS));
+  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_NO_DATA",
                        PyLong_FromLong(THREADED_FETCH_SUCCESS));
 
   PyType_Ready(&py_log_fetcher_type);

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -176,6 +176,7 @@ python_fetcher_option
         | KW_LOADERS python_fetcher_loaders
         | KW_OPTIONS '(' python_fetcher_custom_options ')'
         | threaded_source_driver_option
+        | threaded_fetcher_driver_option
         ;
 
 python_fetcher_custom_options


### PR DESCRIPTION
This patch adds two new constants for `logthrfetcher`:

- `THREADED_FETCH_NO_DATA`
The child can signal the driver that it does not want to provide data for some time. This is very similar to `THREADED_FETCH_ERROR`. The difference is that we do not consider this case as an error, so there is no need to disconnect+reconnect, nor need to emit `msg_error`.
A new option is added to control the time without fetch: `NO_DATA_DELAY`. If not provided, we will reuse `time_reopen`, however users can override this behavior with `no_data_delay()`, and thus handle the two cases independently. The resolution is in seconds.

- `THREADED_FETCH_TRY_AGAIN`
The child can ask the driver to reschedule a fetch without delay. This is the no_delay variant of the `THREADED_FETCH_NO_DATA` above. Child can express that they cannot provide message at that time, however they might do so in the next iteration. Technically - at the cost of child code complexity - a child could retry its own fetch logic instantly, and provide message in the same iteration, thus eliminating the need of this constant.  With this constant howver, child code can be simplified in some cases.