### PR TITLE
Invalidate LEGACY_MSGHDR when PID or PROGRAM is unset

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -573,6 +573,9 @@ void
 log_msg_unset_value(LogMessage *self, NVHandle handle)
 {
   nv_table_unset_value(self->payload, handle);
+
+  if (handle == LM_V_PROGRAM || handle == LM_V_PID)
+    log_msg_unset_value(self, LM_V_LEGACY_MSGHDR);
 }
 
 void

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -508,6 +508,12 @@ _log_name_value_updates(LogMessage *self)
   return (self->flags & LF_INTERNAL) == 0;
 }
 
+static inline gboolean
+_value_invalidates_legacy_header(NVHandle handle)
+{
+  return handle == LM_V_PROGRAM || handle == LM_V_PID;
+}
+
 void
 log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *value, gssize value_len)
 {
@@ -565,7 +571,8 @@ log_msg_set_value(LogMessage *self, NVHandle handle, const gchar *value, gssize 
 
   if (new_entry)
     log_msg_update_sdata(self, handle, name, name_len);
-  if (handle == LM_V_PROGRAM || handle == LM_V_PID)
+
+  if (_value_invalidates_legacy_header(handle))
     log_msg_unset_value(self, LM_V_LEGACY_MSGHDR);
 }
 
@@ -574,7 +581,7 @@ log_msg_unset_value(LogMessage *self, NVHandle handle)
 {
   nv_table_unset_value(self->payload, handle);
 
-  if (handle == LM_V_PROGRAM || handle == LM_V_PID)
+  if (_value_invalidates_legacy_header(handle))
     log_msg_unset_value(self, LM_V_LEGACY_MSGHDR);
 }
 


### PR DESCRIPTION
`log_msg_set_value()` contains the same invalidation logic for the legacy message header.
The same has to be done for `unset()` in order to be consistent.

For example, the legacy message header is used by `LogWriter` if no template is set, and unsetting the `PID` will not remove the `PID` field from the output:

```
rewrite { unset(value("PID")); };
Aug  2 11:11:11 test test[2222]: test
```

```
rewrite { set("" value("PID")); };
Aug  2 11:11:11 test test: test
```

More info: https://serverfault.com/questions/981150/disable-process-id-showing-in-syslog-ng-logs/981212