### PR TITLE
cfg-grammar: add new path type for files

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -74,6 +74,7 @@ set (LIB_HEADERS
     cfg-block.h
     cfg-block-generator.h
     cfg-parser.h
+    cfg-path.h
     cfg-tree.h
     children.h
     crypto.h
@@ -162,6 +163,7 @@ set(LIB_SOURCES
     cfg-lexer.c
     cfg-lexer-subst.c
     cfg-parser.c
+    cfg-path.c
     cfg-tree.c
     children.c
     dnscache.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -109,6 +109,7 @@ pkginclude_HEADERS			+= \
 	lib/cfg-block.h			\
 	lib/cfg-block-generator.h	\
 	lib/cfg-parser.h		\
+	lib/cfg-path.h			\
 	lib/cfg-tree.h			\
 	lib/children.h			\
 	lib/crypto.h			\
@@ -195,6 +196,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/cfg-lexer.c			\
 	lib/cfg-lexer-subst.c		\
 	lib/cfg-parser.c		\
+	lib/cfg-path.c			\
 	lib/cfg-tree.c			\
 	lib/children.c			\
 	lib/dnscache.c			\

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -194,7 +194,6 @@ void cfg_token_block_free(CfgTokenBlock *self);
 
 void cfg_lexer_register_generator_plugin(PluginContext *context, CfgBlockGenerator *gen);
 
-
 #define CFG_LEXER_ERROR cfg_lexer_error_quark()
 
 GQuark cfg_lexer_error_quark(void);

--- a/lib/cfg-path.c
+++ b/lib/cfg-path.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2019 Balabit
+ * Copyright (c) 2019 Mehul Prajapati
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-path.h"
+
+void
+cfg_path_track_file(GlobalConfig *cfg, const gchar *file_path, const gchar *path_type)
+{
+  CfgFilePath *cfg_file_path = g_new0(CfgFilePath, 1);
+  cfg_file_path->path_type = g_strdup(path_type);
+  cfg_file_path->file_path = g_strdup(file_path);
+  cfg->file_list = g_list_append(cfg->file_list, cfg_file_path);
+}

--- a/lib/cfg-path.h
+++ b/lib/cfg-path.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2019 Balabit
+ * Copyright (c) 2019 Mehul Prajapati
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef CFG_PATH_H_INCLUDED
+#define CFG_PATH_H_INCLUDED
+
+#include "cfg.h"
+
+typedef struct _CfgFilePath
+{
+  gchar *path_type;
+  gchar *file_path;
+} CfgFilePath;
+
+void cfg_path_track_file(GlobalConfig *cfg, const gchar *file_path, const gchar *path_type);
+#endif

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -23,6 +23,7 @@
  */
 
 #include "cfg.h"
+#include "cfg-path.h"
 #include "cfg-grammar.h"
 #include "module-config.h"
 #include "cfg-tree.h"
@@ -563,6 +564,16 @@ _load_file_into_string(const gchar *fname)
   return content;
 }
 
+static void
+_cfg_file_path_free(gpointer data)
+{
+  CfgFilePath *self = (CfgFilePath *)data;
+
+  g_free(self->file_path);
+  g_free(self->path_type);
+  g_free(self);
+}
+
 gboolean
 cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
 {
@@ -633,6 +644,8 @@ cfg_free(GlobalConfig *self)
     g_string_free(self->preprocess_config, TRUE);
   if (self->original_config)
     g_string_free(self->original_config, TRUE);
+
+  g_list_free_full(self->file_list, _cfg_file_path_free);
 
   g_free(self);
 }

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -122,6 +122,8 @@ struct _GlobalConfig
 
   GString *preprocess_config;
   GString *original_config;
+
+  GList *file_list;
 };
 
 gboolean cfg_load_module(GlobalConfig *cfg, const gchar *module_name);

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -74,6 +74,9 @@ control_connection_send_reply(ControlConnection *self, GString *reply)
 
   self->pos = 0;
   self->waiting_for_output = FALSE;
+
+  g_assert(self->output_buffer->len > 0);
+
   if (self->output_buffer->str[self->output_buffer->len - 1] != '\n')
     {
       g_string_append_c(self->output_buffer, '\n');

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -26,6 +26,7 @@
 #include "control/control-server.h"
 #include "messages.h"
 #include "cfg.h"
+#include "cfg-path.h"
 #include "apphook.h"
 #include "secret-storage/secret-storage.h"
 
@@ -257,6 +258,24 @@ process_credentials(ControlConnection *cc, GString *command, gpointer user_data)
   control_connection_send_reply(cc, result);
 }
 
+static void
+control_connection_list_files(ControlConnection *cc, GString *command, gpointer user_data)
+{
+  MainLoop *main_loop = (MainLoop *) user_data;
+  GlobalConfig *config = main_loop_get_current_config(main_loop);
+  GString *result = g_string_new("");
+
+  for (GList *v = config->file_list; v; v = v->next)
+    {
+      CfgFilePath *cfg_file_path = (CfgFilePath *) v->data;
+      g_string_append_printf(result, "%s: %s\n", cfg_file_path->path_type, cfg_file_path->file_path);
+    }
+
+  if (result->len == 0)
+    g_string_assign(result, "No files available\n");
+
+  control_connection_send_reply(cc, result);
+}
 
 ControlCommand default_commands[] =
 {
@@ -267,6 +286,7 @@ ControlCommand default_commands[] =
   { "CONFIG", control_connection_config },
   { "LICENSE", show_ose_license_info },
   { "PWD", process_credentials },
+  { "LISTFILES", control_connection_list_files },
   { NULL, NULL },
 };
 

--- a/modules/add-contextual-data/add-contextual-data-grammar.ym
+++ b/modules/add-contextual-data/add-contextual-data-grammar.ym
@@ -82,7 +82,7 @@ parser_add_contextual_data_opts
         ;
 
 parser_add_contextual_data_opt
-        : KW_DATABASE '(' string ')'
+        : KW_DATABASE '(' path_no_check ')'
         {
             add_contextual_data_set_filename(last_parser, $3);
             free($3);

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -112,10 +112,10 @@ afamqp_tls_options
     ;
 
 afamqp_tls_option
-    : KW_CA_FILE '(' string ')'               { afamqp_dd_set_ca_file(last_driver, $3); free($3); }
-    | KW_KEY_FILE '(' string ')'              { afamqp_dd_set_key_file(last_driver, $3); free($3); }
-    | KW_CERT_FILE '(' string ')'              { afamqp_dd_set_cert_file(last_driver, $3); free($3); }
-    | KW_PEER_VERIFY '(' yesno ')'               { afamqp_dd_set_peer_verify(last_driver, $3); }
+    : KW_CA_FILE '(' path_check ')'        { afamqp_dd_set_ca_file(last_driver, $3); free($3); }
+    | KW_KEY_FILE '(' path_secret ')'      { afamqp_dd_set_key_file(last_driver, $3); free($3); }
+    | KW_CERT_FILE '(' path_check ')'      { afamqp_dd_set_cert_file(last_driver, $3); free($3); }
+    | KW_PEER_VERIFY '(' yesno ')'         { afamqp_dd_set_peer_verify(last_driver, $3); }
     ;
 
 /* INCLUDE_RULES */

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -780,22 +780,22 @@ tls_option
 	                "unknown peer-verify() argument");
             free($3);
           }
-	| KW_KEY_FILE '(' string ')'
+	| KW_KEY_FILE '(' path_secret ')'
 	  {
 	    tls_context_set_key_file(last_tls_context, $3);
             free($3);
           }
-	| KW_CERT_FILE '(' string ')'
+	| KW_CERT_FILE '(' path_check ')'
 	  {
 	    tls_context_set_cert_file(last_tls_context, $3);
             free($3);
           }
-        | KW_DHPARAM_FILE '(' string ')'
+        | KW_DHPARAM_FILE '(' path_check ')'
           {
             tls_context_set_dhparam_file(last_tls_context, $3);
             free($3);
           }
-        | KW_PKCS12_FILE '(' string ')'
+        | KW_PKCS12_FILE '(' path_check ')'
           {
             tls_context_set_pkcs12_file(last_tls_context, $3);
             free($3);

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -102,7 +102,7 @@ parser_db_opts
 
 /* NOTE: we don't support parser_opt as we don't want the user to specify a template */
 parser_db_opt
-        : KW_FILE '(' string ')'                		{ log_db_parser_set_db_file(((LogDBParser *) last_parser), $3); free($3); }
+        : KW_FILE '(' path_no_check ')'                		{ log_db_parser_set_db_file(((LogDBParser *) last_parser), $3); free($3); }
 	| KW_DROP_UNMATCHED '(' yesno ')'			{ log_db_parser_set_drop_unmatched(((LogDBParser *) last_parser), $3); };
         | KW_PROGRAM_TEMPLATE '(' template_content ')'
           {

--- a/modules/geoip/geoip-parser-grammar.ym
+++ b/modules/geoip/geoip-parser-grammar.ym
@@ -88,7 +88,7 @@ parser_geoip_opts
 parser_geoip_opt
         : KW_PREFIX '(' string ')'
           { geoip_parser_set_prefix(last_parser, $3); free($3); }
-        | KW_DATABASE '(' string ')'
+        | KW_DATABASE '(' path_check ')'
           { geoip_parser_set_database(last_parser, $3); free($3); }
         ;
 

--- a/modules/geoip2/geoip-parser-grammar.ym
+++ b/modules/geoip2/geoip-parser-grammar.ym
@@ -85,7 +85,7 @@ parser_expr_maxminddb
 parser_geoip_opt
         : KW_PREFIX '(' string ')'
           { geoip_parser_set_prefix(last_parser, $3); free($3); }
-        | KW_DATABASE '(' string ')'
+        | KW_DATABASE '(' path_check ')'
           { geoip_parser_set_database_path(last_parser, $3); free($3); }
         ;
 

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -138,9 +138,9 @@ http_tls_options
 
 http_tls_option
     : KW_CA_DIR     '(' string ')'            { http_dd_set_ca_dir(last_driver, $3); free($3); }
-    | KW_CA_FILE    '(' string ')'            { http_dd_set_ca_file(last_driver, $3); free($3); }
-    | KW_CERT_FILE  '(' string ')'            { http_dd_set_cert_file(last_driver, $3); free($3); }
-    | KW_KEY_FILE   '(' string ')'            { http_dd_set_key_file(last_driver, $3); free($3); }
+    | KW_CA_FILE    '(' path_check ')'        { http_dd_set_ca_file(last_driver, $3); free($3); }
+    | KW_CERT_FILE  '(' path_check ')'        { http_dd_set_cert_file(last_driver, $3); free($3); }
+    | KW_KEY_FILE   '(' path_secret ')'       { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
     | KW_USE_SYSTEM_CERT_STORE '(' yesno ')'  { http_dd_set_use_system_cert_store(last_driver, $3); }
     | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -91,7 +91,7 @@ kafka_option
         {
             kafka_dd_merge_config(last_driver, $3);
         }
-        | KW_PROPERTIES_FILE '(' string ')'
+        | KW_PROPERTIES_FILE '(' path_check ')'
 	  {
             GList *file_props = kafka_read_properties_file($3);
             free($3);

--- a/modules/pseudofile/pseudofile-grammar.ym
+++ b/modules/pseudofile/pseudofile-grammar.ym
@@ -64,7 +64,7 @@ start
 
 dest_pseudofile
 	: KW_PSEUDOFILE
-          '(' string						{ last_driver = pseudofile_dd_new($3, configuration); }
+          '(' path_check					{ last_driver = pseudofile_dd_new($3, configuration); }
 	  pseudofile_opts
 	  ')'							{ $$ = last_driver; free($3); }
 	;

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -182,14 +182,14 @@ riemann_tls_options
         ;
 
 riemann_tls_option
-        : KW_CA_FILE '(' string ')' { riemann_dd_set_tls_cacert(last_driver, $3); free($3); }
-        | KW_CERT_FILE '(' string ')' { riemann_dd_set_tls_cert(last_driver, $3); free($3); }
-        | KW_KEY_FILE '(' string ')' { riemann_dd_set_tls_key(last_driver, $3); free($3); }
+        : KW_CA_FILE '(' path_check ')'    { riemann_dd_set_tls_cacert(last_driver, $3); free($3); }
+        | KW_CERT_FILE '(' path_check ')'  { riemann_dd_set_tls_cert(last_driver, $3); free($3); }
+        | KW_KEY_FILE '(' path_secret ')'  { riemann_dd_set_tls_key(last_driver, $3); free($3); }
 
 	/* for compatibility with early riemann code where key() was used
 	 * for the key file, which doesn't match the option name in tls()
 	 * options */
-        | KW_KEY '(' string ')'
+        | KW_KEY '(' path_secret ')'
           {
             msg_warning("WARNING: your riemann configuration uses the key() "
                         "option which was obsoleted in favour of key-file(), "

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -250,6 +250,12 @@ slng_reopen(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
   return _dispatch_command("REOPEN");
 }
 
+static gint
+slng_listfiles(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  return _dispatch_command("LISTFILES");
+}
+
 static const gint QUERY_COMMAND = 0;
 static gboolean query_is_get_sum = FALSE;
 static gboolean query_reset = FALSE;
@@ -603,6 +609,7 @@ static CommandDescriptor modes[] =
   { "show-license-info", license_options, "Show information about the license", slng_license, NULL },
   { "credentials", no_options, "Credentials manager", NULL, credentials_commands },
   { "config", config_options, "Print current config", slng_config, NULL },
+  { "list-files", no_options, "Print files present in config", slng_listfiles, NULL },
   { NULL, NULL },
 };
 


### PR DESCRIPTION
Hi,

As a part of GSoC, I am doing improvements in debun script.

The main task is to collect all files which are there in syslog-ng configuration.
As of now, in configuration, if there is a file path, we are defining that as type 'string'.

This patch would replace that 'string' type to 'path' type if there is an absolute path.  Also, I have added a check if a file is actually present or not on that absolute path.
Therefore, I can get a list of all files for ```debun script task``` by just doing a single grep on ```cfg-grammar.y```

If we have this type 'path', somebody could build upon an improvement like to offer
browsing functionality in config snipper if it is a directory.




resolves https://github.com/mehul-m-prajapati/gsoc-debun-tool/issues/7