### PR TITLE
gitignore: tags file and build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ dbld/rules.conf
 debian/build-tree/
 debian/*.log
 debian/autoreconf.*
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ dbld/rules.conf
 debian/build-tree/
 debian/*.log
 debian/autoreconf.*
+build/
 tags


### PR DESCRIPTION
Inspired by https://github.com/balabit/syslog-ng/pull/2784 

well I use the `build` directory to build shame on me, but `ag` could exclude this directory from searching IF it is listed in `.gitignore`
the other `tags` as well
(I know I could create my own ignore file, but well..)