### PR TITLE
python test: use malloc_debug for python unit tests

### DIFF
--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -3,7 +3,11 @@ add_unit_test(LIBTEST CRITERION
   INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
   DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
 
+set_property(TEST test_python_logmsg APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
 add_unit_test(LIBTEST CRITERION
   TARGET test_python_template
   INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
   DEPENDS mod-python "${PYTHON_LIBRARIES}" syslogformat)
+
+set_property(TEST test_python_template APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -1,3 +1,6 @@
+PYTHONMALLOC=malloc_debug
+export PYTHONMALLOC
+
 check_PROGRAMS += \
   ${modules_python_tests_TESTS}
 

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -46,6 +46,12 @@ _py_init_interpreter(void)
   Py_Initialize();
   py_init_argv();
 
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    py_template_options = py_log_template_options_new(&log_template_options);
+  }
+  PyGILState_Release(gstate);
+
   PyEval_InitThreads();
   py_log_message_init();
   py_log_template_init();
@@ -71,7 +77,6 @@ void setup(void)
   log_template_options.ts_format = TS_FMT_BSD;
   log_template_options.time_zone_info[LTZ_SEND]=time_zone_info_new("+05:00");
 
-  py_template_options = py_log_template_options_new(&log_template_options);
   msg_format_options_defaults(&parse_options);
   _py_init_interpreter();
   _init_python_main();
@@ -79,7 +84,11 @@ void setup(void)
 
 void teardown(void)
 {
-  Py_DECREF(py_template_options);
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    Py_DECREF(py_template_options);
+  }
+  PyGILState_Release(gstate);
   app_shutdown();
 }
 


### PR DESCRIPTION
As part of the work to push #2178 python had the most leak from all of them.
After some investigation it turned out that from syslog-ng point of view the memory management is fine, and in fact the leak is reported because of `pymalloc` (for details check out cpython valgrind guide).

Since python 3.6 it is possible to change the allocator via an environment varialbe (`PYTHONMALLOC`). As of now there is: `pymalloc`, `malloc` and those with a combination of `_debug` suffix.
The guid suggest to use `malloc` for valgrind, and there is no big surprise that it also helps with address sanitizer as well.

This PR suggest to use `malloc_debug` as that also additionally reports issues, I could find one misuse of the `GIL`.

Note: this is not going to have effect on Travis or Kira as they are using older version of python. But this still could be a good documentation, and useful locally.