### PR TITLE
Light: Remove working dir from SyslogNgConfig dependencies

### DIFF
--- a/tests/python_functional/conftest.py
+++ b/tests/python_functional/conftest.py
@@ -97,8 +97,8 @@ def testcase_parameters(request):
 
 
 @pytest.fixture
-def config(request, testcase_parameters):
-    return SyslogNgConfig(testcase_parameters.get_working_dir(), request.getfixturevalue("version"))
+def config(request):
+    return SyslogNgConfig(request.getfixturevalue("version"))
 
 
 @pytest.fixture

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -24,8 +24,8 @@ import logging
 
 from pathlib2 import Path
 
-from src.common.operations import calculate_testcase_name
 from src.common.operations import copy_file
+from src.common.pytest_operations import calculate_testcase_name
 
 logger = logging.getLogger(__name__)
 

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -24,6 +24,7 @@ import logging
 
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.operations import copy_file
 from src.common.pytest_operations import calculate_testcase_name
 
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 def pytest_runtest_setup(item):
     def prepare_testcase_working_dir(pytest_request):
         testcase_parameters = pytest_request.getfixturevalue("testcase_parameters")
-        working_directory = testcase_parameters.get_working_dir()
+        tc_parameters.WORKING_DIR = working_directory = testcase_parameters.get_working_dir()
         if not working_directory.exists():
             working_directory.mkdir(parents=True)
         testcase_file_path = testcase_parameters.get_testcase_file()

--- a/tests/python_functional/src/common/operations.py
+++ b/tests/python_functional/src/common/operations.py
@@ -24,6 +24,8 @@ import shutil
 
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
+
 
 def open_file(file_path, mode):
     # Python 2 compatibility note: open() can work only with string representation of path
@@ -43,11 +45,9 @@ def cast_to_list(items):
 
 def copy_shared_file(shared_file_name, syslog_ng_testcase):
     shared_dir = syslog_ng_testcase.testcase_parameters.get_shared_dir()
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    copy_file(Path(shared_dir, shared_file_name), working_dir)
+    copy_file(Path(shared_dir, shared_file_name), tc_parameters.WORKING_DIR)
 
 
-def delete_session_file(shared_file_name, syslog_ng_testcase):
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    shared_file_name = Path(working_dir, shared_file_name)
+def delete_session_file(shared_file_name):
+    shared_file_name = Path(tc_parameters.WORKING_DIR, shared_file_name)
     shared_file_name.unlink()

--- a/tests/python_functional/src/common/pytest_operations.py
+++ b/tests/python_functional/src/common/pytest_operations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #############################################################################
-# Copyright (c) 2015-2018 Balabit
+# Copyright (c) 2015-2019 Balabit
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -20,34 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
-import shutil
-
-from pathlib2 import Path
 
 
-def open_file(file_path, mode):
-    # Python 2 compatibility note: open() can work only with string representation of path
-    return open(str(file_path), mode)
-
-
-def copy_file(src_file_path, dst_dir):
-    # Python 2 compatibility note: shutil.copy() can work only with string representation of path
-    shutil.copy(str(src_file_path), str(dst_dir))
-
-
-def cast_to_list(items):
-    if isinstance(items, list):
-        return items
-    return [items]
-
-
-def copy_shared_file(shared_file_name, syslog_ng_testcase):
-    shared_dir = syslog_ng_testcase.testcase_parameters.get_shared_dir()
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    copy_file(Path(shared_dir, shared_file_name), working_dir)
-
-
-def delete_session_file(shared_file_name, syslog_ng_testcase):
-    working_dir = syslog_ng_testcase.testcase_parameters.get_working_dir()
-    shared_file_name = Path(working_dir, shared_file_name)
-    shared_file_name.unlink()
+def calculate_testcase_name(pytest_request):
+    # In case of parametrized tests we need to replace "[" and "]" because
+    # testcase name will appear in directory name
+    return pytest_request.node.name.replace("[", "_").replace("]", "_")

--- a/tests/python_functional/src/conftest.py
+++ b/tests/python_functional/src/conftest.py
@@ -23,6 +23,7 @@
 #############################################################################
 import pytest
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.testcase_parameters.testcase_parameters import TestcaseParameters
 
 
@@ -35,6 +36,7 @@ def test_message():
 def fake_testcase_parameters(request, tmpdir):
     orig_installdir = request.config.option.installdir
     orig_reportdir = request.config.option.reports
+    tc_parameters.WORKING_DIR = tmpdir.join("workingdir")
     request.config.option.installdir = tmpdir.join("installdir")
     request.config.option.reports = tmpdir.join("reports")
     request.config.option.runwithvalgrind = False

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -24,6 +24,7 @@ import logging
 
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.blocking import wait_until_false
 from src.common.blocking import wait_until_true
 from src.syslog_ng.console_log_reader import ConsoleLogReader
@@ -152,6 +153,6 @@ class SyslogNgCli(object):
                 core_file_found = True
                 self.__process = None
                 self.__syslog_ng_executor.get_backtrace_from_core(core_file=str(core_file))
-                core_file.replace(Path(self.__instance_paths.get_working_dir(), core_file))
+                core_file.replace(Path(tc_parameters.WORKING_DIR, core_file))
             if core_file_found:
                 raise Exception("syslog-ng core file was found and processed")

--- a/tests/python_functional/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_paths.py
@@ -22,6 +22,7 @@
 #############################################################################
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.random_id import get_unique_id
 
 
@@ -35,14 +36,14 @@ class SyslogNgPaths(object):
         if self.__instance_name is not None:
             raise Exception("Instance already configured")
         self.__instance_name = instance_name
-        working_dir = self.__testcase_parameters.get_working_dir()
+        working_dir = tc_parameters.WORKING_DIR
         relative_working_dir = self.__testcase_parameters.get_relative_working_dir()
         install_dir = self.__testcase_parameters.get_install_dir()
         if not install_dir:
             raise ValueError("Missing --installdir start parameter")
 
         self.__syslog_ng_paths = {
-            "dirs": {"working_dir": working_dir, "install_dir": Path(install_dir)},
+            "dirs": {"install_dir": Path(install_dir)},
             "file_paths": {
                 "config_path": Path(working_dir, "syslog_ng_{}.conf".format(instance_name)),
                 "persist_path": Path(working_dir, "syslog_ng_{}.persist".format(instance_name)),
@@ -63,9 +64,6 @@ class SyslogNgPaths(object):
 
     def get_instance_name(self):
         return self.__instance_name
-
-    def get_working_dir(self):
-        return self.__syslog_ng_paths["dirs"]["working_dir"]
 
     def get_install_dir(self):
         return self.__syslog_ng_paths["dirs"]["install_dir"]

--- a/tests/python_functional/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/python_functional/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -30,7 +30,7 @@ def test_syslog_ng_paths(fake_testcase_parameters):
     syslog_ng_paths = SyslogNgPaths(fake_testcase_parameters)
     syslog_ng_paths.set_syslog_ng_paths(instance_name="server")
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths)) == {"dirs", "file_paths", "binary_file_paths"}
-    assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["dirs"])) == {"working_dir", "install_dir"}
+    assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["dirs"])) == {"install_dir"}
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["file_paths"])) == {
         "config_path",
         "persist_path",

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -23,9 +23,8 @@
 
 
 class ConfigRenderer(object):
-    def __init__(self, syslog_ng_config, working_dir):
+    def __init__(self, syslog_ng_config):
         self.__syslog_ng_config = syslog_ng_config
-        self.__working_dir = working_dir
         self.__syslog_ng_config_content = ""
         self.__render()
 

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -22,14 +22,15 @@
 #############################################################################
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
 
 
 class FileDestination(DestinationDriver):
-    def __init__(self, working_dir, file_name, **options):
+    def __init__(self, file_name, **options):
         self.driver_name = "file"
-        self.path = Path(working_dir, file_name)
+        self.path = Path(tc_parameters.WORKING_DIR, file_name)
         super(FileDestination, self).__init__(FileIO, [self.path], options)
 
     def get_path(self):

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -22,22 +22,22 @@
 #############################################################################
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 
 
 class FileSource(SourceDriver):
-    def __init__(self, working_dir, file_name, **options):
-        self.working_dir = working_dir
+    def __init__(self, file_name, **options):
         self.driver_name = "file"
-        self.path = Path(working_dir, file_name)
+        self.path = Path(tc_parameters.WORKING_DIR, file_name)
         super(FileSource, self).__init__(FileIO, [self.path], options)
 
     def get_path(self):
         return self.path
 
     def set_path(self, pathname):
-        self.path = Path(self.working_dir, pathname)
+        self.path = Path(tc_parameters.WORKING_DIR, pathname)
 
     def write_log(self, formatted_log, counter=1):
         self.sd_write_log(self.get_path(), formatted_log, counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -37,8 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class SyslogNgConfig(object):
-    def __init__(self, working_dir, version):
-        self.__working_dir = working_dir
+    def __init__(self, version):
         self.__raw_config = None
         self.__syslog_ng_config = {
             "version": version,
@@ -61,7 +60,7 @@ class SyslogNgConfig(object):
         if self.__raw_config:
             rendered_config = self.__raw_config
         else:
-            rendered_config = ConfigRenderer(self.__syslog_ng_config, self.__working_dir).get_rendered_config()
+            rendered_config = ConfigRenderer(self.__syslog_ng_config).get_rendered_config()
         logger.info("Generated syslog-ng config\n{}\n".format(rendered_config))
         FileIO(config_path).rewrite(rendered_config)
 
@@ -90,10 +89,10 @@ class SyslogNgConfig(object):
         self.__syslog_ng_config["global_options"].update(kwargs)
 
     def create_file_source(self, **kwargs):
-        return FileSource(self.__working_dir, **kwargs)
+        return FileSource(**kwargs)
 
     def create_file_destination(self, **kwargs):
-        return FileDestination(self.__working_dir, **kwargs)
+        return FileDestination(**kwargs)
 
     def create_filter(self, **kwargs):
         return Filter(**kwargs)

--- a/tests/python_functional/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
+++ b/tests/python_functional/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
@@ -22,13 +22,13 @@
 #############################################################################
 from pathlib2 import Path
 
+import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.executors.command_executor import CommandExecutor
 
 
 class SyslogNgCtlExecutor(object):
     def __init__(self, instance_paths):
         self.__instance_paths = instance_paths
-        self.__working_dir = instance_paths.get_working_dir()
         self.__syslog_ng_control_tool_path = instance_paths.get_syslog_ng_ctl_bin()
         self.__syslog_ng_control_socket_path = instance_paths.get_control_socket_path()
         self.__command_executor = CommandExecutor()
@@ -42,7 +42,7 @@ class SyslogNgCtlExecutor(object):
 
     def __construct_std_file_path(self, command_short_name, std_type):
         instance_name = self.__instance_paths.get_instance_name()
-        return Path(self.__working_dir, "syslog_ng_ctl_{}_{}_{}".format(instance_name, command_short_name, std_type))
+        return Path(tc_parameters.WORKING_DIR, "syslog_ng_ctl_{}_{}_{}".format(instance_name, command_short_name, std_type))
 
     def __construct_ctl_command(self, command):
         ctl_command = [self.__syslog_ng_control_tool_path]

--- a/tests/python_functional/src/testcase_parameters/testcase_parameters.py
+++ b/tests/python_functional/src/testcase_parameters/testcase_parameters.py
@@ -24,6 +24,8 @@ from pathlib2 import Path
 
 from src.common.pytest_operations import calculate_testcase_name
 
+WORKING_DIR = None
+
 
 class TestcaseParameters(object):
     def __init__(self, pytest_request):

--- a/tests/python_functional/src/testcase_parameters/testcase_parameters.py
+++ b/tests/python_functional/src/testcase_parameters/testcase_parameters.py
@@ -22,7 +22,7 @@
 #############################################################################
 from pathlib2 import Path
 
-from src.common.operations import calculate_testcase_name
+from src.common.pytest_operations import calculate_testcase_name
 
 
 class TestcaseParameters(object):


### PR DESCRIPTION
This PR is based on my #2768 PR.

The patch set of this PR was previously part of my #2723. I have just separated it from there.
I have decided to create smaller separate PRs to move forward Light related PRs faster.

Patch description:
- with initializing working_dir as a global variable we will able to eliminate it from SyslogNgConfig() class.
- with this change SyslogNgConfig() class can be used more easily in Ligth, and opens it for a refactoring