### PR TITLE
templates: change the $LOGHOST macro to honour use-fqdn()

### DIFF
--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -450,7 +450,9 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
 
     case M_LOGHOST:
     {
-      const gchar *hname = get_local_hostname_fqdn();
+      const gchar *hname = opts->use_fqdn
+                           ? get_local_hostname_fqdn()
+                           : get_local_hostname_short();
 
       result_append(result, hname, -1, escape);
       break;

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -370,6 +370,7 @@ log_template_options_init(LogTemplateOptions *options, GlobalConfig *cfg)
     options->frac_digits = cfg->template_options.frac_digits;
   if (options->on_error == -1)
     options->on_error = cfg->template_options.on_error;
+  options->use_fqdn = cfg->host_resolve_options.use_fqdn;
   options->initialized = TRUE;
 }
 
@@ -395,6 +396,7 @@ log_template_options_defaults(LogTemplateOptions *options)
   options->frac_digits = -1;
   options->ts_format = -1;
   options->on_error = -1;
+  options->use_fqdn = FALSE;
 }
 
 GQuark

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -77,6 +77,7 @@ struct _LogTemplateOptions
   gint ts_format;
   /* number of digits in the fraction of a second part, specified using frac_digits() */
   gint frac_digits;
+  gboolean use_fqdn;
 
   /* timezone for LTZ_LOCAL/LTZ_SEND settings */
   gchar *time_zone[LTZ_MAX];

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -34,6 +34,7 @@
 #include "cfg.h"
 #include "plugin.h"
 #include "scratch-buffers.h"
+#include "hostname.h"
 
 #include <time.h>
 #include <stdlib.h>
@@ -232,6 +233,19 @@ Test(template, test_macros)
   assert_template_format("$SEQNUM", "999");
   assert_template_format("$CONTEXT_ID", "test-context-id");
   assert_template_format("$UNIQID", "cafebabe@000000000000022b");
+}
+
+Test(template, test_loghost_macro)
+{
+  const gchar *fqdn = get_local_hostname_fqdn();
+  const gchar *short_name = get_local_hostname_short();
+
+  /* by default $LOGHOST is using fqdn as the template options we are using uses use_fqdn by default */
+  cr_assert_not(configuration->template_options.use_fqdn);
+  configuration->template_options.use_fqdn = TRUE;
+  assert_template_format("$LOGHOST", fqdn);
+  configuration->template_options.use_fqdn = FALSE;
+  assert_template_format("$LOGHOST", short_name);
 }
 
 Test(template, test_nvpairs)


### PR DESCRIPTION
This has been a dormant branch on my laptop, and I can't really remember what the trigger was to create this branch, but I thought I'd submit it as a PR and possibly find the reason and come up with a decision.

The LOGHOST macro always expanded to the FQDN of the host running
syslog-ng, whereas it is more logical to honour the use-fqdn() setting
like we do with other hostname related operations.

Signed-off-by: Balazs Scheidler <balazs.scheidler@oneidentity.com>