### PR TITLE
Fix minor resource/memory leaks, null pointer dereference

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1273,9 +1273,7 @@ cfg_tree_get_objects(CfgTree *self)
 gboolean
 cfg_tree_add_template(CfgTree *self, LogTemplate *template)
 {
-  gboolean res = TRUE;
-
-  res = (g_hash_table_lookup(self->templates, template->name) == NULL);
+  gboolean res = (g_hash_table_lookup(self->templates, template->name) == NULL);
   g_hash_table_replace(self->templates, template->name, template);
   return res;
 }

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -261,11 +261,9 @@ _fetch_command(Debugger *self)
 static gboolean
 _handle_command(Debugger *self)
 {
-  gint i;
   gint argc;
   gchar **argv;
   GError *error = NULL;
-  gboolean result = TRUE;
   DebuggerCommandFunc command = NULL;
 
   if (!g_shell_parse_argv(self->command_buffer ? : "", &argc, &argv, &error))
@@ -275,7 +273,7 @@ _handle_command(Debugger *self)
       return TRUE;
     }
 
-  for (i = 0; command_table[i].name; i++)
+  for (gint i = 0; command_table[i].name; i++)
     {
       if (strcmp(command_table[i].name, argv[0]) == 0)
         {
@@ -288,7 +286,7 @@ _handle_command(Debugger *self)
       printf("Undefined command %s, try \"help\"\n", argv[0]);
       return TRUE;
     }
-  result = command(self, argc, argv);
+  gboolean result = command(self, argc, argv);
   g_strfreev(argv);
   return result;
 }

--- a/lib/eventlog/src/evtstr.c
+++ b/lib/eventlog/src/evtstr.c
@@ -54,10 +54,11 @@
 static inline int
 evt_str_grow(EVTSTR *es, size_t new_alloc)
 {
-  es->es_buf = realloc(es->es_buf, new_alloc);
-  if (!es->es_buf)
+  char *buf = realloc(es->es_buf, new_alloc);
+  if (!buf)
     return 0;
 
+  es->es_buf = buf;
   es->es_allocated = new_alloc;
   return 1;
 }
@@ -147,6 +148,13 @@ evt_str_init(size_t init_alloc)
       es->es_allocated = init_alloc;
       es->es_length = 0;
       es->es_buf = malloc(init_alloc);
+
+      if (!es->es_buf)
+        {
+          free(es);
+          return NULL;
+        }
+
       es->es_buf[0] = 0;
     }
   return es;

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -68,7 +68,6 @@ log_proto_buffered_server_convert_from_raw(LogProtoBufferedServer *self, const g
   gsize avail_in = raw_buffer_len;
   gsize avail_out;
   gchar *out;
-  gint  ret = -1;
   gboolean success = FALSE;
   LogProtoBufferedServerState *state = log_proto_buffered_server_get_state(self);
 
@@ -77,7 +76,7 @@ log_proto_buffered_server_convert_from_raw(LogProtoBufferedServer *self, const g
       avail_out = state->buffer_size - state->pending_buffer_end;
       out = (gchar *) self->buffer + state->pending_buffer_end;
 
-      ret = g_iconv(self->convert, (gchar **) &raw_buffer, &avail_in, (gchar **) &out, &avail_out);
+      gint ret = g_iconv(self->convert, (gchar **) &raw_buffer, &avail_in, (gchar **) &out, &avail_out);
       if (ret == (gsize) -1)
         {
           switch (errno)
@@ -126,9 +125,6 @@ log_proto_buffered_server_convert_from_raw(LogProtoBufferedServer *self, const g
                     state->buffer_size = self->super.options->max_buffer_size;
 
                   self->buffer = g_realloc(self->buffer, state->buffer_size);
-
-                  /* recalculate the out pointer, and add what we have now */
-                  ret = -1;
                 }
               else
                 {

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -356,8 +356,9 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages,
 
   cr_assert_eq(stats_counter_get(q->dropped_messages), 3);
 
-  send_some_messages(q, fed_messages);
-  log_queue_ack_backlog(q, fed_messages);
+  gint queued_messages = stats_counter_get(q->queued_messages);
+  send_some_messages(q, queued_messages);
+  log_queue_ack_backlog(q, queued_messages);
 
   cr_assert_eq(fed_messages, acked_messages,
                "did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d",
@@ -412,8 +413,9 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages_thre
 
   cr_assert_eq(stats_counter_get(q->dropped_messages), 3);
 
-  send_some_messages(q, fed_messages);
-  log_queue_ack_backlog(q, fed_messages);
+  gint queued_messages = stats_counter_get(q->queued_messages);
+  send_some_messages(q, queued_messages);
+  log_queue_ack_backlog(q, queued_messages);
 
   cr_assert_eq(fed_messages, acked_messages,
                "did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d",

--- a/lib/timeutils/conv.c
+++ b/lib/timeutils/conv.c
@@ -53,13 +53,11 @@ convert_and_normalize_wall_clock_time_to_unix_time(WallClockTime *src, UnixTime 
 void
 convert_and_normalize_wall_clock_time_to_unix_time_with_tz_hint(WallClockTime *src, UnixTime *dst, long gmtoff_hint)
 {
-  gint target_gmtoff = -1;
-
   /* usec is just copied over, doesn't change timezone or anything */
   dst->ut_usec = src->wct_usec;
 
   /* determine target gmtoff if it's coming from the timestamp or from the hint */
-  target_gmtoff = src->wct_gmtoff;
+  gint target_gmtoff = src->wct_gmtoff;
   if (target_gmtoff == -1)
     target_gmtoff = gmtoff_hint;
 

--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <iv.h>
 #include <iv_thread.h>
+#include <criterion/criterion.h>
 
 int acked_messages = 0;
 int fed_messages = 0;
@@ -89,6 +90,7 @@ send_some_messages(LogQueue *q, gint n)
   for (i = 0; i < n; i++)
     {
       LogMessage *msg = log_queue_pop_head(q, &path_options);
+      cr_assert_not_null(msg);
       if (q->use_backlog)
         {
           log_msg_ack(msg, &path_options, AT_PROCESSED);

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -230,20 +230,15 @@ static ContextualDataRecordScanner *
 _get_scanner(AddContextualData *self)
 {
   const gchar *type = get_filename_extension(self->filename);
-  ContextualDataRecordScanner *scanner;
 
-  if (type && strcmp(type, "csv") == 0)
-    {
-      scanner = contextual_data_record_scanner_new(log_pipe_get_config(&self->super.super), self->prefix);
-    }
-  else
+  if (g_strcmp0(type, "csv") != 0)
     {
       msg_error("add-contextual-data(): unknown file extension, only files with a .csv extension are supported",
                 evt_tag_str("filename", self->filename));
       return NULL;
     }
 
-  return scanner;
+  return contextual_data_record_scanner_new(log_pipe_get_config(&self->super.super), self->prefix);
 }
 
 static gboolean

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -232,7 +232,7 @@ _get_scanner(AddContextualData *self)
   const gchar *type = get_filename_extension(self->filename);
   ContextualDataRecordScanner *scanner;
 
-  if (strcmp(type, "csv") == 0)
+  if (type && strcmp(type, "csv") == 0)
     {
       scanner = contextual_data_record_scanner_new(log_pipe_get_config(&self->super.super), self->prefix);
     }

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -482,10 +482,6 @@ static LogThreadedResult
 afsmtp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 {
   AFSMTPDriver *self = (AFSMTPDriver *)s;
-  gboolean success = TRUE;
-  gboolean message_sent = TRUE;
-  smtp_session_t session = NULL;
-  smtp_message_t message;
 
   if (msg->flags & LF_MARK)
     {
@@ -494,11 +490,11 @@ afsmtp_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
       return LTR_SUCCESS;
     }
 
-  session = __build_session(self, msg);
-  message = __build_message(self, msg, session);
+  smtp_session_t session = __build_session(self, msg);
+  smtp_message_t message = __build_message(self, msg, session);
 
-  message_sent = __send_message(self, session);
-  success = message_sent && __check_transfer_status(self, message);
+  gboolean message_sent = __send_message(self, session);
+  gboolean success = message_sent && __check_transfer_status(self, message);
 
   smtp_destroy_session(session);
 

--- a/modules/afsocket/systemd-syslog-source.c
+++ b/modules/afsocket/systemd-syslog-source.c
@@ -39,12 +39,9 @@ static gboolean
 systemd_syslog_sd_acquire_socket(AFSocketSourceDriver *s,
                                  gint *acquired_fd)
 {
-  gint fd, number_of_fds;
-
   *acquired_fd = -1;
-  fd = -1;
 
-  number_of_fds = sd_listen_fds(0);
+  gint number_of_fds = sd_listen_fds(0);
 
   if (number_of_fds > 1)
     {
@@ -60,7 +57,7 @@ systemd_syslog_sd_acquire_socket(AFSocketSourceDriver *s,
     }
   else
     {
-      fd = SD_LISTEN_FDS_START;
+      gint fd = SD_LISTEN_FDS_START;
       msg_debug("Systemd socket activation",
                 evt_tag_int("file-descriptor", fd));
 

--- a/modules/dbparser/radix.c
+++ b/modules/dbparser/radix.c
@@ -866,7 +866,7 @@ r_add_child_check(RNode *root, gchar *key, gpointer value, RNodeGetValueFunc val
 void
 r_add_pchild(RNode *parent, RNode *child)
 {
-  parent->pchildren = realloc(parent->pchildren, (sizeof(RNode *) * (parent->num_pchildren + 1)));
+  parent->pchildren = g_realloc(parent->pchildren, (sizeof(RNode *) * (parent->num_pchildren + 1)));
 
   parent->pchildren[(parent->num_pchildren)++] = child;
 }

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -357,6 +357,9 @@ static gboolean
 _file_is_diskq(const gchar *filename)
 {
   const gchar *filename_ext = get_filename_extension(filename);
+  if (!filename_ext)
+    return FALSE;
+
   gboolean reliable = strcmp(filename_ext, "rqf") == 0;
   if (!reliable && strcmp(filename_ext, "qf") != 0)
     return FALSE;

--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -186,33 +186,30 @@ _is_fd_pollable(gint fd)
 static gboolean
 _detect_linux_dev_kmsg(void)
 {
-  gint fd;
+  gint fd = open("/dev/kmsg", O_RDONLY);
 
-  if ((fd = open("/dev/kmsg", O_RDONLY)) != -1)
-    {
-      if ((lseek (fd, 0, SEEK_END) != -1) && _is_fd_pollable(fd))
-        {
-          return TRUE;
-        }
-      close (fd);
-    }
-  return FALSE;
+  if (fd == -1)
+    return FALSE;
+
+  gboolean seekable = lseek(fd, 0, SEEK_END) != -1;
+  gboolean pollable = _is_fd_pollable(fd);;
+
+  close(fd);
+  return seekable && pollable;
 }
 
 static gboolean
 _detect_linux_proc_kmsg(void)
 {
-  gint fd;
+  gint fd = open("/proc/kmsg", O_RDONLY);
 
-  if ((fd = open("/proc/kmsg", O_RDONLY)) != -1)
-    {
-      if (_is_fd_pollable(fd))
-        {
-          return TRUE;
-        }
-      close (fd);
-    }
-  return FALSE;
+  if (fd == -1)
+    return FALSE;
+
+  gboolean pollable = _is_fd_pollable(fd);
+
+  close(fd);
+  return pollable;
 }
 
 static void

--- a/persist-tool/add.c
+++ b/persist-tool/add.c
@@ -195,9 +195,6 @@ gint
 add_main(int argc, char *argv[])
 {
   int result = 0;
-  gchar *filename;
-  PersistTool *self;
-  gchar *line = g_malloc(MAX_LINE_LEN);
 
   if (!persist_state_dir)
     {
@@ -210,13 +207,10 @@ add_main(int argc, char *argv[])
       fprintf(stderr, "Directory doesn't exist: %s\n", persist_state_dir);
       return 1;
     }
-  filename = g_build_path(G_DIR_SEPARATOR_S, persist_state_dir,
-                          persist_state_name ? persist_state_name : DEFAULT_PERSIST_FILE, NULL);
 
   if (argc < 2)
     {
       fprintf(stderr, "Input missing\n");
-      g_free(filename);
       return 1;
     }
 
@@ -231,18 +225,23 @@ add_main(int argc, char *argv[])
       if (input_file == NULL)
         {
           fprintf(stderr, "Can't open input file; file = \"%s\", error = %s\n", argv[1], strerror(errno));
-          g_free(filename);
           return 1;
         }
     }
 
-  self = persist_tool_new(filename, persist_mode_edit);
+  gchar *filename = g_build_path(G_DIR_SEPARATOR_S, persist_state_dir,
+                                 persist_state_name ? persist_state_name : DEFAULT_PERSIST_FILE, NULL);
+
+
+  PersistTool *self = persist_tool_new(filename, persist_mode_edit);
   if (!self)
     {
       fprintf(stderr,"Error creating persist tool\n");
+      g_free(filename);
       return 1;
     }
 
+  gchar *line = g_malloc(MAX_LINE_LEN);
   while(fgets(line, MAX_LINE_LEN, input_file))
     {
       if (strlen(line) > 3)

--- a/tests/loggen/file_reader.c
+++ b/tests/loggen/file_reader.c
@@ -364,7 +364,8 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
             {
               /* Restart reading from the beginning of the file */
               rewind(source[thread_index]);
-              temp = fgets(buf, buflen, source[thread_index]);
+              if (!fgets(buf, buflen, source[thread_index]))
+                return -1;
             }
           else
             return -1;

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -103,6 +103,9 @@ generate_message(char *buffer, int buffer_size, int thread_id, unsigned long seq
   else
     str_len = generate_log_line(buffer, buffer_size, syslog_proto, thread_id, seq);
 
+  if (str_len < 0)
+    return -1;
+
   g_mutex_lock(message_counter_lock);
   sent_messages_num++;
   raw_message_length += str_len;

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -368,7 +368,7 @@ print_statistic(struct timeval *start_time)
                   (long) diff_tv.tv_sec,
                   (long) diff_tv.tv_usec,
                   msg_count_diff,
-                  thread_stat_count[j]
+                  count
                  );
         }
     }


### PR DESCRIPTION
These bugs were found by [Infer](https://fbinfer.com/), a static analysis tool.

Most of the issues are harmless, I've sorted the commit list, so they are in order of decreasing severity.

```
 83. modules/system-source/system-source.c:195: error: resource acquired by call to `open()` at line 191, column 13 is not released after line 195, column 18.
 92. modules/system-source/system-source.c:211: error: resource acquired by call to `open()` at line 207, column 13 is not released after line 211, column 18.
 85. persist-tool/add.c:204: error: memory dynamically allocated by call to `g_malloc()` at line 200, column 17 is not reachable after line 204, column 15.
 86. persist-tool/add.c:210: error: memory dynamically allocated by call to `g_malloc()` at line 200, column 17 is not reachable after line 210, column 15.
 87. persist-tool/add.c:218: error: memory dynamically allocated by call to `g_malloc()` at line 200, column 17 is not reachable after line 218, column 15.
 88. persist-tool/add.c:233: error: memory dynamically allocated by call to `g_malloc()` at line 200, column 17 is not reachable after line 233, column 19.
101. modules/add-contextual-data/add-contextual-data.c:235: error: pointer `type` last assigned on line 232 could be null and is dereferenced by call to `strcmp()` at line 235, column 7.
102. modules/diskq/dqtool.c:360: error: pointer `filename_ext` last assigned on line 359 could be null and is dereferenced by call to `strcmp()` at line 360, column 23.
118. tests/loggen/loggen.c:363: error: The value written to &count (type long) is never used.
 69. lib/eventlog/src/evtstr.c:150: error: pointer `es->es_buf` last assigned on line 149 could be null and is dereferenced at line 150, column 7.
159. modules/dbparser/radix.c:871: error: pointer `parent->pchildren` last assigned on line 869 could be null and is dereferenced at line 871, column 3.
 33. libtest/queue_utils_lib.c:94: error: pointer `msg` last assigned on line 91 could be null and is dereferenced by call to `log_msg_ack()` at line 94, column 11.
 34. libtest/queue_utils_lib.c:96: error: pointer `msg` last assigned on line 91 could be null and is dereferenced by call to `log_msg_unref()` at line 96, column 7.
  0. modules/afsocket/systemd-syslog-source.c:45: error: The value written to &fd (type int) is never used.
 10. lib/timeutils/conv.c:56: error: The value written to &target_gmtoff (type int) is never used.
 19. lib/logproto/logproto-buffered-server.c:71: error: The value written to &ret (type int) is never used.
 20. lib/logproto/logproto-buffered-server.c:131: error: The value written to &ret (type int) is never used.
133. modules/afsmtp/afsmtp.c:486: error: The value written to &message_sent (type int) is never used.
171. lib/cfg-tree.c:1276: error: The value written to &res (type int) is never used.
120. tests/loggen/file_reader.c:367: error: The value written to &temp (type char*) is never used.
108. lib/debugger/debugger.c:268: error: The value written to &result (type int) is never used.
```