### PR TITLE
pcre: calculate matches_size in pcre_re_compile

### DIFF
--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -291,7 +291,26 @@ typedef struct _LogMatcherPcreRe
   pcre *pattern;
   pcre_extra *extra;
   gint match_options;
+  gsize matches_size;
 } LogMatcherPcreRe;
+
+static gsize
+_calculate_matches_size(LogMatcherPcreRe *self, const gchar *pattern)
+{
+  gint num_matches;
+  if (pcre_fullinfo(self->pattern, self->extra, PCRE_INFO_CAPTURECOUNT, &num_matches) < 0)
+    g_assert_not_reached();
+  if (num_matches > RE_MAX_MATCHES)
+    {
+      msg_warning("WARNING: The regexp pattern has too many possible matches. "
+                "syslog-ng will only handle a limited number.",
+                evt_tag_str("pattern", pattern),
+                evt_tag_int("possible_matches", num_matches),
+                evt_tag_int("match_limit", RE_MAX_MATCHES));
+      num_matches = RE_MAX_MATCHES;
+    }
+  return (3 * (num_matches + 1));
+}
 
 static gboolean
 log_matcher_pcre_re_compile(LogMatcher *s, const gchar *re, GError **error)
@@ -354,6 +373,8 @@ log_matcher_pcre_re_compile(LogMatcher *s, const gchar *re, GError **error)
                   re, errptr);
       return FALSE;
     }
+
+  self->matches_size = _calculate_matches_size(self, re);
 
   return TRUE;
 }
@@ -425,50 +446,34 @@ static gboolean
 log_matcher_pcre_re_match(LogMatcher *s, LogMessage *msg, gint value_handle, const gchar *value, gssize value_len)
 {
   LogMatcherPcreRe *self = (LogMatcherPcreRe *) s;
-  gint *matches;
-  gsize matches_size;
-  gint num_matches;
   gint rc;
+  gint *matches = g_alloca(self->matches_size * sizeof(gint));
 
   if (value_len == -1)
     value_len = strlen(value);
 
-  if (pcre_fullinfo(self->pattern, self->extra, PCRE_INFO_CAPTURECOUNT, &num_matches) < 0)
-    g_assert_not_reached();
-  if (num_matches > RE_MAX_MATCHES)
-    num_matches = RE_MAX_MATCHES;
-
-  matches_size = 3 * (num_matches + 1);
-  matches = g_alloca(matches_size * sizeof(gint));
-
   rc = pcre_exec(self->pattern, self->extra,
-                 value, value_len, 0, self->match_options, matches, matches_size);
-  if (rc < 0)
-    {
-      switch (rc)
-        {
-        case PCRE_ERROR_NOMATCH:
-          break;
+                 value, value_len, 0, self->match_options, matches, self->matches_size);
 
-        default:
-          /* Handle other special cases */
-          msg_error("Error while matching regexp",
-                    evt_tag_int("error_code", rc));
-          break;
-        }
+  if (rc == PCRE_ERROR_NOMATCH)
+    {
       return FALSE;
     }
+
+  if (rc < 0)
+    {
+      msg_error("Error while matching regexp", evt_tag_int("error_code", rc));
+      return FALSE;
+    }
+
   if (rc == 0)
     {
       msg_error("Error while storing matching substrings");
     }
-  else
+  else if ((s->flags & LMF_STORE_MATCHES))
     {
-      if ((s->flags & LMF_STORE_MATCHES))
-        {
-          log_matcher_pcre_re_feed_backrefs(s, msg, value_handle, matches, rc, value);
-          log_matcher_pcre_re_feed_named_substrings(s, msg, matches, value);
-        }
+      log_matcher_pcre_re_feed_backrefs(s, msg, value_handle, matches, rc, value);
+      log_matcher_pcre_re_feed_named_substrings(s, msg, matches, value);
     }
   return TRUE;
 }
@@ -479,27 +484,16 @@ log_matcher_pcre_re_replace(LogMatcher *s, LogMessage *msg, gint value_handle, c
 {
   LogMatcherPcreRe *self = (LogMatcherPcreRe *) s;
   GString *new_value = NULL;
-  gint *matches;
-  gsize matches_size;
-  gint num_matches;
   gint rc;
   gint start_offset, last_offset;
   gint options;
   gboolean last_match_was_empty;
-
-  if (pcre_fullinfo(self->pattern, self->extra, PCRE_INFO_CAPTURECOUNT, &num_matches) < 0)
-    g_assert_not_reached();
-  if (num_matches > RE_MAX_MATCHES)
-    num_matches = RE_MAX_MATCHES;
-
-  matches_size = 3 * (num_matches + 1);
-  matches = g_alloca(matches_size * sizeof(gint));
+  gint *matches = g_alloca(self->matches_size * sizeof(gint));
 
   /* we need zero initialized offsets for the last match as the
    * algorithm tries uses that as the base position */
 
   matches[0] = matches[1] = matches[2] = 0;
-
   if (value_len == -1)
     value_len = strlen(value);
 
@@ -544,7 +538,7 @@ log_matcher_pcre_re_replace(LogMatcher *s, LogMessage *msg, gint value_handle, c
 
       rc = pcre_exec(self->pattern, self->extra,
                      value, value_len,
-                     start_offset, (self->match_options | options), matches, matches_size);
+                     start_offset, (self->match_options | options), matches, self->matches_size);
       if (rc < 0 && rc != PCRE_ERROR_NOMATCH)
         {
           msg_error("Error while matching regexp",
@@ -575,7 +569,7 @@ log_matcher_pcre_re_replace(LogMatcher *s, LogMessage *msg, gint value_handle, c
              captures to RE_MAX_MATCHES */
 
           if (rc == 0)
-            rc = matches_size / 3;
+            rc = self->matches_size / 3;
 
           log_matcher_pcre_re_feed_backrefs(s, msg, value_handle, matches, rc, value);
           log_matcher_pcre_re_feed_named_substrings(s, msg, matches, value);


### PR DESCRIPTION
We can call `pcre_fullinfo()` only once, when we compile the expression, instead of doing these per message.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>