### PR TITLE
Light: fix restart ordering

### DIFF
--- a/tests/python_functional/src/syslog_ng/syslog_ng.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng.py
@@ -38,8 +38,8 @@ class SyslogNg(object):
         self.__syslog_ng_cli.reload(config)
 
     def restart(self, config):
-        self.__syslog_ng_cli.start(config)
         self.__syslog_ng_cli.stop()
+        self.__syslog_ng_cli.start(config)
 
     def get_version(self):
         return self.__syslog_ng_cli.get_version()

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -94,6 +94,9 @@ class SyslogNgCli(object):
 
     # Process commands
     def start(self, config):
+        if self.__process:
+            raise Exception("syslog-ng has been already started")
+
         config.write_content(self.__instance_paths.get_config_path())
 
         self.__syntax_check()


### PR DESCRIPTION
This patch set fixes two related issues in SyslogNg() class
- fixes restart() ordering, started with stop() follows with start()
- do not allow to start same syslog process twice

- testcases are not created 