### PR TITLE
affile: Add option to disable time-reap()

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -968,7 +968,7 @@ options_item
 	| KW_CHECK_HOSTNAME '(' yesno ')'	{ configuration->check_hostname = $3; }
 	| KW_BAD_HOSTNAME '(' string ')'	{ cfg_bad_hostname_set(configuration, $3); free($3); }
 	| KW_TIME_REOPEN '(' positive_integer ')'		{ configuration->time_reopen = $3; }
-	| KW_TIME_REAP '(' positive_integer ')'		{ configuration->time_reap = $3; }
+	| KW_TIME_REAP '(' nonnegative_integer ')'		{ configuration->time_reap = $3; }
 	| KW_TIME_SLEEP '(' nonnegative_integer ')'	{}
 	| KW_SUPPRESS '(' nonnegative_integer ')'		{ configuration->suppress = $3; }
 	| KW_THREADED '(' yesno ')'		{ configuration->threaded = $3; }

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -118,6 +118,7 @@ static void affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw);
 static void
 affile_dw_arm_reaper(AFFileDestWriter *self)
 {
+  g_assert(self->owner->time_reap > 0);
   /* not yet reaped, set up the next callback */
   iv_validate_now();
   self->reap_timer.expires = iv_now;
@@ -183,7 +184,7 @@ affile_dw_reopen(AFFileDestWriter *self)
       proto = file_opener_construct_dst_proto(self->owner->file_opener, transport,
                                               &self->owner->writer_options.proto_options.super);
 
-      if (!iv_timer_registered(&self->reap_timer))
+      if (self->owner->time_reap > 0 && !iv_timer_registered(&self->reap_timer))
         main_loop_call((void *(*)(void *)) affile_dw_arm_reaper, self, TRUE);
     }
   else

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -408,6 +408,14 @@ affile_dd_set_fsync(LogDriver *s, gboolean use_fsync)
   self->use_fsync = use_fsync;
 }
 
+void
+affile_dd_set_time_reap(LogDriver *s, gint time_reap)
+{
+  AFFileDestDriver *self = (AFFileDestDriver *) s;
+
+  self->time_reap = time_reap;
+}
+
 static inline const gchar *
 affile_dd_format_persist_name(const LogPipe *s)
 {

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -793,7 +793,7 @@ affile_dd_new_instance(gchar *filename, GlobalConfig *cfg)
     }
   file_opener_options_defaults(&self->file_opener_options);
 
-  self->time_reap = -1;
+  self->time_reap = self->filename_is_a_template ? -1 : 0;
   g_static_mutex_init(&self->lock);
 
   affile_dest_drivers = g_list_append(affile_dest_drivers, self);

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -58,6 +58,7 @@ void affile_dd_set_create_dirs(LogDriver *s, gboolean create_dirs);
 void affile_dd_set_fsync(LogDriver *s, gboolean enable);
 void affile_dd_set_overwrite_if_older(LogDriver *s, gint overwrite_if_older);
 void affile_dd_set_local_time_zone(LogDriver *s, const gchar *local_time_zone);
+void affile_dd_set_time_reap(LogDriver *s, gint time_reap);
 void affile_dd_global_init(void);
 
 #endif

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -249,7 +249,7 @@ dest_affile_option
 	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
 	| KW_OVERWRITE_IF_OLDER '(' nonnegative_integer ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }
 	| KW_FSYNC '(' yesno ')'		{ affile_dd_set_fsync(last_driver, $3); }
-	| KW_TIME_REAP '(' positive_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
+	| KW_TIME_REAP '(' nonnegative_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
 	;
 
 dest_afpipe_params
@@ -271,7 +271,7 @@ dest_afpipe_option
 	: dest_writer_option
 	| dest_driver_option
 	| file_perm_option
-	| KW_TIME_REAP '(' positive_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
+	| KW_TIME_REAP '(' nonnegative_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
 	;
 
 

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -69,6 +69,7 @@ LogProtoFileReaderOptions *last_log_proto_options;
 %token KW_MULTI_LINE_MODE
 %token KW_MULTI_LINE_PREFIX
 %token KW_MULTI_LINE_GARBAGE
+%token KW_TIME_REAP
 
 %token KW_WILDCARD_FILE
 %token KW_BASE_DIR
@@ -248,6 +249,7 @@ dest_affile_option
 	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
 	| KW_OVERWRITE_IF_OLDER '(' nonnegative_integer ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }
 	| KW_FSYNC '(' yesno ')'		{ affile_dd_set_fsync(last_driver, $3); }
+	| KW_TIME_REAP '(' positive_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
 	;
 
 dest_afpipe_params
@@ -269,6 +271,7 @@ dest_afpipe_option
 	: dest_writer_option
 	| dest_driver_option
 	| file_perm_option
+	| KW_TIME_REAP '(' positive_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
 	;
 
 

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -51,6 +51,7 @@ static CfgLexerKeyword affile_keywords[] =
   { "multi_line_prefix",  KW_MULTI_LINE_PREFIX },
   { "multi_line_garbage", KW_MULTI_LINE_GARBAGE },
   { "multi_line_suffix",  KW_MULTI_LINE_GARBAGE },
+  { "time_reap",          KW_TIME_REAP },
   { NULL }
 };
 


### PR DESCRIPTION
Fixing 2 problems with `time-reap()`

The first problem: `time-reap()` can only be set globally, for all destinations.
The second problem: It can not be disabled. We should be able to disable it, if we are sure, that no problematic templating is set for that destination.

Example usage:
```
@version: 3.21

options {
    time-reap(2); # global time-reap()
};

source s_input {
    example-msg-generator(freq(5));
};

destination d_fifo {
    pipe(
        "/tmp/test.fifo",
        time-reap(0)  # disable time-reap() for this destination
    );
};

log {
    source(s_input);
    destination(d_fifo);
};
```

The PR also introduces a new functionality: If the `pipe()` or `file()` destination's filepath does not have a template, the `time-reap()` is not inherited from the global options, but is disabled, by default. The user can override this by explicitly setting `time-reap()` to non-zero at that destination.

So the hierarchy is the following:
 1. if `time-reap()` is set at the destination, we will use that value
 2. if `time-reap()` is not set at the destination, and the destination does not have a template in its filepath option, we disable `time-reap()`
 3. if `time-reap()` is not set at the destination, and the destination has a template in its filepath, the global option is inherited, which is 60 by default, but can be overridden at `options { ... };`