### PR TITLE
eventlog: flush escaped_buffer when full

### DIFF
--- a/lib/eventlog/src/evtstr.c
+++ b/lib/eventlog/src/evtstr.c
@@ -117,7 +117,7 @@ evt_str_append_escape_bs(EVTSTR *es,
           escaped_buffer[escaped_buffer_length++] = unescaped[i];
         }
 
-      if (escaped_buffer_capacity < escaped_buffer_length + escaped_char_max_len)
+      if (escaped_buffer_capacity <= escaped_buffer_length + escaped_char_max_len)
         {
           if (!evt_str_append_len(es, escaped_buffer, escaped_buffer_length))
             return 0;


### PR DESCRIPTION
This issue could be reproduced with using address sanatizer and debug level, with logs longer than the `escaped_buffer` size (128).