### PR TITLE
on 32bit platform diskq ftruncate could fail due to size 32/64 interface

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -337,7 +337,7 @@ _push_tail (LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, con
                          evt_tag_str  ("filename", qdisk_get_filename (self->super.qdisk)),
                          evt_tag_long ("queue_len", _get_length(s)),
                          evt_tag_int  ("mem_buf_length", self->qoverflow_size),
-                         evt_tag_long ("disk_buf_size", qdisk_get_size (self->super.qdisk)),
+                         evt_tag_long ("disk_buf_size", qdisk_get_maximum_size (self->super.qdisk)),
                          evt_tag_str  ("persist_name", self->super.super.persist_name));
               return FALSE;
             }

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -265,7 +265,7 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
                 evt_tag_str("filename", qdisk_get_filename (self->super.qdisk)),
                 evt_tag_long("queue_len", _get_length(s)),
                 evt_tag_int("mem_buf_size", qdisk_get_memory_size (self->super.qdisk)),
-                evt_tag_long("disk_buf_size", qdisk_get_size (self->super.qdisk)),
+                evt_tag_long("disk_buf_size", qdisk_get_maximum_size (self->super.qdisk)),
                 evt_tag_str("persist_name", self->super.super.persist_name));
 
       return FALSE;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -305,13 +305,17 @@ static void
 _restart_diskq(LogQueueDisk *self)
 {
   gchar *filename = g_strdup(qdisk_get_filename(self->qdisk));
-  gchar *new_file = NULL;
   DiskQueueOptions *options = qdisk_get_options(self->qdisk);
 
   qdisk_stop(self->qdisk);
 
-  new_file = g_strdup_printf("%s.corrupted", filename);
-  rename(filename, new_file);
+  gchar *new_file = g_strdup_printf("%s.corrupted",filename);
+  if (rename(filename, new_file) < 0)
+    {
+      msg_error("Moving corrupt disk-queue failed",
+                evt_tag_str(EVT_TAG_FILENAME, filename),
+                evt_tag_errno(EVT_TAG_OSERROR, errno));
+    }
   g_free(new_file);
 
   if (self->restart)

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -247,7 +247,8 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
       log_msg_unref(*msg);
       *msg = NULL;
       msg_error("Can't read correct message from disk-queue file",
-                evt_tag_str("filename", qdisk_get_filename(self->qdisk)));
+                evt_tag_str("filename", qdisk_get_filename(self->qdisk)),
+                evt_tag_long("read_position", qdisk_get_reader_head(self->qdisk)));
       return TRUE;
     }
 

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -314,7 +314,7 @@ _restart_diskq(LogQueueDisk *self)
     {
       msg_error("Moving corrupt disk-queue failed",
                 evt_tag_str(EVT_TAG_FILENAME, filename),
-                evt_tag_errno(EVT_TAG_OSERROR, errno));
+                evt_tag_error(EVT_TAG_OSERROR));
     }
   g_free(new_file);
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -276,7 +276,7 @@ qdisk_get_empty_space(QDisk *self)
 
   if (wpos > bpos)
     {
-      return (qdisk_get_size(self) - wpos) +
+      return (qdisk_get_maximum_size(self) - wpos) +
              (bpos - QDISK_RESERVED_SPACE);
     }
 
@@ -1021,7 +1021,7 @@ qdisk_set_length(QDisk *self, gint64 new_value)
 }
 
 gint64
-qdisk_get_size(QDisk *self)
+qdisk_get_maximum_size(QDisk *self)
 {
   return self->options->disk_buf_size;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -985,12 +985,6 @@ qdisk_skip_record(QDisk *self, guint64 position)
 }
 
 void
-qdisk_set_backlog_count(QDisk *self, gint64 new_value)
-{
-  self->hdr->backlog_len = new_value;
-}
-
-void
 qdisk_reset_file_if_possible(QDisk *self)
 {
   if (qdisk_is_file_empty(self))
@@ -1072,6 +1066,12 @@ void
 qdisk_dec_backlog(QDisk *self)
 {
   self->hdr->backlog_len--;
+}
+
+void
+qdisk_set_backlog_count(QDisk *self, gint64 new_value)
+{
+  self->hdr->backlog_len = new_value;
 }
 
 gint64

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -436,20 +436,20 @@ qdisk_pop_head(QDisk *self, GString *record)
       if (!self->options->reliable)
         {
           self->hdr->backlog_head = self->hdr->read_head;
-        }
 
-      if (!self->options->read_only && self->hdr->length == 0 && !self->options->reliable)
-        {
-          msg_debug("Queue file became empty, truncating file",
-                    evt_tag_str("filename", self->filename));
-          self->hdr->read_head = QDISK_RESERVED_SPACE;
-          self->hdr->write_head = QDISK_RESERVED_SPACE;
-          if (!self->options->reliable)
+          if (!self->options->read_only && self->hdr->length == 0 && !self->options->reliable)
             {
-              self->hdr->backlog_head = self->hdr->read_head;
+              msg_debug("Queue file became empty, truncating file",
+                        evt_tag_str("filename", self->filename));
+              self->hdr->read_head = QDISK_RESERVED_SPACE;
+              self->hdr->write_head = QDISK_RESERVED_SPACE;
+              if (!self->options->reliable)
+                {
+                  self->hdr->backlog_head = self->hdr->read_head;
+                }
+              self->hdr->length = 0;
+              _truncate_file(self, self->hdr->write_head);
             }
-          self->hdr->length = 0;
-          _truncate_file(self, self->hdr->write_head);
         }
       return TRUE;
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -152,6 +152,13 @@ qdisk_started(QDisk *self)
 }
 
 static inline gboolean
+_is_qdisk_overwritten(QDisk *self)
+{
+  return self->hdr->write_head > self->options->disk_buf_size;
+}
+
+
+static inline gboolean
 _is_backlog_head_prevent_write_head(QDisk *self)
 {
   return self->hdr->backlog_head <= self->hdr->write_head;
@@ -340,7 +347,7 @@ qdisk_push_tail(QDisk *self, GString *record)
         }
       self->file_size = self->hdr->write_head;
 
-      if (self->hdr->write_head > self->options->disk_buf_size && self->hdr->backlog_head  != QDISK_RESERVED_SPACE)
+      if (_is_qdisk_overwritten(self) && self->hdr->backlog_head  != QDISK_RESERVED_SPACE)
         {
           /* we were appending to the file, we are over the limit, and space
            * is available before the read head. truncate and wrap.

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -201,11 +201,11 @@ qdisk_is_space_avail(QDisk *self, gint at_least)
 }
 
 static gboolean
-_truncate_file(QDisk *self, gint64 new_size)
+_truncate_file(QDisk *self, off_t new_size)
 {
   gboolean success = TRUE;
 
-  if (ftruncate(self->fd, (glong)new_size) < 0)
+  if (ftruncate(self->fd, new_size) < 0)
     {
       success = FALSE;
       off_t file_size = -1;
@@ -344,6 +344,8 @@ qdisk_push_tail(QDisk *self, GString *record)
     {
       if (self->file_size > self->hdr->write_head)
         {
+          msg_debug("Unused area ahead of write_head, truncate queue file",
+                    evt_tag_long("new size",  self->hdr->write_head));
           _truncate_file(self, self->hdr->write_head);
         }
       self->file_size = self->hdr->write_head;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -592,9 +592,9 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 
       msg_info("Disk-buffer state loaded",
                evt_tag_str("filename", self->filename),
-               evt_tag_int("qout_length", self->hdr->qout_pos.count),
-               evt_tag_int("qbacklog_length", self->hdr->qbacklog_pos.count),
-               evt_tag_int("qoverflow_length", self->hdr->qoverflow_pos.count),
+               evt_tag_long("qout_length", self->hdr->qout_pos.count),
+               evt_tag_long("qbacklog_length", self->hdr->qbacklog_pos.count),
+               evt_tag_long("qoverflow_length", self->hdr->qoverflow_pos.count),
                evt_tag_long("qdisk_length", self->hdr->length));
 
       _reset_queue_pointers(self);
@@ -730,9 +730,9 @@ qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
   if (!self->options->reliable)
     msg_info("Disk-buffer state saved",
              evt_tag_str("filename", self->filename),
-             evt_tag_int("qout_length", qout_count),
-             evt_tag_int("qbacklog_length", qbacklog_count),
-             evt_tag_int("qoverflow_length", qoverflow_count),
+             evt_tag_long("qout_length", qout_pos.count),
+             evt_tag_long("qbacklog_length", qbacklog_pos.count),
+             evt_tag_long("qoverflow_length", qoverflow_pos.count),
              evt_tag_long("qdisk_length", self->hdr->length));
   else
     msg_info("Reliable disk-buffer state saved",

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -473,7 +473,7 @@ _load_queue(QDisk *self, GQueue *q, gint64 q_ofs, gint32 q_len, gint32 q_count)
         {
           msg_error("Error reading in-memory buffer from disk-queue file",
                     evt_tag_str("filename", self->filename),
-                    read_len < 0 ? evt_tag_errno("error", errno) : evt_tag_str("error", "short read"));
+                    read_len < 0 ? evt_tag_error("error") : evt_tag_str("error", "short read"));
           g_string_free(serialized, TRUE);
           return FALSE;
         }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -378,9 +378,10 @@ qdisk_pop_head(QDisk *self, GString *record)
         }
       if (res != sizeof(n))
         {
-          msg_error("Error reading disk-queue file",
+          msg_error("Error reading disk-queue file, cannot read record-length",
                     evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
-                    evt_tag_str("filename", self->filename));
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_long("offset", self->hdr->read_head));
           return FALSE;
         }
 
@@ -389,14 +390,16 @@ qdisk_pop_head(QDisk *self, GString *record)
         {
           msg_warning("Disk-queue file contains possibly invalid record-length",
                       evt_tag_int("rec_length", n),
-                      evt_tag_str("filename", self->filename));
+                      evt_tag_str("filename", self->filename),
+                      evt_tag_long("offset", self->hdr->read_head));
           return FALSE;
         }
       else if (n == 0)
         {
           msg_error("Disk-queue file contains empty record",
                     evt_tag_int("rec_length", n),
-                    evt_tag_str("filename", self->filename));
+                    evt_tag_str("filename", self->filename),
+                    evt_tag_long("offset", self->hdr->read_head));
           return FALSE;
         }
 
@@ -407,7 +410,8 @@ qdisk_pop_head(QDisk *self, GString *record)
           msg_error("Error reading disk-queue file",
                     evt_tag_str("filename", self->filename),
                     evt_tag_str("error", res < 0 ? g_strerror(errno) : "short read"),
-                    evt_tag_int("read_length", n));
+                    evt_tag_int("expected read length", n),
+                    evt_tag_int("actually read", res));
           return FALSE;
         }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -437,16 +437,13 @@ qdisk_pop_head(QDisk *self, GString *record)
         {
           self->hdr->backlog_head = self->hdr->read_head;
 
-          if (!self->options->read_only && self->hdr->length == 0 && !self->options->reliable)
+          if (!self->options->read_only && self->hdr->length == 0)
             {
               msg_debug("Queue file became empty, truncating file",
                         evt_tag_str("filename", self->filename));
               self->hdr->read_head = QDISK_RESERVED_SPACE;
               self->hdr->write_head = QDISK_RESERVED_SPACE;
-              if (!self->options->reliable)
-                {
-                  self->hdr->backlog_head = self->hdr->read_head;
-                }
+              self->hdr->backlog_head = self->hdr->read_head;
               self->hdr->length = 0;
               _truncate_file(self, self->hdr->write_head);
             }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -437,7 +437,8 @@ qdisk_pop_head(QDisk *self, GString *record)
         {
           self->hdr->backlog_head = self->hdr->read_head;
 
-          if (!self->options->read_only && self->hdr->length == 0)
+          g_assert(self->hdr->backlog_len == 0);
+          if (!self->options->read_only && qdisk_is_file_empty(self))
             {
               msg_debug("Queue file became empty, truncating file",
                         evt_tag_str("filename", self->filename));

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -286,7 +286,6 @@ qdisk_get_empty_space(QDisk *self)
 gboolean
 qdisk_push_tail(QDisk *self, GString *record)
 {
-  guint32 n = GUINT32_TO_BE(record->len);
 
   /* write follows read (e.g. we are appending to the file) OR
    * there's enough space between write and read.
@@ -299,6 +298,7 @@ qdisk_push_tail(QDisk *self, GString *record)
   if (!qdisk_is_space_avail(self, record->len))
     return FALSE;
 
+  guint32 n = GUINT32_TO_BE(record->len);
   if (n == 0)
     {
       msg_error("Error writing empty message into the disk-queue file");

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -65,7 +65,7 @@ gboolean qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *q
 DiskQueueOptions *qdisk_get_options(QDisk *self);
 gint64 qdisk_get_length(QDisk *self);
 void qdisk_set_length(QDisk *self, gint64 new_value);
-gint64 qdisk_get_size(QDisk *self);
+gint64 qdisk_get_maximum_size(QDisk *self);
 gint64 qdisk_get_writer_head(QDisk *self);
 gint64 qdisk_get_reader_head(QDisk *self);
 void qdisk_set_reader_head(QDisk *self, gint64 new_value);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -40,8 +40,8 @@
 typedef struct
 {
   gint64 ofs;
-  gint32 len;
-  gint32 count;
+  guint32 len;
+  guint32 count;
 }
 QDiskQueuePosition;
 

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -365,7 +365,7 @@ ParameterizedTest(restart_test_parameters *test_case, diskq, testcase_diskbuffer
                "Corrupted disk-queue file does not exists!!");
   assert_string(qdisk_get_filename(disk_queue->qdisk), filename,
                 "New disk-queue file's name should be the same\n");
-  cr_assert_eq(qdisk_get_size(disk_queue->qdisk), original_disk_buf_size,
+  cr_assert_eq(qdisk_get_maximum_size(disk_queue->qdisk), original_disk_buf_size,
                "Disk-queue option does not match the original configured value!\n");
   cr_assert_eq(qdisk_get_length(disk_queue->qdisk), 0,
                "New disk-queue file should be empty!\n");

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -65,11 +65,20 @@ _save_diskqueue(LogQueue *q)
   log_queue_unref(q);
 }
 
-static gsize
-_calculate_expected_file_size(gint number_of_msgs)
+static gint64
+_get_file_size(LogQueue *q)
+{
+  struct stat file_stats;
+  const gchar *filename = log_queue_disk_get_filename(q);
+  assert_gint(stat(filename, &file_stats), 0, "Stat call failed, errno:%d", errno);
+  return (gint64)file_stats.st_size;
+}
+
+static gint64
+_calculate_expected_file_size(gint64 number_of_msgs)
 {
   guint diskq_record_len_size = 4;
-  gsize one_msg_size = get_one_message_serialized_size();
+  gint64 one_msg_size = get_one_message_serialized_size();
   return ((one_msg_size + diskq_record_len_size) * number_of_msgs) + QDISK_RESERVED_SPACE;
 }
 
@@ -77,12 +86,10 @@ static void
 _assert_diskq_actual_file_size_with_stored(LogQueue *q)
 {
   QDisk *qdisk = ((LogQueueDisk *)q)->qdisk;
-  gchar *filename = qdisk->filename;
 
-  struct stat diskq_file_stat;
-  cr_assert_eq(stat(filename, &diskq_file_stat), 0, "Stat call failed, errno:%d", errno);
-  cr_assert_eq(qdisk->file_size, diskq_file_stat.st_size,
-               "File size does not match with stored size; Actual file size: %ld, Expected file size: %ld\n", diskq_file_stat.st_size,
+  gint64 actual_file_size = _get_file_size(q);
+  cr_assert_eq(qdisk->file_size, actual_file_size,
+               "File size does not match with stored size; Actual file size: %ld, Expected file size: %ld\n", actual_file_size,
                qdisk->file_size);
 }
 
@@ -90,21 +97,15 @@ static void
 _assert_diskq_actual_file_size_with_expected(LogQueue *q, gboolean should_file_be_empty,
                                              gint64 number_of_messages_on_disk)
 {
-  QDisk *qdisk = ((LogQueueDisk *)q)->qdisk;
-  gchar *filename = qdisk->filename;
-
-  struct stat diskq_file_stat;
-  cr_assert_eq(stat(filename, &diskq_file_stat), 0, "Stat call failed, errno:%d", errno);
-
   if (should_file_be_empty)
     {
-      cr_assert_eq(diskq_file_stat.st_size, QDISK_RESERVED_SPACE, "Truncate after load failed: file is not empty");
+      cr_assert_eq(_get_file_size(q), QDISK_RESERVED_SPACE, "Truncate after load failed: file is not empty");
     }
   else
     {
       // diskq file is truncated on read when it becomes empty,
       // thus we have to assert to the original file size (after push finished), i.e. the max recorded size
-      cr_assert_eq(diskq_file_stat.st_size, _calculate_expected_file_size(number_of_messages_on_disk),
+      cr_assert_eq(_get_file_size(q), _calculate_expected_file_size(number_of_messages_on_disk),
                    "Truncate after load failed: expected size differs");
     }
 }


### PR DESCRIPTION
On 32bit platforms glong is 32bit, therefore we explicitly casted
a signed 64-bit value to a signed 32-bit value, which caused an EINVAL error
on passing a negative value to ftruncate.
