### PR TITLE
Reintroduce test on SYSLOG_NG_HAVE_TIMEZONE

### DIFF
--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -547,7 +547,9 @@ recurse:
               if (ep != NULL)
                 {
                   wct->tm.tm_isdst = i;
+#ifdef SYSLOG_NG_HAVE_TIMEZONE
                   wct->wct_gmtoff = -(timezone);
+#endif
                   wct->wct_zone = tzname[i];
                 }
               bp = ep;


### PR DESCRIPTION
The conditional assignment to wct->wct_gmtoff was [removed in #2709][1]
because we though that the field previously did not exist in some
circumstances which where not true anymore.  In fact, the macros is here
to help us detect what `timezone` is, since it's not the same on all
platforms:

On Linux, timezone is declared in time.h as:
extern long int timezone;

On FreeBSD, timezone is declared in time.h as:
char *timezone(int zone, int dst);

As a consequence, the assignment on FreeBSD produce a compiler error:

```
  CC       lib/timeutils/libsyslog_ng_la-wallclocktime.lo
lib/timeutils/wallclocktime.c:551:37: error: invalid argument type 'char *(*)(int, int)' to unary expression
                  wct->wct_gmtoff = -(timezone);
                                    ^~~~~~~~~~~
1 error generated.
```

Re-add the removed #ifdef to fix the build on FreeBSD.

[1]: https://github.com/balabit/syslog-ng/pull/2709#discussion_r281878398


_Originally posted by @smortex in https://github.com/balabit/syslog-ng/pull/2709#discussion_r292215785_