### PR TITLE
few small fries leak fixed

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -602,6 +602,7 @@ cfg_free(GlobalConfig *self)
 
   if (self->bad_hostname_compiled)
     regfree(&self->bad_hostname);
+  g_free(self->recv_time_zone);
   if (self->source_mangle_callback_list)
     g_list_free(self->source_mangle_callback_list);
   g_free(self->bad_hostname_re);

--- a/lib/logmsg/nvhandle-descriptors.c
+++ b/lib/logmsg/nvhandle-descriptors.c
@@ -39,6 +39,11 @@ nvhandle_desc_array_new(guint reserved_size)
 void
 nvhandle_desc_array_free(NVHandleDescArray *self)
 {
+  for (gint i=0; i < self->len; ++i)
+    {
+      NVHandleDesc *handle = (NVHandleDesc *)&self->data[i];
+      nvhandle_desc_free(handle);
+    }
   g_free(self->data);
   g_ptr_array_free(self->old_buffers, TRUE);
   g_free(self);
@@ -66,4 +71,10 @@ nvhandle_desc_array_append(NVHandleDescArray *self, NVHandleDesc *desc)
 
   self->data[self->len] = *desc;
   self->len++;
+}
+
+void
+nvhandle_desc_free(NVHandleDesc *self)
+{
+  g_free(self->name);
 }

--- a/lib/logmsg/nvhandle-descriptors.h
+++ b/lib/logmsg/nvhandle-descriptors.h
@@ -49,4 +49,7 @@ void nvhandle_desc_array_free(NVHandleDescArray *self);
 void nvhandle_desc_array_append(NVHandleDescArray *self, NVHandleDesc *desc);
 #define nvhandle_desc_array_index(self, i)      (((NVHandleDesc*) (self)->data) [(i)])
 
+/* Does not free *self*. */
+void nvhandle_desc_free(NVHandleDesc *self);
+
 #endif

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -85,7 +85,7 @@ nv_registry_alloc_handle(NVRegistry *self, const gchar *name)
   stored.name_len = len;
   stored.name = g_strdup(name);
   nvhandle_desc_array_append(self->names, &stored);
-  g_hash_table_insert(self->name_map, stored.name, GUINT_TO_POINTER(self->names->len));
+  g_hash_table_insert(self->name_map, g_strdup(name), GUINT_TO_POINTER(self->names->len));
   res = self->names->len;
 exit:
   g_static_mutex_unlock(&nv_registry_lock);

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -286,6 +286,7 @@ Test(secretstorage, test_rlimit)
     {
       cr_assert_not(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
     }
+  g_free(key_fmt);
 }
 
 static void


### PR DESCRIPTION
The `recv_time_zone` is an actual not UT leak, but well only if configured.