### PR TITLE
Fix wildcard-file() option validation

### DIFF
--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -90,8 +90,7 @@ affile_sd_init(LogPipe *s)
   if (!log_src_driver_init_method(s))
     return FALSE;
 
-  file_reader_options_init(&self->file_reader_options, cfg, self->super.super.group);
-  if (!file_reader_options_validate(&self->file_reader_options))
+  if (!file_reader_options_init(&self->file_reader_options, cfg, self->super.super.group))
     return FALSE;
 
   file_opener_options_init(&self->file_opener_options, cfg);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -376,6 +376,12 @@ file_reader_options_init(FileReaderOptions *options, GlobalConfig *cfg, const gc
   log_proto_file_reader_options_init(file_reader_options_get_log_proto_options(options));
 }
 
+gboolean
+file_reader_options_validate(FileReaderOptions *options)
+{
+  return log_proto_file_reader_options_validate(file_reader_options_get_log_proto_options(options));
+}
+
 void
 file_reader_options_deinit(FileReaderOptions *options)
 {

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -369,17 +369,11 @@ file_reader_options_defaults(FileReaderOptions *options)
   options->restore_state = FALSE;
 }
 
-void
+gboolean
 file_reader_options_init(FileReaderOptions *options, GlobalConfig *cfg, const gchar *group)
 {
   log_reader_options_init(&options->reader_options, cfg, group);
-  log_proto_file_reader_options_init(file_reader_options_get_log_proto_options(options));
-}
-
-gboolean
-file_reader_options_validate(FileReaderOptions *options)
-{
-  return log_proto_file_reader_options_validate(file_reader_options_get_log_proto_options(options));
+  return log_proto_file_reader_options_init(file_reader_options_get_log_proto_options(options));
 }
 
 void

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -70,6 +70,7 @@ void file_reader_options_set_follow_freq(FileReaderOptions *options, gint follow
 
 void file_reader_options_defaults(FileReaderOptions *options);
 void file_reader_options_init(FileReaderOptions *options, GlobalConfig *cfg, const gchar *group);
+gboolean file_reader_options_validate(FileReaderOptions *options);
 void file_reader_options_deinit(FileReaderOptions *options);
 
 

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -69,8 +69,7 @@ void file_reader_stop_follow_file(FileReader *self);
 void file_reader_options_set_follow_freq(FileReaderOptions *options, gint follow_freq);
 
 void file_reader_options_defaults(FileReaderOptions *options);
-void file_reader_options_init(FileReaderOptions *options, GlobalConfig *cfg, const gchar *group);
-gboolean file_reader_options_validate(FileReaderOptions *options);
+gboolean file_reader_options_init(FileReaderOptions *options, GlobalConfig *cfg, const gchar *group);
 void file_reader_options_deinit(FileReaderOptions *options);
 
 

--- a/modules/affile/logproto-file-reader.c
+++ b/modules/affile/logproto-file-reader.c
@@ -42,12 +42,6 @@ log_proto_file_reader_options_defaults(LogProtoFileReaderOptions *options)
   options->pad_size = 0;
 }
 
-void
-log_proto_file_reader_options_init(LogProtoFileReaderOptions *options)
-{
-  log_proto_multi_line_server_options_init(&options->super);
-}
-
 static gboolean
 _are_multi_line_settings_invalid(LogProtoFileReaderOptions *options)
 {
@@ -58,7 +52,7 @@ _are_multi_line_settings_invalid(LogProtoFileReaderOptions *options)
                                                    || options->super.garbage);
 }
 
-gboolean
+static gboolean
 log_proto_file_reader_options_validate(LogProtoFileReaderOptions *options)
 {
   if (_are_multi_line_settings_invalid(options))
@@ -75,6 +69,13 @@ log_proto_file_reader_options_validate(LogProtoFileReaderOptions *options)
     }
 
   return TRUE;
+}
+
+gboolean
+log_proto_file_reader_options_init(LogProtoFileReaderOptions *options)
+{
+  log_proto_multi_line_server_options_init(&options->super);
+  return log_proto_file_reader_options_validate(options);
 }
 
 void

--- a/modules/affile/logproto-file-reader.c
+++ b/modules/affile/logproto-file-reader.c
@@ -68,6 +68,12 @@ log_proto_file_reader_options_validate(LogProtoFileReaderOptions *options)
       return FALSE;
     }
 
+  if (options->pad_size > 0 && options->super.mode != MLM_NONE)
+    {
+      msg_error("pad-size() and multi-line-mode() can not be used together");
+      return FALSE;
+    }
+
   return TRUE;
 }
 

--- a/modules/affile/logproto-file-reader.c
+++ b/modules/affile/logproto-file-reader.c
@@ -24,6 +24,7 @@
 #include "logproto-file-reader.h"
 #include "logproto/logproto-record-server.h"
 #include "logproto/logproto-multiline-server.h"
+#include "messages.h"
 
 LogProtoServer *
 log_proto_file_reader_new(LogTransport *transport, const LogProtoFileReaderOptions *options)
@@ -45,6 +46,29 @@ void
 log_proto_file_reader_options_init(LogProtoFileReaderOptions *options)
 {
   log_proto_multi_line_server_options_init(&options->super);
+}
+
+static gboolean
+_are_multi_line_settings_invalid(LogProtoFileReaderOptions *options)
+{
+  gboolean is_garbage_mode = options->super.mode == MLM_PREFIX_GARBAGE;
+  gboolean is_suffix_mode = options->super.mode == MLM_PREFIX_SUFFIX;
+
+  return (!is_garbage_mode && !is_suffix_mode) && (options->super.prefix
+                                                   || options->super.garbage);
+}
+
+gboolean
+log_proto_file_reader_options_validate(LogProtoFileReaderOptions *options)
+{
+  if (_are_multi_line_settings_invalid(options))
+    {
+      msg_error("multi-line-prefix() and/or multi-line-garbage() specified but multi-line-mode() is not regexp based "
+                "(prefix-garbage or prefix-suffix), please set multi-line-mode() properly");
+      return FALSE;
+    }
+
+  return TRUE;
 }
 
 void

--- a/modules/affile/logproto-file-reader.h
+++ b/modules/affile/logproto-file-reader.h
@@ -35,8 +35,7 @@ typedef struct _LogProtoFileReaderOptions
 LogProtoServer *log_proto_file_reader_new(LogTransport *transport, const LogProtoFileReaderOptions *options);
 
 void log_proto_file_reader_options_defaults(LogProtoFileReaderOptions *options);
-void log_proto_file_reader_options_init(LogProtoFileReaderOptions *options);
-gboolean log_proto_file_reader_options_validate(LogProtoFileReaderOptions *options);
+gboolean log_proto_file_reader_options_init(LogProtoFileReaderOptions *options);
 void log_proto_file_reader_options_destroy(LogProtoFileReaderOptions *options);
 
 

--- a/modules/affile/logproto-file-reader.h
+++ b/modules/affile/logproto-file-reader.h
@@ -36,6 +36,7 @@ LogProtoServer *log_proto_file_reader_new(LogTransport *transport, const LogProt
 
 void log_proto_file_reader_options_defaults(LogProtoFileReaderOptions *options);
 void log_proto_file_reader_options_init(LogProtoFileReaderOptions *options);
+gboolean log_proto_file_reader_options_validate(LogProtoFileReaderOptions *options);
 void log_proto_file_reader_options_destroy(LogProtoFileReaderOptions *options);
 
 

--- a/modules/affile/tests/test_wildcard_source.c
+++ b/modules/affile/tests/test_wildcard_source.c
@@ -80,23 +80,31 @@ Test(wildcard_source, initial_test)
   cr_assert_eq(driver->monitor_method, MM_POLL);
 }
 
-Test(wildcard_source, test_option_inheritance)
+Test(wildcard_source, test_option_inheritance_multiline)
 {
   WildcardSourceDriver *driver = _create_wildcard_filesource("base-dir(/test_non_existent_dir)"
                                                              "filename-pattern(*.log)"
                                                              "recursive(yes)"
                                                              "max-files(100)"
                                                              "follow-freq(10)"
-                                                             "follow_freq(10.0)"
-                                                             "pad_size(5)"
+                                                             "follow-freq(10.0)"
                                                              "multi-line-mode(regexp)"
                                                              "multi-line-prefix(\\d+)"
                                                              "multi-line-garbage(garbage)");
   cr_assert_eq(driver->file_reader_options.follow_freq, 10000);
-  cr_assert_eq(file_reader_options_get_log_proto_options(&driver->file_reader_options)->pad_size, 5);
   cr_assert_eq(file_reader_options_get_log_proto_options(&driver->file_reader_options)->super.mode, MLM_PREFIX_GARBAGE);
   cr_assert(file_reader_options_get_log_proto_options(&driver->file_reader_options)->super.prefix != NULL);
   cr_assert(file_reader_options_get_log_proto_options(&driver->file_reader_options)->super.garbage != NULL);
+}
+
+Test(wildcard_source, test_option_inheritance_padded)
+{
+  WildcardSourceDriver *driver = _create_wildcard_filesource("base-dir(/test_non_existent_dir)"
+                                                             "filename-pattern(*.log)"
+                                                             "recursive(yes)"
+                                                             "max-files(100)"
+                                                             "pad-size(5)");
+  cr_assert_eq(file_reader_options_get_log_proto_options(&driver->file_reader_options)->pad_size, 5);
 }
 
 Test(wildcard_source, test_option_duplication)

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -245,7 +245,7 @@ _ensure_minimum_window_size(WildcardSourceDriver *self, GlobalConfig *cfg)
     }
 }
 
-static void
+static gboolean
 _init_reader_options(WildcardSourceDriver *self, GlobalConfig *cfg)
 {
   if (!self->window_size_initialized)
@@ -253,9 +253,9 @@ _init_reader_options(WildcardSourceDriver *self, GlobalConfig *cfg)
       self->file_reader_options.reader_options.super.init_window_size /= self->max_files;
       _ensure_minimum_window_size(self, cfg);
       self->window_size_initialized = TRUE;
-
     }
-  file_reader_options_init(&self->file_reader_options, cfg, self->super.super.group);
+
+  return file_reader_options_init(&self->file_reader_options, cfg, self->super.super.group);
 }
 
 static void
@@ -322,8 +322,7 @@ _init(LogPipe *s)
       return FALSE;
     }
 
-  _init_reader_options(self, cfg);
-  if (!file_reader_options_validate(&self->file_reader_options))
+  if (!_init_reader_options(self, cfg))
     return FALSE;
 
   _init_opener_options(self, cfg);

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -323,6 +323,9 @@ _init(LogPipe *s)
     }
 
   _init_reader_options(self, cfg);
+  if (!file_reader_options_validate(&self->file_reader_options))
+    return FALSE;
+
   _init_opener_options(self, cfg);
 
   if (!_add_directory_monitor(self, self->base_dir))


### PR DESCRIPTION
This PR
- fixes the multi-line option validation when `wildcard-file()` is used (it was missing),
- adds another validation: `pad-size()` and `multi-line-mode()` are mutually exclusive options.