### PR TITLE
Add global context to standalone parsers

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -518,6 +518,19 @@ cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer 
   return res;
 }
 
+gboolean
+cfg_run_parser_with_main_context(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg,
+                                 const gchar *desc)
+{
+  gboolean ret_val;
+
+  cfg_lexer_push_context(lexer, main_parser.context, main_parser.keywords, desc);
+  ret_val = cfg_run_parser(self, lexer, parser, result, arg);
+  cfg_lexer_pop_context(lexer);
+
+  return ret_val;
+}
+
 static void
 cfg_dump_processed_config(GString *preprocess_output, gchar *output_filename)
 {

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -146,6 +146,8 @@ void cfg_set_global_paths(GlobalConfig *self);
 GlobalConfig *cfg_new(gint version);
 GlobalConfig *cfg_new_snippet(void);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
+gboolean cfg_run_parser_with_main_context(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result,
+                                          gpointer arg, const gchar *desc);
 gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gchar *preprocess_into);
 void cfg_load_forced_modules(GlobalConfig *self);
 void cfg_shutdown(GlobalConfig *self);

--- a/modules/basicfuncs/cond-funcs.c
+++ b/modules/basicfuncs/cond-funcs.c
@@ -44,6 +44,14 @@ tf_cond_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
                   "$(%s) Error parsing conditional filter expression", argv[0]);
       return FALSE;
     }
+
+  if (!filter_expr_init(state->filter, parent->cfg))
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(%s) Error initializing conditional filter expression", argv[0]);
+      return FALSE;
+    }
+
   memmove(&argv[1], &argv[2], sizeof(argv[0]) * (argc - 2));
   if (!tf_simple_func_prepare(self, s, parent, argc - 1, argv, error))
     return FALSE;

--- a/modules/basicfuncs/cond-funcs.c
+++ b/modules/basicfuncs/cond-funcs.c
@@ -38,7 +38,8 @@ tf_cond_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
   lexer = cfg_lexer_new_buffer(parent->cfg, argv[1], strlen(argv[1]));
-  if (!cfg_run_parser(parent->cfg, lexer, &filter_expr_parser, (gpointer *) &state->filter, NULL))
+  if (!cfg_run_parser_with_main_context(parent->cfg, lexer, &filter_expr_parser, (gpointer *) &state->filter, NULL,
+                                        "conditional filter"))
     {
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
                   "$(%s) Error parsing conditional filter expression", argv[0]);

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -120,6 +120,8 @@ Test(basicfuncs, test_cond_funcs)
                                       "korte");
   assert_template_format_with_context("$(if '\"$FACILITY_NUM\" >= \"19\" or \"kicsi\" eq \"nagy\"' alma korte)", "alma");
 
+  assert_template_format_with_context("$(if program(\"slog-ng\" type(pcre)) alma korte)", "alma");
+
   assert_template_format_with_context("$(grep 'facility(local3)' $PID)@0", "23323");
   assert_template_format_with_context("$(grep 'facility(local3)' $PID)@1", "23323");
   assert_template_format_with_context("$(grep 'facility(local3)' $PID)@2", "");

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -32,7 +32,8 @@ pdb_action_set_condition(PDBAction *self, GlobalConfig *cfg, const gchar *filter
   CfgLexer *lexer;
 
   lexer = cfg_lexer_new_buffer(cfg, filter_string, strlen(filter_string));
-  if (!cfg_run_parser(cfg, lexer, &filter_expr_parser, (gpointer *) &self->condition, NULL))
+  if (!cfg_run_parser_with_main_context(cfg, lexer, &filter_expr_parser, (gpointer *) &self->condition, NULL,
+                                        "conditional expression"))
     {
       g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Error compiling conditional expression");
       self->condition = NULL;

--- a/modules/dbparser/pdb-action.c
+++ b/modules/dbparser/pdb-action.c
@@ -38,6 +38,13 @@ pdb_action_set_condition(PDBAction *self, GlobalConfig *cfg, const gchar *filter
       self->condition = NULL;
       return;
     }
+
+  if (!filter_expr_init(self->condition, cfg))
+    {
+      g_set_error(error, PDB_ERROR, PDB_ERROR_FAILED, "Error initializing conditional expression");
+      self->condition = NULL;
+      return;
+    }
 }
 
 void

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -422,7 +422,8 @@ pdbtool_match(int argc, char *argv[])
       CfgLexer *lexer;
 
       lexer = cfg_lexer_new_buffer(configuration, filter_string, strlen(filter_string));
-      if (!cfg_run_parser(configuration, lexer, &filter_expr_parser, (gpointer *) &filter, NULL))
+      if (!cfg_run_parser_with_main_context(configuration, lexer, &filter_expr_parser, (gpointer *) &filter, NULL,
+                                            "pdbtool filter expression"))
         {
           fprintf(stderr, "Error parsing filter expression\n");
           return 1;

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -427,6 +427,12 @@ pdbtool_match(int argc, char *argv[])
           fprintf(stderr, "Error parsing filter expression\n");
           return 1;
         }
+
+      if (!filter_expr_init(filter, configuration))
+        {
+          fprintf(stderr, "Error initializing filter expression\n");
+          return 1;
+        }
     }
 
 

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -382,6 +382,22 @@ Test(pattern_db, test_correllation_rule_with_action_condition)
   g_free(filename);
 }
 
+Test(pattern_db, test_correllation_rule_with_action_condition_filter)
+{
+  gchar *filename;
+  PatternDB *patterndb = _create_pattern_db(pdb_ruletest_skeleton, &filename);
+
+  /* tag assigned based on "class" */
+  assert_msg_matches_and_has_tag(patterndb, "correllated-message-with-action-condition", ".classifier.violation", TRUE);
+
+  assert_msg_matches_and_output_message_nvpair_equals(patterndb, "correllated-message-with-action-condition-filter", 1,
+                                                      "MESSAGE",
+                                                      "generated-message-on-condition");
+
+  _destroy_pattern_db(patterndb, filename);
+  g_free(filename);
+}
+
 Test(pattern_db, test_correllation_rule_with_rate_limited_action)
 {
   gchar *filename;

--- a/modules/dbparser/tests/test_patterndb.h
+++ b/modules/dbparser/tests/test_patterndb.h
@@ -172,6 +172,27 @@
        </action>\
      </actions>\
     </rule>\
+    <rule provider='test' id='10f' class='violation' context-scope='program' context-id='$PROGRAM' context-timeout='60'>\
+     <patterns>\
+      <pattern>correllated-message-with-action-condition-filter</pattern>\
+     </patterns>\
+     <actions>\
+       <action trigger='match' condition='message(\"filter-not-exists\" type(pcre))' >\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>not-generated-message</value>\
+           </values>\
+         </message>\
+       </action>\
+       <action trigger='match' condition='message(\"filter\" type(pcre))' >\
+         <message>\
+           <values>\
+             <value name='MESSAGE'>generated-message-on-condition</value>\
+           </values>\
+         </message>\
+       </action>\
+     </actions>\
+    </rule>\
     <rule provider='test' id='11b' class='violation'>\
      <patterns>\
       <pattern>simple-message-with-action-on-match</pattern>\


### PR DESCRIPTION
The problem is described in #2842

This patch:
- allows to parse modules with the keywords from the main_parser.
- calls missing init statements, so filters will work properly.