### PR TITLE
afinet: fix multicast ip detection

### DIFF
--- a/modules/afsocket/afinet-dest-failover.c
+++ b/modules/afsocket/afinet-dest-failover.c
@@ -250,6 +250,7 @@ _setup_failback_fd(AFInetDestDriverFailover *self)
   if (!transport_mapper_open_socket(self->failover_transport_mapper.transport_mapper,
                                     self->failover_transport_mapper.socket_options,
                                     self->bind_addr,
+                                    self->primary_addr,
                                     AFSOCKET_DIR_SEND,
                                     &self->fd.fd))
     {

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -307,8 +307,8 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
   g_assert(self->transport_mapper->transport);
   g_assert(self->bind_addr);
 
-  if (!transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr, AFSOCKET_DIR_SEND,
-                                    &sock))
+  if (!transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr, self->dest_addr,
+                                    AFSOCKET_DIR_SEND, &sock))
     {
       return FALSE;
     }

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -819,8 +819,8 @@ _sd_open_stream(AFSocketSourceDriver *self)
       if (!afsocket_sd_acquire_socket(self, &sock))
         return self->super.super.optional;
       if (sock == -1
-          && !transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr, AFSOCKET_DIR_RECV,
-                                           &sock))
+          && !transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr,
+                                           self->bind_addr, AFSOCKET_DIR_RECV, &sock))
         return self->super.super.optional;
     }
   self->fd = sock;
@@ -836,8 +836,8 @@ _sd_open_dgram(AFSocketSourceDriver *self)
       if (!afsocket_sd_acquire_socket(self, &sock))
         return self->super.super.optional;
       if (sock == -1
-          && !transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr, AFSOCKET_DIR_RECV,
-                                           &sock))
+          && !transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr,
+                                           self->bind_addr, AFSOCKET_DIR_RECV, &sock))
         return self->super.super.optional;
     }
   self->fd = -1;

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -83,7 +83,7 @@ create_socket_with_address(GSockAddr *addr, gint *sock)
   gboolean result;
 
   sock_options = socket_options_inet_new_instance();
-  result = transport_mapper_open_socket(transport_mapper, &sock_options->super, addr, AFSOCKET_DIR_RECV, sock);
+  result = transport_mapper_open_socket(transport_mapper, &sock_options->super, addr, addr, AFSOCKET_DIR_RECV, sock);
   socket_options_free(&sock_options->super);
   return result;
 }

--- a/modules/afsocket/transport-mapper.c
+++ b/modules/afsocket/transport-mapper.c
@@ -52,6 +52,7 @@ gboolean
 transport_mapper_open_socket(TransportMapper *self,
                              SocketOptions *socket_options,
                              GSockAddr *bind_addr,
+                             GSockAddr *peer_addr,
                              AFSocketDirection dir,
                              int *fd)
 {
@@ -68,7 +69,7 @@ transport_mapper_open_socket(TransportMapper *self,
   g_fd_set_nonblock(sock, TRUE);
   g_fd_set_cloexec(sock, TRUE);
 
-  if (!socket_options_setup_socket(socket_options, sock, bind_addr, dir))
+  if (!socket_options_setup_socket(socket_options, sock, peer_addr, dir))
     goto error_close;
 
   if (!transport_mapper_privileged_bind(sock, bind_addr))

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -61,6 +61,7 @@ void transport_mapper_set_address_family(TransportMapper *self, gint address_fam
 gboolean transport_mapper_open_socket(TransportMapper *self,
                                       SocketOptions *socket_options,
                                       GSockAddr *bind_addr,
+                                      GSockAddr *peer_addr,
                                       AFSocketDirection dir,
                                       int *fd);
 


### PR DESCRIPTION
IP multicast detection should to be done on the destination ip,
not the bind ip, as it was erroneously done before.

Fixes #2889

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>