### PR TITLE
Add contextual data make filters config plugin aware

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -477,6 +477,17 @@ cfg_new_snippet(void)
   return self;
 }
 
+/* This function creates a GlobalConfig instance that shares the set of
+ * available plugins as a master one.  */
+GlobalConfig *
+cfg_new_subordinate(GlobalConfig *master)
+{
+  GlobalConfig *self = cfg_new_snippet();
+
+  plugin_context_copy_candidates(&self->plugin_context, &master->plugin_context);
+  return self;
+}
+
 void
 cfg_set_global_paths(GlobalConfig *self)
 {

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -147,6 +147,7 @@ void cfg_set_global_paths(GlobalConfig *self);
 
 GlobalConfig *cfg_new(gint version);
 GlobalConfig *cfg_new_snippet(void);
+GlobalConfig *cfg_new_subordinate(GlobalConfig *master);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
 gboolean cfg_run_parser_with_main_context(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result,
                                           gpointer arg, const gchar *desc);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -181,66 +181,8 @@ _format_module_init_name(const gchar *module_name)
   return module_init_func;
 }
 
-void
-plugin_register(PluginContext *context, Plugin *p, gint number)
-{
-  gint i;
-
-  for (i = 0; i < number; i++)
-    {
-      Plugin *existing_plugin;
-
-      existing_plugin = _find_plugin_in_list(context->plugins, p[i].type, p[i].name);
-      if (existing_plugin)
-        {
-          msg_debug("Attempted to register the same plugin multiple times, dropping the old one",
-                    evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(p[i].type)),
-                    evt_tag_str("name", p[i].name));
-          context->plugins = g_list_remove(context->plugins, existing_plugin);
-        }
-      context->plugins = g_list_prepend(context->plugins, &p[i]);
-    }
-}
-
-Plugin *
-plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name)
-{
-  Plugin *p;
-  PluginCandidate *candidate;
-
-  /* try registered plugins first */
-  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
-  if (p)
-    {
-      return p;
-    }
-
-  candidate = (PluginCandidate *) _find_plugin_in_list(context->candidate_plugins, plugin_type, plugin_name);
-  if (!candidate)
-    return NULL;
-
-  /* try to autoload the module */
-  plugin_load_module(context, candidate->module_name, NULL);
-
-  /* by this time it should've registered */
-  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
-  if (p)
-    {
-      p->failure_info.aux_data = candidate->super.failure_info.aux_data;
-      return p;
-    }
-  else
-    {
-      msg_error("This module claims to support a plugin, which it didn't register after loading",
-                evt_tag_str("module", candidate->module_name),
-                evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(plugin_type)),
-                evt_tag_str("name", plugin_name));
-    }
-  return NULL;
-}
-
 static GModule *
-plugin_dlopen_module_as_filename(const gchar *module_file_name, const gchar *module_name)
+_dlopen_module_as_filename(const gchar *module_file_name, const gchar *module_name)
 {
   GModule *mod = NULL;
 
@@ -260,21 +202,20 @@ plugin_dlopen_module_as_filename(const gchar *module_file_name, const gchar *mod
 }
 
 static GModule *
-plugin_dlopen_module_as_dir_and_filename(const gchar *module_dir_name, const gchar *module_file_name,
-                                         const gchar *module_name)
+_dlopen_module_as_dir_and_filename(const gchar *module_dir_name, const gchar *module_file_name,
+                                   const gchar *module_name)
 {
   gchar *path;
   GModule *mod;
 
   path = g_build_path(G_DIR_SEPARATOR_S, module_dir_name, module_file_name, NULL);
-  mod = plugin_dlopen_module_as_filename(path, module_name);
+  mod = _dlopen_module_as_filename(path, module_name);
   g_free(path);
   return mod;
 }
 
-
 static GModule *
-plugin_dlopen_module_on_path(const gchar *module_name, const gchar *module_path)
+_dlopen_module_on_path(const gchar *module_name, const gchar *module_path)
 {
   gchar *plugin_module_name = NULL;
   gchar **module_path_dirs, *p, *dot;
@@ -342,9 +283,67 @@ plugin_dlopen_module_on_path(const gchar *module_name, const gchar *module_path)
       return NULL;
     }
 
-  mod = plugin_dlopen_module_as_filename(plugin_module_name, module_name);
+  mod = _dlopen_module_as_filename(plugin_module_name, module_name);
   g_free(plugin_module_name);
   return mod;
+}
+
+void
+plugin_register(PluginContext *context, Plugin *p, gint number)
+{
+  gint i;
+
+  for (i = 0; i < number; i++)
+    {
+      Plugin *existing_plugin;
+
+      existing_plugin = _find_plugin_in_list(context->plugins, p[i].type, p[i].name);
+      if (existing_plugin)
+        {
+          msg_debug("Attempted to register the same plugin multiple times, dropping the old one",
+                    evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(p[i].type)),
+                    evt_tag_str("name", p[i].name));
+          context->plugins = g_list_remove(context->plugins, existing_plugin);
+        }
+      context->plugins = g_list_prepend(context->plugins, &p[i]);
+    }
+}
+
+Plugin *
+plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name)
+{
+  Plugin *p;
+  PluginCandidate *candidate;
+
+  /* try registered plugins first */
+  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
+  if (p)
+    {
+      return p;
+    }
+
+  candidate = (PluginCandidate *) _find_plugin_in_list(context->candidate_plugins, plugin_type, plugin_name);
+  if (!candidate)
+    return NULL;
+
+  /* try to autoload the module */
+  plugin_load_module(context, candidate->module_name, NULL);
+
+  /* by this time it should've registered */
+  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
+  if (p)
+    {
+      p->failure_info.aux_data = candidate->super.failure_info.aux_data;
+      return p;
+    }
+  else
+    {
+      msg_error("This module claims to support a plugin, which it didn't register after loading",
+                evt_tag_str("module", candidate->module_name),
+                evt_tag_str("context", cfg_lexer_lookup_context_name_by_type(plugin_type)),
+                evt_tag_str("name", plugin_name));
+    }
+  return NULL;
 }
 
 gboolean
@@ -369,7 +368,7 @@ plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *ar
     }
 
   /* try to load it from external .so */
-  mod = plugin_dlopen_module_on_path(module_name, context->module_path);
+  mod = _dlopen_module_on_path(module_name, context->module_path);
   if (!mod)
     {
       g_free(module_init_func);
@@ -453,7 +452,7 @@ plugin_load_candidate_modules(PluginContext *context)
                         evt_tag_str("path", mod_paths[i]),
                         evt_tag_str("fname", fname),
                         evt_tag_str("module", module_name));
-              mod = plugin_dlopen_module_as_dir_and_filename(mod_paths[i], fname, module_name);
+              mod = _dlopen_module_as_dir_and_filename(mod_paths[i], fname, module_name);
               module_info = _get_module_info(mod);
 
               if (module_info)
@@ -568,7 +567,7 @@ plugin_list_modules(FILE *out, gboolean verbose)
                 so_basename = fname + 3;
               module_name = g_strndup(so_basename, (gint) (strlen(so_basename) - strlen(G_MODULE_SUFFIX) - 1));
 
-              mod = plugin_dlopen_module_as_dir_and_filename(mod_paths[i], fname, module_name);
+              mod = _dlopen_module_as_dir_and_filename(mod_paths[i], fname, module_name);
               module_info = _get_module_info(mod);
               if (verbose)
                 {

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -156,6 +156,16 @@ _find_plugin_in_list(GList *head, gint plugin_type, const gchar *plugin_name)
   return NULL;
 }
 
+static ModuleInfo *
+_get_module_info(GModule *mod)
+{
+  ModuleInfo *module_info = NULL;
+
+  if (mod && g_module_symbol(mod, "module_info", (gpointer *) &module_info))
+    return module_info;
+  return NULL;
+}
+
 void
 plugin_register(PluginContext *context, Plugin *p, gint number)
 {
@@ -214,15 +224,6 @@ plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name)
   return NULL;
 }
 
-static ModuleInfo *
-plugin_get_module_info(GModule *mod)
-{
-  ModuleInfo *module_info = NULL;
-
-  if (mod && g_module_symbol(mod, "module_info", (gpointer *) &module_info))
-    return module_info;
-  return NULL;
-}
 
 static gchar *
 plugin_get_module_init_name(const gchar *module_name)
@@ -376,7 +377,7 @@ plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *ar
       return FALSE;
     }
   g_module_make_resident(mod);
-  module_info = plugin_get_module_info(mod);
+  module_info = _get_module_info(mod);
 
   if (module_info->canonical_name)
     {
@@ -454,7 +455,7 @@ plugin_load_candidate_modules(PluginContext *context)
                         evt_tag_str("fname", fname),
                         evt_tag_str("module", module_name));
               mod = plugin_dlopen_module_as_dir_and_filename(mod_paths[i], fname, module_name);
-              module_info = plugin_get_module_info(mod);
+              module_info = _get_module_info(mod);
 
               if (module_info)
                 {
@@ -569,7 +570,7 @@ plugin_list_modules(FILE *out, gboolean verbose)
               module_name = g_strndup(so_basename, (gint) (strlen(so_basename) - strlen(G_MODULE_SUFFIX) - 1));
 
               mod = plugin_dlopen_module_as_dir_and_filename(mod_paths[i], fname, module_name);
-              module_info = plugin_get_module_info(mod);
+              module_info = _get_module_info(mod);
               if (verbose)
                 {
                   fprintf(out, "Module: %s\n", module_name);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -125,7 +125,7 @@ plugin_construct_from_config(Plugin *self, CfgLexer *lexer, gpointer arg)
  *****************************************************************************/
 
 static Plugin *
-plugin_find_in_list(GList *head, gint plugin_type, const gchar *plugin_name)
+_find_plugin_in_list(GList *head, gint plugin_type, const gchar *plugin_name)
 {
   GList *p;
   Plugin *plugin;
@@ -165,7 +165,7 @@ plugin_register(PluginContext *context, Plugin *p, gint number)
     {
       Plugin *existing_plugin;
 
-      existing_plugin = plugin_find_in_list(context->plugins, p[i].type, p[i].name);
+      existing_plugin = _find_plugin_in_list(context->plugins, p[i].type, p[i].name);
       if (existing_plugin)
         {
           msg_debug("Attempted to register the same plugin multiple times, dropping the old one",
@@ -184,13 +184,13 @@ plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name)
   PluginCandidate *candidate;
 
   /* try registered plugins first */
-  p = plugin_find_in_list(context->plugins, plugin_type, plugin_name);
+  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
   if (p)
     {
       return p;
     }
 
-  candidate = (PluginCandidate *) plugin_find_in_list(context->candidate_plugins, plugin_type, plugin_name);
+  candidate = (PluginCandidate *) _find_plugin_in_list(context->candidate_plugins, plugin_type, plugin_name);
   if (!candidate)
     return NULL;
 
@@ -198,7 +198,7 @@ plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name)
   plugin_load_module(context, candidate->module_name, NULL);
 
   /* by this time it should've registered */
-  p = plugin_find_in_list(context->plugins, plugin_type, plugin_name);
+  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
   if (p)
     {
       p->failure_info.aux_data = candidate->super.failure_info.aux_data;
@@ -463,7 +463,7 @@ plugin_load_candidate_modules(PluginContext *context)
                       Plugin *plugin = &module_info->plugins[j];
                       PluginCandidate *candidate_plugin;
 
-                      candidate_plugin = (PluginCandidate *) plugin_find_in_list(context->candidate_plugins, plugin->type, plugin->name);
+                      candidate_plugin = (PluginCandidate *) _find_plugin_in_list(context->candidate_plugins, plugin->type, plugin->name);
 
                       msg_debug("Registering candidate plugin",
                                 evt_tag_str("module", module_name),

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -166,6 +166,21 @@ _get_module_info(GModule *mod)
   return NULL;
 }
 
+static gchar *
+_format_module_init_name(const gchar *module_name)
+{
+  gchar *module_init_func;
+  gchar *p;
+
+  module_init_func = g_strdup_printf("%s_module_init", module_name);
+  for (p = module_init_func; *p; p++)
+    {
+      if ((*p) == '-')
+        *p = '_';
+    }
+  return module_init_func;
+}
+
 void
 plugin_register(PluginContext *context, Plugin *p, gint number)
 {
@@ -222,22 +237,6 @@ plugin_find(PluginContext *context, gint plugin_type, const gchar *plugin_name)
                 evt_tag_str("name", plugin_name));
     }
   return NULL;
-}
-
-
-static gchar *
-plugin_get_module_init_name(const gchar *module_name)
-{
-  gchar *module_init_func;
-  gchar *p;
-
-  module_init_func = g_strdup_printf("%s_module_init", module_name);
-  for (p = module_init_func; *p; p++)
-    {
-      if ((*p) == '-')
-        *p = '_';
-    }
-  return module_init_func;
 }
 
 static GModule *
@@ -361,7 +360,7 @@ plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *ar
   /* lookup in the main executable */
   if (!main_module_handle)
     main_module_handle = g_module_open(NULL, 0);
-  module_init_func = plugin_get_module_init_name(module_name);
+  module_init_func = _format_module_init_name(module_name);
 
   if (g_module_symbol(main_module_handle, module_init_func, (gpointer *) &init_func))
     {
@@ -382,7 +381,7 @@ plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *ar
   if (module_info->canonical_name)
     {
       g_free(module_init_func);
-      module_init_func = plugin_get_module_init_name(module_info->canonical_name ? : module_name);
+      module_init_func = _format_module_init_name(module_info->canonical_name ? : module_name);
     }
 
   if (!g_module_symbol(mod, module_init_func, (gpointer *) &init_func))

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -515,6 +515,21 @@ _free_candidate_plugins(PluginContext *context)
 }
 
 void
+plugin_context_copy_candidates(PluginContext *context, PluginContext *from)
+{
+  GList *l;
+
+  for (l = from->candidate_plugins; l; l = l->next)
+    {
+      PluginCandidate *pc = (PluginCandidate *) l->data;
+
+      context->candidate_plugins =
+        g_list_prepend(context->candidate_plugins,
+                       plugin_candidate_new(pc->super.type, pc->super.name, pc->module_name));
+    }
+}
+
+void
 plugin_context_set_module_path(PluginContext *context, const gchar *module_path)
 {
   g_free(context->module_path);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -409,12 +409,6 @@ call_init:
  * Candidate modules
  ************************************************************/
 
-static void
-_free_candidate_plugin_list(GList *candidate_plugins)
-{
-  g_list_foreach(candidate_plugins, (GFunc) plugin_candidate_free, NULL);
-  g_list_free(candidate_plugins);
-}
 void
 plugin_load_candidate_modules(PluginContext *context)
 {
@@ -505,11 +499,19 @@ _free_plugin(Plugin *plugin, gpointer user_data)
 }
 
 static void
-plugin_free_plugins(PluginContext *context)
+_free_plugins(PluginContext *context)
 {
   g_list_foreach(context->plugins, (GFunc) _free_plugin, NULL);
   g_list_free(context->plugins);
   context->plugins = NULL;
+}
+
+static void
+_free_candidate_plugins(PluginContext *context)
+{
+  g_list_foreach(context->candidate_plugins, (GFunc) plugin_candidate_free, NULL);
+  g_list_free(context->candidate_plugins);
+  context->candidate_plugins = NULL;
 }
 
 void
@@ -529,9 +531,8 @@ plugin_context_init_instance(PluginContext *context)
 void
 plugin_context_deinit_instance(PluginContext *context)
 {
-  plugin_free_plugins(context);
-  _free_candidate_plugin_list(context->candidate_plugins);
-  context->candidate_plugins = NULL;
+  _free_plugins(context);
+  _free_candidate_plugins(context);
 
   g_free(context->module_path);
 }

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -58,8 +58,11 @@ typedef struct _PluginCandidate
 typedef struct _Plugin Plugin;
 struct _Plugin
 {
-  /* NOTE: the first two fields must match PluginCandidate struct defined in
-     the plugin.c module, please modify them both at the same time! */
+  /* NOTE: the first three fields must match PluginCandidate struct defined
+     in the plugin.c module, please modify them both at the same time!  It
+     is not referenced as "super" as it would make the using sites having to
+     use ugly braces when initializing the structure. */
+
   gint type;
   const gchar *name;
   PluginFailureInfo failure_info;

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -111,6 +111,7 @@ void plugin_list_modules(FILE *out, gboolean verbose);
 
 void plugin_load_candidate_modules(PluginContext *context);
 
+void plugin_context_copy_candidates(PluginContext *context, PluginContext *src_context);
 void plugin_context_set_module_path(PluginContext *context, const gchar *module_path);
 void plugin_context_init_instance(PluginContext *context);
 void plugin_context_deinit_instance(PluginContext *context);

--- a/modules/add-contextual-data/add-contextual-data-filter-selector.c
+++ b/modules/add-contextual-data/add-contextual-data-filter-selector.c
@@ -38,6 +38,7 @@ typedef struct _AddContextualDataFilterSelector
 {
   AddContextualDataSelector super;
   gchar *filters_path;
+  GlobalConfig *master_cfg;
   GlobalConfig *filters_cfg;
   FilterStore *filter_store;
 } AddContextualDataFilterSelector;
@@ -99,7 +100,7 @@ _filter_store_get_first_matching_name(FilterStore *self, LogMessage *msg)
 static gboolean
 _init_filters_from_file(AddContextualDataFilterSelector *self)
 {
-  self->filters_cfg = cfg_new_snippet();
+  self->filters_cfg = cfg_new_subordinate(self->master_cfg);
   if (!cfg_read_config(self->filters_cfg, self->filters_path, NULL))
     {
       cfg_free(self->filters_cfg);
@@ -236,6 +237,7 @@ add_contextual_data_selector_filter_clone(AddContextualDataSelector *s, GlobalCo
 
   cloned->filters_path = g_strdup(self->filters_path);
   cloned->filters_cfg = NULL;
+  cloned->master_cfg = self->master_cfg;
   cloned->filter_store  = _filter_store_clone(self->filter_store);
 
   return &cloned->super;
@@ -248,7 +250,7 @@ add_contextual_data_selector_filter_new(GlobalConfig *cfg, const gchar *filters_
   AddContextualDataFilterSelector *new_instance = _create_empty_add_contextual_data_filter_selector();
 
   new_instance->filters_path = g_strdup(filters_path);
-  new_instance->cfg = NULL;
+  new_instance->master_cfg = cfg;
   new_instance->filters_cfg = NULL;
   new_instance->filter_store = _filter_store_new();
 

--- a/modules/add-contextual-data/add-contextual-data-filter-selector.c
+++ b/modules/add-contextual-data/add-contextual-data-filter-selector.c
@@ -220,13 +220,13 @@ static AddContextualDataSelector *add_contextual_data_selector_filter_clone(AddC
 static AddContextualDataFilterSelector *
 _create_empty_add_contextual_data_filter_selector(void)
 {
-  AddContextualDataFilterSelector *new_instance = g_new0(AddContextualDataFilterSelector, 1);
-  new_instance->super.ordering_required = TRUE;
-  new_instance->super.resolve = add_contextual_data_selector_filter_resolve;
-  new_instance->super.free = add_contextual_data_selector_filter_free;
-  new_instance->super.init = add_contextual_data_selector_filter_init;
-  new_instance->super.clone = add_contextual_data_selector_filter_clone;
-  return new_instance;
+  AddContextualDataFilterSelector *self = g_new0(AddContextualDataFilterSelector, 1);
+  self->super.ordering_required = TRUE;
+  self->super.resolve = add_contextual_data_selector_filter_resolve;
+  self->super.free = add_contextual_data_selector_filter_free;
+  self->super.init = add_contextual_data_selector_filter_init;
+  self->super.clone = add_contextual_data_selector_filter_clone;
+  return self;
 }
 
 static AddContextualDataSelector *
@@ -246,13 +246,12 @@ add_contextual_data_selector_filter_clone(AddContextualDataSelector *s, GlobalCo
 AddContextualDataSelector *
 add_contextual_data_selector_filter_new(GlobalConfig *cfg, const gchar *filters_path)
 {
+  AddContextualDataFilterSelector *self = _create_empty_add_contextual_data_filter_selector();
 
-  AddContextualDataFilterSelector *new_instance = _create_empty_add_contextual_data_filter_selector();
+  self->filters_path = g_strdup(filters_path);
+  self->master_cfg = cfg;
+  self->filters_cfg = NULL;
+  self->filter_store = _filter_store_new();
 
-  new_instance->filters_path = g_strdup(filters_path);
-  new_instance->master_cfg = cfg;
-  new_instance->filters_cfg = NULL;
-  new_instance->filter_store = _filter_store_new();
-
-  return &new_instance->super;
+  return &self->super;
 }


### PR DESCRIPTION
the primary goal of this PR is this patch:

```
add-contextual-data: fix missing plugins in the filters configuration
    
It was reported by Mark Bonsack when using add-contextual-data() using the
filters() selector that the secondary configuration file misses all plugins
that the primary one has already loaded.
    
This patch makes this secondary config use the same set of plugins as the
primary one, eliminating the issue.
```

The branch also contains a plugin refactor (basically just moving code around and renaming stuff to make that uglyness somewhat nicer).

The fix relies on the concept of "subordinate" configurations, which by their definition share some things with the main config, this time the set of plugins available to it. Later, this could potentially be extended, but honestly I hope the entire filters() mode of add-contextual-data() can be eliminated completely.
