### PR TITLE
apphook: fix g_thread_init call order issue with older glibs

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -151,11 +151,9 @@ construct_nondumpable_logger(msg_fatal);
 void
 app_startup(void)
 {
-  main_loop_thread_resource_init();
   msg_init(FALSE);
   iv_set_fatal_msg_handler(app_fatal);
   iv_init();
-  g_thread_init(NULL);
   crypto_init();
   hostname_global_init();
   dns_caching_global_init();
@@ -163,6 +161,8 @@ app_startup(void)
   afinter_global_init();
   child_manager_init();
   alarm_init();
+  g_thread_init(NULL);
+  main_loop_thread_resource_init();
   stats_init();
   tzset();
   log_msg_global_init();


### PR DESCRIPTION
Recently, in app-startup() the g_cond_new() call preceded g_thread_init() call,
which only causes issues with glib versions older than 2.32, where it is not deprecated.

Fixes #2848 