### PR TITLE
add format-flat-json template function

### DIFF
--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -355,3 +355,6 @@ tf_json_free_state(gpointer s)
 
 TEMPLATE_FUNCTION(TFJsonState, tf_json, tf_json_prepare, NULL, tf_json_call,
                   tf_json_free_state, NULL);
+
+TEMPLATE_FUNCTION(TFJsonState, tf_flat_json, tf_json_prepare, NULL, tf_json_call,
+                  tf_json_free_state, NULL);

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -333,15 +333,18 @@ tf_json_call(LogTemplateFunction *self, gpointer s,
              const LogTemplateInvokeArgs *args, GString *result)
 {
   TFJsonState *state = (TFJsonState *)s;
-  gint i;
-  gboolean r = TRUE;
   gsize orig_size = result->len;
 
-  for (i = 0; i < args->num_messages; i++)
-    r &= tf_json_append(result, state->vp, args->messages[i], args->opts, args->seq_num, args->tz);
+  for (gint i = 0; i < args->num_messages; i++)
+    {
+      gboolean r = tf_json_append(result, state->vp, args->messages[i], args->opts, args->seq_num, args->tz);
+      if (!r && (args->opts->on_error & ON_ERROR_DROP_MESSAGE))
+        {
+          g_string_set_size(result, orig_size);
+          return;
+        }
+    }
 
-  if (!r && (args->opts->on_error & ON_ERROR_DROP_MESSAGE))
-    g_string_set_size(result, orig_size);
 }
 
 static void

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -31,6 +31,7 @@
 #include "syslog-ng.h"
 #include "utf8utils.h"
 #include "scanner/list-scanner/list-scanner.h"
+#include "scratch-buffers.h"
 
 typedef struct _TFJsonState
 {
@@ -376,6 +377,18 @@ tf_flat_json_obj_end(const gchar *name,
   return FALSE;
 }
 
+static GString *
+_join_name(const gchar *prefix, const gchar  *subfix)
+{
+  GString *full_name = scratch_buffers_alloc();
+  if (prefix)
+    g_string_append_printf(full_name, "%s.%s", prefix, subfix);
+  else
+    g_string_append(full_name, subfix);
+
+  return full_name;
+}
+
 static gboolean
 tf_flat_json_value(const gchar *name, const gchar *prefix,
                    TypeHint type, const gchar *value, gsize value_len,
@@ -383,9 +396,9 @@ tf_flat_json_value(const gchar *name, const gchar *prefix,
 {
   json_state_t *state = (json_state_t *)user_data;
 
-  gchar buff[1024];
-  sprintf(buff, "%s.%s", prefix, name);
-  tf_json_append_value(buff, value, value_len, state, TRUE);
+  GString *full_name = _join_name(prefix, name);
+
+  tf_json_append_value(full_name->str, value, value_len, state, TRUE);
 
   state->need_comma = TRUE;
 

--- a/modules/json/format-json.h
+++ b/modules/json/format-json.h
@@ -26,5 +26,6 @@
 #include "plugin.h"
 
 TEMPLATE_FUNCTION_DECLARE(tf_json);
+TEMPLATE_FUNCTION_DECLARE(tf_flat_json);
 
 #endif

--- a/modules/json/json-plugin.c
+++ b/modules/json/json-plugin.c
@@ -35,6 +35,7 @@ static Plugin json_plugins[] =
     .parser = &json_parser_parser,
   },
   TEMPLATE_FUNCTION_PLUGIN(tf_json, "format_json"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_flat_json, "format_flat_json"),
 };
 
 gboolean

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -203,6 +203,17 @@ Test(format_json, test_format_json_with_utf8)
   log_msg_unref(msg);
 }
 
+Test(format_json, test_format_flat_json)
+{
+  LogMessage *msg = create_empty_message();
+
+  assert_template_format_msg("$(format-flat-json a.b.c1=abc a.b.d=abd a.bc=abc)",
+                             "{\"a\":{\"bc\":\"abc\",\"b\":{\"d\":\"abd\",\"c1\":\"abc\"}}}",
+                             msg);
+
+  log_msg_unref(msg);
+}
+
 Test(format_json, test_format_json_performance)
 {
   perftest_template("$(format-json APP.*)\n");

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -214,6 +214,17 @@ Test(format_json, test_format_flat_json)
   log_msg_unref(msg);
 }
 
+Test(format_json, test_format_flat_json_direct)
+{
+  LogMessage *msg = create_empty_message();
+
+  assert_template_format_msg("$(format-flat-json a=b c=d)",
+                             "{\"c\":\"d\",\"a\":\"b\"}",
+                             msg);
+
+  log_msg_unref(msg);
+}
+
 Test(format_json, test_format_json_performance)
 {
   perftest_template("$(format-json APP.*)\n");

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -208,7 +208,7 @@ Test(format_json, test_format_flat_json)
   LogMessage *msg = create_empty_message();
 
   assert_template_format_msg("$(format-flat-json a.b.c1=abc a.b.d=abd a.bc=abc)",
-                             "{\"a\":{\"bc\":\"abc\",\"b\":{\"d\":\"abd\",\"c1\":\"abc\"}}}",
+                             "{\"a.bc\":\"abc\",\"a.b.d\":\"abd\",\"a.b.c1\":\"abc\"}",
                              msg);
 
   log_msg_unref(msg);

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -225,6 +225,22 @@ Test(format_json, test_format_flat_json_direct)
   log_msg_unref(msg);
 }
 
+Test(format_json, test_format_flat_json_with_type_hints)
+{
+  assert_template_format("$(format-flat-json i32=int32(1234))",
+                         "{\"i32\":1234}");
+  assert_template_format("$(format-flat-json \"i=ifoo(\")",
+                         "{\"i\":\"ifoo(\"}");
+  assert_template_format("$(format-flat-json b=boolean(TRUE))",
+                         "{\"b\":true}");
+  assert_template_format("$(format-flat-json l=list($comma_value))",
+                         "{\"l\":[\"value\",\"with\",\"a\",\"comma\"]}");
+  assert_template_format("$(format-flat-json b=literal(whatever))",
+                         "{\"b\":whatever}");
+  assert_template_format("$(format-flat-json b=literal($(format-flat-json subkey=bar)))",
+                         "{\"b\":{\"subkey\":\"bar\"}}");
+}
+
 Test(format_json, test_format_json_performance)
 {
   perftest_template("$(format-json APP.*)\n");


### PR DESCRIPTION
The current `$(format-json a.b.c=1)` json formatting template function created a nested json:
```json
{
  "a": {
    "b": {
      "c": "1"
    }
  }
}
```
(withouth the whitespaces)

In some json parsing system cannot handle this nested-json format, as such a *flattened* json (in a sense that the keys are joined together).

With the new function `$(format-flat-json a.b.c=1)` became:
```json
{
  "a.b.c": "1"
}
```

In other functionality and options the `$(format-json)` and `$(format-flat-json)` are identical.

Question:
* Is it better to have a new function name instead of a simple switch (`$(format-json --flatten)`) ?
* Should it support other than `.` separator in the keys between levels ?