### PR TITLE
Revert "Merge pull request #2869"

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1102,14 +1102,38 @@ cfg_lexer_init(CfgLexer *self, GlobalConfig *cfg)
 }
 
 
+/* NOTE: cfg might be NULL in some call sites, but in those cases the lexer
+ * should remain operational, obviously skipping cases where it would be
+ * using the configuration instance.  The lexer and the configuration stuff
+ * should be one-way dependent, right now it is a circular dependency. */
 CfgLexer *
-cfg_lexer_new_common(GlobalConfig *cfg, const gchar *buffer, gsize length)
+cfg_lexer_new(GlobalConfig *cfg, FILE *file, const gchar *filename, GString *preprocess_output)
 {
   CfgLexer *self;
   CfgIncludeLevel *level;
 
   self = g_new0(CfgLexer, 1);
   cfg_lexer_init(self, cfg);
+  self->preprocess_output = preprocess_output;
+
+  level = &self->include_stack[0];
+  level->include_type = CFGI_FILE;
+  level->name = g_strdup(filename);
+  level->yybuf = _cfg_lexer__create_buffer(file, YY_BUF_SIZE, self->state);
+  _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
+
+  return self;
+}
+
+CfgLexer *
+cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
+{
+  CfgLexer *self;
+  CfgIncludeLevel *level;
+
+  self = g_new0(CfgLexer, 1);
+  cfg_lexer_init(self, cfg);
+  self->ignore_pragma = TRUE;
 
   level = &self->include_stack[0];
   level->include_type = CFGI_BUFFER;
@@ -1119,34 +1143,9 @@ cfg_lexer_new_common(GlobalConfig *cfg, const gchar *buffer, gsize length)
   level->buffer.content[length] = 0;
   level->buffer.content[length + 1] = 0;
   level->buffer.content_length = length + 2;
+  level->name = g_strdup("<string>");
   level->yybuf = _cfg_lexer__scan_buffer(level->buffer.content, level->buffer.content_length, self->state);
   _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
-
-  return self;
-}
-
-/* NOTE: cfg might be NULL in some call sites, but in those cases the lexer
- * should remain operational, obviously skipping cases where it would be
- * using the configuration instance.  The lexer and the configuration stuff
- * should be one-way dependent, right now it is a circular dependency. */
-CfgLexer *
-cfg_lexer_new(GlobalConfig *cfg, const gchar *filename, GString *buffer, GString *preprocess_output)
-{
-  CfgLexer *self = cfg_lexer_new_common(cfg, buffer->str, buffer->len);
-
-  self->preprocess_output = preprocess_output;
-  self->include_stack[0].name = g_strdup(filename);
-
-  return self;
-}
-
-CfgLexer *
-cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
-{
-  CfgLexer *self = cfg_lexer_new_common(cfg, buffer, length);
-
-  self->ignore_pragma = TRUE;
-  self->include_stack[0].name = g_strdup("<string>");
 
   return self;
 }

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -176,7 +176,7 @@ void cfg_lexer_inject_token_block(CfgLexer *self, CfgTokenBlock *block);
 int cfg_lexer_lex(CfgLexer *self, YYSTYPE *yylval, YYLTYPE *yylloc);
 void cfg_lexer_free_token(YYSTYPE *token);
 
-CfgLexer *cfg_lexer_new(GlobalConfig *cfg, const gchar *filename, GString *buffer, GString *preprocess_output);
+CfgLexer *cfg_lexer_new(GlobalConfig *cfg, FILE *file, const gchar *filename, GString *preprocess_output);
 CfgLexer *cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length);
 void  cfg_lexer_free(CfgLexer *self);
 

--- a/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
+++ b/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_backtick_substitution(config, syslog_ng):
+    raw_config = """
+@define disable none
+options {
+    mark-mode(`disable`);
+};
+"""
+    raw_config = "@version: {}\n".format(config.get_version()) + raw_config
+    config.set_raw_config(raw_config)
+
+    syslog_ng.start(config)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -50,6 +50,9 @@ class SyslogNgConfig(object):
     def set_version(self, version):
         self.__syslog_ng_config["version"] = version
 
+    def get_version(self):
+        return self.__syslog_ng_config["version"]
+
     def add_include(self, include):
         self.__syslog_ng_config["includes"].append(include)
 


### PR DESCRIPTION
This partially reverts commit 1a20821af0c08c0847293fafa7387d4ef5554aaf, keeping one commit (7573d46df9be58f2c2c13cba4d27fbc7f6a44646), a feature that makes `--preprocess-into=-` use stdout.

Reading the configuration file from a memory buffer can be used to implement multi-pass preprocessing, but the implementation in #2869 is far from complete, it requires additional work and a lot of new tests:

- `YY_INPUT` (used by `_cfg_lexer__create_buffer()`) is currently line-based, and this line-based logic was actively used:
  - backtick substitution (broken: #2906):
    Entering a `block` flex "start condition" should disable backtick substitution. The start condition has to be detected, it's currently done after each line. This can't easily be fixed when `_cfg_lexer__scan_buffer()` is used.

    https://github.com/balabit/syslog-ng/blob/048967ff27720b952ea0264330419a288e6a8c34/lib/cfg-lex.l#L140-L147

  - compatibility for the old include statement (broken):
    `yy_patch_include_statement()` needs free space in the buffer in order to insert the `@` pragma symbol. It was also conditionally disabled when the lexer was in state `block`, `block_content`, `block_string` or `block_qstring`.

- The reverted pull request used a memory buffer only for the main configuration file, all other files (`@include`d files) were processed the old way: reading the file line-by-line.

  https://github.com/balabit/syslog-ng/blob/048967ff27720b952ea0264330419a288e6a8c34/lib/cfg-lexer.c#L358

Resolves #2906