### PR TITLE
redis: handle any number of parameters at `command`

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -426,6 +426,7 @@ DNSCacheOptions *last_dns_cache_options;
 %type   <ptr> dest_plugin
 
 %type   <ptr> template_content
+%type   <ptr> template_content_list
 
 %type   <ptr> filter_content
 
@@ -894,6 +895,11 @@ template_content_inner
 template_content
         : { last_template = log_template_new(configuration, NULL); } template_content_inner	{ $$ = last_template; }
         ;
+
+template_content_list
+	: template_content template_content_list { $$ = g_list_prepend($2, $1); }
+	| { $$ = NULL; }
+	;
 
 /* END_RULES */
 

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -75,19 +75,9 @@ redis_option
             redis_dd_set_auth(last_driver, $3);
             free($3);
           }
-        | KW_COMMAND '(' string template_content ')'
+        | KW_COMMAND '(' string template_content_list ')'
           {
-            redis_dd_set_command_ref(last_driver, $3, $4, NULL, NULL);
-            free($3);
-          }
-        | KW_COMMAND '(' string template_content template_content ')'
-          {
-            redis_dd_set_command_ref(last_driver, $3, $4, $5, NULL);
-            free($3);
-          }
-        | KW_COMMAND '(' string template_content template_content template_content ')'
-          {
-            redis_dd_set_command_ref(last_driver, $3, $4, $5, $6);
+            redis_dd_set_command_ref(last_driver, $3, $4);
             free($3);
           }
         | threaded_dest_driver_option

--- a/modules/redis/redis.h
+++ b/modules/redis/redis.h
@@ -32,8 +32,7 @@ void redis_dd_set_host(LogDriver *d, const gchar *host);
 void redis_dd_set_port(LogDriver *d, gint port);
 void redis_dd_set_auth(LogDriver *d, const gchar *auth);
 void redis_dd_set_command_ref(LogDriver *d, const gchar *command,
-                              LogTemplate *key,
-                              LogTemplate *param1, LogTemplate *param2);
+                              GList *arguments);
 LogTemplateOptions *redis_dd_get_template_options(LogDriver *d);
 
 #endif


### PR DESCRIPTION
There are some redis commands, which needs more that 3 fields after the command.
This PR allows the user to set any number of parameters to redis's `command()` option.
The first must be a string, the remaining ones can be templates as well.

Example usage:
```
destination d_redis {
  redis(
      host("127.0.0.1")
      port(6379)
      command("XADD", "instanceLogged", "*", "message_id", "$HOST")
  );
};
```
Fixes #2813