### PR TITLE
update according to clang, gcc diagnostic differences, and fix newly found issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -175,7 +175,6 @@ matrix:
             -DCMAKE_C_FLAGS=-Werror
             -DPYTHON_VERSION=2
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
-            -DENABLE_EXTRA_WARNINGS=no
             ..
         - make --keep-going -j $(nproc) ARGS="-j $(nproc)" all test install
     - env: B=check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,8 +337,8 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wold-style-declaration
     -Wstrict-prototypes
     -Wswitch-default
+    -Wimplicit-int
     -Wall
-    -Wmissing-parameter-type
     -Wuninitialized
     -Wunused-but-set-parameter
     -Wcast-align

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,17 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wsuggest-attribute=noreturn
     -Wold-style-definition
     -Wundef)
+
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+  set(EXTRA_WARNINGS
+    ${EXTRA_WARNINGS}
+    )
+else()
+  set(EXTRA_WARNINGS
+    ${EXTRA_WARNINGS}
+    )
+endif()
+
 endif()
 
 add_compile_options(${IMPORTANT_WARNINGS} ${ACCEPTABLE_WARNINGS} ${EXTRA_WARNINGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,6 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wimplicit-int
     -Wall
     -Wuninitialized
-    -Wcast-align
     -Wdeprecated
     -Wdeprecated-declarations
     -Woverflow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,6 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wpointer-arith
     -Wpointer-sign
     -Wmissing-format-attribute
-    -Wsuggest-attribute=noreturn
     -Wold-style-definition
     -Wundef)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,6 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wimplicit-int
     -Wall
     -Wuninitialized
-    -Wunused-but-set-parameter
     -Wcast-align
     -Wdeprecated
     -Wdeprecated-declarations
@@ -360,6 +359,7 @@ if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
     )
 else()
   set(EXTRA_WARNINGS
+    -Wunused-but-set-parameter
     ${EXTRA_WARNINGS}
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,6 @@ if (ENABLE_EXTRA_WARNINGS)
   set(EXTRA_WARNINGS
     -Wimplicit-function-declaration
     -Wnested-externs
-    -Wold-style-declaration
     -Wstrict-prototypes
     -Wswitch-default
     -Wimplicit-int
@@ -359,6 +358,7 @@ if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
     )
 else()
   set(EXTRA_WARNINGS
+    -Wold-style-declaration
     -Wunused-but-set-parameter
     ${EXTRA_WARNINGS}
     )

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,6 @@ AM_CFLAGS += \
 	-Wall \
 	-Wuninitialized \
 	-Wunused-but-set-parameter \
-	-Wcast-align \
 	-Wdeprecated \
 	-Wdeprecated-declarations \
 	-Woverflow \

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,6 @@ AM_CFLAGS += \
 	-Wpointer-arith \
 	-Wpointer-sign \
 	-Wmissing-format-attribute \
-	-Wsuggest-attribute=noreturn \
 	-Wold-style-definition \
 	-Wundef
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,8 +70,8 @@ AM_CFLAGS += \
 	-Wold-style-declaration \
 	-Wstrict-prototypes \
 	-Wswitch-default \
+	-Wimplicit-int \
 	-Wall \
-	-Wmissing-parameter-type \
 	-Wuninitialized \
 	-Wunused-but-set-parameter \
 	-Wcast-align \

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -899,7 +899,7 @@ cfg_lexer_append_preprocessed_output(CfgLexer *self, const gchar *token_text)
 static gboolean
 cfg_lexer_parse_and_run_block_generator(CfgLexer *self, Plugin *p, YYSTYPE *yylval)
 {
-  gpointer *args;
+  gpointer *args = NULL;
   CfgIncludeLevel *level = &self->include_stack[self->include_depth];
   CfgBlockGenerator *gen = plugin_construct(p);
   gboolean success = TRUE;

--- a/lib/tests/test_type_hints.c
+++ b/lib/tests/test_type_hints.c
@@ -204,7 +204,7 @@ ParameterizedTestParameters(type_hints, test_double_cast)
   static StringDoublePair string_value_pairs[] =
   {
 #ifdef INFINITY
-    {"INF",INFINITY},
+    {"INF",(gdouble)INFINITY},
 #endif
     {"1.0",1.0},
     {"1e-100000000",0.0}

--- a/lib/tests/test_type_hints.c
+++ b/lib/tests/test_type_hints.c
@@ -214,6 +214,22 @@ ParameterizedTestParameters(type_hints, test_double_cast)
                              sizeof(string_value_pairs) / sizeof(string_value_pairs[0]));
 }
 
+static void
+cr_assert_gdouble_eq(gdouble a, gdouble b)
+{
+  const gint is_a_inf = isinf((long double)a);
+  const gint is_b_inf = isinf((long double)a);
+
+  cr_assert_eq(is_a_inf, is_b_inf);
+  if (is_a_inf && is_b_inf)
+    {
+      cr_assert(TRUE);
+      return;
+    }
+
+  cr_assert(fabs(a-b) < G_MINDOUBLE);
+}
+
 ParameterizedTest(StringDoublePair *string_value_pair, type_hints, test_double_cast)
 {
   gdouble value;
@@ -221,7 +237,8 @@ ParameterizedTest(StringDoublePair *string_value_pair, type_hints, test_double_c
 
   cr_assert(type_cast_to_double(string_value_pair->string, &value, &error),
             "Type cast of \"%s\" to double failed", string_value_pair->string);
-  cr_assert_eq(value, string_value_pair->value);
+
+  cr_assert_gdouble_eq(value, string_value_pair->value);
   cr_assert_null(error);
 }
 

--- a/libtest/testutils.c
+++ b/libtest/testutils.c
@@ -148,24 +148,6 @@ assert_guint64_non_fatal(guint64 actual, guint64 expected, const gchar *error_me
   return FALSE;
 }
 
-gboolean
-assert_gdouble_non_fatal(gdouble actual, gdouble expected, const gchar *error_message, ...)
-{
-  va_list args;
-
-  if (isinf(actual) && isinf(expected))
-    return TRUE;
-
-  if (fabs(actual - expected) < 1e-15)
-    return TRUE;
-
-  va_start(args, error_message);
-  print_failure(error_message, args, "actual=%f, expected=%f", actual, expected);
-  va_end(args);
-
-  return FALSE;
-}
-
 static gboolean G_GNUC_PRINTF(5, 0)
 assert_nstring_non_fatal_va(const gchar *actual, gint actual_len, const gchar *expected, gint expected_len,
                             const gchar *error_message, va_list args)

--- a/libtest/testutils.h
+++ b/libtest/testutils.h
@@ -60,8 +60,6 @@ gboolean assert_gint64_non_fatal(gint64 actual, gint64 expected, const gchar *er
                                  ...) G_GNUC_PRINTF(3, 4);
 gboolean assert_guint64_non_fatal(guint64 actual, guint64 expected, const gchar *error_message,
                                   ...) G_GNUC_PRINTF(3, 4);
-gboolean assert_gdouble_non_fatal(gdouble actual, gdouble expected, const gchar *error_message,
-                                  ...) G_GNUC_PRINTF(3, 4);
 gboolean assert_nstring_non_fatal(const gchar *actual, gint actual_len, const gchar *expected, gint expected_len,
                                   const gchar *error_message, ...) G_GNUC_PRINTF(5, 6);
 gboolean assert_guint32_array_non_fatal(guint32 *actual, guint32 actual_length, guint32 *expected,
@@ -93,8 +91,6 @@ gboolean expect_not_reached(const gchar *error_message, ...) G_GNUC_PRINTF(1, 2)
 
 #define assert_gint32(actual, expected, error_message, ...) (assert_gint64((gint64)actual, (gint64)expected, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
 #define assert_guint32(actual, expected, error_message, ...) (assert_guint64((guint64)actual, (guint64)expected, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
-
-#define assert_gdouble(actual, expected, error_message, ...) (assert_gdouble_non_fatal(actual, expected, error_message, ##__VA_ARGS__) ? 1 : (exit (1),0))
 
 #define assert_string(actual, expected, error_message, ...) (assert_nstring_non_fatal(actual, -1, expected, -1, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))
 #define assert_nstring(actual, actual_len, expected, expected_len, error_message, ...) (assert_nstring_non_fatal(actual, actual_len, expected, expected_len, error_message, ##__VA_ARGS__) ? 1 : (exit(1),0))

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -853,12 +853,6 @@ _batch_lines(const AFSqlDestDriver *self)
   return self->super.batch_lines;
 }
 
-static inline gboolean
-afsql_dd_should_commit_transaction(const AFSqlDestDriver *self)
-{
-  return afsql_dd_is_transaction_handling_enabled(self);
-}
-
 static LogThreadedResult
 afsql_dd_handle_insert_row_error_depending_on_connection_availability(AFSqlDestDriver *self)
 {

--- a/tests/unit/test_zone.c
+++ b/tests/unit/test_zone.c
@@ -88,7 +88,7 @@ test_time_zone(const time_t stamp_to_test, const char *time_zone)
   info = time_zone_info_new(time_zone);
   offset = time_zone_info_get_offset(info, stamp_to_test);
   expected_offset = get_local_timezone_ofs(stamp_to_test);
-  cr_assert_eq(difftime(offset, expected_offset), 0,
+  cr_assert_eq(difftime(offset, expected_offset), 0.0,
                "unixtimestamp: %ld TimeZoneName (%s) localtime offset(%ld), timezone file offset(%ld)\n",
                (glong) stamp_to_test, time_zone, (glong) expected_offset, (glong) offset);
 


### PR DESCRIPTION
The main focus was on `cmake+clang`, sorry `autotools`.
Changes that were to replace/remove a warning was also changed in the `autotools`.
But a few option was removed in case of `clang` as `clang` does not define them, and those were not updated in `autotools` (in case of `autotools` those warnings must be turned on via `--enable-extra-warnings`).

Additionally I also turned on the extra warnings for `cmake+clang` combination.

Note: it seems clang is able to detect issues even if they are hidden via macro usage, while gcc is unable to see such errors (anything written in macros gcc just fine with it).