### PR TITLE
logreader,logsource: move scratch-buffer mark and reclaim into LogSource

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -25,7 +25,6 @@
 #include "logreader.h"
 #include "mainloop-call.h"
 #include "ack-tracker/ack_tracker.h"
-#include "scratch-buffers.h"
 
 static void log_reader_io_handle_in(gpointer s);
 static gboolean log_reader_fetch_log(LogReader *self);
@@ -506,15 +505,11 @@ log_reader_fetch_log(LogReader *self)
         {
           msg_count++;
 
-          ScratchBuffersMarker mark;
-          scratch_buffers_mark(&mark);
           if (!log_reader_handle_line(self, msg, msg_len, &aux))
             {
-              scratch_buffers_reclaim_marked(mark);
               /* window is full, don't generate further messages */
               break;
             }
-          scratch_buffers_reclaim_marked(mark);
         }
     }
   log_transport_aux_data_destroy(&aux);

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -31,6 +31,7 @@
 #include "logmsg/tags.h"
 #include "ack-tracker/ack_tracker.h"
 #include "timeutils/misc.h"
+#include "scratch-buffers.h"
 
 #include <string.h>
 
@@ -533,7 +534,11 @@ log_source_post(LogSource *self, LogMessage *msg)
    */
 
   g_assert(old_window_size > 0);
+
+  ScratchBuffersMarker mark;
+  scratch_buffers_mark(&mark);
   log_pipe_queue(&self->super, msg, &path_options);
+  scratch_buffers_reclaim_marked(mark);
 }
 
 static gboolean


### PR DESCRIPTION
To be able to support using simple scratch_buffers_alloc() call for end-users,
scratch-buffers should be marked and reclaimed after each message that is passed through the log path.
For this the best location is on source side, so this happens after every message  (currently mainloop-workers use an explicit_gc call, therefore reclaiming every used scratch-buffers).

The place for doing this should be in LogSource rather then LogReader, as in case the latter, we need to add scratch_buffers_reclaim to every source: internal(), systemd-journal(), python-source(), and all threaded-source drivers as well.
This shows that it's real place is in LogSource::log_source_post().
