### PR TITLE
WIP: filter: combine multiple or filters via merging regex's

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -272,6 +272,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(transport_sources)		\
 	$(logproto_sources)		\
 	$(filter_sources)		\
+	$(optimizer_sources)		\
 	$(parser_sources)		\
 	$(rewrite_sources)		\
 	$(template_sources)		\

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -248,6 +248,8 @@ extern struct _StatsOptions *last_stats_options;
 
 %token KW_READ_OLD_RECORDS            10304
 
+%token KW_OPTIMIZE_FILTERS            10305
+
 /* log statement options */
 %token KW_FLAGS                       10190
 
@@ -998,6 +1000,7 @@ options_item
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
 	| KW_RECV_TIME_ZONE '(' string ')'	{ configuration->recv_time_zone = g_strdup($3); free($3); }
 	| KW_MIN_IW_SIZE_PER_READER '(' positive_integer ')' { configuration->min_iw_size_per_reader = $3; }
+	| KW_OPTIMIZE_FILTERS '(' yesno ')'	{ configuration->optimize_filters = $3; }
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -126,6 +126,7 @@ static CfgLexerKeyword main_keywords[] =
   { "threaded",           KW_THREADED },
   { "use_rcptid",         KW_USE_RCPTID, KWS_OBSOLETE, "This has been deprecated, try use_uniqid() instead" },
   { "use_uniqid",         KW_USE_UNIQID },
+  { "optimize_filters",   KW_OPTIMIZE_FILTERS },
 
   { "log_fifo_size",      KW_LOG_FIFO_SIZE },
   { "log_fetch_limit",    KW_LOG_FETCH_LIMIT },

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -90,6 +90,7 @@ struct _GlobalConfig
   gint time_reap;
   gint suppress;
   gint type_cast_strictness;
+  gboolean optimize_filters;
 
   gint log_fifo_size;
   gint log_msg_size;

--- a/lib/filter/CMakeLists.txt
+++ b/lib/filter/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(optimizer)
+
 set(FILTER_HEADERS
     filter/filter-expr.h
     filter/filter-op.h
@@ -11,6 +13,7 @@ set(FILTER_HEADERS
     filter/filter-pri.h
     filter/filter-pipe.h
     filter/filter-expr-parser.h
+    ${FILTER_OPTIMIZER_HEADERS}
     PARENT_SCOPE
     )
 
@@ -27,6 +30,7 @@ set(FILTER_SOURCES
     filter/filter-pri.c
     filter/filter-pipe.c
     filter/filter-expr-parser.c
+    ${FILTER_OPTIMIZER_SOURCES}
     PARENT_SCOPE
     )
 

--- a/lib/filter/Makefile.am
+++ b/lib/filter/Makefile.am
@@ -38,3 +38,4 @@ EXTRA_DIST += lib/filter/filter-expr-grammar.ym \
 	lib/filter/CMakeLists.txt
 
 include lib/filter/tests/Makefile.am
+include lib/filter/optimizer/Makefile.am

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -166,6 +166,16 @@ _traversal(FilterExprNode *s, FilterExprNode *parent, FilterExprNodeTraversalCal
   g_ptr_array_free(childs, TRUE);
 }
 
+static void
+_replace_child(FilterExprNode *s, FilterExprNode *old, FilterExprNode *new)
+{
+  FilterCall *self = (FilterCall *)s;
+
+  g_assert(old == self->filter_expr);
+  filter_expr_unref(self->filter_expr);
+  self->filter_expr = new;
+}
+
 FilterExprNode *
 filter_call_next(FilterExprNode *s)
 {
@@ -191,7 +201,7 @@ filter_call_new(gchar *rule, GlobalConfig *cfg)
   self->super.template = NULL;
   self->rule = g_strdup(rule);
   self->super.traversal = _traversal;
-
+  self->super.replace_child = _replace_child;
   return &self->super;
 }
 
@@ -210,6 +220,7 @@ filter_call_direct_new(FilterExprNode *callee)
   self->super.traversal = _traversal;
   self->filter_expr = callee;
   self->super.modify = callee->modify;
+  self->super.replace_child = _replace_child;
 
   return &self->super;
 }

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -130,10 +130,13 @@ static void
 _traversal(FilterExprNode *s, FilterExprNode *parent, FilterExprNodeTraversalCallbackFunction func, gpointer cookie)
 {
   FilterCall *self = (FilterCall *)s;
-  filter_expr_traversal(self->filter_expr, s, func, cookie);
+
+  if (self->filter_expr)
+    filter_expr_traversal(self->filter_expr, s, func, cookie);
 
   GPtrArray *childs = g_ptr_array_sized_new(1);
-  g_ptr_array_add(childs, self->filter_expr);
+  if (self->filter_expr)
+    g_ptr_array_add(childs, self->filter_expr);
   func(s, parent, childs, cookie);
   g_ptr_array_free(childs, TRUE);
 }

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -123,7 +123,6 @@ filter_call_free(FilterExprNode *s)
   stats_unregister_counter(&sc_key, SC_TYPE_NOT_MATCHED, &self->super.not_matched);
   stats_unlock();
 
-  g_free((gchar *) self->super.type);
   g_free(self->rule);
 }
 
@@ -137,6 +136,8 @@ filter_call_new(gchar *rule, GlobalConfig *cfg)
   self->super.eval = filter_call_eval;
   self->super.free_fn = filter_call_free;
   self->super.type = g_strdup_printf("filter(%s)", rule);
+  self->super.pattern = NULL;
+  self->super.template = NULL;
   self->rule = g_strdup(rule);
 
   return &self->super;

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -126,6 +126,18 @@ filter_call_free(FilterExprNode *s)
   g_free(self->rule);
 }
 
+static void
+_traversal(FilterExprNode *s, FilterExprNode *parent, FilterExprNodeTraversalCallbackFunction func, gpointer cookie)
+{
+  FilterCall *self = (FilterCall *)s;
+  filter_expr_traversal(self->filter_expr, s, func, cookie);
+
+  GPtrArray *childs = g_ptr_array_sized_new(1);
+  g_ptr_array_add(childs, self->filter_expr);
+  func(s, parent, childs, cookie);
+  g_ptr_array_free(childs, TRUE);
+}
+
 FilterExprNode *
 filter_call_new(gchar *rule, GlobalConfig *cfg)
 {
@@ -139,6 +151,7 @@ filter_call_new(gchar *rule, GlobalConfig *cfg)
   self->super.pattern = NULL;
   self->super.template = NULL;
   self->rule = g_strdup(rule);
+  self->super.traversal = _traversal;
 
   return &self->super;
 }

--- a/lib/filter/filter-call.h
+++ b/lib/filter/filter-call.h
@@ -29,4 +29,7 @@
 
 FilterExprNode *filter_call_new(gchar *rule, struct _GlobalConfig *cfg);
 
+FilterExprNode *filter_call_direct_new(FilterExprNode *s);
+FilterExprNode *filter_call_next(FilterExprNode *s);
+
 #endif

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -121,42 +121,42 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, gint op)
       self->cmp_op = FCMP_NUM;
     case KW_LT:
       self->cmp_op |= FCMP_LT;
-      self->super.type = "<";
+      self->super.type = g_strdup("<");
       break;
 
     case KW_NUM_LE:
       self->cmp_op = FCMP_NUM;
     case KW_LE:
       self->cmp_op |= FCMP_LT | FCMP_EQ;
-      self->super.type = "<=";
+      self->super.type = g_strdup("<=");
       break;
 
     case KW_NUM_EQ:
       self->cmp_op = FCMP_NUM;
     case KW_EQ:
       self->cmp_op |= FCMP_EQ;
-      self->super.type = "==";
+      self->super.type = g_strdup("==");
       break;
 
     case KW_NUM_NE:
       self->cmp_op = FCMP_NUM;
     case KW_NE:
       self->cmp_op |= FCMP_LT | FCMP_GT;
-      self->super.type = "!=";
+      self->super.type = g_strdup("!=");
       break;
 
     case KW_NUM_GE:
       self->cmp_op = FCMP_NUM;
     case KW_GE:
       self->cmp_op |= FCMP_GT | FCMP_EQ;
-      self->super.type = ">=";
+      self->super.type = g_strdup(">=");
       break;
 
     case KW_NUM_GT:
       self->cmp_op = FCMP_NUM;
     case KW_GT:
       self->cmp_op |= FCMP_GT;
-      self->super.type = ">";
+      self->super.type = g_strdup(">");
       break;
 
     default:

--- a/lib/filter/filter-expr-parser.c
+++ b/lib/filter/filter-expr-parser.c
@@ -63,6 +63,8 @@ static CfgLexerKeyword filter_expr_keywords[] =
 
   { "value",              KW_VALUE },
   { "flags",              KW_FLAGS },
+  { "type",               KW_TYPE },
+  { "template",           KW_TEMPLATE },
 
   { NULL }
 };

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -90,6 +90,11 @@ filter_expr_unref(FilterExprNode *self)
     {
       if (self->free_fn)
         self->free_fn(self);
+
+      g_free(self->type);
+      g_free(self->pattern);
+      g_free(self->template);
+
       g_free(self);
     }
 }

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -57,13 +57,9 @@ filter_expr_traversal(FilterExprNode *self, FilterExprNode *parent, FilterExprNo
                       gpointer cookie)
 {
   if (self->traversal)
-    {
-      self->traversal(self, parent, func, cookie);
-    }
+    self->traversal(self, parent, func, cookie);
   else
-    {
-      func(self, parent, NULL, cookie);
-    }
+    func(self, parent, NULL, cookie);
 }
 
 static inline gboolean

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -38,7 +38,9 @@ struct _FilterExprNode
   guint32 ref_cnt;
   guint32 comp:1,   /* this not is negated */
           modify:1; /* this filter changes the log message */
-  const gchar *type;
+  gchar *type;
+  gchar *pattern;
+  gchar *template;
   gboolean (*init)(FilterExprNode *self, GlobalConfig *cfg);
   gboolean (*eval)(FilterExprNode *self, LogMessage **msg, gint num_msg);
   void (*free_fn)(FilterExprNode *self);

--- a/lib/filter/filter-expr.h
+++ b/lib/filter/filter-expr.h
@@ -47,10 +47,19 @@ struct _FilterExprNode
   gboolean (*eval)(FilterExprNode *self, LogMessage **msg, gint num_msg);
   void (*traversal)(FilterExprNode *self, FilterExprNode *parent, FilterExprNodeTraversalCallbackFunction func,
                     gpointer cookie);
+  void (*replace_child)(FilterExprNode *self, FilterExprNode *old, FilterExprNode *new);
   void (*free_fn)(FilterExprNode *self);
   StatsCounterItem *matched;
   StatsCounterItem *not_matched;
 };
+
+static inline void
+filter_expr_replace_child(FilterExprNode *self, FilterExprNode *old, FilterExprNode *new)
+{
+  g_assert(self->replace_child);
+  if (self->replace_child)
+    self->replace_child(self, old, new);
+}
 
 static inline void
 filter_expr_traversal(FilterExprNode *self, FilterExprNode *parent, FilterExprNodeTraversalCallbackFunction func,

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -94,6 +94,10 @@ filter_in_list_new(const gchar *list_file, const gchar *property)
     }
   fclose(stream);
 
+  self->super.pattern = g_strdup(list_file);
+  self->super.template = g_strdup(property);
+  self->super.type = g_strdup("in-list");
+
   self->super.eval = filter_in_list_eval;
   self->super.free_fn = filter_in_list_free;
   return &self->super;

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -105,6 +105,8 @@ filter_netmask_new(const gchar *cidr)
     }
   self->address.s_addr &= self->netmask.s_addr;
   self->super.eval = filter_netmask_eval;
-  self->super.type = "netmask";
+  self->super.type = g_strdup("netmask");
+  self->super.pattern = g_strdup(cidr);
+  self->super.template = g_strdup("$SOURCEIP");
   return &self->super;
 }

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -105,5 +105,6 @@ filter_netmask_new(const gchar *cidr)
     }
   self->address.s_addr &= self->netmask.s_addr;
   self->super.eval = filter_netmask_eval;
+  self->super.type = "netmask";
   return &self->super;
 }

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -167,7 +167,9 @@ filter_netmask6_new(const gchar *cidr)
     self->address = in6addr_loopback;
 
   self->super.eval = _eval;
-  self->super.type = "netmask6";
+  self->super.type = g_strdup("netmask6");
+  self->super.pattern = g_strdup(cidr);
+  self->super.template = g_strdup("$SOURCEIP");
   return &self->super;
 }
 #endif

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -167,6 +167,7 @@ filter_netmask6_new(const gchar *cidr)
     self->address = in6addr_loopback;
 
   self->super.eval = _eval;
+  self->super.type = "netmask6";
   return &self->super;
 }
 #endif

--- a/lib/filter/filter-op.c
+++ b/lib/filter/filter-op.c
@@ -58,11 +58,26 @@ fop_free(FilterExprNode *s)
 }
 
 static void
+_traversal(FilterExprNode *s, FilterExprNode *parent, FilterExprNodeTraversalCallbackFunction func, gpointer cookie)
+{
+  FilterOp *self = (FilterOp *) s;
+  filter_expr_traversal(self->left, s, func, cookie);
+  filter_expr_traversal(self->right, s, func, cookie);
+
+  GPtrArray *childs = g_ptr_array_sized_new(2);
+  g_ptr_array_add(childs, self->left);
+  g_ptr_array_add(childs, self->right);
+  func(s, parent, childs, cookie);
+  g_ptr_array_free(childs, TRUE);
+}
+
+static void
 fop_init_instance(FilterOp *self)
 {
   filter_expr_node_init_instance(&self->super);
   self->super.init = fop_init;
   self->super.free_fn = fop_free;
+  self->super.traversal = _traversal;
 }
 
 static gboolean

--- a/lib/filter/filter-op.c
+++ b/lib/filter/filter-op.c
@@ -83,7 +83,9 @@ fop_or_new(FilterExprNode *e1, FilterExprNode *e2)
   self->super.eval = fop_or_eval;
   self->left = e1;
   self->right = e2;
-  self->super.type = "OR";
+  self->super.type = g_strdup("OR");
+  self->super.pattern = NULL;
+  self->super.template = NULL;
   return &self->super;
 }
 
@@ -105,6 +107,8 @@ fop_and_new(FilterExprNode *e1, FilterExprNode *e2)
   self->super.eval = fop_and_eval;
   self->left = e1;
   self->right = e2;
-  self->super.type = "AND";
+  self->super.type = g_strdup("AND");
+  self->super.pattern = NULL;
+  self->super.template = NULL;
   return &self->super;
 }

--- a/lib/filter/filter-op.c
+++ b/lib/filter/filter-op.c
@@ -100,6 +100,7 @@ fop_init_instance(FilterOp *self)
   self->super.init = fop_init;
   self->super.free_fn = fop_free;
   self->super.traversal = _traversal;
+  self->super.replace_child = _replace_child;
 }
 
 static gboolean

--- a/lib/filter/filter-op.c
+++ b/lib/filter/filter-op.c
@@ -72,6 +72,28 @@ _traversal(FilterExprNode *s, FilterExprNode *parent, FilterExprNodeTraversalCal
 }
 
 static void
+_replace_child(FilterExprNode *s, FilterExprNode *old, FilterExprNode *new)
+{
+  FilterOp *self = (FilterOp *) s;
+
+  if (self->left == old)
+    {
+      filter_expr_unref(self->left);
+      self->left = new;
+    }
+  else if (self->right == old)
+    {
+      filter_expr_unref(self->right);
+      self->right = new;
+    }
+  else
+    {
+      msg_error("We tried to replace a not existing child of a logical operation filter.");
+      g_assert_not_reached();
+    }
+}
+
+static void
 fop_init_instance(FilterOp *self)
 {
   filter_expr_node_init_instance(&self->super);

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -25,7 +25,7 @@
 #include "filter/filter-pipe.h"
 #include "stats/stats-registry.h"
 #include "filter/optimizer/filter-expr-optimizer.h"
-#include "filter/optimizer/filter-tree-printer.h"
+#include "filter/optimizer/filter-expr-optimizer-registry.h"
 
 /*******************************************************************
  * LogFilterPipe
@@ -129,16 +129,10 @@ log_filter_pipe_free(LogPipe *s)
   log_pipe_free_method(s);
 }
 
-void
-log_filter_pipe_register_optimizer(LogFilterPipe *self, FilterExprOptimizer *optimizer)
-{
-  self->optimizers = g_list_append(self->optimizers, optimizer);
-}
-
 static inline void
 _register_optimizers(LogFilterPipe *self)
 {
-  log_filter_pipe_register_optimizer(self, filter_tree_printer_get_instance());
+  self->optimizers = filter_optimizer_get_optimizers();
 }
 
 LogPipe *

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -129,11 +129,16 @@ log_filter_pipe_free(LogPipe *s)
   log_pipe_free_method(s);
 }
 
+void
+log_filter_pipe_register_optimizer(LogFilterPipe *self, FilterExprOptimizer *optimizer)
+{
+  self->optimizers = g_list_append(self->optimizers, optimizer);
+}
+
 static inline void
 _register_optimizers(LogFilterPipe *self)
 {
-  self->optimizers = g_list_append(self->optimizers, &filter_tree_printer);
-  return;
+  log_filter_pipe_register_optimizer(self, &filter_tree_printer);
 }
 
 LogPipe *

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -138,7 +138,7 @@ log_filter_pipe_register_optimizer(LogFilterPipe *self, FilterExprOptimizer *opt
 static inline void
 _register_optimizers(LogFilterPipe *self)
 {
-  log_filter_pipe_register_optimizer(self, &filter_tree_printer);
+  log_filter_pipe_register_optimizer(self, filter_tree_printer_get_instance());
 }
 
 LogPipe *

--- a/lib/filter/filter-pipe.h
+++ b/lib/filter/filter-pipe.h
@@ -26,6 +26,7 @@
 #define FILTER_PIPE_H_INCLUDED
 
 #include "filter/filter-expr.h"
+#include "filter/optimizer/filter-expr-optimizer.h"
 #include "logpipe.h"
 
 /* convert a filter expression into a drop/accept LogPipe */
@@ -45,5 +46,7 @@ typedef struct _LogFilterPipe
 } LogFilterPipe;
 
 LogPipe *log_filter_pipe_new(FilterExprNode *expr, GlobalConfig *cfg);
+
+void log_filter_pipe_register_optimizer(LogFilterPipe *self, FilterExprOptimizer *optimizer);
 
 #endif

--- a/lib/filter/filter-pri.c
+++ b/lib/filter/filter-pri.c
@@ -65,7 +65,9 @@ filter_facility_new(guint32 facilities)
   filter_expr_node_init_instance(&self->super);
   self->super.eval = filter_facility_eval;
   self->valid = facilities;
-  self->super.type = "facility";
+  self->super.type = g_strdup("facility");
+  self->super.pattern = g_strdup_printf("%d", facilities);
+  self->super.template = g_strdup("FACILITY");
   return &self->super;
 }
 
@@ -95,6 +97,8 @@ filter_level_new(guint32 levels)
   filter_expr_node_init_instance(&self->super);
   self->super.eval = filter_level_eval;
   self->valid = levels;
-  self->super.type = "level";
+  self->super.type = g_strdup("level");
+  self->super.pattern = g_strdup_printf("%d", levels);
+  self->super.template = g_strdup("LEVEL");
   return &self->super;
 }

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -26,6 +26,7 @@
 #include "str-utils.h"
 #include "messages.h"
 #include "scratch-buffers.h"
+#include "logmsg/logmsg.h"
 #include <string.h>
 
 typedef struct _FilterRE
@@ -109,6 +110,10 @@ filter_re_compile_pattern(FilterExprNode *s, const gchar *re, GError **error)
 
   log_matcher_options_init(&self->matcher_options);
   self->matcher = log_matcher_new(&self->matcher_options);
+  g_free(self->super.type);
+  self->super.type = g_strdup(self->matcher_options.type);
+  g_free(self->super.pattern);
+  self->super.pattern = g_strdup(re);
   return log_matcher_compile(self->matcher, re, error);
 }
 
@@ -120,7 +125,14 @@ filter_re_init_instance(FilterRE *self, NVHandle value_handle)
   self->super.init = filter_re_init;
   self->super.eval = filter_re_eval;
   self->super.free_fn = filter_re_free;
-  self->super.type = "regexp";
+  g_free(self->super.type);
+  self->super.type = g_strdup("pcre");
+
+  gssize length;
+  const gchar *temp = log_msg_get_handle_name(value_handle, &length);
+  g_free(self->super.template);
+  self->super.template = g_strdup_printf("%.*s", (gint)length, temp);
+
   log_matcher_options_defaults(&self->matcher_options);
   self->matcher_options.flags |= LMF_MATCH_ONLY;
 }
@@ -144,6 +156,9 @@ filter_source_new(void)
       /* this can only happen if the plain text string matcher will cease to exist */
       g_assert_not_reached();
     }
+
+  self->super.type = g_strdup("string");
+
   return &self->super;
 }
 
@@ -166,6 +181,11 @@ filter_match_set_value_handle(FilterExprNode *s, NVHandle value_handle)
 {
   FilterMatch *self = (FilterMatch *) s;
 
+  gssize length;
+  const gchar *temp = log_msg_get_handle_name(value_handle, &length);
+  g_free(s->template);
+  s->template = g_strdup_printf("%.*s", (gint)length, temp);
+
   self->super.value_handle = value_handle;
 }
 
@@ -176,6 +196,8 @@ filter_match_set_template_ref(FilterExprNode *s, LogTemplate *template)
 
   log_template_unref(self->template);
   self->template = template;
+  g_free(s->template);
+  s->template = g_strdup(template->template);
 }
 
 static gboolean

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -94,6 +94,6 @@ filter_tags_new(GList *tags)
 
   self->super.eval = filter_tags_eval;
   self->super.free_fn = filter_tags_free;
-  self->super.type = "tags";
+  self->super.type = g_strdup("tags");
   return &self->super;
 }

--- a/lib/filter/optimizer/CMakeLists.txt
+++ b/lib/filter/optimizer/CMakeLists.txt
@@ -6,6 +6,7 @@ set(FILTER_OPTIMIZER_HEADERS
 
 set(FILTER_OPTIMIZER_SOURCES
     filter/optimizer/filter-tree-printer.c
+    filter/optimizer/filter-expr-optimizer-registry.c
     PARENT_SCOPE
 )
 

--- a/lib/filter/optimizer/CMakeLists.txt
+++ b/lib/filter/optimizer/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(FILTER_OPTIMIZER_HEADERS
+    filter/optimizer/filter-expr-optimizer.h
+    filter/optimizer/filter-tree-printer.h
+    PARENT_SCOPE
+)
+
+set(FILTER_OPTIMIZER_SOURCES
+    filter/optimizer/filter-tree-printer.c
+    PARENT_SCOPE
+)

--- a/lib/filter/optimizer/CMakeLists.txt
+++ b/lib/filter/optimizer/CMakeLists.txt
@@ -8,3 +8,5 @@ set(FILTER_OPTIMIZER_SOURCES
     filter/optimizer/filter-tree-printer.c
     PARENT_SCOPE
 )
+
+add_test_subdirectory(tests)

--- a/lib/filter/optimizer/CMakeLists.txt
+++ b/lib/filter/optimizer/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(FILTER_OPTIMIZER_HEADERS
     filter/optimizer/filter-expr-optimizer.h
     filter/optimizer/filter-tree-printer.h
+    filter/optimizer/concatenate-or-filters.h
     PARENT_SCOPE
 )
 
 set(FILTER_OPTIMIZER_SOURCES
     filter/optimizer/filter-tree-printer.c
     filter/optimizer/filter-expr-optimizer-registry.c
+    filter/optimizer/concatenate-or-filters.c
     PARENT_SCOPE
 )
 

--- a/lib/filter/optimizer/Makefile.am
+++ b/lib/filter/optimizer/Makefile.am
@@ -1,0 +1,11 @@
+optimizerincludedir = ${pkgincludedir}/filter/optimizer
+
+optimizerinclude_HEADERS = \
+	lib/filter/optimizer/filter-expr-optimizer.h	\
+	lib/filter/optimizer/filter-tree-printer.h
+
+optimizer_sources = \
+	lib/filter/optimizer/filter-tree-printer.c
+
+EXTRA_DIST += \
+	lib/filter/optimizer/CMakeLists.txt

--- a/lib/filter/optimizer/Makefile.am
+++ b/lib/filter/optimizer/Makefile.am
@@ -9,3 +9,5 @@ optimizer_sources = \
 
 EXTRA_DIST += \
 	lib/filter/optimizer/CMakeLists.txt
+
+include lib/filter/optimizer/tests/Makefile.am

--- a/lib/filter/optimizer/Makefile.am
+++ b/lib/filter/optimizer/Makefile.am
@@ -3,10 +3,12 @@ optimizerincludedir = ${pkgincludedir}/filter/optimizer
 optimizerinclude_HEADERS = \
 	lib/filter/optimizer/filter-expr-optimizer-registry.h	\
 	lib/filter/optimizer/filter-expr-optimizer.h	\
+	lib/filter/optimizer/concatenate-or-filters.h	\
 	lib/filter/optimizer/filter-tree-printer.h
 
 optimizer_sources = \
 	lib/filter/optimizer/filter-expr-optimizer-registry.c	\
+	lib/filter/optimizer/concatenate-or-filters.c	\
 	lib/filter/optimizer/filter-tree-printer.c
 
 EXTRA_DIST += \

--- a/lib/filter/optimizer/Makefile.am
+++ b/lib/filter/optimizer/Makefile.am
@@ -1,10 +1,12 @@
 optimizerincludedir = ${pkgincludedir}/filter/optimizer
 
 optimizerinclude_HEADERS = \
+	lib/filter/optimizer/filter-expr-optimizer-registry.h	\
 	lib/filter/optimizer/filter-expr-optimizer.h	\
 	lib/filter/optimizer/filter-tree-printer.h
 
 optimizer_sources = \
+	lib/filter/optimizer/filter-expr-optimizer-registry.c	\
 	lib/filter/optimizer/filter-tree-printer.c
 
 EXTRA_DIST += \

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -40,8 +40,8 @@ _concatenate(FilterExprNode *current, FilterExprNode *parent, FilterExprNode *le
 {
   GString *new_filter = g_string_new("");
 
-  g_string_printf(new_filter, "%smatch(\"%s|%s\" value('PROGRAM'));", (left->comp ? "not " : ""), left->pattern,
-                  right->pattern);
+  g_string_printf(new_filter, "%smatch(\"%s|%s\" value('%s'));", (left->comp ? "not " : ""), left->pattern,
+                  right->pattern, left->template);
 
   FilterExprNode *new_opt = _compile_standalone_filter(new_filter->str);
   filter_expr_replace_child(parent, current, new_opt);

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -118,7 +118,13 @@ _concatenate_or_filters_cb(FilterExprNode *current, FilterExprNode *parent, GPtr
 
   if (_can_we_concatenate(current, left, right))
     {
+      *stack = g_list_remove_link(*stack, left_link);
+      *stack = g_list_remove_link(*stack, right_link);
+
       *stack = g_list_append(*stack, _concatenate(current, parent, left, right));
+
+      g_list_free_1(left_link);
+      g_list_free_1(right_link);
     }
   else
     {

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -35,13 +35,21 @@ static FilterExprNode *_compile_standalone_filter(gchar *config_snippet)
   return tmp;
 }
 
+static gboolean
+_is_it_template(gchar *candidate)
+{
+  return (strchr(candidate, '$') != NULL);
+}
+
 static FilterExprNode *
 _concatenate(FilterExprNode *current, FilterExprNode *parent, FilterExprNode *left, FilterExprNode *right)
 {
   GString *new_filter = g_string_new("");
 
-  g_string_printf(new_filter, "%smatch(\"%s|%s\" value('%s'));", (left->comp ? "not " : ""), left->pattern,
-                  right->pattern, left->template);
+  const gboolean is_it_template = _is_it_template(left->template);
+
+  g_string_printf(new_filter, "%smatch(\"%s|%s\" %s('%s'));", (left->comp ? "not " : ""), left->pattern, right->pattern,
+                  (is_it_template ? "template" : "value"), left->template);
 
   FilterExprNode *new_opt = _compile_standalone_filter(new_filter->str);
   filter_expr_replace_child(parent, current, new_opt);

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filter/optimizer/concatenate-or-filters.h"
+
+static void
+_concatenate(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs)
+{
+  // TODO
+  return;
+}
+
+
+
+
+static gboolean
+_can_we_concatenate(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs)
+{
+  // Is it an OR filter
+  if (strcmp(current->type, "OR") != 0)
+    return FALSE;
+
+  // OR filters always have two child element, left and right
+  g_assert(childs->len == 2);
+  FilterExprNode *left = (FilterExprNode *)g_ptr_array_index(childs, 0);
+  FilterExprNode *right = (FilterExprNode *)g_ptr_array_index(childs, 1);
+
+  // Currently we only concatenate if childs are not negated.
+  if (!left->comp && !right->comp)
+    return FALSE;
+
+  // Different filters are concatenated differently, but they always have to have the same type.
+  if (strcmp(left->type, right->type) !=0 )
+    return FALSE;
+
+  //.. TODO
+  return TRUE;
+}
+
+
+
+
+static gpointer
+_concatenate_or_filters_init(FilterExprNode *root)
+{
+  // I don't need a cookie for this job. So just return the root element,
+  // as a valid not NULL pointer, and DO NOT free it up later :)
+  return root;
+}
+
+static void
+_concatenate_or_filters_deinit(gpointer cookie)
+{
+  return;
+}
+
+static void
+_concatenate_or_filters_cb(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs, gpointer cookie)
+{
+  if (_can_we_concatenate(current, parent, childs))
+    {
+      _concatenate(current, parent, childs);
+    }
+}
+
+FilterExprOptimizer concatenate_or_filters =
+{
+  .name = "concatenate-or-filters",
+  .init = _concatenate_or_filters_init,
+  .deinit = _concatenate_or_filters_deinit,
+  .cb = _concatenate_or_filters_cb
+};
+
+FilterExprOptimizer *concatenate_or_filters_get_instance(void)
+{
+  return &concatenate_or_filters;
+}

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -40,7 +40,7 @@ _concatenate(FilterExprNode *current, FilterExprNode *parent, FilterExprNode *le
 {
   GString *new_filter = g_string_new("");
 
-  g_string_printf(new_filter, "program(\"%s|%s\");", left->pattern, right->pattern);
+  g_string_printf(new_filter, "%sprogram(\"%s|%s\");", (left->comp ? "not " : ""), left->pattern, right->pattern);
 
   FilterExprNode *new_opt = _compile_standalone_filter(new_filter->str);
   filter_expr_replace_child(parent, current, new_opt);

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -21,64 +21,95 @@
  *
  */
 #include "filter/optimizer/concatenate-or-filters.h"
+#include "filter/filter-expr-parser.h"
 
-static void
-_concatenate(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs)
+
+static FilterExprNode *_compile_standalone_filter(gchar *config_snippet)
 {
-  // TODO
-  return;
+  GlobalConfig *cfg = cfg_new_snippet();
+  CfgLexer *lexer = cfg_lexer_new_buffer(cfg, config_snippet, strlen(config_snippet));
+  FilterExprNode *tmp;
+  g_assert(cfg_run_parser(cfg, lexer, &filter_expr_parser, (gpointer *) &tmp, NULL));
+
+  cfg_free(cfg);
+  return tmp;
+}
+
+static FilterExprNode *
+_concatenate(FilterExprNode *current, FilterExprNode *parent, FilterExprNode *left, FilterExprNode *right)
+{
+  GString *new_filter = g_string_new("");
+
+  g_string_printf(new_filter, "program(\"%s|%s\");", left->pattern, right->pattern);
+
+  FilterExprNode *new_opt = _compile_standalone_filter(new_filter->str);
+  filter_expr_replace_child(parent, current, new_opt);
+  return new_opt;
 }
 
 
 
 
 static gboolean
-_can_we_concatenate(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs)
+_can_we_concatenate(FilterExprNode *current, FilterExprNode *left, FilterExprNode *right)
 {
   // Is it an OR filter
   if (strcmp(current->type, "OR") != 0)
     return FALSE;
 
-  // OR filters always have two child element, left and right
-  g_assert(childs->len == 2);
-  FilterExprNode *left = (FilterExprNode *)g_ptr_array_index(childs, 0);
-  FilterExprNode *right = (FilterExprNode *)g_ptr_array_index(childs, 1);
-
-  // Currently we only concatenate if childs are not negated.
-  if (!left->comp && !right->comp)
+  if (left->comp != right->comp)
     return FALSE;
 
-  // Different filters are concatenated differently, but they always have to have the same type.
   if (strcmp(left->type, right->type) !=0 )
     return FALSE;
 
-  //.. TODO
+  if (strcmp(left->template, right->template) !=0 )
+    return FALSE;
+
   return TRUE;
 }
-
 
 
 
 static gpointer
 _concatenate_or_filters_init(FilterExprNode *root)
 {
-  // I don't need a cookie for this job. So just return the root element,
-  // as a valid not NULL pointer, and DO NOT free it up later :)
-  return root;
+  GList **stack = g_new0(GList *, 1);
+
+  return stack;
 }
 
 static void
 _concatenate_or_filters_deinit(gpointer cookie)
 {
-  return;
+  GList **stack = (GList **)cookie;
+  g_free(stack);
 }
 
 static void
 _concatenate_or_filters_cb(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs, gpointer cookie)
 {
-  if (_can_we_concatenate(current, parent, childs))
+  GList **stack = (GList **)cookie;
+
+  GList *left_link = NULL;
+  FilterExprNode *left = NULL;
+  GList *right_link = NULL;
+  FilterExprNode *right = NULL;
+  if (strcmp(current->type, "OR") == 0)
     {
-      _concatenate(current, parent, childs);
+      left_link = g_list_last(*stack);
+      right_link = g_list_last(*stack)->prev;
+      left = (FilterExprNode *)left_link->data;
+      right = (FilterExprNode *)right_link->data;
+    }
+
+  if (_can_we_concatenate(current, left, right))
+    {
+      *stack = g_list_append(*stack, _concatenate(current, parent, left, right));
+    }
+  else
+    {
+      *stack = g_list_append(*stack, current);
     }
 }
 

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -63,6 +63,10 @@ _can_we_concatenate(FilterExprNode *current, FilterExprNode *left, FilterExprNod
   if (strcmp(left->type, right->type) !=0 )
     return FALSE;
 
+  //Glob is not trivial to convert to regex, nor scope
+  if (strcmp(left->type, "glob") == 0)
+    return FALSE;
+
   if (strcmp(left->template, right->template) !=0 )
     return FALSE;
 

--- a/lib/filter/optimizer/concatenate-or-filters.c
+++ b/lib/filter/optimizer/concatenate-or-filters.c
@@ -40,7 +40,8 @@ _concatenate(FilterExprNode *current, FilterExprNode *parent, FilterExprNode *le
 {
   GString *new_filter = g_string_new("");
 
-  g_string_printf(new_filter, "%sprogram(\"%s|%s\");", (left->comp ? "not " : ""), left->pattern, right->pattern);
+  g_string_printf(new_filter, "%smatch(\"%s|%s\" value('PROGRAM'));", (left->comp ? "not " : ""), left->pattern,
+                  right->pattern);
 
   FilterExprNode *new_opt = _compile_standalone_filter(new_filter->str);
   filter_expr_replace_child(parent, current, new_opt);

--- a/lib/filter/optimizer/concatenate-or-filters.h
+++ b/lib/filter/optimizer/concatenate-or-filters.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2019 Balabit
- * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,18 +21,12 @@
  *
  */
 
-#include "filter/optimizer/filter-expr-optimizer-registry.h"
+#ifndef CONCATENATE_OR_FILTERS_H_INCLUDED
+#define CONCATENATE_OR_FILTERS_H_INCLUDED
 
-#include "filter/optimizer/filter-tree-printer.h"
-#include "filter/optimizer/concatenate-or-filters.h"
+#include "filter/filter-expr.h"
+#include "filter/optimizer/filter-expr-optimizer.h"
 
-GList *filter_optimizer_get_optimizers(void)
-{
-  GList *optimizers = NULL;
+FilterExprOptimizer *concatenate_or_filters_get_instance(void);
 
-  optimizers = g_list_append(optimizers, filter_tree_printer_get_instance());
-  optimizers = g_list_append(optimizers, concatenate_or_filters_get_instance());
-
-  return optimizers;
-}
-
+#endif

--- a/lib/filter/optimizer/filter-expr-optimizer-registry.c
+++ b/lib/filter/optimizer/filter-expr-optimizer-registry.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filter/optimizer/filter-expr-optimizer-registry.h"
+
+#include "filter/optimizer/filter-tree-printer.h"
+
+GList *filter_optimizer_get_optimizers(void)
+{
+  GList *optimizers = NULL;
+
+  optimizers = g_list_append(optimizers, filter_tree_printer_get_instance());
+
+  return optimizers;
+}
+

--- a/lib/filter/optimizer/filter-expr-optimizer-registry.h
+++ b/lib/filter/optimizer/filter-expr-optimizer-registry.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTER_EXPR_OPTIMIZER_REGISTRY_H_INCLUDED
+#define FILTER_EXPR_OPTIMIZER_REGISTRY_H_INCLUDED
+
+#include "filter/optimizer/filter-expr-optimizer.h"
+
+GList *filter_optimizer_get_optimizers(void);
+
+#endif
+
+

--- a/lib/filter/optimizer/filter-expr-optimizer.h
+++ b/lib/filter/optimizer/filter-expr-optimizer.h
@@ -52,7 +52,7 @@ filter_expr_optimizer_run(FilterExprNode *self, FilterExprOptimizer *optimizer)
     }
 
   msg_debug("Running filter-optimizer", evt_tag_str("name", optimizer->name));
-  filter_expr_traversal(dummy_root, NULL, optimizer->cb, cookie);
+  filter_expr_traversal(self, dummy_root, optimizer->cb, cookie);
   optimizer->deinit(cookie);
   FilterExprNode *result = filter_call_next(dummy_root);
   filter_expr_unref(dummy_root);

--- a/lib/filter/optimizer/filter-tree-printer.c
+++ b/lib/filter/optimizer/filter-tree-printer.c
@@ -27,7 +27,7 @@ _filter_tree_printer_init(FilterExprNode *root)
 {
   gint *cookie = g_malloc0(sizeof(gint)); // indentation
   *cookie = 20;
-  printf("%-*s%s\n", *cookie, "parent", "child(s)");
+  msg_trace("filter-optimizer: ", evt_tag_printf("tree", "%-*s%s\n", *cookie, "parent", "child(s)"));
   return cookie;
 }
 
@@ -40,10 +40,11 @@ _filter_tree_printer_deinit(gpointer cookie)
 static void
 _filter_tree_printer_cb(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs, gpointer cookie)
 {
+  GString *line = g_string_new("");
   if (parent == NULL)
-    printf("%-*s", *(gint *)cookie, "root");
+    g_string_append_printf(line, "%-*s", *(gint *)cookie, "root");
   else
-    printf("%-*s", *(gint *)cookie, parent->type);
+    g_string_append_printf(line, "%-*s", *(gint *)cookie, parent->type);
 
   if (childs)
     {
@@ -51,15 +52,16 @@ _filter_tree_printer_cb(FilterExprNode *current, FilterExprNode *parent, GPtrArr
       for (i = 0; i < childs->len; i++)
         {
           FilterExprNode *child = (FilterExprNode *)g_ptr_array_index(childs, i);
-          printf("%s ", child->type);
+          g_string_append_printf(line, "%s ", child->type);
         }
     }
   else
     {
-      printf("leaf");
+      g_string_append(line, "leaf");
     }
 
-  printf("\n");
+  msg_trace("filter-optimizer: ", evt_tag_printf("tree", "%s", line->str));
+  g_string_free(line, TRUE);
 }
 
 FilterExprOptimizer filter_tree_printer =

--- a/lib/filter/optimizer/filter-tree-printer.c
+++ b/lib/filter/optimizer/filter-tree-printer.c
@@ -69,3 +69,9 @@ FilterExprOptimizer filter_tree_printer =
   .deinit = _filter_tree_printer_deinit,
   .cb = _filter_tree_printer_cb
 };
+
+FilterExprOptimizer *
+filter_tree_printer_get_instance(void)
+{
+  return &filter_tree_printer;
+}

--- a/lib/filter/optimizer/filter-tree-printer.c
+++ b/lib/filter/optimizer/filter-tree-printer.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filter/optimizer/filter-tree-printer.h"
+
+static gpointer
+_filter_tree_printer_init(FilterExprNode *root)
+{
+  gint *cookie = g_malloc0(sizeof(gint)); // indentation
+  *cookie = 20;
+  printf("%-*s%s\n", *cookie, "parent", "child(s)");
+  return cookie;
+}
+
+static void
+_filter_tree_printer_deinit(gpointer cookie)
+{
+  g_free(cookie);
+}
+
+static void
+_filter_tree_printer_cb(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs, gpointer cookie)
+{
+  if (parent == NULL)
+    printf("%-*s", *(gint *)cookie, "root");
+  else
+    printf("%-*s", *(gint *)cookie, parent->type);
+
+  if (childs)
+    {
+      gint i;
+      for (i = 0; i < childs->len; i++)
+        {
+          FilterExprNode *child = (FilterExprNode *)g_ptr_array_index(childs, i);
+          printf("%s ", child->type);
+        }
+    }
+  else
+    {
+      printf("leaf");
+    }
+
+  printf("\n");
+}
+
+FilterExprOptimizer filter_tree_printer =
+{
+  .name = "filter-tree-printer",
+  .init = _filter_tree_printer_init,
+  .deinit = _filter_tree_printer_deinit,
+  .cb = _filter_tree_printer_cb
+};

--- a/lib/filter/optimizer/filter-tree-printer.h
+++ b/lib/filter/optimizer/filter-tree-printer.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
- * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2019 Balabit
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,28 +21,12 @@
  *
  */
 
-#ifndef FILTER_PIPE_H_INCLUDED
-#define FILTER_PIPE_H_INCLUDED
+#ifndef FILTER_TREE_PRINTER_H_INCLUDED
+#define FILTER_TREE_PRINTER_H_INCLUDED
 
 #include "filter/filter-expr.h"
-#include "logpipe.h"
+#include "filter/optimizer/filter-expr-optimizer.h"
 
-/* convert a filter expression into a drop/accept LogPipe */
-
-/*
- * This class encapsulates a LogPipe that either drops/allows a LogMessage
- * to go through.
- */
-typedef struct _LogFilterPipe
-{
-  LogPipe super;
-  FilterExprNode *expr;
-  gchar *name;
-  StatsCounterItem *matched;
-  StatsCounterItem *not_matched;
-  GList *optimizers;
-} LogFilterPipe;
-
-LogPipe *log_filter_pipe_new(FilterExprNode *expr, GlobalConfig *cfg);
+extern FilterExprOptimizer filter_tree_printer;
 
 #endif

--- a/lib/filter/optimizer/filter-tree-printer.h
+++ b/lib/filter/optimizer/filter-tree-printer.h
@@ -27,6 +27,6 @@
 #include "filter/filter-expr.h"
 #include "filter/optimizer/filter-expr-optimizer.h"
 
-extern FilterExprOptimizer filter_tree_printer;
+FilterExprOptimizer *filter_tree_printer_get_instance(void);
 
 #endif

--- a/lib/filter/optimizer/tests/CMakeLists.txt
+++ b/lib/filter/optimizer/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(CRITERION TARGET test_optimizer)

--- a/lib/filter/optimizer/tests/Makefile.am
+++ b/lib/filter/optimizer/tests/Makefile.am
@@ -1,0 +1,13 @@
+lib_filter_optimizer_tests_TESTS = \
+  lib/filter/optimizer/tests/test_optimizer
+
+check_PROGRAMS += ${lib_filter_optimizer_tests_TESTS}
+
+lib_filter_optimizer_tests_test_optimizer_CFLAGS  = $(TEST_CFLAGS) \
+  -I${top_srcdir}/lib/filter/optimizer/tests
+lib_filter_optimizer_tests_test_optimizer_LDADD   = $(TEST_LDADD) \
+  $(PREOPEN_SYSLOGFORMAT)
+lib_filter_optimizer_tests_test_optimizer_SOURCES = \
+  lib/filter/optimizer/tests/test_optimizer.c
+
+EXTRA_DIST += lib/filter/optimizer/tests/CMakeLists.txt

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -366,5 +366,21 @@ Test(filter_optimizer, multiple_or_filter)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, different_precedent)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('f1') or (program('f2') or program('f3'));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "PROGRAM");
+  cr_assert_str_eq(result->pattern, "f3|f2|f1");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
+
 
 

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -26,6 +26,7 @@
 #include "filter/filter-expr-parser.h"
 #include "cfg-lexer.h"
 #include "filter/optimizer/filter-expr-optimizer.h"
+#include "filter/optimizer/concatenate-or-filters.h"
 #include "apphook.h"
 
 
@@ -194,6 +195,26 @@ Test(replace_optimizer, complex_filter)
 TestSuite(replace_optimizer, .init = app_startup, .fini = app_shutdown);
 
 
+Test(filter_optimizer, no_optimize)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('foo');");
 
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(expr);
+}
+
+Test(filter_optimizer, same_filter_expr_with_and)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') and program('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(expr);
+}
 
 

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -246,7 +246,7 @@ Test(filter_optimizer, type_string_or_programs)
   FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
 
   cr_assert_str_eq(result->type, "pcre");
-  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->template, "PROGRAM");
   cr_assert_str_eq(result->pattern, "f2|f1");
   cr_assert_eq(result->modify, FALSE);
   cr_assert_eq(result->comp, FALSE);
@@ -261,7 +261,7 @@ Test(filter_optimizer, type_pcre_or_programs)
   FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
 
   cr_assert_str_eq(result->type, "pcre");
-  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->template, "PROGRAM");
   cr_assert_str_eq(result->pattern, "f2|f1");
   cr_assert_eq(result->modify, FALSE);
   cr_assert_eq(result->comp, FALSE);
@@ -287,7 +287,7 @@ Test(filter_optimizer, same_filter_expr_with_or)
   FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
 
   cr_assert_str_eq(result->type, "pcre");
-  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->template, "PROGRAM");
   cr_assert_str_eq(result->pattern, "boo|foo");
   cr_assert_eq(result->modify, FALSE);
   cr_assert_eq(result->comp, FALSE);
@@ -302,7 +302,7 @@ Test(filter_optimizer, same_negated_filter_expr_with_or)
   FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
 
   cr_assert_str_eq(result->type, "pcre");
-  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->template, "PROGRAM");
   cr_assert_str_eq(result->pattern, "boo|foo");
   cr_assert_eq(result->modify, FALSE);
   cr_assert_eq(result->comp, TRUE);
@@ -317,7 +317,7 @@ Test(filter_optimizer, multiple_or_filter)
   FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
 
   cr_assert_str_eq(result->type, "pcre");
-  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->template, "PROGRAM");
   cr_assert_str_eq(result->pattern, "f3|f2|f1");
   cr_assert_eq(result->modify, FALSE);
   cr_assert_eq(result->comp, FALSE);

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -295,6 +295,17 @@ Test(filter_optimizer, same_match_filter_via_set_handler)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, different_match_filter_via_set_handler)
+{
+  FilterExprNode *expr = _compile_standalone_filter("match('f1' value('1')) or match('f2' value('2'));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(result);
+}
+
 Test(filter_optimizer, same_filter_expr_with_or)
 {
   FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -269,6 +269,17 @@ Test(filter_optimizer, type_pcre_or_programs)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, type_glob_or_programs)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('f1' type(glob)) or program('f2' type(glob));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(result);
+}
+
 Test(filter_optimizer, same_filter_expr_with_or)
 {
   FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -306,6 +306,21 @@ Test(filter_optimizer, different_match_filter_via_set_handler)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, same_match_filter_via_set_template)
+{
+  FilterExprNode *expr = _compile_standalone_filter("match('f1' template('$1')) or match('f2' template('$1'));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "$1");
+  cr_assert_str_eq(result->pattern, "f2|f1");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
 Test(filter_optimizer, same_filter_expr_with_or)
 {
   FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -228,6 +228,47 @@ Test(filter_optimizer, same_filter_expr_with_or_but_one_negated)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, different_filter_with_or)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') or message('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(result);
+}
+
+Test(filter_optimizer, type_string_or_programs)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('f1' type(string)) or program('f2' type(string));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->pattern, "f2|f1");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
+Test(filter_optimizer, type_pcre_or_programs)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('f1' type(pcre)) or program('f2' type(pcre));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->pattern, "f2|f1");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
 Test(filter_optimizer, same_filter_expr_with_or)
 {
   FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -217,4 +217,31 @@ Test(filter_optimizer, same_filter_expr_with_and)
   filter_expr_unref(expr);
 }
 
+Test(filter_optimizer, same_filter_expr_with_or_but_one_negated)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') or not program('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(result);
+}
+
+Test(filter_optimizer, same_filter_expr_with_or)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->pattern, "boo|foo");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
+
 

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <criterion/criterion.h>
+
+#include "filter/filter-expr-parser.h"
+#include "cfg-lexer.h"
+#include "filter/optimizer/filter-expr-optimizer.h"
+#include "filter/optimizer/concatenate-or-filters.h"
+
+
+gint counter;
+
+static gpointer
+_dummy_init(FilterExprNode *root)
+{
+  ++counter;
+
+  return (gpointer)&counter;
+}
+
+static void
+_dummy_deinit(gpointer cookie)
+{
+  ++counter;
+}
+
+static void
+_dummy_cb(FilterExprNode *current, FilterExprNode *parent, GPtrArray *childs, gpointer cookie)
+{
+  ++counter;
+}
+
+FilterExprOptimizer dummy =
+{
+  .name = "dummy",
+  .init =  _dummy_init,
+  .deinit = _dummy_deinit,
+  .cb = _dummy_cb
+};
+
+static FilterExprNode *_compile_standalone_filter(gchar *config_snippet)
+{
+  GlobalConfig *cfg = cfg_new_snippet();
+  CfgLexer *lexer = cfg_lexer_new_buffer(cfg, config_snippet, strlen(config_snippet));
+  FilterExprNode *tmp;
+  cr_assert(cfg_run_parser(cfg, lexer, &filter_expr_parser, (gpointer *) &tmp, NULL));
+
+  cfg_free(cfg);
+  return tmp;
+}
+
+
+Test(filter_optimizer, simple_filter)
+{
+  app_startup();
+  FilterExprNode *expr = _compile_standalone_filter("program('foo');");
+
+  cr_assert(filter_expr_optimizer_run(expr,  &dummy));
+  cr_assert_eq(counter, 3, "%d==%d", counter, 3);
+
+  filter_expr_unref(expr);
+  app_shutdown();
+}
+
+Test(filter_optimizer, multiple_filter_expr)
+{
+  app_startup();
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') and message('blaze');");
+
+  cr_assert(filter_expr_optimizer_run(expr,  &dummy));
+  cr_assert_eq(counter, 5);
+
+  filter_expr_unref(expr);
+  app_shutdown();
+}
+
+
+TestSuite(filter_optimizer, .init = app_startup, .fini = app_shutdown);
+
+Test(filter_optimizer, no_optimize)
+{
+  app_startup();
+  FilterExprNode *expr = _compile_standalone_filter("program('foo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  &concatenate_or_filters);
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(expr);
+  app_shutdown();
+}
+
+Test(filter_optimizer, same_filter_expr_with_and)
+{
+  app_startup();
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') and program('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  &concatenate_or_filters);
+
+  cr_assert_eq(expr, result);
+
+  filter_expr_unref(expr);
+  app_shutdown();
+}
+
+Test(filter_optimizer, same_filter_expr_with_or)
+{
+  app_startup();
+  FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  &concatenate_or_filters);
+
+  cr_assert_neq(expr, result);
+
+  filter_expr_unref(result);
+  app_shutdown();
+}
+
+
+

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -381,6 +381,19 @@ Test(filter_optimizer, different_precedent)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, pattarn_with_speciel_chars)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('f1\\\"') or (program('f2') or program('f3'));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "PROGRAM");
+  cr_assert_str_eq(result->pattern, "f3|f2|f1\\\"");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+}
+
 
 
 

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -243,5 +243,20 @@ Test(filter_optimizer, same_filter_expr_with_or)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, same_negated_filter_expr_with_or)
+{
+  FilterExprNode *expr = _compile_standalone_filter("not program('foo') or not program('boo');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->pattern, "boo|foo");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, TRUE);
+
+  filter_expr_unref(result);
+}
+
 
 

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -258,5 +258,20 @@ Test(filter_optimizer, same_negated_filter_expr_with_or)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, multiple_or_filter)
+{
+  FilterExprNode *expr = _compile_standalone_filter("program('f1') or program('f2') or program('f3');");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "$PROGRAM");
+  cr_assert_str_eq(result->pattern, "f3|f2|f1");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
 
 

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -280,6 +280,21 @@ Test(filter_optimizer, type_glob_or_programs)
   filter_expr_unref(result);
 }
 
+Test(filter_optimizer, same_match_filter_via_set_handler)
+{
+  FilterExprNode *expr = _compile_standalone_filter("match('f1' value('1')) or match('f2' value('1'));");
+
+  FilterExprNode *result = filter_expr_optimizer_run(expr,  concatenate_or_filters_get_instance());
+
+  cr_assert_str_eq(result->type, "pcre");
+  cr_assert_str_eq(result->template, "1");
+  cr_assert_str_eq(result->pattern, "f2|f1");
+  cr_assert_eq(result->modify, FALSE);
+  cr_assert_eq(result->comp, FALSE);
+
+  filter_expr_unref(result);
+}
+
 Test(filter_optimizer, same_filter_expr_with_or)
 {
   FilterExprNode *expr = _compile_standalone_filter("program('foo') or program('boo');");

--- a/lib/filter/optimizer/tests/test_optimizer.c
+++ b/lib/filter/optimizer/tests/test_optimizer.c
@@ -27,6 +27,7 @@
 #include "cfg-lexer.h"
 #include "filter/optimizer/filter-expr-optimizer.h"
 #include "filter/optimizer/concatenate-or-filters.h"
+#include "apphook.h"
 
 
 gint counter;

--- a/lib/filter/tests/test_filter_call.c
+++ b/lib/filter/tests/test_filter_call.c
@@ -22,6 +22,7 @@
  *
  */
 #include "filter/filter-call.h"
+#include "filter/filter-pri.h"
 #include "filter/filter-expr.h"
 #include "apphook.h"
 
@@ -35,6 +36,22 @@ Test(filter_call, undefined_filter_ref)
 
   cr_assert_not(filter_expr_init(filter, configuration));
 
+  filter_expr_unref(filter);
+}
+
+Test(filter_call, replace_existing_child)
+{
+  FilterExprNode *old = filter_level_new(0);
+  FilterExprNode *new = filter_level_new(0);
+
+  FilterExprNode *filter = filter_call_direct_new( old );
+
+  filter_expr_replace_child(filter, old, new);
+
+  FilterExprNode *filter_next = filter_call_next(filter);
+  cr_assert_eq(filter_next, new, "Filter call didn't replace the child element.");
+
+  filter_expr_unref(filter_next);
   filter_expr_unref(filter);
 }
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -243,6 +243,8 @@ gboolean log_msg_is_handle_macro(NVHandle handle);
 gboolean log_msg_is_handle_sdata(NVHandle handle);
 gboolean log_msg_is_handle_match(NVHandle handle);
 
+const gchar *log_msg_get_handle_name(NVHandle handle, gssize *length);
+
 static inline gboolean
 log_msg_is_handle_settable_with_an_indirect_value(NVHandle handle)
 {


### PR DESCRIPTION
The #2833 is split into multiple PR, and this is one of them. This PR depends on #2863 and as such contains patches from #2863 , the first commit for this branch starts here: https://github.com/balabit/syslog-ng/commit/08aebed13c2ec5445ae5bdfa6aeaceca11b47525

This optimiser algorithm provides a way to combine multiple filter connected with `or` operator into one, that is assumed have better performance. (performance data is going to be provided here)
The following: `message("pattern1") or message("pattern2") or ... or message("patternK");` could be replaced with the `message("pattern1|pattern2|...|patternK");`.

- [ ] Share performance data

