### PR TITLE
[WIP]run-id: validate if run-id written correctly to persist file

### DIFF
--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -38,6 +38,29 @@ typedef struct _RunIDState
   gint run_id;
 } RunIDState;
 
+static gboolean
+_validate_run_id(PersistState *state, PersistEntryHandle handle)
+{
+  RunIDState *temp_state = persist_state_map_entry(state, handle);
+  if (!temp_state)
+    {
+      msg_error("Failed to map run_id from persist file.");
+      return FALSE;
+    }
+
+  gboolean result = cached_run_id == temp_state->run_id;
+  if (!result)
+    {
+      msg_error("Failed to save run_id.",
+                evt_tag_int("cached run_id", cached_run_id),
+                evt_tag_int("saved run_id", temp_state->run_id));
+    }
+
+  persist_state_unmap_entry(state, handle);
+
+  return result;
+}
+
 gboolean
 run_id_init(PersistState *state)
 {
@@ -66,7 +89,7 @@ run_id_init(PersistState *state)
 
   persist_state_unmap_entry(state, handle);
 
-  return TRUE;
+  return _validate_run_id(state, handle);
 };
 
 int


### PR DESCRIPTION
Why we need to validate this?
Thanks to @furiel, we know that there are some persist state related
issues across syslog-ng versions, that can lead to a weird situation,
namely, even we increase run-id, it won't be written to the persist
file.

Signed-off-by: Laszlo Budai <laszlo.budai@outlook.com>

@furiel : please check if my understanding is correct.
