### PR TITLE
Follow-up Python pylib path change in deb and rpm packaging

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -114,13 +114,10 @@ override_dh_auto_configure:
 # we override libdir above to place everything useful there. We want
 # the .pc file elsewhere, though, so do that here at install time.
 #
-# Similarly, we want to install python modules to their proper place,
-# and this is a great time to tell the build system where that is.
 # Also removing .la files, these files don't needed and just confuse
 # the list-missing option
 override_dh_auto_install:
-	dh_auto_install -- pkgconfigdir=/usr/lib/pkgconfig \
-			   PYSETUP_OPTIONS="--install-layout=deb --root=$(CURDIR)/debian/tmp/"
+	dh_auto_install -- pkgconfigdir=/usr/lib/pkgconfig
 	find . -name \*.la | xargs --no-run-if-empty rm
 
 override_dh_auto_test: ;

--- a/packaging/debian/syslog-ng-mod-python.install
+++ b/packaging/debian/syslog-ng-mod-python.install
@@ -1,2 +1,2 @@
 usr/lib/syslog-ng/*/libmod-python.so
-usr/lib/python*
+usr/lib/syslog-ng/*/python/*

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -550,8 +550,8 @@ fi
 %{_libdir}/%{name}/libhttp.so
 
 %files python
-/usr/lib/python%{py_ver}/site-packages/syslogng-1.0-py%{py_ver}.egg-info
-/usr/lib/python%{py_ver}/site-packages/syslogng/*
+%{_libdir}/%{name}/python/syslogng-1.0-py%{py_ver}.egg-info
+%{_libdir}/%{name}/python/syslogng/*
 %{_libdir}/%{name}/libmod-python.so
 
 %files devel

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -296,7 +296,7 @@ export GEOIP_LIBS=-lGeoIP
     --sysconfdir=%{_sysconfdir}/%{name} \
     --localstatedir=%{_sharedstatedir}/%{name} \
     --datadir=%{_datadir} \
-    --with-module-dir=/%{_libdir}/%{name} \
+    --with-module-dir=%{_libdir}/%{name} \
     --with-systemdsystemunitdir=%{_unitdir} \
     --with-ivykis=system \
 %if 0%{?rhel}


### PR DESCRIPTION
In #2438, syslog-ng Python modules have been moved from `/usr/lib/python2.7/site-packages/` to `/usr/lib/syslog-ng/python`.