### PR TITLE
Allow passing mutiple formats to date-parser

### DIFF
--- a/modules/date/date-grammar.ym
+++ b/modules/date/date-grammar.ym
@@ -72,13 +72,13 @@ date_parser_options
 date_parser_option
         : KW_FORMAT '(' string_list ')'             { date_parser_set_formats(last_parser, $3); }
         | KW_TIME_ZONE '(' string ')'               { date_parser_set_timezone(last_parser, $3); free($3); }
-	| KW_TIME_STAMP '(' date_parser_stamp ')'   { date_parser_set_time_stamp(last_parser, $3); }
-	| KW_FLAGS '(' date_parser_flags ')'
+        | KW_TIME_STAMP '(' date_parser_stamp ')'   { date_parser_set_time_stamp(last_parser, $3); }
+        | KW_FLAGS '(' date_parser_flags ')'
         | parser_opt
         ;
 
 date_parser_stamp
-	: string
+        : string
           {
             $$ = log_msg_lookup_time_stamp_name($1);
             CHECK_ERROR($$ != -1, @1, "unknown time stamp name %s", $1);
@@ -86,7 +86,7 @@ date_parser_stamp
           }
 
 date_parser_flags
-	: string date_parser_flags         { CHECK_ERROR(date_parser_process_flag(last_parser, $1), @1, "Unknown flag %s", $1); free($1); }
+        : string date_parser_flags         { CHECK_ERROR(date_parser_process_flag(last_parser, $1), @1, "Unknown flag %s", $1); free($1); }
         |
         ;
 

--- a/modules/date/date-grammar.ym
+++ b/modules/date/date-grammar.ym
@@ -70,7 +70,7 @@ date_parser_options
         ;
 
 date_parser_option
-        : KW_FORMAT '(' string ')'                  { date_parser_set_format(last_parser, $3); free($3); }
+        : KW_FORMAT '(' string_list ')'             { date_parser_set_formats(last_parser, $3); }
         | KW_TIME_ZONE '(' string ')'               { date_parser_set_timezone(last_parser, $3); free($3); }
 	| KW_TIME_STAMP '(' date_parser_stamp ')'   { date_parser_set_time_stamp(last_parser, $3); }
 	| KW_FLAGS '(' date_parser_flags ')'

--- a/modules/date/date-parser.h
+++ b/modules/date/date-parser.h
@@ -29,7 +29,7 @@
 LogParser *date_parser_new(GlobalConfig *cfg);
 
 void date_parser_set_offset(LogParser *s, goffset offset);
-void date_parser_set_format(LogParser *s, const gchar *format);
+void date_parser_set_formats(LogParser *s, GList *formats);
 void date_parser_set_timezone(LogParser *s, gchar *tz);
 void date_parser_set_time_stamp(LogParser *s, LogMessageTimeStamp timestamp);
 gboolean date_parser_process_flag(LogParser *s, gchar *flag);

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -37,25 +37,19 @@
 
 #
 # parses a cisco timestamp with explicit date-parser
-# It ignores msec and timezone information
+# It ignores timezone information
 #
 block parser cisco-timestamp-parser(template()) {
     channel {
-        if {
-            # timestamp from Cisco Unified Call Manager, example "Jun 14 11:57:27 PM.685 UTC"
-            # NOTE: drops msecs and timezone
-            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2} ((AM)|(PM)))' template(`template`) flags(store-matches)); };
-        } elif {
-            # timestamp without AM/PM mark, example: "Apr 29 13:58:40.411"
-            # NOTE: drops msecs and timezone
-            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
-        } else {
-            # timestamp with year information, example: "Apr 29 2017 13:58:40.411"
-            filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{4} \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
+        filter {
+            match('^\*?([A-Za-z]{3} [0-9 ]\d (\d{4} )?\d{2}:\d{2}:\d{2}(\.\d{3})?( (AM|PM))?)' template(`template`) flags(store-matches));
         };
         parser {
-            date-parser(format('%b %d %I:%M:%S %p',
+            date-parser(format('%b %d %I:%M:%S %p.%f',
+                               '%b %d %I:%M:%S %p',
+                               '%b %d %H:%M:%S.%f',
                                '%b %d %H:%M:%S',
+                               '%b %d %Y %H:%M:%S.%f',
                                '%b %d %Y %H:%M:%S')
                         template("$1"));
         };

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -37,7 +37,7 @@
 
 #
 # parses a cisco timestamp with explicit date-parser
-# It ignores msec and year information
+# It ignores msec and timezone information
 #
 block parser cisco-timestamp-parser(template()) {
     channel {
@@ -45,17 +45,19 @@ block parser cisco-timestamp-parser(template()) {
             # timestamp from Cisco Unified Call Manager, example "Jun 14 11:57:27 PM.685 UTC"
             # NOTE: drops msecs and timezone
             filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2} ((AM)|(PM)))' template(`template`) flags(store-matches)); };
-            parser { date-parser(format('%b %d %H:%M:%S %p') template("$1")); };
         } elif {
             # timestamp without AM/PM mark, example: "Apr 29 13:58:40.411"
             # NOTE: drops msecs and timezone
-
             filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
-            parser { date-parser(format('%b %d %H:%M:%S') template("$1")); };
         } else {
             # timestamp with year information, example: "Apr 29 2017 13:58:40.411"
             filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{4} \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
-            parser { date-parser(format('%b %d %Y %H:%M:%S') template("$1")); };
+        };
+        parser {
+            date-parser(format('%b %d %H:%M:%S %p',
+                               '%b %d %H:%M:%S',
+                               '%b %d %Y %H:%M:%S')
+                        template("$1"));
         };
     };
 };

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -54,7 +54,7 @@ block parser cisco-timestamp-parser(template()) {
             filter { match('^[.*]?([A-Za-z]{3} [0-9 ]\d \d{4} \d{2}:\d{2}:\d{2})' template(`template`) flags(store-matches)); };
         };
         parser {
-            date-parser(format('%b %d %H:%M:%S %p',
+            date-parser(format('%b %d %I:%M:%S %p',
                                '%b %d %H:%M:%S',
                                '%b %d %Y %H:%M:%S')
                         template("$1"));


### PR DESCRIPTION
Thanks to this change, a single date-parser is able to process different date formats, making it easy to catch on when some programs change the way they log information.

Internal variables where renamed from `format` to `formats` to reflect the fact that the variable is now a list of formats, but the public template name has been kept back to avoid breaking existing configuration:

```
date-parser(format(
     "%FT%T.%f",
     "%F %T,%f",
     "%F %T"
    ));
```

_Suggested by @bazsi in https://github.com/balabit/syslog-ng/pull/2709#issuecomment-489568587_