### PR TITLE
dbparser: remove unnecessary lock

### DIFF
--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -687,10 +687,7 @@ static void
 _pattern_db_process_unmatching_rule(PatternDB *self, PDBProcessParams *process_params)
 {
   LogMessage *msg = process_params->msg;
-
-  g_static_rw_lock_writer_lock(&self->lock);
   _emit_message(self, process_params, FALSE, msg);
-  g_static_rw_lock_writer_unlock(&self->lock);
 }
 
 static gboolean


### PR DESCRIPTION
After the extraction of `_pattern_db_advance_time_and_flush_expired()` in f5d2335ae3aacb4aeb56cbd5cf6bdc049cb6343a, this lock became unnecessary as `_emit_message()` operates only on `process_params` (per-thread, stack variable), and uses only a readonly field from `self`.