### PR TITLE
Fix persist versions

### DIFF
--- a/lib/host-id.h
+++ b/lib/host-id.h
@@ -28,6 +28,7 @@
 #include "persistable-state-header.h"
 
 #define HOST_ID_PERSIST_KEY "host_id"
+#define HOST_ID_LEGACY_PERSIST_KEY "hostid"
 
 typedef struct _HostIdState
 {

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -489,6 +489,7 @@ log_proto_buffered_server_restart_with_state(LogProtoServer *s, PersistState *pe
         {
           msg_error("Internal error restoring log reader state, stored data is too new",
                     evt_tag_int("version", state->header.version));
+          persist_state_unmap_entry(persist_state, old_state_handle);
           goto error;
         }
       persist_state_unmap_entry(persist_state, old_state_handle);

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -415,6 +415,58 @@ error_converting_v3:
   return FALSE;
 }
 
+static void
+_log_proto_buffered_server_swap_bytes_if_needed(PersistState *persist_state, PersistEntryHandle old_state_handle)
+{
+  LogProtoBufferedServerState *state;
+  state = (LogProtoBufferedServerState *)(persist_state_map_entry(persist_state, old_state_handle));
+
+  if ((state->header.big_endian && G_BYTE_ORDER == G_LITTLE_ENDIAN) ||
+      (!state->header.big_endian && G_BYTE_ORDER == G_BIG_ENDIAN))
+    {
+
+      /* byte order conversion in order to avoid the hassle with
+          scattered byte order conversions in the code */
+
+      state->header.big_endian = !state->header.big_endian;
+      state->buffer_pos = GUINT32_SWAP_LE_BE(state->buffer_pos);
+      state->pending_buffer_pos = GUINT32_SWAP_LE_BE(state->pending_buffer_pos);
+      state->pending_buffer_end = GUINT32_SWAP_LE_BE(state->pending_buffer_end);
+      state->buffer_size = GUINT32_SWAP_LE_BE(state->buffer_size);
+      state->raw_stream_pos = GUINT64_SWAP_LE_BE(state->raw_stream_pos);
+      state->raw_buffer_size = GUINT32_SWAP_LE_BE(state->raw_buffer_size);
+      state->pending_raw_stream_pos = GUINT64_SWAP_LE_BE(state->pending_raw_stream_pos);
+      state->pending_raw_buffer_size = GUINT32_SWAP_LE_BE(state->pending_raw_buffer_size);
+      state->file_size = GUINT64_SWAP_LE_BE(state->file_size);
+      state->file_inode = GUINT64_SWAP_LE_BE(state->file_inode);
+    }
+
+  persist_state_unmap_entry(persist_state, old_state_handle);
+}
+
+static gboolean
+_log_proto_buffered_server_convert_header_version(PersistState *persist_state, PersistEntryHandle old_state_handle)
+{
+  LogProtoBufferedServerState *state;
+  gboolean result = TRUE;
+
+  state = persist_state_map_entry(persist_state, old_state_handle);
+  if (state->header.version > 1)
+    {
+      msg_error("Internal error restoring log reader state, stored data is too new",
+                evt_tag_int("version", state->header.version));
+      result = FALSE;
+    }
+
+  if (state->header.version == 1)
+    {
+      state->header.version = 0;
+    }
+  persist_state_unmap_entry(persist_state, old_state_handle);
+
+  return result;
+}
+
 gboolean
 log_proto_buffered_server_restart_with_state(LogProtoServer *s, PersistState *persist_state, const gchar *persist_name)
 {
@@ -461,38 +513,14 @@ log_proto_buffered_server_restart_with_state(LogProtoServer *s, PersistState *pe
     }
   else if (persist_version == 4)
     {
-      LogProtoBufferedServerState *state;
 
-      old_state = persist_state_map_entry(persist_state, old_state_handle);
-      state = old_state;
-      if ((state->header.big_endian && G_BYTE_ORDER == G_LITTLE_ENDIAN) ||
-          (!state->header.big_endian && G_BYTE_ORDER == G_BIG_ENDIAN))
+      _log_proto_buffered_server_swap_bytes_if_needed(persist_state, old_state_handle);
+
+      if (!_log_proto_buffered_server_convert_header_version(persist_state, old_state_handle))
         {
-
-          /* byte order conversion in order to avoid the hassle with
-             scattered byte order conversions in the code */
-
-          state->header.big_endian = !state->header.big_endian;
-          state->buffer_pos = GUINT32_SWAP_LE_BE(state->buffer_pos);
-          state->pending_buffer_pos = GUINT32_SWAP_LE_BE(state->pending_buffer_pos);
-          state->pending_buffer_end = GUINT32_SWAP_LE_BE(state->pending_buffer_end);
-          state->buffer_size = GUINT32_SWAP_LE_BE(state->buffer_size);
-          state->raw_stream_pos = GUINT64_SWAP_LE_BE(state->raw_stream_pos);
-          state->raw_buffer_size = GUINT32_SWAP_LE_BE(state->raw_buffer_size);
-          state->pending_raw_stream_pos = GUINT64_SWAP_LE_BE(state->pending_raw_stream_pos);
-          state->pending_raw_buffer_size = GUINT32_SWAP_LE_BE(state->pending_raw_buffer_size);
-          state->file_size = GUINT64_SWAP_LE_BE(state->file_size);
-          state->file_inode = GUINT64_SWAP_LE_BE(state->file_inode);
-        }
-
-      if (state->header.version > 0)
-        {
-          msg_error("Internal error restoring log reader state, stored data is too new",
-                    evt_tag_int("version", state->header.version));
-          persist_state_unmap_entry(persist_state, old_state_handle);
           goto error;
         }
-      persist_state_unmap_entry(persist_state, old_state_handle);
+
       log_proto_buffered_server_apply_state(self, old_state_handle, persist_name);
       return TRUE;
     }

--- a/lib/rcptid.c
+++ b/lib/rcptid.c
@@ -67,6 +67,7 @@ rcptid_restore_entry(void)
     {
       msg_error("Internal error restoring log reader state, stored data is too new",
                 evt_tag_int("version", data->header.version));
+      rcptid_unmap_state();
       return FALSE;
     }
 

--- a/lib/rcptid.c
+++ b/lib/rcptid.c
@@ -168,10 +168,16 @@ rcptid_init(PersistState *state, gboolean use_rcptid)
   rcptid_service.persist_state = state;
   rcptid_service.persist_handle = persist_state_lookup_entry(state, "next.rcptid", &size, &version);
 
-  if (rcptid_service.persist_handle)
-    return rcptid_restore_entry();
+  if (rcptid_service.persist_handle && size == sizeof(RcptidState))
+    {
+      return rcptid_restore_entry();
+    }
   else
-    return rcptid_create_new_entry();
+    {
+      if (rcptid_service.persist_handle)
+        msg_warning("rcpt-id: persist state: invalid size, allocating a new one");
+      return rcptid_create_new_entry();
+    }
 }
 
 void

--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -38,24 +38,85 @@ typedef struct _RunIDState
   gint run_id;
 } RunIDState;
 
-gboolean
-run_id_init(PersistState *state)
+
+static void
+_run_id_set_entry(PersistState *state, PersistEntryHandle handle, guint32 value)
+{
+  RunIDState *mapped_entry;
+
+  mapped_entry = persist_state_map_entry(state, handle);
+  mapped_entry->run_id = value;
+  persist_state_unmap_entry(state, handle);
+}
+
+static guint32
+_run_id_recover_legacy_entry(PersistState *state, PersistEntryHandle handle)
+{
+  guint32 old_entry;
+  guint32 *mapped_entry;
+
+  mapped_entry = persist_state_map_entry(state, handle);
+  old_entry = *mapped_entry;
+  persist_state_unmap_entry(state, handle);
+
+  return old_entry;
+}
+
+static PersistEntryHandle
+_run_id_process_existing_entry(PersistState *state, PersistEntryHandle handle, gsize size, guint8 version)
+{
+  if ((size == sizeof(RunIDState)))
+    {
+      return handle;
+    }
+
+  if (size == sizeof(guint32))
+    {
+      // In some legacy code we only used a single guint32 value to store the run_id. (without the proper header)
+      // If the size of the entry matches exactly, we convert it. Otherwise we can not use it, and allocate a new one.
+      msg_warning("run-id: persist state: found a legacy run-id state, reinitialize it");
+
+      guint32 old_entry = _run_id_recover_legacy_entry(state, handle);
+      PersistEntryHandle new_handle = persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState));
+
+      if (new_handle)
+        _run_id_set_entry(state, new_handle, old_entry);
+      return new_handle;
+    }
+
+  msg_warning("run-id: persist state: invalid run-id found, allocating a new state",
+              evt_tag_int("size", size),
+              evt_tag_int("version", version));
+
+  return persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState));
+}
+
+static PersistEntryHandle
+_run_id_get_validated_handle(PersistState *state)
 {
   gsize size;
   guint8 version;
   PersistEntryHandle handle;
-  RunIDState *run_id_state;
 
   handle = persist_state_lookup_entry(state, RUN_ID_PERSIST_KEY, &size, &version);
 
-  if (handle == 0 || size != sizeof(RunIDState))
+  if (handle)
     {
-      if (handle != 0)
-        msg_warning("run-id: persist state: invalid size, allocating a new one");
-      handle = persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState));
+      return _run_id_process_existing_entry(state, handle, size, version);
     }
 
-  if (!handle)
+  return persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState));
+}
+
+gboolean
+run_id_init(PersistState *state)
+{
+  PersistEntryHandle handle;
+  RunIDState *run_id_state;
+
+  handle = _run_id_get_validated_handle(state);
+
+  if (handle == 0)
     {
       msg_error("run-id: could not allocate persist state");
       return FALSE;

--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -48,9 +48,11 @@ run_id_init(PersistState *state)
 
   handle = persist_state_lookup_entry(state, RUN_ID_PERSIST_KEY, &size, &version);
 
-  if (handle == 0)
+  if (handle == 0 || size != sizeof(RunIDState))
     {
-      handle = persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState) );
+      if (handle != 0)
+        msg_warning("run-id: persist state: invalid size, allocating a new one");
+      handle = persist_state_alloc_entry(state, RUN_ID_PERSIST_KEY, sizeof(RunIDState));
     }
 
   if (!handle)


### PR DESCRIPTION
Work in progress. Based on @lbudai's #2862 
The main goal of the PR is to seamlessly convert old persist entries into their newer format.
WIP because: LogProtoBufferedServerState will require additional work, unfortunately we have mixing persist file and persist entry logic.