### PR TITLE
Light: Remove unused Light dependencies

### DIFF
--- a/dbld/images/helpers/pip_packages.manifest
+++ b/dbld/images/helpers/pip_packages.manifest
@@ -6,7 +6,6 @@ ply                     [centos, debian, ubuntu]
 pylint                  [centos-7, debian, ubuntu]
 
 # pip packages for python functional tests
-mockito                 [centos, debian, ubuntu]
 pathlib2                [centos, debian, ubuntu]
 psutil                  [centos, debian, ubuntu]
 pytest                  [centos, debian, ubuntu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ pep8==1.7.1
 pylint==1.8.2
 astroid==1.6.1
 logilab-common<=0.63.0
-colorlog
-mockito
 pathlib2
 psutil
 pytest


### PR DESCRIPTION
- Ligth is not depends anymore on this pip packages

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>