### PR TITLE
Travis,cmake: ut verbose if failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,8 @@ matrix:
             -DPYTHON_VERSION=2
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
-        - make --keep-going -j $(nproc) ARGS="-j $(nproc)" all test install
+        - make --keep-going -j $(nproc) all install
+        - ctest -j $(nproc)
         - make VERBOSE=1 func-test
         - make pytest-linters
         - make pytest-self-check
@@ -176,7 +177,8 @@ matrix:
             -DPYTHON_VERSION=2
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
-        - make --keep-going -j $(nproc) ARGS="-j $(nproc)" all test install
+        - make --keep-going -j $(nproc) all install
+        - ctest -j $(nproc)
 
     - env: B=check
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: c
 git:
   submodules: false
 
-env: B=autotools
-
 os: linux
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ matrix:
       script:
         - tests/commits/check.sh
 
-    - env: B=trusty-cmake-internal
+    - env: B=cmake-submodules-and-pytest
       compiler: gcc
       dist: trusty
       sudo: required
@@ -161,7 +161,7 @@ matrix:
         - make pytest-self-check
         - make pytest-check
 
-    - env: B=trusty-cmake
+    - env: B=cmake
       compiler: clang
       dist: trusty
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ matrix:
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
         - make --keep-going -j $(nproc) all install
-        - ctest -j $(nproc)
+        - ctest -j $(nproc) --output-on-failure
         - make VERBOSE=1 func-test
         - make pytest-linters
         - make pytest-self-check
@@ -178,7 +178,7 @@ matrix:
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
         - make --keep-going -j $(nproc) all install
-        - ctest -j $(nproc)
+        - ctest -j $(nproc) --output-on-failure
 
     - env: B=check
       os: osx


### PR DESCRIPTION
The autotools find and prints the output of test execution, in case of cmake only the result failed/passed is printed. This PR changes the behaviour, so if a test failed it act as if verbose flag were used, otherwise state passed as before.

Also contains some cleanup, and renaming.