### PR TITLE
[WIP] python: initialize Python "program name" with Py_SetProgramName()

### DIFF
--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -25,6 +25,12 @@
 #include "python-helpers.h"
 
 void
+py_set_program_name(void)
+{
+  Py_SetProgramName("syslog-ng");
+}
+
+void
 py_init_argv(void)
 {
   static char *argv[] = {"syslog-ng"};

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -25,6 +25,12 @@
 #include "python-helpers.h"
 
 void
+py_set_program_name(void)
+{
+  Py_SetProgramName(L"syslog-ng");
+}
+
+void
 py_init_argv(void)
 {
   static wchar_t *argv[] = {L"syslog-ng"};

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -42,6 +42,7 @@
 #define PYTHON_MODULE_VERSION "python3"
 #endif
 
+void py_set_program_name(void);
 void py_init_argv(void);
 PyObject *int_as_pyobject(gint num);
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -96,6 +96,7 @@ _py_init_interpreter(void)
     {
       python_debugger_append_inittab();
 
+      py_set_program_name();
       _set_python_path();
       Py_Initialize();
       py_init_argv();

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -33,6 +33,7 @@ static PyObject *_python_main_dict;
 static void
 _py_init_interpreter(void)
 {
+  py_set_program_name();
   Py_Initialize();
   py_init_argv();
 

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -43,6 +43,7 @@ PyObject *py_template_options;
 static void
 _py_init_interpreter(void)
 {
+  py_set_program_name();
   Py_Initialize();
   py_init_argv();
 


### PR DESCRIPTION
"The `Py_SetProgramName()` function should be called before `Py_Initialize()` to inform the interpreter about paths to Python run-time libraries."

Setting it before `Py_Initialize()` is useful when syslog-ng is bundled with its own Python interpreter, so it finds the bundled libraries automatically.
It does not cause problems when system Python is used, because it falls back to system search paths.