### PR TITLE
Revert "packaging/debian: merge rdkafka and kafka modules"

### DIFF
--- a/packaging/debian/Makefile.am
+++ b/packaging/debian/Makefile.am
@@ -69,6 +69,7 @@ EXTRA_DIST		+= \
 		packaging/debian/syslog-ng-mod-java-http.install \
 		packaging/debian/syslog-ng-mod-examples.install \
 		packaging/debian/syslog-ng.systemd \
+		packaging/debian/syslog-ng-mod-rdkafka.install \
 		packaging/debian/copyright \
 		packaging/debian/MPL \
 		packaging/debian/not-installed \

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -773,7 +773,7 @@ Description: Enhanced system logging daemon (HDFS destination)
 Package: syslog-ng-mod-kafka
 Architecture: any
 Multi-Arch: foreign
-Depends: syslog-ng-core (= ${binary:Version}), syslog-ng-mod-java-common-lib, syslog-ng-mod-java, ${shlibs:Depends}, ${misc:Depends}
+Depends: syslog-ng-core (= ${binary:Version}), syslog-ng-mod-java-common-lib, syslog-ng-mod-java
 Description: Enhanced system logging daemon (Kafka destination)
  syslog-ng is an enhanced log daemon, supporting a wide range of input
  and output methods: syslog, unstructured text, message queues,
@@ -882,3 +882,26 @@ Description: Enhanced system logging daemon (example plugins)
     AMQP), files or databases (like PostgreSQL or MongoDB).
  .
  This package provides a collection of example plugins.
+
+Package: syslog-ng-mod-rdkafka
+Architecture: any
+Multi-Arch: foreign
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Enhanced system logging daemon (Kafka destination, based on librdkafka)
+ syslog-ng is an enhanced log daemon, supporting a wide range of input
+ and output methods: syslog, unstructured text, message queues,
+ databases (SQL and NoSQL alike) and more.
+ .
+ Key features:
+ .
+  * receive and send RFC3164 and RFC5424 style syslog messages
+  * work with any kind of unstructured data
+  * receive and send JSON formatted messages
+  * classify and structure logs with builtin parsers (csv-parser(),
+    db-parser(), etc.)
+  * normalize, crunch and process logs as they flow through the system
+  * hand on messages for further processing using message queues (like
+    AMQP), files or databases (like PostgreSQL or MongoDB).
+ .
+ This package provides a native Kafka destination, written entirely in the C programming
+ language, based on the librdkafka client library.

--- a/packaging/debian/syslog-ng-mod-kafka.install
+++ b/packaging/debian/syslog-ng-mod-kafka.install
@@ -1,3 +1,2 @@
 usr/lib/syslog-ng/*/java-modules/kafka.jar
 usr/share/syslog-ng/include/scl/kafka/*
-usr/lib/syslog-ng/*/libkafka.so

--- a/packaging/debian/syslog-ng-mod-rdkafka.install
+++ b/packaging/debian/syslog-ng-mod-rdkafka.install
@@ -1,0 +1,1 @@
+usr/lib/syslog-ng/*/libkafka.so


### PR DESCRIPTION
This reverts commit 6f252f4b6bb171ae4ff5949e5539dedc7ba5734a.

I'm not sure that we really want to merge them... when someone installs the native mod-rdkafka, I'm sure that this user don't want to install the whole Java ecosystem (and even if this what the users want, then we have to _replace_ the previous mod-rdkafka by mod-kafka). With this patch we 'broke' current installations (mod-rdkafka has version 3.21). 

Of course I'm open to discuss it, but I have a very strong opinion on this question :)