### PR TITLE
Dbld gradle caching

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -26,6 +26,9 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
 	-e CONFIGURE_OPTS="$${CONFIGURE_OPTS:-$(CONFIGURE_OPTS)}" \
 	-e CCACHE_DIR=/build/ccache \
 	-e PATH=/usr/lib/ccache:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+	-e GRADLE_USER_HOME=/build/gradle-home \
+	-e GRADLE_PROJECT_CACHE_DIR=/build/gradle-cache \
+	-e GRADLE_FLAGS=--build-cache \
 	$(if $(wildcard ${HOME}/.gitconfig),-v ${HOME}/.gitconfig:${HOME}/.gitconfig)
 ROOT_DIR=$(shell pwd)
 DBLD_DIR=$(ROOT_DIR)/dbld

--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -2,7 +2,8 @@ if ENABLE_JAVA_MODULES
 
 
 GRADLE_PROJECT_DIR ?= $(abs_top_srcdir)/modules/java-modules
-GRADLE_PROJECT_CACHE_DIR ?= $(abs_top_builddir)/modules/java-modules/.gradle
+GRADLE_PROJECT_CACHE_DIR_DEFAULT = $(abs_top_builddir)/modules/java-modules/.gradle
+GRADLE_PROJECT_CACHE_DIR ?= $(GRADLE_PROJECT_CACHE_DIR_DEFAULT)
 GRADLE_FLAGS ?=
 GRADLE_ARGS = $(GRADLE_FLAGS) \
 	--project-dir $(GRADLE_PROJECT_DIR) \
@@ -34,9 +35,9 @@ java-modules-uninstall-exec-hook:
 	rm -f $(JAVA_INSTALLED_JARS)
 
 java-modules-clean-hook:
-	rm -rf $(abs_top_builddir)/modules/java-modules/*.log
-	$(GRADLE_COMMAND) -q clean
-	rm -rf $(GRADLE_WORKDIR)
+	$(GRADLE_COMMAND) clean
+	rm -f $(abs_top_builddir)/modules/java-modules/*.log
+	[ "$(GRADLE_PROJECT_CACHE_DIR)" = "$(GRADLE_PROJECT_CACHE_DIR_DEFAULT)" ] && rm -rf "$(GRADLE_PROJECT_CACHE_DIR)" || true
 
 INSTALL_EXEC_HOOKS += java-modules-install-exec-hook
 UNINSTALL_HOOKS += java-modules-uninstall-exec-hook

--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -1,22 +1,29 @@
 if ENABLE_JAVA_MODULES
 
-export GRADLE_OPTS
 
 JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
 MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar' -not -path "$(abs_top_builddir)/modules/java-modules/.gradle/*")
 JAVA_MODULES_INSTALLED_JARS=$(shell find $(JAVA_MOD_DST_DIR) -name '*.jar')
-GRADLE_WORKDIR=$(abs_top_builddir)/modules/java-modules/.gradle
+GRADLE_PROJECT_DIR ?= $(abs_top_srcdir)/modules/java-modules
+GRADLE_PROJECT_CACHE_DIR ?= $(abs_top_builddir)/modules/java-modules/.gradle
+GRADLE_FLAGS ?=
+GRADLE_ARGS = $(GRADLE_FLAGS) \
+	--project-dir $(GRADLE_PROJECT_DIR) \
+	--project-cache-dir=$(GRADLE_PROJECT_CACHE_DIR) \
+	-PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules \
+	-PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs
+GRADLE_COMMAND = $(AM_V_GEN) $(GRADLE) $(GRADLE_ARGS)
 
 java-modules: $(SYSLOG_NG_CORE_JAR)
-	$(AM_V_GEN) $(GRADLE) --project-cache-dir $(GRADLE_WORKDIR) -g $(GRADLE_WORKDIR) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs build
+	$(GRADLE_COMMAND) build
 
 all-local: java-modules
 
 log4j-copy-jar:
-	$(AM_V_GEN) $(GRADLE) --project-cache-dir $(GRADLE_WORKDIR) -g $(GRADLE_WORKDIR) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs -PjarDestDir=$(JAVA_MOD_DST_DIR) copyLog4j
+	$(GRADLE_COMMAND) -PjarDestDir=$(JAVA_MOD_DST_DIR) copyLog4j
 
 jest-copy-jar:
-	$(AM_V_GEN) $(GRADLE) --project-cache-dir $(GRADLE_WORKDIR) -g $(GRADLE_WORKDIR) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs -PjarDestDir=$(JAVA_MOD_DST_DIR) copyJestRuntimeDeps
+	$(GRADLE_COMMAND) -PjarDestDir=$(JAVA_MOD_DST_DIR) copyJestRuntimeDeps
 
 java-modules-install-exec-hook: log4j-copy-jar jest-copy-jar
 	$(mkinstalldirs) $(JAVA_MOD_DST_DIR)
@@ -27,9 +34,8 @@ java-modules-uninstall-exec-hook:
 
 java-modules-clean-hook:
 	rm -rf $(abs_top_builddir)/modules/java-modules/*.log
-	$(GRADLE) --project-cache-dir $(GRADLE_WORKDIR) -q -g $(GRADLE_WORKDIR) -p $(abs_top_srcdir)/modules/java-modules -PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules -PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs clean
+	$(GRADLE_COMMAND) -q clean
 	rm -rf $(GRADLE_WORKDIR)
-
 
 INSTALL_EXEC_HOOKS += java-modules-install-exec-hook
 UNINSTALL_HOOKS += java-modules-uninstall-exec-hook

--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -1,9 +1,6 @@
 if ENABLE_JAVA_MODULES
 
 
-JAVA_MOD_DST_DIR=$(DESTDIR)/$(moduledir)/java-modules
-MOD_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar' -not -path "$(abs_top_builddir)/modules/java-modules/.gradle/*")
-JAVA_MODULES_INSTALLED_JARS=$(shell find $(JAVA_MOD_DST_DIR) -name '*.jar')
 GRADLE_PROJECT_DIR ?= $(abs_top_srcdir)/modules/java-modules
 GRADLE_PROJECT_CACHE_DIR ?= $(abs_top_builddir)/modules/java-modules/.gradle
 GRADLE_FLAGS ?=
@@ -14,23 +11,27 @@ GRADLE_ARGS = $(GRADLE_FLAGS) \
 	-PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs
 GRADLE_COMMAND = $(AM_V_GEN) $(GRADLE) $(GRADLE_ARGS)
 
+JAVA_MODULEDIR=$(DESTDIR)/$(moduledir)/java-modules
+JAVA_BUILT_JARS=$(shell find $(abs_top_builddir)/modules/java-modules -name '*.jar' -not -path "$(GRADLE_PROJECT_CACHE_DIR)/*")
+JAVA_INSTALLED_JARS=$(shell find $(JAVA_MODULEDIR) -name '*.jar')
+
 java-modules: $(SYSLOG_NG_CORE_JAR)
 	$(GRADLE_COMMAND) build
 
 all-local: java-modules
 
 log4j-copy-jar:
-	$(GRADLE_COMMAND) -PjarDestDir=$(JAVA_MOD_DST_DIR) copyLog4j
+	$(GRADLE_COMMAND) -PjarDestDir=$(JAVA_MODULEDIR) copyLog4j
 
 jest-copy-jar:
-	$(GRADLE_COMMAND) -PjarDestDir=$(JAVA_MOD_DST_DIR) copyJestRuntimeDeps
+	$(GRADLE_COMMAND) -PjarDestDir=$(JAVA_MODULEDIR) copyJestRuntimeDeps
 
 java-modules-install-exec-hook: log4j-copy-jar jest-copy-jar
-	$(mkinstalldirs) $(JAVA_MOD_DST_DIR)
-	cp $(MOD_JARS) $(JAVA_MOD_DST_DIR)
+	$(mkinstalldirs) $(JAVA_MODULEDIR)
+	cp $(JAVA_BUILT_JARS) $(JAVA_MODULEDIR)
 
 java-modules-uninstall-exec-hook:
-	rm -f $(JAVA_MODULES_INSTALLED_JARS)
+	rm -f $(JAVA_INSTALLED_JARS)
 
 java-modules-clean-hook:
 	rm -rf $(abs_top_builddir)/modules/java-modules/*.log


### PR DESCRIPTION
This branch has been split off from #2775 and does the following:

* cleans up gradle argument passing from Makefiles (but not in CMakeLists.txt, help appreciated there)
* enables build-caching (e.g. --build-cache option)
* enables gradle cache-reuse in dbld builds, e.g. the gradle cache dir is stored `/dbld/build/gradle-home`

This speeds up java builds to a point I found them bearable without `--disable-java`, also it speeds up CI builds if the dbld environment is still on the host (e.g. jenkins, but not travis where this is not persisted).
