### PR TITLE
Fix SCL block parameter substitution 

### DIFF
--- a/lib/cfg-lexer-subst.c
+++ b/lib/cfg-lexer-subst.c
@@ -79,6 +79,7 @@ _track_string_state(CfgLexerSubst *self, CfgLexerStringTrackState last_state, co
         return CLS_WITHIN_QSTRING;
       return CLS_NOT_STRING;
     case CLS_WITHIN_STRING:
+    case CLS_WITHIN_STRING_QUOTED_CHARACTER:
       if (*p == '\\')
         return CLS_WITHIN_STRING_QUOTE;
       else if (*p == '"')
@@ -86,8 +87,6 @@ _track_string_state(CfgLexerSubst *self, CfgLexerStringTrackState last_state, co
       return CLS_WITHIN_STRING;
     case CLS_WITHIN_STRING_QUOTE:
       return CLS_WITHIN_STRING_QUOTED_CHARACTER;
-    case CLS_WITHIN_STRING_QUOTED_CHARACTER:
-      return CLS_WITHIN_STRING;
     case CLS_WITHIN_QSTRING:
       if (*p == '\'')
         return CLS_NOT_STRING;

--- a/lib/tests/test_cfg_lexer_subst.c
+++ b/lib/tests/test_cfg_lexer_subst.c
@@ -276,4 +276,20 @@ Test(cfg_lexer_subst, test_strings_with_embedded_apostrophe_cause_an_error_when_
   cfg_lexer_subst_free(subst);
 }
 
+Test(cfg_lexer_subst, test_tracking_string_state)
+{
+  const gchar *additional_values[] =
+  {
+    "quoted_escaped_newline", "\"\\n\"",
+    NULL, NULL
+  };
+
+  CfgLexerSubst *subst = construct_object_with_values(additional_values);
+
+  assert_invoke_result(subst, "\"hello\\n\" `quoted_escaped_newline`", "\"hello\\n\" \"\\n\"");
+  assert_invoke_result(subst, "\"hello\\n\\n\" `quoted_escaped_newline`", "\"hello\\n\\n\" \"\\n\"");
+  assert_invoke_result(subst, "\"hello\\n\\n \" `quoted_escaped_newline`", "\"hello\\n\\n \" \"\\n\"");
+  cfg_lexer_subst_free(subst);
+}
+
 TestSuite(cfg_lexer_subst, .init = app_startup, .fini = app_shutdown);


### PR DESCRIPTION
After a quoted character, transitioning into `CLS_WITHIN_STRING` is not
enough, because another quote or "string end" character may follow.

Here is the state machine of `_track_string_state()`, the red lines were missing.

![string_state](https://user-images.githubusercontent.com/3130044/64129044-fc79df00-cdb9-11e9-8327-d6c95aca2ddf.png)


Fixes #2879