### PR TITLE
ctags: add ctags config (for excluding dbld...)

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,4 @@
+--exclude=tags
+--exclude=.git
+--exclude=dbld
+

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -1,4 +1,5 @@
  ignore
+.ctags
 scl/syslogconf/convert-syslogconf.awk$
 .*/.*\.am$
 .*\.(ql|yml|md|y|l|txt|xml|xsd|log|key|crt|files|in|conf\.example|gradle|mk|supp|sub|guess|list|pc\.cmake)$
@@ -80,3 +81,4 @@ modules/http/tests
  GPLv2+_SSL,non-balabit
 modules/http/(http|http-parser|http-plugin|)\.[ch]
 modules/http/http-grammar.ym
+


### PR DESCRIPTION
motivation: sometimes when I forget to remove dbld/install (always...),
then ctags parses dbld/install/{header-files} and I'm finding myself in
a sitation when I don't understand why my changes
 a) even compiles at the very first attempt (first, I'm happy, later it
becomes suspicious)
 b) don't have any effects... this could be very-very frustrating

Signed-off-by: Laszlo Budai <laszlo.budai@balabit.com>