### PR TITLE
travis: commit style check use commit range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,11 @@ matrix:
       compiler: gcc
       install:
       before_script:
+      git:
+        submodules: false
+        depth: false
       script:
-        - tests/commits/check.sh
+        - tests/commits/check.sh "${TRAVIS_COMMIT_RANGE}"
 
     - env: B=cmake-submodules-and-pytest
       compiler: gcc

--- a/tests/commits/check.sh
+++ b/tests/commits/check.sh
@@ -23,11 +23,6 @@
 
 commit_range=origin/master..HEAD
 
-if [ -n "$TRAVIS_COMMIT" ]; then
-  git fetch -q origin master:master
-  commit_range="master..$TRAVIS_COMMIT"
-fi
-
 if [ $# -gt 0 ]; then
   commit_range=$1
 fi


### PR DESCRIPTION
Moves travis specific code into `.travis.yml` and uses `${TRAVIS_COMMIT_RANGE}` variable configured by travis to specify the commits needs to be tested.

This range contains the commit of the current branch, and commits that are in the upstream (target remote/branch) has and the current branch do not have.

Note: when there is no PR opened just the branch pushed into github, this is empty (and falls back to the script default).