### PR TITLE
Dbld image caching

### DIFF
--- a/dbld/images/centos-7.dockerfile
+++ b/dbld/images/centos-7.dockerfile
@@ -2,7 +2,9 @@ FROM centos:7
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/centos-7.dockerfile
+++ b/dbld/images/centos-7.dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
-ENV OS_PLATFORM centos-7
+
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/debian-buster.dockerfile
+++ b/dbld/images/debian-buster.dockerfile
@@ -1,10 +1,12 @@
 FROM debian:buster
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM debian-buster
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/debian-buster.dockerfile
+++ b/dbld/images/debian-buster.dockerfile
@@ -2,7 +2,9 @@ FROM debian:buster
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/debian-jessie.dockerfile
+++ b/dbld/images/debian-jessie.dockerfile
@@ -1,10 +1,12 @@
 FROM debian:8
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM debian-jessie
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/debian-jessie.dockerfile
+++ b/dbld/images/debian-jessie.dockerfile
@@ -2,7 +2,9 @@ FROM debian:8
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/debian-stretch.dockerfile
+++ b/dbld/images/debian-stretch.dockerfile
@@ -2,7 +2,9 @@ FROM debian:9
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/debian-stretch.dockerfile
+++ b/dbld/images/debian-stretch.dockerfile
@@ -1,10 +1,12 @@
 FROM debian:9
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM debian-stretch
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/devshell.dockerfile
+++ b/dbld/images/devshell.dockerfile
@@ -1,10 +1,12 @@
 FROM balabit/syslog-ng-ubuntu-bionic:latest
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM devshell
 
 RUN /helpers/dependencies.sh enable_dbgsyms
 RUN /helpers/dependencies.sh install_perf

--- a/dbld/images/devshell.dockerfile
+++ b/dbld/images/devshell.dockerfile
@@ -2,7 +2,9 @@ FROM balabit/syslog-ng-ubuntu-bionic:latest
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/fedora-30.dockerfile
+++ b/dbld/images/fedora-30.dockerfile
@@ -2,7 +2,9 @@ FROM fedora:30
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/fedora-30.dockerfile
+++ b/dbld/images/fedora-30.dockerfile
@@ -1,6 +1,8 @@
 FROM fedora:30
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
-ENV OS_PLATFORM fedora-30
+
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/hooks/build
+++ b/dbld/images/hooks/build
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set +x
+set +e
+
+OS_PLATFORM=$(basename $DOCKERFILE_PATH .dockerfile)
+
+docker build --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=OS_PLATFORM=${OS_PLATFORM} -t $IMAGE_NAME -f $DOCKERFILE_PATH .

--- a/dbld/images/ubuntu-bionic.dockerfile
+++ b/dbld/images/ubuntu-bionic.dockerfile
@@ -1,10 +1,13 @@
 FROM ubuntu:18.04
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM ubuntu-bionic
+
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/ubuntu-bionic.dockerfile
+++ b/dbld/images/ubuntu-bionic.dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:18.04
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/ubuntu-cosmic.dockerfile
+++ b/dbld/images/ubuntu-cosmic.dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:18.10
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM ubuntu-cosmic
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/ubuntu-cosmic.dockerfile
+++ b/dbld/images/ubuntu-cosmic.dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:18.10
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/ubuntu-trusty.dockerfile
+++ b/dbld/images/ubuntu-trusty.dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:14.04
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/images/ubuntu-trusty.dockerfile
+++ b/dbld/images/ubuntu-trusty.dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:14.04
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM ubuntu-trusty
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/ubuntu-xenial.dockerfile
+++ b/dbld/images/ubuntu-xenial.dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:16.04
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
+ARG OS_PLATFORM
+ENV OS_PLATFORM ${OS_PLATFORM}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
-ENV OS_PLATFORM ubuntu-xenial
 
 COPY helpers/* /helpers/
 

--- a/dbld/images/ubuntu-xenial.dockerfile
+++ b/dbld/images/ubuntu-xenial.dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:16.04
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 
 ARG OS_PLATFORM
+ARG COMMIT
 ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true

--- a/dbld/rules
+++ b/dbld/rules
@@ -141,6 +141,29 @@ pull-image: pull-image-$(DEFAULT_IMAGE)
 pull-image-%:
 	$(DOCKER) pull balabit/syslog-ng-$*
 
+cache-image-%:
+	IMAGE=$$(docker images -q balabit/syslog-ng-$*:latest | head -1);						\
+	if [ "$$IMAGE" = "" ]; then 											\
+		$(MAKE) -f $(DBLD_DIR)/rules pull-image-$*;								\
+	fi;														\
+	IMAGE=$$(docker images -q balabit/syslog-ng-$*:latest | head -1);						\
+	if [ "$$IMAGE" != "" ]; then 											\
+		image_commit=$$(docker inspect  --format '{{ index .Config.Labels "COMMIT"}}' $$IMAGE);			\
+		dbld_changes=$$( 											\
+			(git cat-file -e $${image_commit:-NO_COMMIT_LABEL_IN_DBLD_IMAGE}^{commit} 			\
+				&& git diff $${image_commit} -- dbld | wc -l						\
+				|| echo 1)										\
+		);													\
+	else														\
+		dbld_changes=1; 											\
+	fi;														\
+	if [ "$${dbld_changes}" -gt 0 ]; then									\
+		echo "$IMAGE: triggering rebuild, as dbld directory changed since the build of the image, or the cached image has no COMMIT label, or couldn't fetch from dockerhub" &&	\
+		$(MAKE) -f $(DBLD_DIR)/rules image-$*;									\
+	else 														\
+		echo "DBLD version in image matches, not initiating rebuild...";					\
+	fi
+
 exec: exec-$(DEFAULT_IMAGE)
 exec: EXEC_COMMAND=echo Specify EXEC_COMMAND to do something sensible here
 exec-%: setup

--- a/dbld/rules
+++ b/dbld/rules
@@ -134,7 +134,7 @@ shell-%: setup
 images: $(foreach image,$(IMAGES), image-$(image))
 image: image-$(DEFAULT_IMAGE)
 image-%:
-	cd $(DBLD_DIR)/images/ && $(DOCKER) build --network=host -t balabit/syslog-ng-$* -f $*.dockerfile .
+	cd $(DBLD_DIR)/images/ && $(DOCKER) build --build-arg=OS_PLATFORM=$* --build-arg=COMMIT=$$(git rev-parse --short HEAD) --network=host -t balabit/syslog-ng-$* -f $*.dockerfile .
 
 pull-images: $(foreach image,$(BUILDER_IMAGES), pull-image-$(image))
 pull-image: pull-image-$(DEFAULT_IMAGE)


### PR DESCRIPTION
This branch annotates dbld images with the commit ID they were built with and do this both
for locally generated images (e.g. ./dbld/rules image-<whatever>) and dockerhub generated ones.

It also adds a check-image-<whatever> target that rebuilds the image conditionally, e.g. in case the dbld subdirectory has changed since the local copy. This can be used to significantly improve
CI performance if the previous image is still locally available.