### PR TITLE
java-modules: add gradle-user-home to gradle_args

### DIFF
--- a/modules/java-modules/Makefile.am
+++ b/modules/java-modules/Makefile.am
@@ -8,6 +8,7 @@ GRADLE_FLAGS ?=
 GRADLE_ARGS = $(GRADLE_FLAGS) \
 	--project-dir $(GRADLE_PROJECT_DIR) \
 	--project-cache-dir=$(GRADLE_PROJECT_CACHE_DIR) \
+	--gradle-user-home=$(GRADLE_PROJECT_CACHE_DIR) \
 	-PsyslogBuildDir=$(abs_top_builddir)/modules/java-modules \
 	-PsyslogDepsDir=$(abs_top_builddir)/modules/java/syslog-ng-core/libs
 GRADLE_COMMAND = $(AM_V_GEN) $(GRADLE) $(GRADLE_ARGS)


### PR DESCRIPTION
With 283523530b29cea8091585c9f69d68734646a966 it was removed (`-g $(GRADLE_WORKDIR)` option), but it is needed to be able to disable caching.

It does not break caching, and provides the old functionality, when caching is not enabled.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>