### PR TITLE
lib/filter: add unit tests to filter-op

### DIFF
--- a/lib/filter/tests/CMakeLists.txt
+++ b/lib/filter/tests/CMakeLists.txt
@@ -22,6 +22,12 @@ set(TEST_FILTERS_FOP_CMP_SOURCE
   test_filters_common.h
   )
 
+set(TEST_FILTERS_FOP_SOURCE
+  test_filters_fop.c
+  test_filters_common.c
+  test_filters_common.h
+  )
+
 set(TEST_FILTERS_NETMASK_SOURCE
   test_filters_netmask.c
   test_filters_common.c
@@ -38,6 +44,7 @@ add_unit_test(CRITERION TARGET test_filters_facility SOURCES ${TEST_FILTERS_FACI
 add_unit_test(CRITERION TARGET test_filters_level_new SOURCES ${TEST_FILTERS_LEVEL_NEW_SOURCE} DEPENDS syslogformat)
 add_unit_test(LIBTEST CRITERION TARGET test_filters_regexp SOURCES ${TEST_FILTERS_REGEXP_SOURCE} DEPENDS syslogformat)
 add_unit_test(CRITERION TARGET test_filters_fop_cmp SOURCES ${TEST_FILTERS_FOP_CMP_SOURCE} DEPENDS syslogformat)
+add_unit_test(CRITERION TARGET test_filters_fop SOURCES ${TEST_FILTERS_FOP_SOURCE} DEPENDS syslogformat)
 add_unit_test(CRITERION TARGET test_filters_netmask SOURCES ${TEST_FILTERS_NETMASK_SOURCE} DEPENDS syslogformat)
 
 add_unit_test(CRITERION TARGET test_filters_in_list DEPENDS syslogformat)

--- a/lib/filter/tests/Makefile.am
+++ b/lib/filter/tests/Makefile.am
@@ -5,6 +5,7 @@ lib_filter_tests_TESTS		 =              \
 		lib/filter/tests/test_filters_in_list		\
 		lib/filter/tests/test_filters_regexp \
 		lib/filter/tests/test_filters_fop_cmp \
+		lib/filter/tests/test_filters_fop		\
 		lib/filter/tests/test_filters_netmask
 
 EXTRA_DIST += lib/filter/tests/CMakeLists.txt
@@ -48,6 +49,15 @@ lib_filter_tests_test_filters_fop_cmp_LDADD      = $(TEST_LDADD)  \
 	$(PREOPEN_SYSLOGFORMAT)
 lib_filter_tests_test_filters_fop_cmp_SOURCES = 			\
 	lib/filter/tests/test_filters_fop_cmp.c \
+	lib/filter/tests/test_filters_common.c \
+	lib/filter/tests/test_filters_common.h
+
+lib_filter_tests_test_filters_fop_CFLAGS         = $(TEST_CFLAGS) \
+	-I${top_srcdir}/lib/filter/tests
+lib_filter_tests_test_filters_fop_LDADD          = $(TEST_LDADD)  \
+	$(PREOPEN_SYSLOGFORMAT)
+lib_filter_tests_test_filters_fop_SOURCES = 			\
+	lib/filter/tests/test_filters_fop.c \
 	lib/filter/tests/test_filters_common.c \
 	lib/filter/tests/test_filters_common.h
 

--- a/lib/filter/tests/test_filters_fop.c
+++ b/lib/filter/tests/test_filters_fop.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2019 Szemere
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filter/filter-op.h"
+#include "filter/filter-expr.h"
+#include "filter/filter-pri.h"
+#include "filter/filter-expr-parser.h"
+#include "test_filters_common.h"
+#include "cfg-lexer.h"
+#include "apphook.h"
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+static FilterExprNode *
+_compile_standalone_filter(gchar *config_snippet)
+{
+  GlobalConfig *cfg = cfg_new_snippet();
+  FilterExprNode *tmp;
+
+  CfgLexer *lexer = cfg_lexer_new_buffer(cfg, config_snippet, strlen(config_snippet));
+  cr_assert(lexer, "Couldn't initialize a buffer for CfgLexer");
+
+  cr_assert(cfg_run_parser(cfg, lexer, &filter_expr_parser, (gpointer *) &tmp, NULL));
+
+  cfg_free(cfg);
+
+  return tmp;
+}
+
+typedef struct _FilterParams
+{
+  gchar *config_snippet;
+  gboolean expected_result;
+} FilterParams;
+
+ParameterizedTestParameters(filter_op, test_or_evaluation)
+{
+  static FilterParams test_data_list[] =
+  {
+    // Filters inside evaluates to TRUE
+    {.config_snippet = "    facility(2) or     facility(2)", .expected_result = TRUE  },
+    {.config_snippet = "    facility(2) or not facility(2)", .expected_result = TRUE  },
+    {.config_snippet = "not facility(2) or     facility(2)", .expected_result = TRUE  },
+    {.config_snippet = "not facility(2) or not facility(2)", .expected_result = FALSE },
+    // note: The above expression evaluated in the following way: not (TRUE or (not TRUE))
+    //       The expression below has the same expected result, but for a different reason.
+    {.config_snippet = "(not facility(2)) or (not facility(2))", .expected_result = FALSE },
+
+    // Filters inside evaluates to FALSE
+    {.config_snippet = "    facility(3) or     facility(3)", .expected_result = FALSE },
+    {.config_snippet = "    facility(3) or not facility(3)", .expected_result = TRUE  },
+    {.config_snippet = "not facility(3) or     facility(3)", .expected_result = TRUE  },
+    {.config_snippet = "not facility(3) or not facility(3)", .expected_result = TRUE  },
+    // same as before
+    {.config_snippet = "(not facility(3)) or (not facility(3))", .expected_result = TRUE  },
+
+    // Mixed TRUE and FALSE evaluations
+    {.config_snippet = "    facility(2) or     facility(3)", .expected_result = TRUE  },
+    {.config_snippet = "    facility(2) or not facility(3)", .expected_result = TRUE  },
+    {.config_snippet = "not facility(2) or     facility(3)", .expected_result = FALSE },
+    {.config_snippet = "not facility(2) or not facility(3)", .expected_result = TRUE  },
+    // same as before
+    {.config_snippet = "(not facility(2)) or (not facility(3))", .expected_result = TRUE },
+  };
+
+  return cr_make_param_array(FilterParams, test_data_list, G_N_ELEMENTS(test_data_list));
+}
+
+ParameterizedTest(FilterParams *params, filter_op, test_or_evaluation)
+{
+  const gchar *msg = "<16> openvpn[2499]: PTHREAD support initialized";
+  FilterExprNode *filter = _compile_standalone_filter(params->config_snippet);
+  testcase(msg, filter, params->expected_result);
+}
+
+TestSuite(filter_op, .init = setup, .fini = teardown);


### PR DESCRIPTION
Add unit tests to cover OR filters.
note: still left AND filters out since they only differs in their eval functions:

```
return (filter_expr_eval_with_context(self->left, msgs, num_msg)
          || filter_expr_eval_with_context(self->right, msgs, num_msg)) ^ s->comp;
```
vs
```
  return (filter_expr_eval_with_context(self->left, msgs, num_msg)
          && filter_expr_eval_with_context(self->right, msgs, num_msg)) ^ s->comp;
```


TODO: the `_compile_standalone_filter` function is copied from an ongoing work on #2833, later it should be transfered into `test_filters_common.c` as a "library" function.
