### PR TITLE
logthrsource/fetcher: crash after failed reload

### DIFF
--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -315,6 +315,10 @@ log_threaded_fetcher_driver_init_method(LogPipe *s)
   if (!log_threaded_source_driver_init_method(s))
     return FALSE;
 
+  log_threaded_source_set_wakeup_func(&self->super, _wakeup);
+  log_threaded_source_driver_set_worker_run_func(&self->super, _worker_run);
+  log_threaded_source_driver_set_worker_request_exit_func(&self->super, _worker_request_exit);
+
   g_assert(self->fetch);
 
   if (cfg && self->time_reopen == -1)
@@ -347,10 +351,6 @@ log_threaded_fetcher_driver_init_instance(LogThreadedFetcherDriver *self, Global
   self->no_data_delay = -1;
 
   _init_watches(self);
-
-  log_threaded_source_driver_set_worker_run_func(&self->super, _worker_run);
-  log_threaded_source_driver_set_worker_request_exit_func(&self->super, _worker_request_exit);
-  log_threaded_source_set_wakeup_func(&self->super, _wakeup);
 
   self->super.super.super.super.init = log_threaded_fetcher_driver_init_method;
   self->super.super.super.super.deinit = log_threaded_fetcher_driver_deinit_method;

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -203,9 +203,6 @@ log_threaded_source_worker_init(LogPipe *s)
   if (!log_source_init(s))
     return FALSE;
 
-  g_assert(self->run);
-  g_assert(self->request_exit);
-
   /* The worker thread has to be started after CfgTree is completely initialized. */
   register_application_hook(AH_CONFIG_CHANGED, _start_worker_thread, self);
 
@@ -242,12 +239,14 @@ log_threaded_source_worker_new(GlobalConfig *cfg)
   return self;
 }
 
-
 gboolean
 log_threaded_source_driver_init_method(LogPipe *s)
 {
   LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
+
+  self->worker = log_threaded_source_worker_new(cfg);
+  self->worker->wakeup = log_threaded_source_wakeup;
 
   if (!log_src_driver_init_method(s))
     return FALSE;
@@ -353,9 +352,6 @@ log_threaded_source_driver_init_instance(LogThreadedSourceDriver *self, GlobalCo
   log_src_driver_init_instance(&self->super, cfg);
 
   log_threaded_source_worker_options_defaults(&self->worker_options);
-
-  self->worker = log_threaded_source_worker_new(cfg);
-  self->worker->wakeup = log_threaded_source_wakeup;
 
   self->super.super.super.init = log_threaded_source_driver_init_method;
   self->super.super.super.deinit = log_threaded_source_driver_deinit_method;


### PR DESCRIPTION
For example with diskq-source: syslog-ng crashes after a failed reload.

Example: start syslog-ng with the config below, comment out the nonexistent destination, then reload. 
After reload, syslog-ng will crash.

```
@version: 3.23

log {
  source { example-diskq-source(file("/tmp/doesnotmatter.bin")); };
#  destination(doesnotexist);
};

```

The root cause is that the worker in logthreaded source (and thus logthreaded fetcher) is created during new, but freed during deinit. During reload, syslog-ng calls deinit for all pipes. But if the reload fails, syslog-ng will reinitialize pipes: calling init. In the end, the same worker that was deallocated previously will be used by the source.

Delaying the construction of worker fixes the problem.