### PR TITLE
fix heap usage after free in cfg_run_parser_with_main_context

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -526,7 +526,6 @@ cfg_run_parser_with_main_context(GlobalConfig *self, CfgLexer *lexer, CfgParser 
 
   cfg_lexer_push_context(lexer, main_parser.context, main_parser.keywords, desc);
   ret_val = cfg_run_parser(self, lexer, parser, result, arg);
-  cfg_lexer_pop_context(lexer);
 
   return ret_val;
 }


### PR DESCRIPTION
The cfg_run_parser_with_main_context uses a cfg_run_parser, that frees the lexer.
Therefore pop-ing from the freed lexer is not okay.