### PR TITLE
syslog-ng-sysconfdir define

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -496,6 +496,7 @@ cfg_set_global_paths(GlobalConfig *self)
   cfg_args_set(self->globals, "syslog-ng-root", get_installation_path_for(SYSLOG_NG_PATH_PREFIX));
   cfg_args_set(self->globals, "syslog-ng-data", get_installation_path_for(SYSLOG_NG_PATH_DATADIR));
   cfg_args_set(self->globals, "syslog-ng-include", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
+  cfg_args_set(self->globals, "syslog-ng-sysconfdir", get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR));
   cfg_args_set(self->globals, "scl-root", get_installation_path_for(SYSLOG_NG_PATH_SCLDIR));
   cfg_args_set(self->globals, "module-path", resolvedConfigurablePaths.initial_module_path);
   cfg_args_set(self->globals, "module-install-dir", resolvedConfigurablePaths.initial_module_path);


### PR DESCRIPTION
This patch adds a global `@define` to make it easy to locate the default syslogng sysconfdir.

requested by @rfaircloth-splunk
