### PR TITLE
[WIP] lib/filter: fix standalone filter grammar parsing 

### DIFF
--- a/lib/filter/filter-expr-parser.c
+++ b/lib/filter/filter-expr-parser.c
@@ -31,6 +31,7 @@ int filter_expr_parse(CfgLexer *lexer, FilterExprNode **node, gpointer arg);
 
 static CfgLexerKeyword filter_expr_keywords[] =
 {
+  { "filter",             KW_FILTER },
   { "or",                 KW_OR },
   { "and",                KW_AND },
   { "not",                KW_NOT },


### PR DESCRIPTION
CUDO for @Kokan for the deep investigation. It was an instructive investigation.

When specific parsers are called from the global config, they automatically
inherit all the global keywords. They only extend the list with their own
unique keywords. (static CfgLexerKeyword bar[] =...)  

Unlike other parsers, the filter parser is used as a standalone parser too.
(for example: grep/if templates, pdbtool) In such cases, the filter parser
only recognize keywords, which are declared in filter-expr-parser.c

Why this is a problem? The “filter” keyword has a double meaning. One is to
declare named filters at the global config level. The other one is to call
a previously declared filter (filter call). Because the "filter" keyword is
declared globally, a stand alone filter parser can not recognize it, and
simply handled it as an “LL_IDENTIFIER”, which results in parsing errors.

The solution is to declare the missing keyword in filter parser. This will
implicate that the keyword will be redundant when we are using the parser
normally, but fortunately the lexer handles this situation gracefully.
