### PR TITLE
Light: fix get_short_hostname(), use keep-hostname(yes) for basic tests

### DIFF
--- a/tests/python_functional/functional_tests/logpath/test_flags_catch_all.py
+++ b/tests/python_functional/functional_tests/logpath/test_flags_catch_all.py
@@ -40,6 +40,7 @@ def test_flags_catch_all(config, syslog_ng, log_message, bsd_formatter):
 
     config.create_logpath(statements=[file_source, inner_logpath])
     config.create_logpath(statements=[catch_all_destination], flags="catch-all")
+    config.create_global_options(keep_hostname="yes")
 
     input_message = bsd_formatter.format_message(log_message)
     expected_message = bsd_formatter.format_message(log_message.remove_priority())

--- a/tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py
+++ b/tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py
@@ -22,10 +22,8 @@
 #############################################################################
 import pytest
 
-from src.common.network_operations import get_short_hostname
-
-input_log = "<38>Feb 11 21:27:22 {} testprogram[9999]: test message\n".format(get_short_hostname())
-expected_log = "Feb 11 21:27:22 {} testprogram[9999]: test message\n".format(get_short_hostname())
+input_log = "<38>Feb 11 21:27:22 testhost testprogram[9999]: test message\n"
+expected_log = "Feb 11 21:27:22 testhost testprogram[9999]: test message\n"
 
 
 @pytest.mark.parametrize(
@@ -38,6 +36,7 @@ def test_acceptance(config, syslog_ng, input_log, expected_log, counter):
     file_source = config.create_file_source(file_name="input.log")
     file_destination = config.create_file_destination(file_name="output.log")
     config.create_logpath(statements=[file_source, file_destination])
+    config.create_global_options(keep_hostname="yes")
 
     file_source.write_log(input_log, counter)
     syslog_ng.start(config)

--- a/tests/python_functional/src/common/network_operations.py
+++ b/tests/python_functional/src/common/network_operations.py
@@ -27,7 +27,10 @@ def get_hostname():
 
 
 def get_fqdn():
-    return socket.getfqdn()
+    fqdn = socket.getfqdn(get_hostname())
+    if "." not in fqdn:
+        return get_hostname()
+    return fqdn
 
 
 def get_short_hostname():

--- a/tests/python_functional/src/message_builder/log_message.py
+++ b/tests/python_functional/src/message_builder/log_message.py
@@ -22,8 +22,6 @@
 #############################################################################
 import time
 
-from src.common.network_operations import get_short_hostname
-
 
 class LogMessage(object):
     def __init__(self):
@@ -31,7 +29,7 @@ class LogMessage(object):
         self.timestamp_value = time.time()
         self.bsd_timestamp_value = "Feb 11 21:27:22"
         self.iso_timestamp_value = "2019-02-11T21:27:22+01:00"
-        self.hostname_value = get_short_hostname()
+        self.hostname_value = "testhost"
         self.program_value = "testprogram"
         self.pid_value = "9999"
         self.message_value = "test message"


### PR DESCRIPTION
This PR makes Travis green again.

Travis now has multiple hostnames:
```
127.0.1.1 travis-job-0198b942-d444-4c1f-95e9-84a18577f20d travis-job-0198b942-d444-4c1f-95e9-84a18577f20d ip4-loopback trusty64
127.0.0.1 localhost nettuno travis vagrant travis-job-0198b942-d444-4c1f-95e9-84a18577f20d 
```

In Light, `get_short_hostname()` returns a different hostname than what syslog-ng resolves, making a few non-hostname-related tests fail.

In my opinion, a basic file source acceptance test and a catch-all path test should not use dynamic values, so I changed them to a static hostname and enabled `keep-hostname()`.
I have the same opinion on `LogMessage`. If it has a default value for hostname, it should not be dynamic (should not be dependent of the environment).

Of course, `get_short_hostname()` can be reimplemented to return the same name syslog-ng would resolve, but these 2 tests are not meant to test such thing.