### PR TITLE
radix: fix grouping in pcre

### DIFF
--- a/modules/dbparser/tests/test_radix.c
+++ b/modules/dbparser/tests/test_radix.c
@@ -1004,6 +1004,16 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .key = "jjjj abcabcd foobar",
       .expected_pattern = {"regexp", "abcabc", NULL},
     },
+    {
+      .node_to_insert = {"@PCRE:regexp:(foo|bar)@", NULL},
+      .key = "foo",
+      .expected_pattern = {"regexp", "foo", NULL},
+    },
+    {
+      .node_to_insert = {"@PCRE:regexp:(?:foo|bar)@", NULL},
+      .key = "foo",
+      .expected_pattern = {"regexp", "foo", NULL},
+    },
     /* test_nlstring_matches */
     {
       .node_to_insert = {"@NLSTRING:nlstring@\n", NULL},


### PR DESCRIPTION
`pcre_exec()` did not have enough place to store the offsets in the offset_vector (`matches` variable). I copied the API usage from `logmatcher.c`, which seems to work.

https://www.pcre.org/original/doc/html/pcre_exec.html requires the offset vector's size to be a multiple of 3. `ovecsize     Number of elements in the vector (a multiple of 3)`

Note for the reviewers:
 * radix.c is abyssal for me, and I could not really prove to myself, that adding the `matches` array to `RParserPCREState` will not cause a race condition.

Fixes #2793 