### PR TITLE
LightVerboseLogOnError: Increase default pytest verbosity on error

### DIFF
--- a/tests/python_functional/CMakeLists.txt
+++ b/tests/python_functional/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_custom_target(pytest-self-check
-   COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests/python_functional/src)
+   COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests/python_functional/src --showlocals --verbosity=3)
 
 add_custom_target(pytest-check
-   COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests/python_functional/functional_tests --installdir=${CMAKE_INSTALL_PREFIX})
+   COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests/python_functional/functional_tests --installdir=${CMAKE_INSTALL_PREFIX} --showlocals --verbosity=3)
 
 add_custom_target(pytest-linters
    COMMAND find ${PROJECT_SOURCE_DIR}/tests/python_functional/ -name "*.py" -not -path "*reports*" -not -path "*tox*" -print0 | xargs -0 pre-commit run --show-diff-on-failure --config=${PROJECT_SOURCE_DIR}/tests/python_functional/.pre-commit-config.yaml --files WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/tests/python_functional/Makefile.am
+++ b/tests/python_functional/Makefile.am
@@ -7,10 +7,10 @@ PYTEST_SUBDIR=
 PYTEST_VERBOSE=false
 
 pytest-self-check:
-	@${PYTHON} -m pytest $(top_srcdir)/tests/python_functional/src
+	@${PYTHON} -m pytest $(top_srcdir)/tests/python_functional/src --showlocals --verbosity=3
 
 pytest-check:
-	@${PYTHON} -m pytest -o log_cli=$(PYTEST_VERBOSE) $(top_srcdir)/tests/python_functional/functional_tests/$(PYTEST_SUBDIR) --installdir=${prefix}
+	@${PYTHON} -m pytest -o log_cli=$(PYTEST_VERBOSE) $(top_srcdir)/tests/python_functional/functional_tests/$(PYTEST_SUBDIR) --installdir=${prefix} --showlocals --verbosity=3
 
 pytest-linters:
 	@find $(top_srcdir)/tests/python_functional/ -name "*.py" \


### PR DESCRIPTION
- effects only when using `make pytest-check` and `make pytest-self-check`

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>

For now there is only one option to increase (foreground) log verbosity for Light when running through `make pytest-check` or `make pytest-self-check`. This is `PYTEST_VERBOSE` variable https://github.com/balabit/syslog-ng/blob/a6f3148ccd5b08331b43e217668f2c2c1398211d/tests/python_functional/Makefile.am#L7.

This variable (maybe not the best variable name) can enable to display internal logging records (printed with logger.info(...) or logger.error(...) ) on console. The drawback if this variable is enabled it will used on every testcase so our console will contains "everything".

There can be cases when we only need verbose logs when our tescases are failing.
This PR wants to fix this case with adding "--showlocals --verbosity=3" command line parameters.

An example failed console log before this PR:
* notice that we could not see why syslog-ng can not started.
```
――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_acceptance[with_one_log] ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

config = <src.syslog_ng_config.syslog_ng_config.SyslogNgConfig object at 0x7f54b8334250>
syslog_ng = <src.syslog_ng.syslog_ng.SyslogNg object at 0x7f54b8334c90>
input_log = '<38>Feb 11 21:27:22 testhost testprogram[9999]: test message\n'
expected_log = 'Feb 11 21:27:22 testhost testprogram[9999]: test message\n', counter = 1

    @pytest.mark.parametrize(
        "input_log, expected_log, counter", [
            (input_log, expected_log, 1),
            (input_log, expected_log, 10),
        ], ids=["with_one_log", "with_ten_logs"],
    )
    def test_acceptance(config, syslog_ng, input_log, expected_log, counter):
        file_source = config.create_file_source(file_name="input.log", aaa="aaa")
        file_destination = config.create_file_destination(file_name="output.log")
        config.create_logpath(statements=[file_source, file_destination])
        config.create_global_options(keep_hostname="yes")
    
        file_source.write_log(input_log, counter)
>       syslog_ng.start(config)

../tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py:42: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../tests/python_functional/src/syslog_ng/syslog_ng.py:32: in start
    self.__syslog_ng_cli.start(config)
../tests/python_functional/src/syslog_ng/syslog_ng_cli.py:103: in start
    self.__syntax_check()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <src.syslog_ng.syslog_ng_cli.SyslogNgCli object at 0x7f54b8334e50>

    def __syntax_check(self):
        result = self.__syntax_only()
        if result["exit_code"] != 0:
            logger.error(result["stderr"])
>           raise Exception("syslog-ng can not started exit_code={}".format(result["exit_code"]))
E           Exception: syslog-ng can not started exit_code=1

../tests/python_functional/src/syslog_ng/syslog_ng_cli.py:67: Exception

 functional_tests/source_drivers/file_source/test_acceptance.py ⨯ 
```

An example failed console log after this PR:
* the difference is that local variables will be displayed
* in stderr there is a reason why syslog-ng can not started
* **Update:** Maybe in this special case it is also good if print result['stderr'] in line: https://github.com/balabit/syslog-ng/blob/a6f3148ccd5b08331b43e217668f2c2c1398211d/tests/python_functional/src/syslog_ng/syslog_ng_cli.py#L67
* this run is with python2, with python3 the variables will also indented along new lines (for better reading)
```
――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_acceptance[with_one_log] ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

config = <src.syslog_ng_config.syslog_ng_config.SyslogNgConfig object at 0x7f313e122750>
syslog_ng = <src.syslog_ng.syslog_ng.SyslogNg object at 0x7f313e122f90>
input_log = '<38>Feb 11 21:27:22 testhost testprogram[9999]: test message\n'
expected_log = 'Feb 11 21:27:22 testhost testprogram[9999]: test message\n', counter = 1

    @pytest.mark.parametrize(
        "input_log, expected_log, counter", [
            (input_log, expected_log, 1),
            (input_log, expected_log, 10),
        ], ids=["with_one_log", "with_ten_logs"],
    )
    def test_acceptance(config, syslog_ng, input_log, expected_log, counter):
        file_source = config.create_file_source(file_name="input.log", aaa="aaa")
        file_destination = config.create_file_destination(file_name="output.log")
        config.create_logpath(statements=[file_source, file_destination])
        config.create_global_options(keep_hostname="yes")
    
        file_source.write_log(input_log, counter)
>       syslog_ng.start(config)

config     = <src.syslog_ng_config.syslog_ng_config.SyslogNgConfig object at 0x7f313e122750>
counter    = 1
expected_log = 'Feb 11 21:27:22 testhost testprogram[9999]: test message\n'
file_destination = <src.syslog_ng_config.statements.destinations.file_destination.FileDestination object at 0x7f313e1228d0>
file_source = <src.syslog_ng_config.statements.sources.file_source.FileSource object at 0x7f313e122fd0>
input_log  = '<38>Feb 11 21:27:22 testhost testprogram[9999]: test message\n'
syslog_ng  = <src.syslog_ng.syslog_ng.SyslogNg object at 0x7f313e122f90>

../tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py:42: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../tests/python_functional/src/syslog_ng/syslog_ng.py:32: in start
    self.__syslog_ng_cli.start(config)
../tests/python_functional/src/syslog_ng/syslog_ng_cli.py:103: in start
    self.__syntax_check()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <src.syslog_ng.syslog_ng_cli.SyslogNgCli object at 0x7f313e122050>

    def __syntax_check(self):
        result = self.__syntax_only()
        if result["exit_code"] != 0:
            logger.error(result["stderr"])
>           raise Exception("syslog-ng can not started exit_code={}".format(result["exit_code"]))
E           Exception: syslog-ng can not started exit_code=1

result     = {'exit_code': 1,
 'stderr': "syslog-ng: Error setting capabilities, capability management disabled; error='Operation not permitted'\nError parsing affile, inner-src plugin aaa not found in /home/micek/na_akkor_ujra/git-projects/github_mitzkia/syslog-ng/build/reports/2019-09-15-06-36-04-126734/test_acceptance_with_one_log_/syslog_ng_server.conf:9:9-9:12:\n4       };\n5       \n6       source source_17428 {\n7           file (\n8               /home/micek/na_akkor_ujra/git-projects/github_mitzkia/syslog-ng/build/reports/2019-09-15-06-36-04-126734/test_acceptance_with_one_log_/input.log\n9----->         aaa(aaa)\n9----->         ^^^\n10          );\n11      };\n12      \n13      destination destination_81576 {\n14          file (\n\n",
 'stdout': ''}
self       = <src.syslog_ng.syslog_ng_cli.SyslogNgCli object at 0x7f313e122050>

../tests/python_functional/src/syslog_ng/syslog_ng_cli.py:67: Exception

 functional_tests/source_drivers/file_source/test_acceptance.py::test_acceptance[with_one_log] ⨯ 
```