### PR TITLE
cfg parsing: read config file into memory + preprocess-into to stdout

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1102,44 +1102,14 @@ cfg_lexer_init(CfgLexer *self, GlobalConfig *cfg)
 }
 
 
-/* NOTE: cfg might be NULL in some call sites, but in those cases the lexer
- * should remain operational, obviously skipping cases where it would be
- * using the configuration instance.  The lexer and the configuration stuff
- * should be one-way dependent, right now it is a circular dependency. */
 CfgLexer *
-cfg_lexer_new(GlobalConfig *cfg, const gchar *filename, GString *buffer, GString *preprocess_output)
+cfg_lexer_new_common(GlobalConfig *cfg, const gchar *buffer, gsize length)
 {
   CfgLexer *self;
   CfgIncludeLevel *level;
 
   self = g_new0(CfgLexer, 1);
   cfg_lexer_init(self, cfg);
-  self->preprocess_output = preprocess_output;
-
-  level = &self->include_stack[0];
-  level->include_type = CFGI_BUFFER;
-  level->buffer.original_content = g_strdup(buffer->str);
-  level->buffer.content = g_malloc(buffer->len+2);
-  memcpy(level->buffer.content, buffer->str, buffer->len);
-  level->buffer.content[buffer->len] = 0;
-  level->buffer.content[buffer->len + 1] = 0;
-  level->buffer.content_length = buffer->len + 2;
-  level->name = g_strdup(filename);
-  level->yybuf = _cfg_lexer__scan_buffer(level->buffer.content, level->buffer.content_length, self->state);
-  _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
-
-  return self;
-}
-
-CfgLexer *
-cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
-{
-  CfgLexer *self;
-  CfgIncludeLevel *level;
-
-  self = g_new0(CfgLexer, 1);
-  cfg_lexer_init(self, cfg);
-  self->ignore_pragma = TRUE;
 
   level = &self->include_stack[0];
   level->include_type = CFGI_BUFFER;
@@ -1149,9 +1119,34 @@ cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
   level->buffer.content[length] = 0;
   level->buffer.content[length + 1] = 0;
   level->buffer.content_length = length + 2;
-  level->name = g_strdup("<string>");
   level->yybuf = _cfg_lexer__scan_buffer(level->buffer.content, level->buffer.content_length, self->state);
   _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
+
+  return self;
+}
+
+/* NOTE: cfg might be NULL in some call sites, but in those cases the lexer
+ * should remain operational, obviously skipping cases where it would be
+ * using the configuration instance.  The lexer and the configuration stuff
+ * should be one-way dependent, right now it is a circular dependency. */
+CfgLexer *
+cfg_lexer_new(GlobalConfig *cfg, const gchar *filename, GString *buffer, GString *preprocess_output)
+{
+  CfgLexer *self = cfg_lexer_new_common(cfg, buffer->str, buffer->len);
+
+  self->preprocess_output = preprocess_output;
+  self->include_stack[0].name = g_strdup(filename);
+
+  return self;
+}
+
+CfgLexer *
+cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
+{
+  CfgLexer *self = cfg_lexer_new_common(cfg, buffer, length);
+
+  self->ignore_pragma = TRUE;
+  self->include_stack[0].name = g_strdup("<string>");
 
   return self;
 }

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -176,7 +176,7 @@ void cfg_lexer_inject_token_block(CfgLexer *self, CfgTokenBlock *block);
 int cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc);
 void cfg_lexer_free_token(YYSTYPE *token);
 
-CfgLexer *cfg_lexer_new(GlobalConfig *cfg, FILE *file, const gchar *filename, GString *preprocess_output);
+CfgLexer *cfg_lexer_new(GlobalConfig *cfg, const gchar *filename, GString *buffer, GString *preprocess_output);
 CfgLexer *cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length);
 void  cfg_lexer_free(CfgLexer *self);
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -541,8 +541,14 @@ _load_file_into_string(const gchar *fname)
   gchar *buff;
   GString *content = g_string_new("");
 
-  if (!g_file_get_contents(fname, &buff, NULL, NULL))
+  GError *error = NULL;
+  if (!g_file_get_contents(fname, &buff, NULL, &error))
     {
+      msg_error("Error opening configuration file",
+                evt_tag_str(EVT_TAG_FILENAME, fname),
+                evt_tag_str(EVT_TAG_OSERROR, error->message));
+
+      g_error_free(error);
       return content;
     }
 
@@ -562,10 +568,6 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
 
   if ((cfg_file = fopen(fname, "r")) == NULL)
     {
-      msg_error("Error opening configuration file",
-                evt_tag_str(EVT_TAG_FILENAME, fname),
-                evt_tag_error(EVT_TAG_OSERROR));
-
       return FALSE;
     }
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -545,7 +545,6 @@ static GString *
 _load_file_into_string(const gchar *fname)
 {
   gchar *buff;
-  GString *content = g_string_new("");
 
   GError *error = NULL;
   if (!g_file_get_contents(fname, &buff, NULL, &error))
@@ -555,11 +554,10 @@ _load_file_into_string(const gchar *fname)
                 evt_tag_str(EVT_TAG_OSERROR, error->message));
 
       g_error_free(error);
-      g_string_free(content, TRUE);
       return NULL;
     }
 
-  g_string_append(content, buff);
+  GString *content = g_string_new(buff);
   g_free(buff);
 
   return content;

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -562,17 +562,10 @@ _load_file_into_string(const gchar *fname)
 gboolean
 cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
 {
-  FILE *cfg_file;
   gint res;
+  CfgLexer *lexer;
 
   self->filename = fname;
-
-  if ((cfg_file = fopen(fname, "r")) == NULL)
-    {
-      return FALSE;
-    }
-
-  CfgLexer *lexer;
   self->preprocess_config = g_string_sized_new(8192);
   self->original_config = _load_file_into_string(fname);
   if (!self->original_config)
@@ -582,7 +575,7 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
 
   lexer = cfg_lexer_new(self, fname, self->original_config, self->preprocess_config);
   res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
-  fclose(cfg_file);
+
   if (preprocess_into)
     {
       cfg_dump_processed_config(self->preprocess_config, preprocess_into);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -523,6 +523,12 @@ cfg_dump_processed_config(GString *preprocess_output, gchar *output_filename)
 {
   FILE *output_file;
 
+  if (strcmp(output_filename, "-")==0)
+    {
+      fprintf(stdout, "%s", preprocess_output->str);
+      return;
+    }
+
   output_file = fopen(output_filename,"w+");
   if (!output_file)
     {

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -541,11 +541,13 @@ _load_file_into_string(const gchar *fname)
   gchar *buff;
   GString *content = g_string_new("");
 
-  if (g_file_get_contents(fname, &buff, NULL, NULL))
+  if (!g_file_get_contents(fname, &buff, NULL, NULL))
     {
-      g_string_append(content, buff);
-      g_free(buff);
+      return content;
     }
+
+  g_string_append(content, buff);
+  g_free(buff);
 
   return content;
 }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -571,7 +571,7 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
   self->preprocess_config = g_string_sized_new(8192);
   self->original_config = _load_file_into_string(fname);
 
-  lexer = cfg_lexer_new(self, cfg_file, fname, self->preprocess_config);
+  lexer = cfg_lexer_new(self, fname, self->original_config, self->preprocess_config);
   res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
   fclose(cfg_file);
   if (preprocess_into)

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -549,7 +549,8 @@ _load_file_into_string(const gchar *fname)
                 evt_tag_str(EVT_TAG_OSERROR, error->message));
 
       g_error_free(error);
-      return content;
+      g_string_free(content, TRUE);
+      return NULL;
     }
 
   g_string_append(content, buff);
@@ -574,6 +575,10 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
   CfgLexer *lexer;
   self->preprocess_config = g_string_sized_new(8192);
   self->original_config = _load_file_into_string(fname);
+  if (!self->original_config)
+    {
+      return FALSE;
+    }
 
   lexer = cfg_lexer_new(self, fname, self->original_config, self->preprocess_config);
   res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -558,34 +558,28 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
 
   self->filename = fname;
 
-  if ((cfg_file = fopen(fname, "r")) != NULL)
-    {
-      CfgLexer *lexer;
-      self->preprocess_config = g_string_sized_new(8192);
-      self->original_config = _load_file_into_string(fname);
-
-      lexer = cfg_lexer_new(self, cfg_file, fname, self->preprocess_config);
-      res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
-      fclose(cfg_file);
-      if (preprocess_into)
-        {
-          cfg_dump_processed_config(self->preprocess_config, preprocess_into);
-        }
-
-      if (res)
-        {
-          /* successfully parsed */
-          return TRUE;
-        }
-    }
-  else
+  if ((cfg_file = fopen(fname, "r")) == NULL)
     {
       msg_error("Error opening configuration file",
                 evt_tag_str(EVT_TAG_FILENAME, fname),
                 evt_tag_error(EVT_TAG_OSERROR));
+
+      return FALSE;
     }
 
-  return FALSE;
+  CfgLexer *lexer;
+  self->preprocess_config = g_string_sized_new(8192);
+  self->original_config = _load_file_into_string(fname);
+
+  lexer = cfg_lexer_new(self, cfg_file, fname, self->preprocess_config);
+  res = cfg_run_parser(self, lexer, &main_parser, (gpointer *) &self, NULL);
+  fclose(cfg_file);
+  if (preprocess_into)
+    {
+      cfg_dump_processed_config(self->preprocess_config, preprocess_into);
+    }
+
+  return res;
 }
 
 void


### PR DESCRIPTION
This branch has some refactor and two change:
* the `preprocess-into` accepts `-` and prints the preprocess config into `stdout` (this could be achieved currently with `--preprocess-into=/dev/stdout`)
* read the whole configuration file into memory and run the parser on that