### PR TITLE
[WIP] stats type to const gchar *

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -455,7 +455,7 @@ afinter_message_posted(LogMessage *msg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "internal_queue_length", NULL );
       stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
     }
@@ -488,7 +488,7 @@ afinter_global_deinit(void)
     {
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "internal_queue_length", NULL );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
       g_queue_free_full(internal_msg_queue, (GDestroyNotify)log_msg_unref);

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -343,7 +343,7 @@ afinter_sd_init(LogPipe *s)
 
   log_source_options_init(&self->source_options, cfg, self->super.super.group);
   self->source_options.stats_level = STATS_LEVEL0;
-  self->source_options.stats_source = SCS_INTERNAL;
+  self->source_options.stats_source = "internal";
   self->source = afinter_source_new(self, &self->source_options);
   log_pipe_append(&self->source->super, s);
 
@@ -455,7 +455,7 @@ afinter_message_posted(LogMessage *msg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "internal_queue_length", NULL );
+      stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "internal_queue_length", NULL );
       stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
     }
@@ -488,7 +488,7 @@ afinter_global_deinit(void)
     {
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "internal_queue_length", NULL );
+      stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "internal_queue_length", NULL );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
       stats_unlock();
       g_queue_free_full(internal_msg_queue, (GDestroyNotify)log_msg_unref);

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -166,7 +166,7 @@ Test(control_cmds, test_stats)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, "id", "received" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, "id", "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_unlock();
 
@@ -188,7 +188,7 @@ Test(control_cmds, test_reset_stats)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, "id", "received" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, "id", "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_counter_set(counter, 666);
   stats_unlock();

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -166,7 +166,7 @@ Test(control_cmds, test_stats)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, "id", "received" );
+  stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, "id", "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_unlock();
 
@@ -188,7 +188,7 @@ Test(control_cmds, test_reset_stats)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, "id", "received" );
+  stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, "id", "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
   stats_counter_set(counter, 666);
   stats_unlock();

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -176,10 +176,10 @@ log_src_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_SOURCE, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key,  SCS_CENTER, NULL, "received" );
+  stats_cluster_logpipe_key_set(&sc_key,  SCS_CENTER, SCS_NONE, NULL, "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
 
@@ -196,10 +196,10 @@ log_src_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_GROUP, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_SOURCE, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, NULL, "received" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, NULL, "received" );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
   return TRUE;
@@ -310,10 +310,10 @@ log_dest_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_DESTINATION, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, NULL, "queued" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, NULL, "queued" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 
@@ -341,10 +341,10 @@ log_dest_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION | SCS_GROUP, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_DESTINATION, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, NULL, "queued" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, NULL, "queued" );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -176,7 +176,7 @@ log_src_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_SOURCE, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_GROUP | SCS_SOURCE, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
   stats_cluster_logpipe_key_set(&sc_key,  "center", SCS_NONE, NULL, "received" );
@@ -196,7 +196,7 @@ log_src_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_SOURCE, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_GROUP | SCS_SOURCE, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
   stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, NULL, "received" );
@@ -310,7 +310,7 @@ log_dest_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_DESTINATION, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_GROUP | SCS_DESTINATION, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
   stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, NULL, "queued" );
@@ -341,7 +341,7 @@ log_dest_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_DESTINATION, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_GROUP | SCS_DESTINATION, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
   stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, NULL, "queued" );

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -176,10 +176,10 @@ log_src_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_SOURCE, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_SOURCE, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key,  SCS_CENTER, SCS_NONE, NULL, "received" );
+  stats_cluster_logpipe_key_set(&sc_key,  "center", SCS_NONE, NULL, "received" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
 
@@ -196,10 +196,10 @@ log_src_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_SOURCE, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_SOURCE, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, NULL, "received" );
+  stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, NULL, "received" );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->received_global_messages);
   stats_unlock();
   return TRUE;
@@ -310,10 +310,10 @@ log_dest_driver_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_DESTINATION, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_DESTINATION, self->super.group, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED,
                          &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, NULL, "queued" );
+  stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, NULL, "queued" );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 
@@ -341,10 +341,10 @@ log_dest_driver_deinit_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GROUP, SCS_DESTINATION, self->super.group, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "group", SCS_DESTINATION, self->super.group, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED,
                            &self->super.processed_group_messages);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_CENTER, SCS_NONE, NULL, "queued" );
+  stats_cluster_logpipe_key_set(&sc_key, "center", SCS_NONE, NULL, "queued" );
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->queued_global_messages);
   stats_unlock();
 

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -92,7 +92,7 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, self->rule, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->rule, NULL );
       stats_register_counter(1, &sc_key, SC_TYPE_MATCHED, &self->super.matched);
       stats_register_counter(1, &sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
       stats_unlock();
@@ -118,7 +118,7 @@ filter_call_free(FilterExprNode *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, self->rule, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->rule, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_MATCHED, &self->super.matched);
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
   stats_unlock();

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -92,7 +92,7 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->rule, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->rule, NULL );
       stats_register_counter(1, &sc_key, SC_TYPE_MATCHED, &self->super.matched);
       stats_register_counter(1, &sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
       stats_unlock();
@@ -118,7 +118,7 @@ filter_call_free(FilterExprNode *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->rule, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->rule, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_MATCHED, &self->super.matched);
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
   stats_unlock();

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -92,7 +92,7 @@ filter_call_init(FilterExprNode *s, GlobalConfig *cfg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->rule, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->rule, NULL );
       stats_register_counter(1, &sc_key, SC_TYPE_MATCHED, &self->super.matched);
       stats_register_counter(1, &sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
       stats_unlock();
@@ -118,7 +118,7 @@ filter_call_free(FilterExprNode *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->rule, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->rule, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_MATCHED, &self->super.matched);
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
   stats_unlock();

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -28,6 +28,7 @@
 /****************************************************************
  * Filter expression nodes
  ****************************************************************/
+const gchar *SCS_FILTER = "filter";
 
 void
 filter_expr_node_init_instance(FilterExprNode *self)

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -55,6 +55,8 @@ filter_expr_init(FilterExprNode *self, GlobalConfig *cfg)
   return TRUE;
 }
 
+extern const gchar *SCS_FILTER;
+
 gboolean filter_expr_eval(FilterExprNode *self, LogMessage *msg);
 gboolean filter_expr_eval_with_context(FilterExprNode *self, LogMessage **msgs, gint num_msg);
 gboolean filter_expr_eval_root(FilterExprNode *self, LogMessage **msg, const LogPathOptions *path_options);

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -43,7 +43,7 @@ log_filter_pipe_init(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_MATCHED, &self->matched);
   stats_register_counter(1, &sc_key, SC_TYPE_NOT_MATCHED, &self->not_matched);
   stats_unlock();
@@ -102,7 +102,7 @@ log_filter_pipe_free(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_MATCHED, &self->matched);
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->not_matched);
   stats_unlock();

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -43,7 +43,7 @@ log_filter_pipe_init(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_MATCHED, &self->matched);
   stats_register_counter(1, &sc_key, SC_TYPE_NOT_MATCHED, &self->not_matched);
   stats_unlock();
@@ -102,7 +102,7 @@ log_filter_pipe_free(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, "filter", SCS_NONE, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_MATCHED, &self->matched);
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->not_matched);
   stats_unlock();

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -43,7 +43,7 @@ log_filter_pipe_init(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_MATCHED, &self->matched);
   stats_register_counter(1, &sc_key, SC_TYPE_NOT_MATCHED, &self->not_matched);
   stats_unlock();
@@ -102,7 +102,7 @@ log_filter_pipe_free(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILTER, SCS_NONE, self->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_MATCHED, &self->matched);
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->not_matched);
   stats_unlock();

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -84,7 +84,7 @@ teardown(void)
 
 TestSuite(test_filters_statistics, .init = setup, .fini = teardown);
 
-Test(test_filters_statistics, filter_stastistics)
+Test(test_filters_statistics, filter_statistics)
 {
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, configuration);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1800,16 +1800,16 @@ log_msg_register_stats(void)
 {
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "msg_clones", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "msg_clones", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_msg_clones);
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "payload_reallocs", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "payload_reallocs", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_payload_reallocs);
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "sdata_updates", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "sdata_updates", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_sdata_updates);
 
-  stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "msg_allocated_bytes", NULL);
+  stats_cluster_single_key_set(&sc_key, "global", SCS_NONE, "msg_allocated_bytes", NULL);
   stats_register_counter(1, &sc_key, SC_TYPE_SINGLE_VALUE, &count_allocated_bytes);
   stats_unlock();
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1800,16 +1800,16 @@ log_msg_register_stats(void)
 {
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "msg_clones", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "msg_clones", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_msg_clones);
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "payload_reallocs", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "payload_reallocs", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_payload_reallocs);
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "sdata_updates", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "sdata_updates", NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &count_sdata_updates);
 
-  stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, "msg_allocated_bytes", NULL);
+  stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "msg_allocated_bytes", NULL);
   stats_register_counter(1, &sc_key, SC_TYPE_SINGLE_VALUE, &count_allocated_bytes);
   stats_unlock();
 }

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -90,7 +90,7 @@ log_tags_get_by_name(const gchar *name)
 
           stats_lock();
           StatsClusterKey sc_key;
-          stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, name, NULL );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, SCS_NONE, name, NULL );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
           stats_unlock();
 
@@ -176,7 +176,7 @@ log_tags_reinit_stats(void)
     {
       const gchar *name = log_tags_list[id].name;
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, name, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, SCS_NONE, name, NULL );
 
       if (stats_check_level(3))
         stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
@@ -217,7 +217,7 @@ log_tags_global_deinit(void)
   StatsClusterKey sc_key;
   for (i = 0; i < log_tags_num; i++)
     {
-      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, log_tags_list[i].name, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, SCS_NONE, log_tags_list[i].name, NULL );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &log_tags_list[i].counter);
       g_free(log_tags_list[i].name);
     }

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -90,7 +90,7 @@ log_tags_get_by_name(const gchar *name)
 
           stats_lock();
           StatsClusterKey sc_key;
-          stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, SCS_NONE, name, NULL );
+          stats_cluster_logpipe_key_set(&sc_key, "tag", SCS_NONE, name, NULL );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
           stats_unlock();
 
@@ -176,7 +176,7 @@ log_tags_reinit_stats(void)
     {
       const gchar *name = log_tags_list[id].name;
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, SCS_NONE, name, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, "tag", SCS_NONE, name, NULL );
 
       if (stats_check_level(3))
         stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
@@ -217,7 +217,7 @@ log_tags_global_deinit(void)
   StatsClusterKey sc_key;
   for (i = 0; i < log_tags_num; i++)
     {
-      stats_cluster_logpipe_key_set(&sc_key, SCS_TAG, SCS_NONE, log_tags_list[i].name, NULL );
+      stats_cluster_logpipe_key_set(&sc_key, "tag", SCS_NONE, log_tags_list[i].name, NULL );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &log_tags_list[i].counter);
       g_free(log_tags_list[i].name);
     }

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -232,7 +232,7 @@ log_source_init(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance);
+  stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source, SCS_SOURCE, self->stats_id, self->stats_instance);
   stats_register_counter(self->options->stats_level, &sc_key,
                          SC_TYPE_PROCESSED, &self->recvd_messages);
   stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_STAMP, &self->last_message_seen);
@@ -248,7 +248,7 @@ log_source_deinit(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id, self->stats_instance);
+  stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source, SCS_SOURCE, self->stats_id, self->stats_instance);
   stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->recvd_messages);
   stats_unregister_counter(&sc_key, SC_TYPE_STAMP, &self->last_message_seen);
   stats_unlock();

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -46,7 +46,7 @@ typedef struct _LogSourceOptions
   GArray *tags;
   GList *source_queue_callbacks;
   gint stats_level;
-  gint stats_source;
+  const gchar *stats_source;
 } LogSourceOptions;
 
 typedef struct _LogSource LogSource;

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -964,7 +964,7 @@ log_threaded_dest_driver_queue(LogPipe *s, LogMessage *msg,
 static void
 _init_stats_key(LogThreadedDestDriver *self, StatsClusterKey *sc_key)
 {
-  stats_cluster_logpipe_key_set(sc_key, self->stats_source | SCS_DESTINATION,
+  stats_cluster_logpipe_key_set(sc_key, self->stats_source, SCS_DESTINATION,
                                 self->super.super.id,
                                 self->format_stats_instance(self));
 }

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -135,7 +135,7 @@ struct _LogThreadedDestDriver
   gint workers_started;
   guint last_worker;
 
-  gint stats_source;
+  const gchar *stats_source;
 
   /* this counter is not thread safe if there are multiple worker threads,
    * in that case, one needs to use LogThreadedDestWorker->seq_num, which is

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1365,7 +1365,7 @@ _register_counters(LogWriter *self)
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source | SCS_DESTINATION, self->stats_id,
+    stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source, SCS_DESTINATION, self->stats_id,
                                   self->stats_instance);
 
     if (self->options->suppress > 0)
@@ -1418,7 +1418,7 @@ _unregister_counters(LogWriter *self)
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source | SCS_DESTINATION, self->stats_id,
+    stats_cluster_logpipe_key_set(&sc_key, self->options->stats_source, SCS_DESTINATION, self->stats_id,
                                   self->stats_instance);
 
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -70,7 +70,7 @@ typedef struct _LogWriterOptions
   gint mark_mode;
   gint mark_freq;
   gint stats_level;
-  gint stats_source;
+  const gchar *stats_source;
 } LogWriterOptions;
 
 typedef struct _LogWriter LogWriter;

--- a/lib/msg-stats.c
+++ b/lib/msg-stats.c
@@ -57,19 +57,19 @@ msg_stats_update_counters(const gchar *source_id, const LogMessage *msg)
       stats_lock();
 
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST, NULL) );
+      stats_cluster_logpipe_key_set(&sc_key, "host", SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST, NULL) );
       stats_register_and_increment_dynamic_counter(2, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
 
       if (stats_check_level(3))
         {
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER, SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL) );
+          stats_cluster_logpipe_key_set(&sc_key, "sender", SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL) );
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_PROGRAM, SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL) );
+          stats_cluster_logpipe_key_set(&sc_key, "program", SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL) );
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
 
-          stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST, NULL));
+          stats_cluster_logpipe_key_set(&sc_key, "host", SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST, NULL));
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER, SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST_FROM,
+          stats_cluster_logpipe_key_set(&sc_key, "sender", SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST_FROM,
                                         NULL));
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
         }
@@ -93,17 +93,17 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY, SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, "severity", SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, "facility", SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, "other" );
+      stats_cluster_logpipe_key_set(&sc_key, "facility", SCS_SOURCE, NULL, "other" );
       stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   else
@@ -112,17 +112,17 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY, SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, "severity", SCS_SOURCE, NULL, name );
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, "facility", SCS_SOURCE, NULL, name );
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, "other" );
+      stats_cluster_logpipe_key_set(&sc_key, "facility", SCS_SOURCE, NULL, "other" );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   stats_unlock();

--- a/lib/msg-stats.c
+++ b/lib/msg-stats.c
@@ -57,19 +57,19 @@ msg_stats_update_counters(const gchar *source_id, const LogMessage *msg)
       stats_lock();
 
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST, NULL) );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST, NULL) );
       stats_register_and_increment_dynamic_counter(2, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
 
       if (stats_check_level(3))
         {
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL) );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER, SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_HOST_FROM, NULL) );
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_PROGRAM | SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL) );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_PROGRAM, SCS_SOURCE, NULL, log_msg_get_value(msg, LM_V_PROGRAM, NULL) );
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
 
-          stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST, NULL));
+          stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST, NULL));
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER | SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST_FROM,
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SENDER, SCS_SOURCE, source_id, log_msg_get_value(msg, LM_V_HOST_FROM,
                                         NULL));
           stats_register_and_increment_dynamic_counter(3, &sc_key, msg->timestamps[LM_TS_RECVD].ut_sec);
         }
@@ -93,17 +93,17 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY, SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, name );
           stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other" );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, "other" );
       stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   else
@@ -112,17 +112,17 @@ stats_syslog_reinit(void)
       for (i = 0; i < SEVERITY_MAX; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY | SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_SEVERITY, SCS_SOURCE, NULL, name );
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &severity_counters[i]);
         }
 
       for (i = 0; i < FACILITY_MAX - 1; i++)
         {
           g_snprintf(name, sizeof(name), "%d", i);
-          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, name );
+          stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, name );
           stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[i]);
         }
-      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY | SCS_SOURCE, NULL, "other" );
+      stats_cluster_logpipe_key_set(&sc_key, SCS_FACILITY, SCS_SOURCE, NULL, "other" );
       stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &facility_counters[FACILITY_MAX - 1]);
     }
   stats_unlock();

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -120,7 +120,7 @@ log_parser_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, self->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_DISCARDED, &self->super.discarded_messages);
   stats_unlock();
 
@@ -134,7 +134,7 @@ log_parser_free_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, self->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_DISCARDED, &self->super.discarded_messages);
   stats_unlock();
 

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -120,7 +120,7 @@ log_parser_init_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "parser", SCS_NONE, self->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_DISCARDED, &self->super.discarded_messages);
   stats_unlock();
 
@@ -134,7 +134,7 @@ log_parser_free_method(LogPipe *s)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, self->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "parser", SCS_NONE, self->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_DISCARDED, &self->super.discarded_messages);
   stats_unlock();
 

--- a/lib/scratch-buffers.c
+++ b/lib/scratch-buffers.c
@@ -299,9 +299,9 @@ scratch_buffers_register_stats(void)
   StatsClusterKey sc_key;
 
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_count", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_count", NULL);
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_count);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_bytes", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_bytes", NULL);
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_bytes);
   stats_unlock();
 }
@@ -312,9 +312,9 @@ scratch_buffers_unregister_stats(void)
   StatsClusterKey sc_key;
 
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_count", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_count", NULL);
   stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_count);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "scratch_buffers_bytes", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_bytes", NULL);
   stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_bytes);
   stats_unlock();
 }

--- a/lib/scratch-buffers.c
+++ b/lib/scratch-buffers.c
@@ -299,9 +299,9 @@ scratch_buffers_register_stats(void)
   StatsClusterKey sc_key;
 
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_count", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "scratch_buffers_count", NULL);
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_count);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_bytes", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "scratch_buffers_bytes", NULL);
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_bytes);
   stats_unlock();
 }
@@ -312,9 +312,9 @@ scratch_buffers_unregister_stats(void)
   StatsClusterKey sc_key;
 
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_count", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "scratch_buffers_count", NULL);
   stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_count);
-  stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "scratch_buffers_bytes", NULL);
+  stats_cluster_logpipe_key_set(&sc_key, "global", SCS_NONE, "scratch_buffers_bytes", NULL);
   stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &stats_scratch_buffers_bytes);
   stats_unlock();
 }

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -55,10 +55,10 @@ _counter_group_logpipe_init(StatsCounterGroupInit *self, StatsCounterGroup *coun
 }
 
 void
-stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+stats_cluster_logpipe_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
                               const gchar *instance)
 {
-  stats_cluster_key_set(key, stats_get_module_name(component), direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_logpipe_init
   });

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -58,11 +58,7 @@ void
 stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
                               const gchar *instance)
 {
-  // Todo: delete this from the final version: just a manko during development
-  g_assert(!(component & SCS_SOURCE));
-  g_assert(!(component & SCS_DESTINATION));
-
-  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, stats_get_module_name(component), direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_logpipe_init
   });

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -62,7 +62,7 @@ stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, guint dir
   g_assert(!(component & SCS_SOURCE));
   g_assert(!(component & SCS_DESTINATION));
 
-  stats_cluster_key_set(key, component | direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_logpipe_init
   });

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -55,10 +55,10 @@ _counter_group_logpipe_init(StatsCounterGroupInit *self, StatsCounterGroup *coun
 }
 
 void
-stats_cluster_logpipe_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
+stats_cluster_logpipe_key_set(StatsClusterKey *key, const gchar *component, guint flags, const gchar *id,
                               const gchar *instance)
 {
-  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, flags, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_logpipe_init
   });

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -55,9 +55,14 @@ _counter_group_logpipe_init(StatsCounterGroupInit *self, StatsCounterGroup *coun
 }
 
 void
-stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance)
+stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+                              const gchar *instance)
 {
-  stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
+  // Todo: delete this from the final version: just a manko during development
+  g_assert(!(component & SCS_SOURCE));
+  g_assert(!(component & SCS_DESTINATION));
+
+  stats_cluster_key_set(key, component | direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_logpipe_init
   });

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -42,7 +42,7 @@ typedef enum
   SC_TYPE_MAX
 } StatsCounterGroupLogPipe;
 
-void stats_cluster_logpipe_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
+void stats_cluster_logpipe_key_set(StatsClusterKey *key, const gchar *component, guint flags, const gchar *id,
                                    const gchar *instance);
 
 #endif

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -42,6 +42,7 @@ typedef enum
   SC_TYPE_MAX
 } StatsCounterGroupLogPipe;
 
-void stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance);
+void stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+                                   const gchar *instance);
 
 #endif

--- a/lib/stats/stats-cluster-logpipe.h
+++ b/lib/stats/stats-cluster-logpipe.h
@@ -42,7 +42,7 @@ typedef enum
   SC_TYPE_MAX
 } StatsCounterGroupLogPipe;
 
-void stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+void stats_cluster_logpipe_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
                                    const gchar *instance);
 
 #endif

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -46,9 +46,14 @@ _counter_group_init(StatsCounterGroupInit *self, StatsCounterGroup *counter_grou
 }
 
 void
-stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance)
+stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+                             const gchar *instance)
 {
-  stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
+  // Todo: delete this from the final version: just a manko during development
+  g_assert(!(component & SCS_SOURCE));
+  g_assert(!(component & SCS_DESTINATION));
+
+  stats_cluster_key_set(key, component | direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names,_counter_group_init
   });
@@ -78,14 +83,18 @@ _group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupIni
 }
 
 void
-stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance,
+stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+                                       const gchar *instance,
                                        const gchar *name)
 {
-  stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
+  // Todo: delete this from the final version: just a manko during development
+  g_assert(!(component & SCS_SOURCE));
+  g_assert(!(component & SCS_DESTINATION));
+
+  stats_cluster_key_set(key, component | direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_init_with_name, _group_init_equals
   });
   key->counter_group_init.counter_names = g_new0(const char *, 1);
   key->counter_group_init.counter_names[0] = name;
 }
-

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -49,11 +49,7 @@ void
 stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
                              const gchar *instance)
 {
-  // Todo: delete this from the final version: just a manko during development
-  g_assert(!(component & SCS_SOURCE));
-  g_assert(!(component & SCS_DESTINATION));
-
-  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, stats_get_module_name(component), direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names,_counter_group_init
   });
@@ -87,11 +83,7 @@ stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, 
                                        const gchar *instance,
                                        const gchar *name)
 {
-  // Todo: delete this from the final version: just a manko during development
-  g_assert(!(component & SCS_SOURCE));
-  g_assert(!(component & SCS_DESTINATION));
-
-  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, stats_get_module_name(component), direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_init_with_name, _group_init_equals
   });

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -46,10 +46,10 @@ _counter_group_init(StatsCounterGroupInit *self, StatsCounterGroup *counter_grou
 }
 
 void
-stats_cluster_single_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
+stats_cluster_single_key_set(StatsClusterKey *key, const gchar *component, guint flags, const gchar *id,
                              const gchar *instance)
 {
-  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, flags, id, instance, (StatsCounterGroupInit)
   {
     tag_names,_counter_group_init
   });
@@ -79,11 +79,11 @@ _group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupIni
 }
 
 void
-stats_cluster_single_key_set_with_name(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
+stats_cluster_single_key_set_with_name(StatsClusterKey *key, const gchar *component, guint flags, const gchar *id,
                                        const gchar *instance,
                                        const gchar *name)
 {
-  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, flags, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_init_with_name, _group_init_equals
   });

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -46,10 +46,10 @@ _counter_group_init(StatsCounterGroupInit *self, StatsCounterGroup *counter_grou
 }
 
 void
-stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+stats_cluster_single_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
                              const gchar *instance)
 {
-  stats_cluster_key_set(key, stats_get_module_name(component), direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names,_counter_group_init
   });
@@ -79,11 +79,11 @@ _group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupIni
 }
 
 void
-stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+stats_cluster_single_key_set_with_name(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
                                        const gchar *instance,
                                        const gchar *name)
 {
-  stats_cluster_key_set(key, stats_get_module_name(component), direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_init_with_name, _group_init_equals
   });

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -53,7 +53,7 @@ stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, guint dire
   g_assert(!(component & SCS_SOURCE));
   g_assert(!(component & SCS_DESTINATION));
 
-  stats_cluster_key_set(key, component | direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names,_counter_group_init
   });
@@ -91,7 +91,7 @@ stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, 
   g_assert(!(component & SCS_SOURCE));
   g_assert(!(component & SCS_DESTINATION));
 
-  stats_cluster_key_set(key, component | direction, id, instance, (StatsCounterGroupInit)
+  stats_cluster_key_set(key, component, direction, id, instance, (StatsCounterGroupInit)
   {
     tag_names, _counter_group_init_with_name, _group_init_equals
   });

--- a/lib/stats/stats-cluster-single.h
+++ b/lib/stats/stats-cluster-single.h
@@ -33,9 +33,9 @@ typedef enum
   SC_TYPE_SINGLE_MAX
 } StatsCounterGroupSingle;
 
-void stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gchar *id, const gchar *instance);
-void stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, const gchar *id,
+void stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+                                  const gchar *instance);
+void stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
                                             const gchar *instance, const gchar *name);
 
 #endif
-

--- a/lib/stats/stats-cluster-single.h
+++ b/lib/stats/stats-cluster-single.h
@@ -33,9 +33,9 @@ typedef enum
   SC_TYPE_SINGLE_MAX
 } StatsCounterGroupSingle;
 
-void stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
+void stats_cluster_single_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
                                   const gchar *instance);
-void stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, guint direction, const gchar *id,
-                                            const gchar *instance, const gchar *name);
+void stats_cluster_single_key_set_with_name(StatsClusterKey *key, const gchar *component, guint direction,
+                                            const gchar *id, const gchar *instance, const gchar *name);
 
 #endif

--- a/lib/stats/stats-cluster-single.h
+++ b/lib/stats/stats-cluster-single.h
@@ -33,9 +33,9 @@ typedef enum
   SC_TYPE_SINGLE_MAX
 } StatsCounterGroupSingle;
 
-void stats_cluster_single_key_set(StatsClusterKey *key, const gchar *component, guint direction, const gchar *id,
+void stats_cluster_single_key_set(StatsClusterKey *key, const gchar *component, guint flags, const gchar *id,
                                   const gchar *instance);
-void stats_cluster_single_key_set_with_name(StatsClusterKey *key, const gchar *component, guint direction,
+void stats_cluster_single_key_set_with_name(StatsClusterKey *key, const gchar *component, guint flags,
                                             const gchar *id, const gchar *instance, const gchar *name);
 
 #endif

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -38,10 +38,10 @@ _clone_stats_cluster_key(StatsClusterKey *dst, const StatsClusterKey *src)
 }
 
 void
-stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance,
-                      StatsCounterGroupInit counter_group_init)
+stats_cluster_key_set(StatsClusterKey *self, guint16 component, guint direction, const gchar *id,
+                      const gchar *instance, StatsCounterGroupInit counter_group_init)
 {
-  self->component = component;
+  self->component = component | direction;
   self->id = (id?id:"");
   self->instance = (instance?instance:"");
   self->counter_group_init = counter_group_init;

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -39,10 +39,10 @@ _clone_stats_cluster_key(StatsClusterKey *dst, const StatsClusterKey *src)
 }
 
 void
-stats_cluster_key_set(StatsClusterKey *self, guint16 component, guint direction, const gchar *id,
+stats_cluster_key_set(StatsClusterKey *self, const gchar *component, guint direction, const gchar *id,
                       const gchar *instance, StatsCounterGroupInit counter_group_init)
 {
-  self->component = stats_get_module_name(component);
+  self->component = component;
   self->direction = direction;
   self->id = (id?id:"");
   self->instance = (instance?instance:"");

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -79,61 +79,6 @@ stats_cluster_get_type_name(StatsCluster *self, gint type)
   return "";
 }
 
-const gchar *
-stats_get_module_name(gint source)
-{
-  static const gchar *module_names[] =
-  {
-    "none",
-    "file",
-    "pipe",
-    "tcp",
-    "udp",
-    "tcp6",
-    "udp6",
-    "unix-stream",
-    "unix-dgram",
-    "syslog",
-    "network",
-    "internal",
-    "logstore",
-    "program",
-    "sql",
-    "sun-streams",
-    "usertty",
-    "group",
-    "center",
-    "host",
-    "global",
-    "mongodb",
-    "class",
-    "rule_id",
-    "tag",
-    "severity",
-    "facility",
-    "sender",
-    "smtp",
-    "amqp",
-    "stomp",
-    "redis",
-    "snmp",
-    "riemann",
-    "journald",
-    "java",
-    "http",
-    "python",
-    "filter",
-    "parser",
-    "monitoring",
-    "stdin",
-    "openbsd",
-    "kafka"
-  };
-  G_STATIC_ASSERT(sizeof(module_names)/sizeof(module_names[0])==SCS_MAX);
-  return module_names[source & SCS_SOURCE_MASK];
-}
-
-
 static const gchar *
 _get_component_prefix(gint direction)
 {
@@ -153,7 +98,7 @@ _get_component_prefix(gint direction)
 const gchar *
 stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gsize buf_len)
 {
-  if (self->key.component == stats_get_module_name(SCS_GROUP))
+  if (!strcmp(self->key.component, "group")) // TODO: this is bad, but at this point component == "group" is not enough.
     {
       switch (self->key.direction)
         {

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -155,7 +155,7 @@ StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 StatsCluster *stats_cluster_dynamic_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
-void stats_cluster_key_set(StatsClusterKey *self, guint16 component, guint direction, const gchar *id,
+void stats_cluster_key_set(StatsClusterKey *self, const gchar *component, guint direction, const gchar *id,
                            const gchar *instance, StatsCounterGroupInit counter_group_ctor);
 const gchar *stats_get_module_name(gint source);
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -32,7 +32,8 @@ enum
   /* direction bits, used to distinguish between source/destination drivers */
   SCS_NONE = 0,
   SCS_SOURCE = 1,
-  SCS_DESTINATION = 2
+  SCS_DESTINATION = 2,
+  SCS_GROUP = 4
 };
 
 typedef struct _StatsCounterGroup StatsCounterGroup;
@@ -61,7 +62,7 @@ struct _StatsClusterKey
 {
   /* syslog-ng component/driver/subsystem that registered this cluster */
   const gchar *component;
-  guint direction;
+  guint flags;
   const gchar *id;
   const gchar *instance;
   StatsCounterGroupInit counter_group_init;
@@ -108,6 +109,6 @@ StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 StatsCluster *stats_cluster_dynamic_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
-void stats_cluster_key_set(StatsClusterKey *self, const gchar *component, guint direction, const gchar *id,
+void stats_cluster_key_set(StatsClusterKey *self, const gchar *component, guint flags, const gchar *id,
                            const gchar *instance, StatsCounterGroupInit counter_group_ctor);
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -154,7 +154,7 @@ StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 StatsCluster *stats_cluster_dynamic_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);
 
-void stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id, const gchar *instance,
-                           StatsCounterGroupInit counter_group_ctor);
+void stats_cluster_key_set(StatsClusterKey *self, guint16 component, guint direction, const gchar *id,
+                           const gchar *instance, StatsCounterGroupInit counter_group_ctor);
 
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -34,6 +34,7 @@ enum
   SCS_DESTINATION    = 0x0200,
 
   /* drivers, this should be registered dynamically */
+  SCS_NONE           = 0,
   SCS_FILE           = 1,
   SCS_PIPE           = 2,
   SCS_TCP            = 3,

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -30,56 +30,9 @@
 enum
 {
   /* direction bits, used to distinguish between source/destination drivers */
-  SCS_SOURCE         = 0x0100,
-  SCS_DESTINATION    = 0x0200,
-
-  /* drivers, this should be registered dynamically */
-  SCS_NONE           = 0,
-  SCS_FILE           = 1,
-  SCS_PIPE           = 2,
-  SCS_TCP            = 3,
-  SCS_UDP            = 4,
-  SCS_TCP6           = 5,
-  SCS_UDP6           = 6,
-  SCS_UNIX_STREAM    = 7,
-  SCS_UNIX_DGRAM     = 8,
-  SCS_SYSLOG         = 9,
-  SCS_NETWORK        = 10,
-  SCS_INTERNAL       = 11,
-  SCS_LOGSTORE       = 12,
-  SCS_PROGRAM        = 13,
-  SCS_SQL            = 14,
-  SCS_SUN_STREAMS    = 15,
-  SCS_USERTTY        = 16,
-  SCS_GROUP          = 17,
-  SCS_CENTER         = 18,
-  SCS_HOST           = 19,
-  SCS_GLOBAL         = 20,
-  SCS_MONGODB        = 21,
-  SCS_CLASS          = 22,
-  SCS_RULE_ID        = 23,
-  SCS_TAG            = 24,
-  SCS_SEVERITY       = 25,
-  SCS_FACILITY       = 26,
-  SCS_SENDER         = 27,
-  SCS_SMTP           = 28,
-  SCS_AMQP           = 29,
-  SCS_STOMP          = 30,
-  SCS_REDIS          = 31,
-  SCS_SNMP           = 32,
-  SCS_RIEMANN        = 33,
-  SCS_JOURNALD       = 34,
-  SCS_JAVA           = 35,
-  SCS_HTTP           = 36,
-  SCS_PYTHON         = 37,
-  SCS_FILTER         = 38,
-  SCS_PARSER         = 39,
-  SCS_MONITORING     = 40,
-  SCS_STDIN          = 41,
-  SCS_OPENBSD        = 42,
-  SCS_KAFKA          = 43,
-  SCS_MAX,
-  SCS_SOURCE_MASK    = 0xff
+  SCS_NONE = 0,
+  SCS_SOURCE = 1,
+  SCS_DESTINATION = 2
 };
 
 typedef struct _StatsCounterGroup StatsCounterGroup;
@@ -157,5 +110,4 @@ void stats_cluster_free(StatsCluster *self);
 
 void stats_cluster_key_set(StatsClusterKey *self, const gchar *component, guint direction, const gchar *id,
                            const gchar *instance, StatsCounterGroupInit counter_group_ctor);
-const gchar *stats_get_module_name(gint source);
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -107,7 +107,8 @@ void stats_counter_group_free(StatsCounterGroup *self);
 struct _StatsClusterKey
 {
   /* syslog-ng component/driver/subsystem that registered this cluster */
-  guint16 component;
+  const gchar *component;
+  guint direction;
   const gchar *id;
   const gchar *instance;
   StatsCounterGroupInit counter_group_init;
@@ -156,5 +157,5 @@ void stats_cluster_free(StatsCluster *self);
 
 void stats_cluster_key_set(StatsClusterKey *self, guint16 component, guint direction, const gchar *id,
                            const gchar *instance, StatsCounterGroupInit counter_group_ctor);
-
+const gchar *stats_get_module_name(gint source);
 #endif

--- a/lib/stats/tests/test_dynamic_ctr_reg.c
+++ b/lib/stats/tests/test_dynamic_ctr_reg.c
@@ -69,16 +69,16 @@ Test(stats_dynamic_clusters, register_limited)
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_NONE, NULL, "testhost1");
+    stats_cluster_logpipe_key_set(&sc_key, "host", SCS_NONE, NULL, "testhost1");
     StatsCounterItem *counter = NULL;
     StatsCluster *sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_not_null(sc);
-    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_NONE, NULL, "testhost2");
+    stats_cluster_logpipe_key_set(&sc_key, "host", SCS_NONE, NULL, "testhost2");
     sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_not_null(sc);
     cr_assert_eq(stats_contains_counter(&sc_key, SC_TYPE_PROCESSED), TRUE);
     cr_assert_eq(counter, stats_get_counter(&sc_key, SC_TYPE_PROCESSED));
-    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_NONE, NULL, "testhost3");
+    stats_cluster_logpipe_key_set(&sc_key, "host", SCS_NONE, NULL, "testhost3");
     sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_null(sc);
     cr_expect_not(stats_contains_counter(&sc_key, SC_TYPE_PROCESSED));

--- a/lib/stats/tests/test_dynamic_ctr_reg.c
+++ b/lib/stats/tests/test_dynamic_ctr_reg.c
@@ -69,20 +69,19 @@ Test(stats_dynamic_clusters, register_limited)
   stats_lock();
   {
     StatsClusterKey sc_key;
-    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost1");
+    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_NONE, NULL, "testhost1");
     StatsCounterItem *counter = NULL;
     StatsCluster *sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_not_null(sc);
-    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost2");
+    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_NONE, NULL, "testhost2");
     sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_not_null(sc);
     cr_assert_eq(stats_contains_counter(&sc_key, SC_TYPE_PROCESSED), TRUE);
     cr_assert_eq(counter, stats_get_counter(&sc_key, SC_TYPE_PROCESSED));
-    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST | SCS_SENDER, NULL, "testhost3");
+    stats_cluster_logpipe_key_set(&sc_key, SCS_HOST, SCS_NONE, NULL, "testhost3");
     sc = stats_register_dynamic_counter(1, &sc_key, SC_TYPE_PROCESSED, &counter);
     cr_assert_null(sc);
     cr_expect_not(stats_contains_counter(&sc_key, SC_TYPE_PROCESSED));
   }
   stats_unlock();
 }
-

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -31,7 +31,7 @@ Test(stats_cluster, test_stats_cluster_single)
 {
   StatsCluster *sc;
   StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "logmsg_allocated_bytes", NULL);
+  stats_cluster_single_key_set(&sc_key, "global", SCS_NONE, "logmsg_allocated_bytes", NULL);
 
   sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->query_key, "global.logmsg_allocated_bytes", "Unexpected query key");
@@ -43,7 +43,7 @@ Test(stats_cluster, test_stats_cluster_new_replaces_NULL_with_an_empty_string)
 {
   StatsCluster *sc;
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, NULL, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, NULL, NULL );
 
   sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->key.id, "", "StatsCluster->id is not properly defaulted to an empty string");
@@ -82,23 +82,23 @@ assert_stats_cluster_mismatches_and_free(StatsCluster *sc1, StatsCluster *sc2)
 Test(stats_cluster, test_stats_cluster_equal_if_component_id_and_instance_are_the_same)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id", "instance" );
   assert_stats_cluster_equals_and_free(stats_cluster_new(&sc_key),
                                        stats_cluster_new(&sc_key));
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance1" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id", "instance1" );
   StatsClusterKey sc_key2;
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_FILE, SCS_SOURCE, "id", "instance2" );
+  stats_cluster_logpipe_key_set(&sc_key2, "file", SCS_SOURCE, "id", "instance2" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id1", "instance" );
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_FILE, SCS_SOURCE, "id2", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id1", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key2, "file", SCS_SOURCE, "id2", "instance" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_FILE, SCS_DESTINATION, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key2, "file", SCS_DESTINATION, "id", "instance" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 }
@@ -107,8 +107,8 @@ Test(stats_cluster, test_stats_cluster_key_not_equal_when_custom_tags_are_differ
 {
   StatsClusterKey sc_key1;
   StatsClusterKey sc_key2;
-  stats_cluster_single_key_set_with_name(&sc_key1, SCS_FILE, SCS_SOURCE, "id", "instance", "name1");
-  stats_cluster_single_key_set_with_name(&sc_key2, SCS_FILE, SCS_SOURCE, "id", "instance", "name2");
+  stats_cluster_single_key_set_with_name(&sc_key1, "file", SCS_SOURCE, "id", "instance", "name1");
+  stats_cluster_single_key_set_with_name(&sc_key2, "file", SCS_SOURCE, "id", "instance", "name2");
   cr_assert_not(stats_cluster_key_equal(&sc_key1, &sc_key2), "%s", __FUNCTION__);
 }
 
@@ -116,8 +116,8 @@ Test(stats_cluster, test_stats_cluster_key_equal_when_custom_tags_are_the_same)
 {
   StatsClusterKey sc_key1;
   StatsClusterKey sc_key2;
-  stats_cluster_single_key_set_with_name(&sc_key1, SCS_FILE, SCS_SOURCE, "id", "instance", "name");
-  stats_cluster_single_key_set_with_name(&sc_key2, SCS_FILE, SCS_SOURCE, "id", "instance", "name");
+  stats_cluster_single_key_set_with_name(&sc_key1, "file", SCS_SOURCE, "id", "instance", "name");
+  stats_cluster_single_key_set_with_name(&sc_key2, "file", SCS_SOURCE, "id", "instance", "name");
   cr_assert(stats_cluster_key_equal(&sc_key1, &sc_key2), "%s", __FUNCTION__);
 }
 
@@ -168,7 +168,7 @@ assert_stats_foreach_yielded_counters_matches(StatsCluster *sc, ...)
 Test(stats_cluster, test_stats_foreach_counter_yields_tracked_counters)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
 
   assert_stats_foreach_yielded_counters_matches(sc, -1);
@@ -184,7 +184,7 @@ Test(stats_cluster, test_stats_foreach_counter_yields_tracked_counters)
 Test(stats_cluster, test_stats_foreach_counter_never_forgets_untracked_counters)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   StatsCounterItem *processed, *stamp;
 
@@ -200,7 +200,7 @@ Test(stats_cluster, test_stats_foreach_counter_never_forgets_untracked_counters)
 }
 
 static void
-assert_stats_component_name(gint component, guint direction, const gchar *expected)
+assert_stats_component_name(const gchar *component, guint direction, const gchar *expected)
 {
   gchar buf[32];
   const gchar *name;
@@ -215,17 +215,17 @@ assert_stats_component_name(gint component, guint direction, const gchar *expect
 
 Test(stats_cluster, test_get_component_name_translates_component_to_name_properly)
 {
-  assert_stats_component_name(SCS_FILE, SCS_SOURCE, "src.file");
-  assert_stats_component_name(SCS_FILE, SCS_DESTINATION, "dst.file");
-  assert_stats_component_name(SCS_GLOBAL, SCS_NONE, "global");
-  assert_stats_component_name(SCS_GROUP, SCS_SOURCE, "source");
-  assert_stats_component_name(SCS_GROUP, SCS_DESTINATION, "destination");
+  assert_stats_component_name("file", SCS_SOURCE, "src.file");
+  assert_stats_component_name("file", SCS_DESTINATION, "dst.file");
+  assert_stats_component_name("global", SCS_NONE, "global");
+  assert_stats_component_name("group", SCS_SOURCE, "source");
+  assert_stats_component_name("group", SCS_DESTINATION, "destination");
 }
 
 Test(stats_cluster, test_get_counter)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_SOURCE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   StatsCounterItem *processed;
 

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -218,8 +218,8 @@ Test(stats_cluster, test_get_component_name_translates_component_to_name_properl
   assert_stats_component_name("file", SCS_SOURCE, "src.file");
   assert_stats_component_name("file", SCS_DESTINATION, "dst.file");
   assert_stats_component_name("global", SCS_NONE, "global");
-  assert_stats_component_name("group", SCS_SOURCE, "source");
-  assert_stats_component_name("group", SCS_DESTINATION, "destination");
+  assert_stats_component_name("group", SCS_GROUP | SCS_SOURCE, "source");
+  assert_stats_component_name("group", SCS_GROUP | SCS_DESTINATION, "destination");
 }
 
 Test(stats_cluster, test_get_counter)

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -31,7 +31,7 @@ Test(stats_cluster, test_stats_cluster_single)
 {
   StatsCluster *sc;
   StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, "logmsg_allocated_bytes", NULL);
+  stats_cluster_single_key_set(&sc_key, SCS_GLOBAL, SCS_NONE, "logmsg_allocated_bytes", NULL);
 
   sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->query_key, "global.logmsg_allocated_bytes", "Unexpected query key");
@@ -43,7 +43,7 @@ Test(stats_cluster, test_stats_cluster_new_replaces_NULL_with_an_empty_string)
 {
   StatsCluster *sc;
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, NULL, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, NULL, NULL );
 
   sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->key.id, "", "StatsCluster->id is not properly defaulted to an empty string");
@@ -82,23 +82,23 @@ assert_stats_cluster_mismatches_and_free(StatsCluster *sc1, StatsCluster *sc2)
 Test(stats_cluster, test_stats_cluster_equal_if_component_id_and_instance_are_the_same)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
   assert_stats_cluster_equals_and_free(stats_cluster_new(&sc_key),
                                        stats_cluster_new(&sc_key));
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance1" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance1" );
   StatsClusterKey sc_key2;
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance2" );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_FILE, SCS_SOURCE, "id", "instance2" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id1", "instance" );
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_SOURCE | SCS_FILE, "id2", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id1", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_FILE, SCS_SOURCE, "id2", "instance" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_DESTINATION | SCS_FILE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_FILE, SCS_DESTINATION, "id", "instance" );
   assert_stats_cluster_mismatches_and_free(stats_cluster_new(&sc_key),
                                            stats_cluster_new(&sc_key2));
 }
@@ -107,8 +107,8 @@ Test(stats_cluster, test_stats_cluster_key_not_equal_when_custom_tags_are_differ
 {
   StatsClusterKey sc_key1;
   StatsClusterKey sc_key2;
-  stats_cluster_single_key_set_with_name(&sc_key1, SCS_SOURCE | SCS_FILE, "id", "instance", "name1");
-  stats_cluster_single_key_set_with_name(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance", "name2");
+  stats_cluster_single_key_set_with_name(&sc_key1, SCS_FILE, SCS_SOURCE, "id", "instance", "name1");
+  stats_cluster_single_key_set_with_name(&sc_key2, SCS_FILE, SCS_SOURCE, "id", "instance", "name2");
   cr_assert_not(stats_cluster_key_equal(&sc_key1, &sc_key2), "%s", __FUNCTION__);
 }
 
@@ -116,8 +116,8 @@ Test(stats_cluster, test_stats_cluster_key_equal_when_custom_tags_are_the_same)
 {
   StatsClusterKey sc_key1;
   StatsClusterKey sc_key2;
-  stats_cluster_single_key_set_with_name(&sc_key1, SCS_SOURCE | SCS_FILE, "id", "instance", "name");
-  stats_cluster_single_key_set_with_name(&sc_key2, SCS_SOURCE | SCS_FILE, "id", "instance", "name");
+  stats_cluster_single_key_set_with_name(&sc_key1, SCS_FILE, SCS_SOURCE, "id", "instance", "name");
+  stats_cluster_single_key_set_with_name(&sc_key2, SCS_FILE, SCS_SOURCE, "id", "instance", "name");
   cr_assert(stats_cluster_key_equal(&sc_key1, &sc_key2), "%s", __FUNCTION__);
 }
 
@@ -168,7 +168,7 @@ assert_stats_foreach_yielded_counters_matches(StatsCluster *sc, ...)
 Test(stats_cluster, test_stats_foreach_counter_yields_tracked_counters)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
 
   assert_stats_foreach_yielded_counters_matches(sc, -1);
@@ -184,7 +184,7 @@ Test(stats_cluster, test_stats_foreach_counter_yields_tracked_counters)
 Test(stats_cluster, test_stats_foreach_counter_never_forgets_untracked_counters)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   StatsCounterItem *processed, *stamp;
 
@@ -200,12 +200,12 @@ Test(stats_cluster, test_stats_foreach_counter_never_forgets_untracked_counters)
 }
 
 static void
-assert_stats_component_name(gint component, const gchar *expected)
+assert_stats_component_name(gint component, guint direction, const gchar *expected)
 {
   gchar buf[32];
   const gchar *name;
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, component, NULL, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, component, direction, NULL, NULL );
   StatsCluster *sc = stats_cluster_new(&sc_key);
 
   name = stats_cluster_get_component_name(sc, buf, sizeof(buf));
@@ -215,17 +215,17 @@ assert_stats_component_name(gint component, const gchar *expected)
 
 Test(stats_cluster, test_get_component_name_translates_component_to_name_properly)
 {
-  assert_stats_component_name(SCS_SOURCE | SCS_FILE, "src.file");
-  assert_stats_component_name(SCS_DESTINATION | SCS_FILE, "dst.file");
-  assert_stats_component_name(SCS_GLOBAL, "global");
-  assert_stats_component_name(SCS_SOURCE | SCS_GROUP, "source");
-  assert_stats_component_name(SCS_DESTINATION | SCS_GROUP, "destination");
+  assert_stats_component_name(SCS_FILE, SCS_SOURCE, "src.file");
+  assert_stats_component_name(SCS_FILE, SCS_DESTINATION, "dst.file");
+  assert_stats_component_name(SCS_GLOBAL, SCS_NONE, "global");
+  assert_stats_component_name(SCS_GROUP, SCS_SOURCE, "source");
+  assert_stats_component_name(SCS_GROUP, SCS_DESTINATION, "destination");
 }
 
 Test(stats_cluster, test_get_counter)
 {
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_SOURCE | SCS_FILE, "id", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_SOURCE, "id", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   StatsCounterItem *processed;
 

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -41,6 +41,7 @@
 typedef struct _CounterHashContent
 {
   const gint component;
+  const guint direction;
   const gchar *id;
   const gchar *instance;
   const gint type;
@@ -52,7 +53,7 @@ typedef struct _QueryTestCase
   const gchar *expected;
 } QueryTestCase;
 
-typedef void(*ClusterKeySet)(StatsClusterKey *, guint16, const gchar *, const gchar *);
+typedef void(*ClusterKeySet)(StatsClusterKey *, guint16, guint, const gchar *, const gchar *);
 
 static void
 _add_two_to_value(GList *counters, StatsCounterItem **result)
@@ -91,7 +92,7 @@ _register_counters(const CounterHashContent *counters, size_t n, ClusterKeySet k
     {
       StatsCounterItem *item = NULL;
       StatsClusterKey sc_key;
-      key_set(&sc_key, counters[i].component, counters[i].id, counters[i].instance );
+      key_set(&sc_key, counters[i].component, counters[i].direction, counters[i].id, counters[i].instance );
       stats_register_counter(0, &sc_key, counters[i].type, &item);
       gchar *name = _construct_view_name(counters[i].id);
       GList *queries = _construct_view_query_list(counters[i].instance);
@@ -107,7 +108,7 @@ _register_single_counter_with_name(void)
   {
     StatsClusterKey sc_key;
     StatsCounterItem *ctr_item;
-    stats_cluster_single_key_set_with_name(&sc_key, SCS_GLOBAL, "id", "instance", "name");
+    stats_cluster_single_key_set_with_name(&sc_key, SCS_GLOBAL, SCS_NONE, "id", "instance", "name");
     stats_register_counter(0, &sc_key, SC_TYPE_SINGLE_VALUE, &ctr_item);
   }
   stats_unlock();
@@ -118,17 +119,17 @@ _initialize_counter_hash(void)
 {
   const CounterHashContent logpipe_cluster_counters[] =
   {
-    {SCS_CENTER, "guba.polo", "frozen", SC_TYPE_SUPPRESSED},
-    {SCS_FILE | SCS_SOURCE, "guba", "processed", SC_TYPE_PROCESSED},
-    {SCS_GLOBAL, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
-    {SCS_PIPE | SCS_SOURCE, "guba.gumi.disz", "frozen", SC_TYPE_SUPPRESSED},
-    {SCS_TCP | SCS_DESTINATION, "guba.labda", "received", SC_TYPE_DROPPED},
-    {SCS_TCP | SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_QUEUED},
+    {SCS_CENTER, SCS_NONE, "guba.polo", "frozen", SC_TYPE_SUPPRESSED},
+    {SCS_FILE, SCS_SOURCE, "guba", "processed", SC_TYPE_PROCESSED},
+    {SCS_GLOBAL, SCS_NONE, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
+    {SCS_PIPE, SCS_SOURCE, "guba.gumi.disz", "frozen", SC_TYPE_SUPPRESSED},
+    {SCS_TCP, SCS_DESTINATION, "guba.labda", "received", SC_TYPE_DROPPED},
+    {SCS_TCP, SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_QUEUED},
   };
 
   const CounterHashContent single_cluster_counters[] =
   {
-    {SCS_GLOBAL, "", "guba", SC_TYPE_SINGLE_VALUE}
+    {SCS_GLOBAL, SCS_NONE, "", "guba", SC_TYPE_SINGLE_VALUE}
   };
 
   app_startup();
@@ -209,7 +210,7 @@ Test(cluster_query_key, test_global_key)
 {
   const gchar *expected_key = "dst.file.d_file.instance";
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION|SCS_FILE, "d_file", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_DESTINATION, "d_file", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->query_key, expected_key,
                    "generated query key(%s) does not match to the expected key(%s)",

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -40,7 +40,7 @@
 
 typedef struct _CounterHashContent
 {
-  const gint component;
+  const gchar *component;
   const guint direction;
   const gchar *id;
   const gchar *instance;
@@ -53,7 +53,7 @@ typedef struct _QueryTestCase
   const gchar *expected;
 } QueryTestCase;
 
-typedef void(*ClusterKeySet)(StatsClusterKey *, guint16, guint, const gchar *, const gchar *);
+typedef void(*ClusterKeySet)(StatsClusterKey *, const gchar *, guint, const gchar *, const gchar *);
 
 static void
 _add_two_to_value(GList *counters, StatsCounterItem **result)
@@ -108,7 +108,7 @@ _register_single_counter_with_name(void)
   {
     StatsClusterKey sc_key;
     StatsCounterItem *ctr_item;
-    stats_cluster_single_key_set_with_name(&sc_key, SCS_GLOBAL, SCS_NONE, "id", "instance", "name");
+    stats_cluster_single_key_set_with_name(&sc_key, "global", SCS_NONE, "id", "instance", "name");
     stats_register_counter(0, &sc_key, SC_TYPE_SINGLE_VALUE, &ctr_item);
   }
   stats_unlock();
@@ -119,17 +119,17 @@ _initialize_counter_hash(void)
 {
   const CounterHashContent logpipe_cluster_counters[] =
   {
-    {SCS_CENTER, SCS_NONE, "guba.polo", "frozen", SC_TYPE_SUPPRESSED},
-    {SCS_FILE, SCS_SOURCE, "guba", "processed", SC_TYPE_PROCESSED},
-    {SCS_GLOBAL, SCS_NONE, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
-    {SCS_PIPE, SCS_SOURCE, "guba.gumi.disz", "frozen", SC_TYPE_SUPPRESSED},
-    {SCS_TCP, SCS_DESTINATION, "guba.labda", "received", SC_TYPE_DROPPED},
-    {SCS_TCP, SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_QUEUED},
+    {"center", SCS_NONE, "guba.polo", "frozen", SC_TYPE_SUPPRESSED},
+    {"file", SCS_SOURCE, "guba", "processed", SC_TYPE_PROCESSED},
+    {"global", SCS_NONE, "guba.gumi.diszno", "frozen", SC_TYPE_SUPPRESSED},
+    {"pipe", SCS_SOURCE, "guba.gumi.disz", "frozen", SC_TYPE_SUPPRESSED},
+    {"tcp", SCS_DESTINATION, "guba.labda", "received", SC_TYPE_DROPPED},
+    {"tcp", SCS_SOURCE, "guba.frizbi", "left", SC_TYPE_QUEUED},
   };
 
   const CounterHashContent single_cluster_counters[] =
   {
-    {SCS_GLOBAL, SCS_NONE, "", "guba", SC_TYPE_SINGLE_VALUE}
+    {"global", SCS_NONE, "", "guba", SC_TYPE_SINGLE_VALUE}
   };
 
   app_startup();
@@ -210,7 +210,7 @@ Test(cluster_query_key, test_global_key)
 {
   const gchar *expected_key = "dst.file.d_file.instance";
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_FILE, SCS_DESTINATION, "d_file", "instance" );
+  stats_cluster_logpipe_key_set(&sc_key, "file", SCS_DESTINATION, "d_file", "instance" );
   StatsCluster *sc = stats_cluster_new(&sc_key);
   cr_assert_str_eq(sc->query_key, expected_key,
                    "generated query key(%s) does not match to the expected key(%s)",

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -791,7 +791,7 @@ afamqp_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = afamqp_worker_insert;
 
   self->super.format_stats_instance = afamqp_dd_format_stats_instance;
-  self->super.stats_source = SCS_AMQP;
+  self->super.stats_source = "amqp";
 
   self->routing_key_template = log_template_new(cfg, NULL);
 

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -798,7 +798,7 @@ affile_dd_new(gchar *filename, GlobalConfig *cfg)
   AFFileDestDriver *self = affile_dd_new_instance(filename, cfg);
 
   self->writer_flags |= LW_SOFT_FLOW_CONTROL;
-  self->writer_options.stats_source = SCS_FILE;
+  self->writer_options.stats_source = "file";
   self->file_opener = file_opener_for_regular_dest_files_new(&self->writer_options, &self->use_fsync);
   return &self->super.super;
 }

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -175,7 +175,7 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
 {
   AFFileSourceDriver *self = affile_sd_new_instance(filename, cfg);
 
-  self->file_reader_options.reader_options.super.stats_source = SCS_FILE;
+  self->file_reader_options.reader_options.super.stats_source = "file";
 
   if (_is_device_node(filename) || _is_linux_proc_kmsg(filename))
     self->file_reader_options.follow_freq = 0;

--- a/modules/affile/named-pipe.c
+++ b/modules/affile/named-pipe.c
@@ -115,7 +115,7 @@ pipe_sd_new(gchar *filename, GlobalConfig *cfg)
 {
   AFFileSourceDriver *self = affile_sd_new_instance(filename, cfg);
 
-  self->file_reader_options.reader_options.super.stats_source = SCS_PIPE;
+  self->file_reader_options.reader_options.super.stats_source = "pipe";
 
   if (cfg_is_config_version_older(cfg, 0x0302))
     {
@@ -139,7 +139,7 @@ pipe_dd_new(gchar *filename, GlobalConfig *cfg)
 {
   AFFileDestDriver *self = affile_dd_new_instance(filename, cfg);
 
-  self->writer_options.stats_source = SCS_PIPE;
+  self->writer_options.stats_source = "pipe";
   self->file_opener = file_opener_for_named_pipes_new();
   return &self->super.super;
 }

--- a/modules/affile/stdin.c
+++ b/modules/affile/stdin.c
@@ -61,7 +61,7 @@ stdin_sd_new(GlobalConfig *cfg)
   AFFileSourceDriver *self = affile_sd_new_instance("-", cfg);
 
   self->file_reader_options.exit_on_eof = TRUE;
-  self->file_reader_options.reader_options.super.stats_source = SCS_STDIN;
+  self->file_reader_options.reader_options.super.stats_source = "stdin";
   self->file_opener = file_opener_for_stdin_new();
   return &self->super.super;
 }

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -436,7 +436,7 @@ wildcard_sd_new(GlobalConfig *cfg)
   file_opener_options_defaults_dont_change_permissions(&self->file_opener_options);
   self->file_reader_options.follow_freq = 1000;
   self->file_reader_options.reader_options.super.init_window_size = cfg->min_iw_size_per_reader * DEFAULT_MAX_FILES;
-  self->file_reader_options.reader_options.super.stats_source = SCS_FILE;
+  self->file_reader_options.reader_options.super.stats_source = "file";
   self->file_reader_options.restore_state = TRUE;
 
   self->max_files = DEFAULT_MAX_FILES;

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -574,7 +574,7 @@ afmongodb_dd_new(GlobalConfig *cfg)
   self->super.worker.disconnect = _worker_disconnect;
   self->super.worker.insert = _worker_insert;
   self->super.format_stats_instance = _format_stats_instance;
-  self->super.stats_source = SCS_MONGODB;
+  self->super.stats_source = "mongodb";
 
 #if SYSLOG_NG_ENABLE_LEGACY_MONGODB_OPTIONS
   afmongodb_dd_init_legacy(self);

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -314,7 +314,7 @@ afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg)
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;
   self->reader_options.super.stats_level = STATS_LEVEL0;
-  self->reader_options.super.stats_source = SCS_PROGRAM;
+  self->reader_options.super.stats_source = "program";
   return &self->super.super;
 }
 
@@ -589,7 +589,7 @@ afprogram_dd_new(gchar *cmdline, GlobalConfig *cfg)
   afprogram_set_inherit_environment(&self->process_info, TRUE);
   log_writer_options_defaults(&self->writer_options);
   self->writer_options.stats_level = STATS_LEVEL0;
-  self->writer_options.stats_source = SCS_PROGRAM;
+  self->writer_options.stats_source = "program";
   return &self->super.super;
 }
 

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -669,7 +669,7 @@ afsmtp_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = afsmtp_worker_insert;
 
   self->super.format_stats_instance = afsmtp_dd_format_stats_instance;
-  self->super.stats_source = SCS_SMTP;
+  self->super.stats_source = "smtp";
 
   afsmtp_dd_set_host((LogDriver *)self, "127.0.0.1");
   afsmtp_dd_set_port((LogDriver *)self, 25);

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -140,7 +140,7 @@ Test(transport_mapper_inet, test_tcp_apply_transport_sets_defaults)
 
   assert_transport_mapper_transport(transport_mapper, "tcp");
   assert_transport_mapper_logproto(transport_mapper, "text");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_TCP);
+  assert_transport_mapper_stats_source(transport_mapper, "tcp");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -152,7 +152,7 @@ Test(transport_mapper_inet, test_tcp6_apply_transport_sets_defaults)
 
   assert_transport_mapper_transport(transport_mapper, "tcp");
   assert_transport_mapper_logproto(transport_mapper, "text");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_TCP6);
+  assert_transport_mapper_stats_source(transport_mapper, "tcp6");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -164,7 +164,7 @@ Test(transport_mapper_inet, test_udp_apply_transport_sets_defaults)
 
   assert_transport_mapper_transport(transport_mapper, "udp");
   assert_transport_mapper_logproto(transport_mapper, "dgram");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_UDP);
+  assert_transport_mapper_stats_source(transport_mapper, "udp");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -183,7 +183,7 @@ Test(transport_mapper_inet, test_udp6_apply_transport_sets_defaults)
 
   assert_transport_mapper_transport(transport_mapper, "udp");
   assert_transport_mapper_logproto(transport_mapper, "dgram");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_UDP6);
+  assert_transport_mapper_stats_source(transport_mapper, "udp6");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -195,7 +195,7 @@ Test(transport_mapper_inet, test_network_transport_udp_apply_transport_sets_defa
 
   assert_transport_mapper_transport(transport_mapper, "udp");
   assert_transport_mapper_logproto(transport_mapper, "dgram");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
+  assert_transport_mapper_stats_source(transport_mapper, "network");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -214,7 +214,7 @@ Test(transport_mapper_inet, test_network_transport_tcp_apply_transport_sets_defa
 
   assert_transport_mapper_transport(transport_mapper, "tcp");
   assert_transport_mapper_logproto(transport_mapper, "text");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
+  assert_transport_mapper_stats_source(transport_mapper, "network");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -233,7 +233,7 @@ Test(transport_mapper_inet, test_network_transport_tls_apply_transport_sets_defa
 
   assert_transport_mapper_transport(transport_mapper, "tls");
   assert_transport_mapper_logproto(transport_mapper, "text");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
+  assert_transport_mapper_stats_source(transport_mapper, "network");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -245,7 +245,7 @@ Test(transport_mapper_inet, test_network_transport_foo_apply_transport_sets_defa
 
   assert_transport_mapper_transport(transport_mapper, "foo");
   assert_transport_mapper_logproto(transport_mapper, "foo");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
+  assert_transport_mapper_stats_source(transport_mapper, "network");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -257,7 +257,7 @@ Test(transport_mapper_inet, test_syslog_transport_udp_apply_transport_sets_defau
 
   assert_transport_mapper_transport(transport_mapper, "udp");
   assert_transport_mapper_logproto(transport_mapper, "dgram");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_SYSLOG);
+  assert_transport_mapper_stats_source(transport_mapper, "syslog");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 
@@ -276,7 +276,7 @@ Test(transport_mapper_inet, test_syslog_transport_tcp_apply_transport_sets_defau
 
   assert_transport_mapper_transport(transport_mapper, "tcp");
   assert_transport_mapper_logproto(transport_mapper, "framed");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_SYSLOG);
+  assert_transport_mapper_stats_source(transport_mapper, "syslog");
   assert_transport_mapper_inet_server_port(transport_mapper, 601);
 }
 
@@ -295,7 +295,7 @@ Test(transport_mapper_inet, test_syslog_transport_tls_apply_transport_sets_defau
 
   assert_transport_mapper_transport(transport_mapper, "tls");
   assert_transport_mapper_logproto(transport_mapper, "framed");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_SYSLOG);
+  assert_transport_mapper_stats_source(transport_mapper, "syslog");
   assert_transport_mapper_inet_server_port(transport_mapper, 6514);
 }
 
@@ -307,7 +307,7 @@ Test(transport_mapper_inet, test_syslog_transport_foo_apply_transport_sets_defau
 
   assert_transport_mapper_transport(transport_mapper, "foo");
   assert_transport_mapper_logproto(transport_mapper, "foo");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_SYSLOG);
+  assert_transport_mapper_stats_source(transport_mapper, "syslog");
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
 }
 

--- a/modules/afsocket/tests/test-transport-mapper-unix.c
+++ b/modules/afsocket/tests/test-transport-mapper-unix.c
@@ -34,7 +34,7 @@ Test(transport_mapper_unix, test_transport_mapper_unix_stream_apply_transport_se
   assert_transport_mapper_sock_type(transport_mapper, SOCK_STREAM);
   assert_transport_mapper_sock_proto(transport_mapper, 0);
   assert_transport_mapper_logproto(transport_mapper, "text");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_UNIX_STREAM);
+  assert_transport_mapper_stats_source(transport_mapper, "unix-stream");
 }
 
 Test(transport_mapper_unix, test_transport_mapper_unix_dgram_apply_transport_sets_defaults)
@@ -46,7 +46,7 @@ Test(transport_mapper_unix, test_transport_mapper_unix_dgram_apply_transport_set
   assert_transport_mapper_sock_type(transport_mapper, SOCK_DGRAM);
   assert_transport_mapper_sock_proto(transport_mapper, 0);
   assert_transport_mapper_logproto(transport_mapper, "dgram");
-  assert_transport_mapper_stats_source(transport_mapper, SCS_UNIX_DGRAM);
+  assert_transport_mapper_stats_source(transport_mapper, "unix-dgram");
 }
 
 static void

--- a/modules/afsocket/tests/transport-mapper-lib.h
+++ b/modules/afsocket/tests/transport-mapper-lib.h
@@ -59,9 +59,9 @@ assert_transport_mapper_logproto(TransportMapper *options, const gchar *expected
 }
 
 static inline void
-assert_transport_mapper_stats_source(TransportMapper *options, gint stats_source)
+assert_transport_mapper_stats_source(TransportMapper *options, const gchar *stats_source)
 {
-  cr_assert_eq(options->stats_source, stats_source, "TransportMapper contains a mismatching stats_source");
+  cr_assert_str_eq(options->stats_source, stats_source, "TransportMapper contains a mismatching stats_source");
 }
 
 static inline void

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -309,7 +309,7 @@ transport_mapper_tcp_new(void)
   self->super.sock_type = SOCK_STREAM;
   self->super.sock_proto = IPPROTO_TCP;
   self->super.logproto = "text";
-  self->super.stats_source = SCS_TCP;
+  self->super.stats_source = "tcp";
   self->server_port = TCP_PORT;
   self->require_tls_when_has_tls_context = TRUE;
   return &self->super;
@@ -321,7 +321,7 @@ transport_mapper_tcp6_new(void)
   TransportMapper *self = transport_mapper_tcp_new();
 
   self->address_family = AF_INET6;
-  self->stats_source = SCS_TCP6;
+  self->stats_source = "tcp6";
   return self;
 }
 
@@ -333,7 +333,7 @@ transport_mapper_udp_new(void)
   self->super.sock_type = SOCK_DGRAM;
   self->super.sock_proto = IPPROTO_UDP;
   self->super.logproto = "dgram";
-  self->super.stats_source = SCS_UDP;
+  self->super.stats_source = "udp";
   self->server_port = UDP_PORT;
   return &self->super;
 }
@@ -344,7 +344,7 @@ transport_mapper_udp6_new(void)
   TransportMapper *self = transport_mapper_udp_new();
 
   self->address_family = AF_INET6;
-  self->stats_source = SCS_UDP6;
+  self->stats_source = "udp6";
   return self;
 }
 
@@ -404,7 +404,7 @@ transport_mapper_network_new(void)
   TransportMapperInet *self = transport_mapper_inet_new_instance("tcp");
 
   self->super.apply_transport = transport_mapper_network_apply_transport;
-  self->super.stats_source = SCS_NETWORK;
+  self->super.stats_source = "network";
   return &self->super;
 }
 
@@ -479,6 +479,6 @@ transport_mapper_syslog_new(void)
   TransportMapperInet *self = transport_mapper_inet_new_instance("tcp");
 
   self->super.apply_transport = transport_mapper_syslog_apply_transport;
-  self->super.stats_source = SCS_SYSLOG;
+  self->super.stats_source = "syslog";
   return &self->super;
 }

--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -83,7 +83,7 @@ transport_mapper_unix_dgram_new(void)
   TransportMapperUnix *self = transport_mapper_unix_new_instance("unix-dgram", SOCK_DGRAM);
 
   self->super.logproto = "dgram";
-  self->super.stats_source = SCS_UNIX_DGRAM;
+  self->super.stats_source = "unix-dgram";
 
   return &self->super;
 }
@@ -94,7 +94,7 @@ transport_mapper_unix_stream_new(void)
   TransportMapperUnix *self = transport_mapper_unix_new_instance("unix-stream", SOCK_STREAM);
 
   self->super.logproto = "text";
-  self->super.stats_source = SCS_UNIX_STREAM;
+  self->super.stats_source = "unix-stream";
 
   return &self->super;
 }

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -46,7 +46,7 @@ struct _TransportMapper
   gboolean create_multitransport;
 
   const gchar *logproto;
-  gint stats_source;
+  const gchar *stats_source;
 
   gboolean (*apply_transport)(TransportMapper *self, GlobalConfig *cfg);
   LogTransport *(*construct_log_transport)(TransportMapper *self, gint fd);

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1195,7 +1195,7 @@ afsql_dd_new(GlobalConfig *cfg)
   self->dbd_options_numeric = g_hash_table_new_full(g_str_hash, g_int_equal, g_free, NULL);
 
   log_template_options_defaults(&self->template_options);
-  self->super.stats_source = SCS_SQL;
+  self->super.stats_source = "sql";
 
   return &self->super.super.super;
 }

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -392,7 +392,7 @@ afstomp_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = afstomp_worker_insert;
 
   self->super.format_stats_instance = afstomp_dd_format_stats_instance;
-  self->super.stats_source = SCS_STOMP;
+  self->super.stats_source = "stomp";
 
   afstomp_dd_set_host((LogDriver *) self, "127.0.0.1");
   afstomp_dd_set_port((LogDriver *) self, 61613);

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -276,6 +276,6 @@ afstreams_sd_new(gchar *filename, GlobalConfig *cfg)
   self->reader_options.parse_options.flags |= LP_LOCAL;
   self->reader_options.parse_options.flags &= ~LP_EXPECT_HOSTNAME;
   self->reader_options.super.stats_level = STATS_LEVEL1;
-  self->reader_options.super.stats_source = SCS_SUN_STREAMS;
+  self->reader_options.super.stats_source = "sun-streams";
   return &self->super.super;
 }

--- a/modules/csvparser/tests/test_csvparser_statistics.c
+++ b/modules/csvparser/tests/test_csvparser_statistics.c
@@ -40,7 +40,7 @@ _create_parser(GlobalConfig *cfg)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, p->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "parser", SCS_NONE, p->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_DISCARDED, &p->super.discarded_messages);
   stats_unlock();
 
@@ -56,7 +56,7 @@ _unregister_statistics(LogParser *p)
 {
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, p->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "parser", SCS_NONE, p->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_DISCARDED, &p->super.discarded_messages);
   stats_unlock();
 

--- a/modules/csvparser/tests/test_csvparser_statistics.c
+++ b/modules/csvparser/tests/test_csvparser_statistics.c
@@ -40,7 +40,7 @@ _create_parser(GlobalConfig *cfg)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, p->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, p->name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_DISCARDED, &p->super.discarded_messages);
   stats_unlock();
 
@@ -56,7 +56,7 @@ _unregister_statistics(LogParser *p)
 {
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, p->name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_PARSER, SCS_NONE, p->name, NULL );
   stats_unregister_counter(&sc_key, SC_TYPE_DISCARDED, &p->super.discarded_messages);
   stats_unlock();
 

--- a/modules/csvparser/tests/test_csvparser_statistics.c
+++ b/modules/csvparser/tests/test_csvparser_statistics.c
@@ -71,7 +71,7 @@ _parse_msg(LogParser *self, gchar *msg)
   log_msg_unref(logmsg);
 }
 
-Test(test_filters_statistics, filter_stastistics)
+Test(test_filters_statistics, filter_statistics)
 {
   app_startup();
   configuration = cfg_new_snippet();

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -131,7 +131,7 @@ Test(diskq, testcase_ack_and_rewind_messages)
   log_queue_set_use_backlog(q, TRUE);
 
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, "queued messages", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "java", SCS_DESTINATION, "queued messages", NULL );
   stats_lock();
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
   stats_unlock();
@@ -419,9 +419,9 @@ init_statistics(LogQueue *q)
 
   StatsClusterKey sc_key1, sc_key2;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key1, SCS_JAVA, SCS_DESTINATION, "queued messages", NULL );
+  stats_cluster_logpipe_key_set(&sc_key1, "java", SCS_DESTINATION, "queued messages", NULL );
   stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->queued_messages);
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_JAVA, SCS_DESTINATION, "memory usage", NULL );
+  stats_cluster_logpipe_key_set(&sc_key2, "java", SCS_DESTINATION, "memory usage", NULL );
   stats_register_counter(1, &sc_key2, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
   stats_counter_set(q->queued_messages, 0);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -131,7 +131,7 @@ Test(diskq, testcase_ack_and_rewind_messages)
   log_queue_set_use_backlog(q, TRUE);
 
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, "queued messages", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, "queued messages", NULL );
   stats_lock();
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
   stats_unlock();
@@ -419,9 +419,9 @@ init_statistics(LogQueue *q)
 
   StatsClusterKey sc_key1, sc_key2;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key1, SCS_DESTINATION, "queued messages", NULL );
+  stats_cluster_logpipe_key_set(&sc_key1, SCS_JAVA, SCS_DESTINATION, "queued messages", NULL );
   stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->queued_messages);
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_DESTINATION, "memory usage", NULL );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_JAVA, SCS_DESTINATION, "memory usage", NULL );
   stats_register_counter(1, &sc_key2, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
   stats_counter_set(q->queued_messages, 0);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -71,7 +71,7 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "java", SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
   stats_counter_set(q->dropped_messages, 0);
   stats_unlock();

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -71,7 +71,7 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
   stats_counter_set(q->dropped_messages, 0);
   stats_unlock();

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -530,7 +530,7 @@ http_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = http_dd_free;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
   self->super.format_stats_instance = _format_stats_instance;
-  self->super.stats_source = SCS_HTTP;
+  self->super.stats_source = "http";
   self->super.worker.construct = http_dw_new;
 
   curl_global_init(CURL_GLOBAL_ALL);

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -308,7 +308,7 @@ java_dd_new(GlobalConfig *cfg)
   self->super.worker.flush = java_worker_flush;
 
   self->super.format_stats_instance = java_dd_format_stats_instance;
-  self->super.stats_source = SCS_JAVA;
+  self->super.stats_source = "java";
 
   self->template = log_template_new(cfg, NULL);
   self->class_path = g_string_new(".");

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -424,7 +424,7 @@ kafka_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.generate_persist_name = _format_persist_name;
 
   self->super.format_stats_instance = _format_stats_instance;
-  self->super.stats_source = SCS_KAFKA;
+  self->super.stats_source = "kafka";
   self->super.worker.construct = _construct_worker;
   /* one minute */
   self->flush_timeout_on_shutdown = 60000;

--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -179,7 +179,7 @@ openbsd_sd_new(GlobalConfig *cfg)
   self->reader_options.parse_options.flags |= LP_LOCAL;
   self->reader_options.parse_options.flags &= ~LP_EXPECT_HOSTNAME;
   self->reader_options.super.stats_level = STATS_LEVEL1;
-  self->reader_options.super.stats_source = SCS_OPENBSD;
+  self->reader_options.super.stats_source = "openbsd";
 
   return &self->super.super;
 }

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -582,7 +582,7 @@ python_dd_new(GlobalConfig *cfg)
   self->super.worker.flush = python_dd_flush;
 
   self->super.format_stats_instance = python_dd_format_stats_instance;
-  self->super.stats_source = SCS_PYTHON;
+  self->super.stats_source = "python";
 
   self->options = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -536,7 +536,7 @@ python_fetcher_new(GlobalConfig *cfg)
 
   self->super.super.format_stats_instance = python_fetcher_format_stats_instance;
   self->super.super.worker_options.super.stats_level = STATS_LEVEL0;
-  self->super.super.worker_options.super.stats_source = SCS_PYTHON;
+  self->super.super.worker_options.super.stats_source = "python";
 
   self->super.fetch = python_fetcher_fetch;
 

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -561,7 +561,7 @@ python_sd_new(GlobalConfig *cfg)
 
   self->super.format_stats_instance = python_sd_format_stats_instance;
   self->super.worker_options.super.stats_level = STATS_LEVEL0;
-  self->super.worker_options.super.stats_source = SCS_PYTHON;
+  self->super.worker_options.super.stats_source = "python";
 
   log_threaded_source_driver_set_worker_request_exit_func(&self->super, python_sd_request_exit);
   log_threaded_source_driver_set_worker_run_func(&self->super, python_sd_run);

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -397,7 +397,7 @@ redis_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = redis_worker_insert;
 
   self->super.format_stats_instance = redis_dd_format_stats_instance;
-  self->super.stats_source = SCS_REDIS;
+  self->super.stats_source = "redis";
 
   redis_dd_set_host((LogDriver *)self, "127.0.0.1");
   redis_dd_set_port((LogDriver *)self, 6379);

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -335,7 +335,7 @@ riemann_dd_new(GlobalConfig *cfg)
   self->super.worker.construct = riemann_dw_new;
 
   self->super.format_stats_instance = riemann_dd_format_stats_instance;
-  self->super.stats_source = SCS_RIEMANN;
+  self->super.stats_source = "riemann";
 
   self->port = -1;
   self->type = RIEMANN_CLIENT_TCP;

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -682,14 +682,14 @@ snmpdest_dd_init(LogPipe *s)
   self->queue = log_dest_driver_acquire_queue(&self->super, snmpdest_dd_format_persist_name(self));
 
   stats_lock();
-  stats_cluster_logpipe_key_set(&self->sc_key_queued, SCS_SNMP, SCS_NONE, snmpdest_dd_format_stats_instance(self), NULL );
+  stats_cluster_logpipe_key_set(&self->sc_key_queued, "snmp", SCS_NONE, snmpdest_dd_format_stats_instance(self), NULL );
   stats_register_counter(1, &self->sc_key_queued, SC_TYPE_QUEUED, &self->queued_messages);
 
-  stats_cluster_logpipe_key_set(&self->sc_key_dropped, SCS_SNMP, SCS_NONE, snmpdest_dd_format_stats_instance(self),
+  stats_cluster_logpipe_key_set(&self->sc_key_dropped, "snmp", SCS_NONE, snmpdest_dd_format_stats_instance(self),
                                 NULL );
   stats_register_counter(1, &self->sc_key_dropped, SC_TYPE_DROPPED, &self->dropped_messages);
 
-  stats_cluster_logpipe_key_set(&self->sc_key_processed, SCS_SNMP, SCS_NONE, snmpdest_dd_format_stats_instance(self),
+  stats_cluster_logpipe_key_set(&self->sc_key_processed, "snmp", SCS_NONE, snmpdest_dd_format_stats_instance(self),
                                 NULL );
   stats_register_counter(1, &self->sc_key_processed, SC_TYPE_PROCESSED, &self->processed_messages);
   stats_unlock();

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -682,13 +682,15 @@ snmpdest_dd_init(LogPipe *s)
   self->queue = log_dest_driver_acquire_queue(&self->super, snmpdest_dd_format_persist_name(self));
 
   stats_lock();
-  stats_cluster_logpipe_key_set(&self->sc_key_queued, SCS_SNMP, snmpdest_dd_format_stats_instance(self), NULL );
+  stats_cluster_logpipe_key_set(&self->sc_key_queued, SCS_SNMP, SCS_NONE, snmpdest_dd_format_stats_instance(self), NULL );
   stats_register_counter(1, &self->sc_key_queued, SC_TYPE_QUEUED, &self->queued_messages);
 
-  stats_cluster_logpipe_key_set(&self->sc_key_dropped, SCS_SNMP, snmpdest_dd_format_stats_instance(self), NULL );
+  stats_cluster_logpipe_key_set(&self->sc_key_dropped, SCS_SNMP, SCS_NONE, snmpdest_dd_format_stats_instance(self),
+                                NULL );
   stats_register_counter(1, &self->sc_key_dropped, SC_TYPE_DROPPED, &self->dropped_messages);
 
-  stats_cluster_logpipe_key_set(&self->sc_key_processed, SCS_SNMP, snmpdest_dd_format_stats_instance(self), NULL );
+  stats_cluster_logpipe_key_set(&self->sc_key_processed, SCS_SNMP, SCS_NONE, snmpdest_dd_format_stats_instance(self),
+                                NULL );
   stats_register_counter(1, &self->sc_key_processed, SC_TYPE_PROCESSED, &self->processed_messages);
   stats_unlock();
 

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -733,7 +733,7 @@ journal_reader_options_defaults(JournalReaderOptions *options)
 {
   log_source_options_defaults(&options->super);
   options->super.stats_level = STATS_LEVEL0;
-  options->super.stats_source = SCS_JOURNALD;
+  options->super.stats_source = "journald";
   options->fetch_limit = DEFAULT_FETCH_LIMIT;
   options->default_pri = DEFAULT_PRIO;
   options->max_field_size = DEFAULT_FIELD_SIZE;

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -189,7 +189,7 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
 
   StatsClusterKey sc_key;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
   stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
@@ -288,7 +288,7 @@ Test(logqueue, log_queue_fifo_rewind_all_and_memory_usage)
 
   StatsClusterKey sc_key;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
 

--- a/tests/unit/test_logqueue.c
+++ b/tests/unit/test_logqueue.c
@@ -189,7 +189,7 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
 
   StatsClusterKey sc_key;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "java", SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
   stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
@@ -288,7 +288,7 @@ Test(logqueue, log_queue_fifo_rewind_all_and_memory_usage)
 
   StatsClusterKey sc_key;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key, SCS_JAVA, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, "java", SCS_DESTINATION, q->persist_name, NULL );
   stats_register_counter(1, &sc_key, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
 


### PR DESCRIPTION
This is a competing alternative to https://github.com/balabit/syslog-ng/pull/2761.

Module specific SCS_ constants disappear. The lookup strings are passed by modules during registration.

Review warmly welcome, but please let me do the MERGE, because this has two followup tasks that need to be scheduled properly.

Some key points for reviewers:
- As future improvement, we wanted to support users to provide their own strings. This suggests some kind of dynamic support, but this alternative (as opposed to #2761) makes this harder, because implementation needs to ensure the string to register lives through statistics (this time of writing module deinit is not supported), possibly statically allocated. This is nothing impossible to resolve, just a bit inconvenient.
- I needed to modify the `stats_cluster_hash` to imitate original behaviour. Please give it some thought that we hare having something that is equally useful.
- SCS_GROUP needed to be addressed specifically, please check last patch.