### PR TITLE
logmatcher: posix not supported, not even for 3.6

### DIFF
--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -211,7 +211,7 @@ filter_re_params
           {
             GError *error = NULL;
 
-            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_filter_expr, configuration, $2, &error), @2, error, "compiling the regexp failed");
+            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_filter_expr, $2, &error), @2, error, "compiling the regexp failed");
             free($2);
           }
 	;
@@ -231,7 +231,7 @@ filter_match_params
           {
             GError *error = NULL;
 
-            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_filter_expr, configuration, $2, &error), @2, error, "compiling the regexp failed");
+            CHECK_ERROR_GERROR(filter_re_compile_pattern(last_filter_expr, $2, &error), @2, error, "compiling the regexp failed");
             free($2);
 
             if (filter_match_is_usage_obsolete(last_filter_expr))

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -103,12 +103,12 @@ filter_re_get_matcher_options(FilterExprNode *s)
 }
 
 gboolean
-filter_re_compile_pattern(FilterExprNode *s, GlobalConfig *cfg, const gchar *re, GError **error)
+filter_re_compile_pattern(FilterExprNode *s, const gchar *re, GError **error)
 {
   FilterRE *self = (FilterRE *) s;
 
-  log_matcher_options_init(&self->matcher_options, cfg);
-  self->matcher = log_matcher_new(cfg, &self->matcher_options);
+  log_matcher_options_init(&self->matcher_options);
+  self->matcher = log_matcher_new(&self->matcher_options);
   return log_matcher_compile(self->matcher, re, error);
 }
 

--- a/lib/filter/filter-re.h
+++ b/lib/filter/filter-re.h
@@ -29,7 +29,7 @@
 #include "logmatcher.h"
 
 LogMatcherOptions *filter_re_get_matcher_options(FilterExprNode *s);
-gboolean filter_re_compile_pattern(FilterExprNode *s, GlobalConfig *cfg, const gchar *re, GError **error);
+gboolean filter_re_compile_pattern(FilterExprNode *s, const gchar *re, GError **error);
 
 FilterExprNode *filter_re_new(NVHandle value_handle);
 FilterExprNode *filter_source_new(void);

--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -78,7 +78,7 @@ compile_pattern(FilterExprNode *f, const gchar *regexp, const gchar *type, gint 
   matcher_options->flags = flags;
   log_matcher_options_set_type(matcher_options, type);
 
-  result = filter_re_compile_pattern(f, configuration, regexp, NULL);
+  result = filter_re_compile_pattern(f, regexp, NULL);
 
   if (result)
     return f;

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -201,7 +201,7 @@ log_matcher_string_replace(LogMatcher *s, LogMessage *msg, gint value_handle, co
 }
 
 LogMatcher *
-log_matcher_string_new(GlobalConfig *cfg, const LogMatcherOptions *options)
+log_matcher_string_new(const LogMatcherOptions *options)
 {
   LogMatcherString *self = g_new0(LogMatcherString, 1);
 
@@ -270,7 +270,7 @@ log_matcher_glob_free(LogMatcher *s)
 }
 
 LogMatcher *
-log_matcher_glob_new(GlobalConfig *cfg, const LogMatcherOptions *options)
+log_matcher_glob_new(const LogMatcherOptions *options)
 {
   LogMatcherGlob *self = g_new0(LogMatcherGlob, 1);
 
@@ -614,7 +614,7 @@ log_matcher_pcre_re_free(LogMatcher *s)
 }
 
 LogMatcher *
-log_matcher_pcre_re_new(GlobalConfig *cfg, const LogMatcherOptions *options)
+log_matcher_pcre_re_new(const LogMatcherOptions *options)
 {
   LogMatcherPcreRe *self = g_new0(LogMatcherPcreRe, 1);
 
@@ -627,7 +627,7 @@ log_matcher_pcre_re_new(GlobalConfig *cfg, const LogMatcherOptions *options)
   return &self->super;
 }
 
-typedef LogMatcher *(*LogMatcherConstructFunc)(GlobalConfig *cfg, const LogMatcherOptions *options);
+typedef LogMatcher *(*LogMatcherConstructFunc)(const LogMatcherOptions *options);
 
 struct
 {
@@ -655,12 +655,12 @@ log_matcher_lookup_construct(const gchar *type)
 }
 
 LogMatcher *
-log_matcher_new(GlobalConfig *cfg, const LogMatcherOptions *options)
+log_matcher_new(const LogMatcherOptions *options)
 {
   LogMatcherConstructFunc construct;
 
   construct = log_matcher_lookup_construct(options->type);
-  return construct(cfg, options);
+  return construct(options);
 }
 
 LogMatcher *
@@ -736,16 +736,12 @@ log_matcher_options_defaults(LogMatcherOptions *options)
 }
 
 void
-log_matcher_options_init(LogMatcherOptions *options, GlobalConfig *cfg)
+log_matcher_options_init(LogMatcherOptions *options)
 {
   if (!options->type)
     {
       const gchar *default_matcher = "pcre";
 
-      if (cfg_is_config_version_older(cfg, 0x0306))
-        {
-          default_matcher = "posix";
-        }
       if (!log_matcher_options_set_type(options, default_matcher))
         g_assert_not_reached();
     }

--- a/lib/logmatcher.h
+++ b/lib/logmatcher.h
@@ -107,11 +107,11 @@ log_matcher_is_replace_supported(LogMatcher *s)
   return s->replace != NULL;
 }
 
-LogMatcher *log_matcher_pcre_re_new(GlobalConfig *cfg, const LogMatcherOptions *options);
-LogMatcher *log_matcher_string_new(GlobalConfig *cfg, const LogMatcherOptions *options);
-LogMatcher *log_matcher_glob_new(GlobalConfig *cfg, const LogMatcherOptions *options);
+LogMatcher *log_matcher_pcre_re_new(const LogMatcherOptions *options);
+LogMatcher *log_matcher_string_new(const LogMatcherOptions *options);
+LogMatcher *log_matcher_glob_new(const LogMatcherOptions *options);
 
-LogMatcher *log_matcher_new(GlobalConfig *cfg, const LogMatcherOptions *options);
+LogMatcher *log_matcher_new(const LogMatcherOptions *options);
 LogMatcher *log_matcher_ref(LogMatcher *s);
 void log_matcher_unref(LogMatcher *s);
 
@@ -119,7 +119,7 @@ void log_matcher_unref(LogMatcher *s);
 gboolean log_matcher_options_set_type(LogMatcherOptions *options, const gchar *type);
 gboolean log_matcher_options_process_flag(LogMatcherOptions *self, const gchar *flag);
 void log_matcher_options_defaults(LogMatcherOptions *options);
-void log_matcher_options_init(LogMatcherOptions *options, GlobalConfig *cfg);
+void log_matcher_options_init(LogMatcherOptions *options);
 void log_matcher_options_destroy(LogMatcherOptions *options);
 
 #endif

--- a/lib/rewrite/rewrite-subst.c
+++ b/lib/rewrite/rewrite-subst.c
@@ -94,10 +94,9 @@ gboolean
 log_rewrite_subst_compile_pattern(LogRewrite *s, const gchar *regexp, GError **error)
 {
   LogRewriteSubst *self = (LogRewriteSubst *) s;
-  GlobalConfig *cfg = log_pipe_get_config(&s->super);
 
-  log_matcher_options_init(&self->matcher_options, cfg);
-  self->matcher = log_matcher_new(cfg, &self->matcher_options);
+  log_matcher_options_init(&self->matcher_options);
+  self->matcher = log_matcher_new(&self->matcher_options);
 
   if (!log_matcher_is_replace_supported(self->matcher))
     {

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -55,14 +55,14 @@ _create_log_message(const gchar *log)
 }
 
 static LogMatcher *
-_construct_matcher(gint matcher_flags, LogMatcher *(*construct)(GlobalConfig *cfg, const LogMatcherOptions *options))
+_construct_matcher(gint matcher_flags, LogMatcher *(*construct)(const LogMatcherOptions *options))
 {
   LogMatcherOptions matcher_options;
 
   log_matcher_options_defaults(&matcher_options);
   matcher_options.flags = matcher_flags;
 
-  return construct(configuration, &matcher_options);
+  return construct(&matcher_options);
 }
 
 


### PR DESCRIPTION
pcre/posix support in logmatcher

version | pcre | posix 
------------ | ------------- | -------------
3.6 or below | supported | default
3.14 or above | default | not supported

The removed code handled the case when the configuration was still 3.6, as it sets the default handle to `posix` instead of `pcre`, the called setter function replaces the `posix` with `pcre` as `posix` is no longer supported.

The `GlobalConfig` was passed around just to do the above `pcre`=>`posix`=>`pcre` dance.