### PR TITLE
LightPreCommitConfig: Remove pyupgrade from hooks

### DIFF
--- a/tests/python_functional/.pre-commit-config.yaml
+++ b/tests/python_functional/.pre-commit-config.yaml
@@ -25,8 +25,3 @@ repos:
     -   id: add-trailing-comma
         args: [--py36-plus]
         files: 'tests/python_functional/'
--   repo: https://github.com/asottile/pyupgrade
-    rev: v1.17.0
-    hooks:
-    -   id: pyupgrade
-        files: 'tests/python_functional/'


### PR DESCRIPTION
- it was added accidentally
- until we need to support Python v2 we did not profit from it
during the linting process

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>